### PR TITLE
Specifying version for `prompt-toolkit` and python >= 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ colorama
 pycryptodomex
 requests
 tabulate
-prompt_toolkit
+prompt_toolkit==2.0.10
 asciitree
 pytest
 protobuf

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     'libkeepass',
     'requests',
     'tabulate',
-    'prompt_toolkit>=2.0.4',
+    'prompt_toolkit>=2.0.4,<=2.0.10',
     'asciitree',
     'protobuf>=3.6.0',
     'pyperclip'
@@ -33,13 +33,13 @@ setup(name='keepercommander',
       classifiers=["Development Status :: 4 - Beta",
                    "License :: OSI Approved :: MIT License",
                    "Operating System :: OS Independent",
-                   "Programming Language :: Python :: 3.4",
+                   "Programming Language :: Python :: 3.5",
                    "Topic :: Security"],
       keywords='security password',
 
       packages=find_packages(),
       include_package_data=True,
-      python_requires='>=3.4',
+      python_requires='>=3.5',
       entry_points={
           "console_scripts": [
               "keeper=keepercommander.__main__:main",


### PR DESCRIPTION
This commit is related to issue #265 