### PR TITLE
Minor improvements to persistent login, documentation, and device-aprove

### DIFF
--- a/keepercommander/__init__.py
+++ b/keepercommander/__init__.py
@@ -10,4 +10,4 @@
 # Contact: ops@keepersecurity.com
 #
 
-__version__ = '4.59'
+__version__ = '4.61'

--- a/keepercommander/plugins/azureadpwd/azureadpwd.py
+++ b/keepercommander/plugins/azureadpwd/azureadpwd.py
@@ -48,7 +48,7 @@ def rotate(record, newpassword):
         result = app.acquire_token_silent(scopes=[default_scope], account=None)
 
         if not result:
-            logging.info("No suitable token exists in cache. Let's get a new one from AAD.")
+            logging.debug("No suitable token exists in cache. Let's get a new one from AAD.")
             result = app.acquire_token_for_client(scopes=[default_scope])
 
         if "access_token" in result:
@@ -100,12 +100,14 @@ def rotate(record, newpassword):
                     logging.error("Insufficient privileges to perform the password reset")
                     logging.error('\tIf you have access to Azure with administrator permission then you can enable\n'
                           '\tpermission by navigating to Azure Portal -> Azure AD -> Roles and administrators ->\n'
-                          '\tUser Administrator -> Click on "Add Assignments" > select the application with client\n'
+                          '\t"Helpdesk Administrator" -> Click on "Add Assignments" > select the application with client\n'
                           '\tid "%s" > click on Add button.' % client_id)
                 else:
                     logging.error("Unknown status code: %d, message: %s" % (resp_status_code, resp_data['error']['message']))
             else:
                 logging.error("Unhandled status code: %d, message: %s" % (resp_status_code, usr_pwd_update_resp.json()['error']['message']))
+        else:
+            logging.error('Azure error: %s, description: %s' % (result['error'], result['error_description']))
     except Exception as ex:
         logging.error(ex)
 


### PR DESCRIPTION
- registering data key when persistent login is turned on
- added aliases for `this-device`: `ip-auto-approve` and `persistent-login`
- updated message text for azure ad plugin
- new fields and export functionality for `device-approve` command