### PR TITLE
Allow specifying path to config file as environment variable KEEPER_CONFIG_FILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,7 @@ $ keeper --config=my_config_file.json
 
 ### Advanced Configuration File
 
-By default, Keeper will look for a file called ```config.json``` in the current working directory and it will use this file for reading and writing session parameters. For example, if you login with two factor authentication, the device token is written to this file. The configuration file loaded can also be customized through the ```config``` parameter. The config file can also be used to automate and schedule commands.
+By default, Keeper will look for a file pointed to by the environment variable `KEEPER_CONFIG_FILE`, falling back to ```config.json``` in the current working directory, and will use this file for reading and writing session parameters. For example, if you login with two factor authentication, the device token is written to this file. The configuration file loaded can also be customized through the ```config``` parameter. The config file can also be used to automate and schedule commands.
 
 Below is a fully loaded config file. 
 
@@ -1413,7 +1413,7 @@ In this case, you will be asked for the Keeper Master Password. There are a few 
 
 2. `KEEPER_PASSWORD` environment variable. i.e. `KEEPER_PASSWORD=<Keeper Password> keeper --user<Keeper Email>`. This method is demonstrated in the Jenkins script explained below.
 
-3. Stored to `config.json` file. Commander searches for file named `config.json` in the current working directory and uses the ```password``` parameter.
+3. Stored to `config.json` file. Commander searches for the file pointed to by the environment variable `KEEPER_CONFIG_FILE`, falling back to `config.json` in the current working directory, and uses the ```password``` parameter.
 
 ```json
 {

--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -28,7 +28,9 @@ from . import cli
 
 def get_params_from_config(config_filename):
     params = KeeperParams()
-    params.config_filename = config_filename or 'config.json'
+    params.config_filename = (
+        config_filename or os.getenv('KEEPER_CONFIG_FILE', 'config.json')
+    )
 
     if os.path.exists(params.config_filename):
         try:


### PR DESCRIPTION
I'd like to put something like in my shell's rc file, or maybe at the root of a deep git repo:

```
export KEEPER_CONFIG_FILE="$one_central_safe_place/.keeperrc.json"
```

Then I can run `keeper` anywhere in the filesystem and it'll always use that `.keeperrc.json` for reading / caching credentials.

I could see this as dangerous for a novice who might not realize they have very important credentials stored perhaps unprotected in clear text, but this tool seems to be targeted at tech professionals who ought to know how to take measured risks and what's safe and what's not.

I'll admit though I'm only barely familiar with KeeperCommander's API, so perhaps there's a security issue here I'm overlooking? Or is this a safe convenience to add?

Thanks,
DCM