### PR TITLE
Updated class RecordUploadAttachmentCommand

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -668,12 +668,11 @@ class RecordUploadAttachmentCommand(Command):
 
         files = []
         if 'file' in kwargs:
-            for name in kwargs['file']:
-                file_name = os.path.abspath(os.path.expanduser(name))
-                if os.path.isfile(file_name):
-                    files.append(file_name)
-                else:
-                    api.print_error('File {0} does not exists'.format(name))
+            file_name = os.path.abspath(os.path.expanduser(kwargs['file']))
+            if os.path.isfile(file_name):
+                files.append(file_name)
+            else:
+                api.print_error('File {0} does not exists'.format(kwargs['file']))
         if len(files) == 0:
             api.print_error('No files to upload')
             return


### PR DESCRIPTION
There is an issue when trying to add a file as an attachment. When using the argument --file the current setup reads through the string character by character and tries to add a file with the name of each character. By removing the loop through and adding the kwargs['file'] variable you'd be able to upload one file. A comma seperated array could probably be a solution for this class if want to add more than one file at the time. 

Current result when trying to add a file from a regular windows file path like <c:\users\tony\desktop\pythonversion.png>:
    + CategoryInfo          : NotSpecified: (File C does not exists:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
File : does not exists
File \ does not exists
File u does not exists
File s does not exists
File e does not exists
File r does not exists
File s does not exists
File \ does not exists
File t does not exists
File o does not exists
File n does not exists
File y does not exists
File \ does not exists
File d does not exists
File e does not exists
File s does not exists
File k does not exists
File t does not exists
File o does not exists
File p does not exists
File \ does not exists
File p does not exists
File y does not exists
File t does not exists
File h does not exists
File o does not exists
File n does not exists
File v does not exists
File e does not exists
File r does not exists
File s does not exists
File i does not exists
File o does not exists
File n does not exists
File . does not exists
File P does not exists
File N does not exists
File G does not exists
No files to upload