### PR TITLE
RSA decoding and null conversion bug fixes

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -252,6 +252,9 @@ def decrypt_aes(data, key):
 
 def decrypt_rsa(data, rsa_key):
     decoded_key = base64.urlsafe_b64decode(data + '==')
+    # some keys might come shorter due to stripping leading 0's
+    if 250 < len(decoded_key) < 256:
+        decoded_key = bytearray(256 - len(decoded_key)) + decoded_key
     dsize = SHA.digest_size
     sentinel = Random.new().read(15 + dsize)
     cipher = PKCS1_v1_5.new(rsa_key)

--- a/keepercommander/record.py
+++ b/keepercommander/record.py
@@ -25,18 +25,22 @@ class Record:
         self.revision = revision 
 
     def load(self,data,revision=''):
+
+        def xstr(s):
+            return str(s or '')
+
         if 'folder' in data:
-            self.folder = data['folder']
+            self.folder = xstr(data['folder'])
         if 'title' in data:
-            self.title = data['title']
+            self.title = xstr(data['title'])
         if 'secret1' in data:
-            self.login = data['secret1']
+            self.login = xstr(data['secret1'])
         if 'secret2' in data:
-            self.password = data['secret2']
+            self.password = xstr(data['secret2'])
         if 'notes' in data:
-            self.notes = data['notes']
+            self.notes = xstr(data['notes'])
         if 'link' in data:
-            self.login_url = data['link']
+            self.login_url = xstr(data['link'])
         if 'custom' in data:
             self.custom_fields = data['custom']
         if revision:


### PR DESCRIPTION
Two fixes:
- If record comes with null's instead of text, it is properly read
- If RSA key comes shorter than 256 bytes, it is left padded with 0's preventing decryption error