### PR TITLE
Bumping version

### DIFF
--- a/keepercommander/__init__.py
+++ b/keepercommander/__init__.py
@@ -10,4 +10,4 @@
 # Contact: ops@keepersecurity.com
 #
 
-__version__ = '4.82'
+__version__ = '4.83'

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -580,7 +580,7 @@ This command reads the custom fields for names starting with "connect:"
 
 Connection command may contain template parameters.
 Parameter syntax is ${<parameter_name>}
- 
+
 Supported parameters:
 
     ${user_email}                   Keeper user email address

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -443,6 +443,9 @@ class VersionCommand(Command):
     def get_parser(self):
         return whoami_parser
 
+    def is_authorised(self):
+        return False
+
     def execute(self, params, **kwargs):
 
         this_app_version = __version__
@@ -577,7 +580,7 @@ This command reads the custom fields for names starting with "connect:"
 
 Connection command may contain template parameters.
 Parameter syntax is ${<parameter_name>}
-
+ 
 Supported parameters:
 
     ${user_email}                   Keeper user email address

--- a/keepercommander/rest_api.py
+++ b/keepercommander/rest_api.py
@@ -23,11 +23,11 @@ from . import APIRequest_pb2 as proto
 
 from Cryptodome.PublicKey import RSA
 from Cryptodome.Cipher import AES, PKCS1_v1_5
+from . import __version__
 
 
 LEGACY_CLIENT_VERSION = 'c14.0.0'
-CLIENT_VERSION = 'c15.0.0'
-
+CLIENT_VERSION = 'c15.' + __version__
 
 SERVER_PUBLIC_KEYS = {
     1: RSA.importKey(base64.urlsafe_b64decode(


### PR DESCRIPTION
- bumping version to 4.83 (code and api)
- making `version` command not requiring user to be logged in