### PR TITLE
Rotate cli command

### DIFF
--- a/keepercommander/__init__.py
+++ b/keepercommander/__init__.py
@@ -14,7 +14,12 @@ __version__ = '0.3.7'
 @click.version_option(version=__version__)
 @click.pass_context
 def main(ctx, debug, server, user, password, config):
-
+    '''
+    \b
+    Some commands have their own options. To see the help message for a specific command, type
+    keeper COMMAND --help
+    for example: keeper import --help
+    '''
     try:
         params = cli.get_params(config)
         ctx.obj = params
@@ -34,6 +39,7 @@ def main(ctx, debug, server, user, password, config):
 main.add_command(cli.info)
 main.add_command(cli.shell)
 main.add_command(cli.list)
+main.add_command(cli.rotate)
 main.add_command(cli.export)
 main.add_command(cli._import)
 main.add_command(cli.delete_all)

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -44,6 +44,25 @@ def list(params):
     except Exception as e:
         raise click.ClickException(e)
 
+@click.command(help = 'Rotate Keeper record')
+@click.pass_obj
+@click.option('--uid', help='uid of the record to rotate the password on')
+@click.option('--match', help='regular expression to select records for password rotation')
+def rotate(params, uid, match):
+    if not (uid or match):
+        raise click.ClickException("Need to specify either uid or match option")
+    try:
+        api.sync_down(params)
+        if uid:
+            api.rotate_password(params, uid)
+        else:
+            if filter:
+                results = api.search_records(params, match)
+                for r in results:
+                    api.rotate_password(params, r.record_uid)
+    except Exception as e:
+        raise click.ClickException(e)
+
 @click.command('import', help='Import data from local file to Keeper')
 @click.pass_obj
 @click.option('--format', type=click.Choice(['tab-separated', 'json']))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,12 @@ def test_list():
     assert result.exception == None
     assert result.exit_code == 0
 
+def test_rotate():
+    runner = CliRunner()
+    result = runner.invoke(main, ['--config', TEST_CONFIG_FILE, 'rotate', '--match', '"MySQL Dev"'])
+    assert result.exception == None
+    assert result.exit_code == 0
+
 def test_export():
     runner = CliRunner()
     result = runner.invoke(main, ['--config', TEST_CONFIG_FILE, 'export', 'keeper.txt'])


### PR DESCRIPTION
Exposing rotate functionality previously available only from keeper
shell as a cli command. Example: keeper rotate —match=“MySQL Dev”