### PR TITLE
Adding time delay parameter for scheduling commands

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -13,6 +13,8 @@ import sys
 import getpass
 import json
 import click
+import datetime
+import time
 
 from keepercommander import display, api, imp_exp
 from keepercommander.params import KeeperParams
@@ -80,9 +82,16 @@ def get_params(config_filename):
                     params.password = params.config['password']
 
                 if 'challenge' in params.config:
-                    import yubikey.yubikey
-                    challenge = params.config['challenge']
-                    params.password = yubikey.yubikey.get_response(challenge)
+                    try:
+                        import keepercommander.yubikey.yubikey
+                        challenge = params.config['challenge']
+                        params.password = keepercommander.yubikey.yubikey.get_response(challenge)
+                    except Exception as e:
+                        print(e)
+                        sys.exit(1)
+
+                if 'timedelay' in params.config:
+                    params.timedelay = params.config['timedelay']
 
                 if 'mfa_token' in params.config:
                     params.mfa_token = params.config['mfa_token']
@@ -183,6 +192,33 @@ def do_command(params):
 
     return True
 
+def runcommands(params):
+    keep_running = True
+    timedelay = params.timedelay
+
+    while keep_running:
+        for c in params.commands:
+            params.command = c
+            print('Executing [' + params.command + ']...')
+            try:
+                if not do_command(params):
+                    print('Command ' + params.command + ' failed.')
+            except CommunicationError as e:
+                print("Communication Error:" + str(e.message))
+            except AuthenticationError as e:
+                print("AuthenticationError Error: " + str(e.message))
+            except:
+                print('An unexpected error occurred: ' + str(sys.exc_info()[0]))
+
+            params.command = ''
+
+        if (timedelay == 0):
+            keep_running = False
+        else:
+            print(datetime.datetime.now().strftime('%Y/%m/%d %H:%M:%S') + \
+                ' Waiting for ' + str(timedelay) + ' seconds')
+            time.sleep(timedelay)
+
 def loop(params):
 
     display.welcome()
@@ -198,21 +234,7 @@ def loop(params):
 
             # if commands are provided, execute those then exit
         if params.commands:
-            for c in params.commands:
-                params.command = c
-                print('Executing [' + params.command + ']...')
-                try:
-                    if not do_command(params):
-                        print('Command ' + params.command + ' failed.')
-                except CommunicationError as e:
-                    print("Communication Error:" + str(e.message))
-                except AuthenticationError as e:
-                    print("AuthenticationError Error: " + str(e.message))
-                except:
-                    print('An unexpected error occurred: ' + str(sys.exc_info()[0]))
-
-                params.command = ''
-
+            runcommands(params)
             goodbye()
 
         if params.debug: print('Params: ' + str(params))

--- a/keepercommander/params.py
+++ b/keepercommander/params.py
@@ -20,7 +20,7 @@ class KeeperParams:
                  data_key='',private_key='',
                  revision=0, rsa_key='', auth_verifier='',
                  record_cache={}, meta_data_cache={}, shared_folder_cache={},
-                 debug=False):
+                 debug=False, timedelay=0):
         self.config_filename = config_filename
         self.config = config
         self.auth_verifier = auth_verifier 
@@ -45,4 +45,5 @@ class KeeperParams:
         self.shared_folder_cache = shared_folder_cache
         self.rsa_key = rsa_key
         self.debug = debug
+        self.timedelay = timedelay
 


### PR DESCRIPTION
You can now specify the number of seconds between running all the commands. This allows basic scheduling with the configuration retained in memory only.