### PR TITLE
Use logging instead of print in password prompt

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -194,7 +194,7 @@ def loop(params):
 
     if params.user:
         if not params.password:
-            print('Enter password for {0}'.format(params.user))
+            logging.info('Enter password for {0}'.format(params.user))
             params.password = getpass.getpass(prompt='Password: ', stream=None)
         if params.password:
             logging.info('Logging in...')


### PR DESCRIPTION
So that the text 'Enter password for ...' doesn't end up in the standard output.

At the moment, when I do `keeper get MYUID --format json > mysecret.json`, the json file looks like this:

```
Enter password for you@me.com
{
  "record_uid": "MYUID",
  "title": "my secret note",
  "notes": "a very secret note"
}
```

The prompt text makes it hard to parse the JSON, hence this change.