### PR TITLE
Adding export restriction

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -161,6 +161,11 @@ class RecordExportCommand(ImporterCommand):
         return export_parser
 
     def execute(self, params, **kwargs):
+
+        if is_export_restricted(params):
+            logging.warning('Permissions Required: `export` command is disabled. Please contact your enterprise administrator.')
+            return
+
         export_format = kwargs['format'] if 'format' in kwargs else None
         export_name = kwargs['name'] if 'name' in kwargs else None
         if format:
@@ -189,3 +194,17 @@ class RecordExportCommand(ImporterCommand):
             imp_exp.export(params, export_format, export_name, **extra)
         else:
             logging.error('Missing argument')
+
+
+def is_export_restricted(params):
+    is_export_restricted = False
+
+    booleans = params.enforcements['booleans'] if 'booleans' in params.enforcements else []
+
+    if len(booleans) > 0:
+        restrict_export_boolean = next((s for s in booleans if s['key'] == 'restrict_export'), None)
+
+        if restrict_export_boolean:
+            is_export_restricted = restrict_export_boolean['value']
+
+    return is_export_restricted


### PR DESCRIPTION
Implementing capability to don't allow user to perform `export` if user enterprise permissions restrict that.

Similar warning in the Web Vault
![image](https://user-images.githubusercontent.com/187306/112353982-81249a80-8c89-11eb-8077-469eaadb966f.png)
