### PR TITLE
Error while adding a user to administrator group

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -1590,7 +1590,7 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                             if user_pkeys[user_id]:
                                 rq['tree_key'] = api.encrypt_rsa(params.enterprise['unencrypted_tree_key'], user_pkeys[user_id])
                                 if role_key:
-                                    rq['role_admin_key'] = api.encrypt_aes(role_key, user_pkeys[user_id])
+                                    rq['role_admin_key'] = api.encrypt_rsa(role_key, user_pkeys[user_id])
                                 request_batch.append(rq)
                         else:
                             request_batch.append(rq)


### PR DESCRIPTION
To reproduce the issue the administrator group should have a role key assigned to the role (it means Account Transfer or Manage Companies privilege)
It needs to be an old `role_key` not new `role_key2` 

Also, it seems that the Commander does not support `role_key2`.