### PR TITLE
Windows plugin fix

### DIFF
--- a/keepercommander/__init__.py
+++ b/keepercommander/__init__.py
@@ -3,7 +3,7 @@ import click
 
 from keepercommander import cli, display, api
 
-__version__ = '0.3.6'
+__version__ = '0.3.7'
 
 @click.group()
 @click.option('--server', '-s', envvar='KEEPER_SERVER', help='Host address')

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -760,9 +760,16 @@ def rotate_password(params, record_uid):
         print("Rotating with plugin " + str(plugin_name))
         plugin = plugin_manager.get_plugin(plugin_name)
         if plugin:
-            success =  plugin.rotate(record_object, new_password)
-
+            old_password = record_object.password
+            success = plugin.rotate(record_object, new_password)
             if success:
+                # Some plugins might need to change the password in the process of rotation
+                # f.e. windows plugin gets rid of certain characters. If password is changed,
+                # plugin puts it into the record object
+                if record_object.password != old_password:
+                    print(new_password)
+                    print(record_object.password)
+                    new_password = record_object.password
                 if params.debug: 
                     print('Password rotation on target system is successful.')
             else:

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -767,8 +767,6 @@ def rotate_password(params, record_uid):
                 # f.e. windows plugin gets rid of certain characters. If password is changed,
                 # plugin puts it into the record object
                 if record_object.password != old_password:
-                    print(new_password)
-                    print(record_object.password)
                     new_password = record_object.password
                 if params.debug: 
                     print('Password rotation on target system is successful.')

--- a/keepercommander/plugins/windows/README.md
+++ b/keepercommander/plugins/windows/README.md
@@ -5,20 +5,14 @@ This plugin allows rotating a windows user's password using the net user command
 
 ### Dependencies 
 
-1) Install the below modules
-
-```
-pip3 install pexpect
-```
-
-2) Add the following Custom Fields to the record that you want to rotate within Keeper
+1) Add the following Custom Fields to the record that you want to rotate within Keeper
 
 ```
 Name: cmdr:plugin
 Value: windows
 ```
 
-3) The plugin will use the Login field as the username of the passwd command when rotating a password.
+2) The plugin will use the Login field as the username of the passwd command when rotating a password.
 
 ### Optional custom fields
 

--- a/keepercommander/plugins/windows/windows.py
+++ b/keepercommander/plugins/windows/windows.py
@@ -10,12 +10,7 @@
 # Contact: ops@keepersecurity.com
 #
 
-import pexpect
-
-"""Commander Plugin for Windows net Command
-   Dependencies: 
-       pip3 install pexpect
-"""
+import subprocess, re
 
 def rotate(record, newpassword):
     """ Grab any required fields from the record """
@@ -23,14 +18,16 @@ def rotate(record, newpassword):
 
     result = False
 
-    child = pexpect.spawn('net user ', [user, newpassword])
-
-    i = child.expect(['The command completed succesfully.', pexpect.EOF])
+    # the characters below mess with windows command line
+    np = re.sub('[<>&|]', '', newpassword)
+    i = subprocess.call("net user {0} {1}".format(user, np), shell = True)
 
     if i == 0:
         print('Password changed succesfully')
+        if np != newpassword:
+            record.password = np
         result = True
-    elif i == 1:
+    else:
         print('Password change failed')
 
     return result


### PR DESCRIPTION
pexpect does not work on Windows, switched to subprocess.
Also, windows net command cannot process certain characters in the
password string, so those are stripped out, which required a
modification to password rotation code.