### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,25 +141,6 @@ Current login mechanism is by default uses new Login V3 flow. This login flow in
 - Now all devices that access Keeper require to be registered using email, sms push, or security key
 - Ability to use SSO login. At this time Commander only supports login with alternate master password.
 
-##### Disabling Login V3
-If you need to disable Login V3 flow for any reason (ex. issue with automation) there are two way of doing that:
-
-1. Setting `login_v3` flag to `false` in the configuration file
-    
-    Example configuration file:
-    ```json
-   {
-        "login_v3": false
-   }
-    ```
-2. Passing command line argument `--login-v3 false` or `-lv3 false`
-    
-    Example command:
-    ```shell script
-   keeper -lv3 false
-   ```
-
-
 ##### Device approval
 
 Login V3 now by default requires all devices to be approved before authenticating a user. On the first run Commander
@@ -1989,10 +1970,10 @@ pip install -r requirements.txt
 pip install -r extra_dependencies.txt
 
 # build one-folder package
-pyinstaller keeper_folder.spec
+pyinstaller keeper-folder.spec
 
 # or build one-file package
-pyinstaller keeper_file.spec
+pyinstaller keeper-file.spec
 
 # your packages are in dist/ folder
 ``` 

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -390,8 +390,9 @@ class WhoamiCommand(Command):
                 if 'bytes_total' in params.license:
                     storage_bytes = int(params.license['bytes_total'])  # note: int64 in protobuf in python produces string as opposed to an int or long.
                     storage_gb = storage_bytes >> 30
+                    storage_bytes_used = params.license['bytes_used'] if 'bytes_used' in params.license else 0
                     print('{0:>20s} {1:>20s}: {2}GB'.format('Storage', 'Capacity', storage_gb))
-                    storage_usage = (int(params.license['bytes_used']) * 100 // storage_bytes) if storage_bytes != 0 else 0     # note: int64 in protobuf in python produces string  as opposed to an int or long.
+                    storage_usage = (int(storage_bytes_used) * 100 // storage_bytes) if storage_bytes != 0 else 0     # note: int64 in protobuf in python produces string  as opposed to an int or long.
                     print('{0:>20s} {1:>20s}: {2}%'.format('', 'Usage', storage_usage))
                     print('{0:>20s} {1:>20s}: {2}'.format('', 'Renewal Date', params.license['storage_expiration_date']))
 

--- a/keepercommander/importer/csv/csv.py
+++ b/keepercommander/importer/csv/csv.py
@@ -91,7 +91,7 @@ class KeeperCsvExporter(BaseExporter):
                             if folder.can_share:
                                 domain = domain + '#reshare'
                         break
-                row = [path, r.title or '', r.login or '', r.password or '', r.login_url or '', r.notes or '', domain]
+                row = [path, r.title or '', r.login or '', r.password or '', r.login_url or '', r.notes or '', domain, r.uid]
                 if r.custom_fields:
                     for cf in r.custom_fields:
                         row.append(cf)

--- a/keepercommander/plugins/commands.py
+++ b/keepercommander/plugins/commands.py
@@ -108,7 +108,7 @@ def rotate_password(params, record_uid, name=None):
     if success:
         logging.debug("Password rotation is successful for \"%s\".", plugin_name)
     else:
-        logging.warning("Password rotation failed for \"%s\".", plugin_name)
+        logging.warning("Password rotation failed for record uid=[%s], plugin \"%s\"." % (record.record_uid, plugin_name))
         return False
 
     if api.update_record(params, record):

--- a/keepercommander/plugins/ssh/ssh.py
+++ b/keepercommander/plugins/ssh/ssh.py
@@ -64,5 +64,6 @@ def rotate(record, newpassword):
         logging.error("Timed out waiting for response.")
     except pxssh.ExceptionPxssh as e:
         logging.error("Failed to login with ssh.")
+        logging.error(e)
 
     return result


### PR DESCRIPTION
- added more detailed error when plugin failed to execute
- added uid to the csv export
- removed documentation to disable login v3
- `share-folder` command: added force capability to ignore default folder permissions when initially sharing a record
- `share-report` command: added flat `share-report` to include date the record was shared
- `whoami` command: fixed error displaying storage used