### PR TITLE
Added --update option to import command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
-go2: tags
-	python3 keeper.py
+PYTHON_FILES := ${shell find . -name '*.py' -print}
 
-tags:
-	ctags $$(find * -name '*.py' -print)
+go2: tags targeted-report
+	python3 -m pudb keeper.py
+	# python3 keeper.py
 
-go:
+tags: ${PYTHON_FILES}
+	# Create the tags file, for the benefit of vi/vim/neovim.
+	ctags ${PYTHON_FILES}
+
+.PHONY: targeted-report
+targeted-report:
+	# This is only checking things that have passed pylint previously - or are currently being made pylint-conformant.
+	python3 -m pylint ./keepercommander/importer/imp_exp.py
+
+report:
+	# pylint all the .py's.
 	# pylint $$(find . -name '*.py' -print | sort -R) | ./desired-pylint-warnings
-	pylint $$(find . -name '*.py' -print)
+	pylint ${PYTHON_FILES} || true
 
 clean:
 	rm -f tags

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -47,6 +47,8 @@ unpad_char = lambda s: s[0:-ord(s[-1])]
 
 decode_uid_to_str = lambda uid: base64.urlsafe_b64encode(uid).decode().rstrip('=')
 
+LOCALE='en_US'
+
 def run_command(params, request):
     # type: (KeeperParams, dict) -> dict
     if 'client_version' not in request:
@@ -1346,7 +1348,7 @@ def communicate(params, request):
 
     def authorize_request(rq):
         rq['client_time'] = current_milli_time()
-        rq['locale'] = 'en_US'
+        rq['locale'] = LOCALE
         rq['device_id'] = 'Commander'
         rq['session_token'] = params.session_token
         rq['username'] = params.user.lower()

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -1,4 +1,4 @@
-#_  __
+#  _  __
 # | |/ /___ ___ _ __  ___ _ _ ®
 # | ' </ -_) -_) '_ \/ -_) '_|
 # |_|\_\___\___| .__/\___|_|
@@ -38,6 +38,13 @@ import_parser.add_argument('--format', dest='format', choices=['json', 'csv', 'k
 import_parser.add_argument('--folder', dest='folder', action='store', help='import into a separate folder.')
 import_parser.add_argument('-s', '--shared', dest='shared', action='store_true', help='import folders as Keeper shared folders')
 import_parser.add_argument('-p', '--permissions', dest='permissions', action='store', help='default shared folder permissions: manage (U)sers, manage (R)ecords, can (E)dit, can (S)hare, or (A)ll, (N)one')
+import_parser.add_argument(
+    '--update',
+    dest='update',
+    default=False,
+    action='store_true',
+    help='Update records with common login, url or title',
+)
 import_parser.add_argument('name', type=str, help='file name (json, csv, keepass) or account name (lastpass)')
 import_parser.error = raise_parse_exception
 import_parser.exit = suppress_exit
@@ -84,6 +91,7 @@ import --format=json sample_data/import.json.txt
 
 
 class KeeperAttachment(ImportAttachment):
+    # FIXME: Note that this may be a duplicate of keepercommander/importer/imp_exp.py's KeeperAttachment.
     def __init__(self, params, record_uid,):
         ImportAttachment.__init__(self)
         self.params = params
@@ -120,6 +128,7 @@ class RecordImportCommand(ImporterCommand):
         return import_parser
 
     def execute(self, params, **kwargs):
+        update_flag = kwargs['update']
         import_format = kwargs['format'] if 'format' in kwargs else None
         import_name = kwargs['name'] if 'name' in kwargs else None
         shared = kwargs.get('shared') or False
@@ -152,7 +161,7 @@ class RecordImportCommand(ImporterCommand):
             logging.info('Processing... please wait.')
             imp_exp._import(params, import_format, import_name, shared=shared, import_into=kwargs.get('folder'),
                             manage_users=manage_users, manage_records=manage_records,
-                            can_edit=can_edit, can_share=can_share)
+                            can_edit=can_edit, can_share=can_share, update_flag=update_flag)
         else:
             logging.error('Missing argument')
 

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -1,27 +1,31 @@
-#  _  __  
+#  _  __
 # | |/ /___ ___ _ __  ___ _ _ ®
 # | ' </ -_) -_) '_ \/ -_) '_|
 # |_|\_\___\___| .__/\___|_|
-#              |_|            
+#              |_|
 #
-# Keeper Commander 
+# Keeper Commander
 # Copyright 2017 Keeper Security Inc.
 # Contact: ops@keepersecurity.com
 #
 
-import os
-import json
-import hashlib
-import base64
-import requests
-import io
-import re
-import logging
+"""Import and export functionality."""
 
 from contextlib import contextmanager
+import collections
+import base64
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+
 from Cryptodome.Cipher import AES
+import requests
 
 from keepercommander import api
+from keepercommander.rest_api import CLIENT_VERSION  # pylint: disable=no-name-in-module
 from ..params import KeeperParams
 
 from .importer import importer_for_format, exporter_for_format, path_components, PathDelimiter, BaseExporter, \
@@ -36,6 +40,7 @@ EMAIL_PATTERN = r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
 
 
 def get_import_folder(params, folder_uid, record_uid):
+    """Get a folder name from a folder uid (?)."""
     folder = ImportFolder()
 
     uid = folder_uid
@@ -74,6 +79,7 @@ def get_import_folder(params, folder_uid, record_uid):
 
 
 def get_folder_path(params, folder_uid):
+    """Get the path corresponding to a folder uid."""
     uid = folder_uid
     path = ''
     while uid in params.folder_cache:
@@ -92,6 +98,7 @@ def get_folder_path(params, folder_uid):
 
 
 def export(params, file_format, filename, **export_args):
+    """Export data from Vault to a file in an assortment of formats."""
     api.sync_down(params)
 
     exporter = exporter_for_format(file_format)()  # type: BaseExporter
@@ -186,15 +193,16 @@ def export(params, file_format, filename, **export_args):
 
 
 def _import(params, file_format, filename, **kwargs):
+    """Import records from one of a variety of sources."""
     api.sync_down(params)
 
     shared = kwargs.get('shared') or False
     import_into = kwargs.get('import_into') or ''
     if import_into:
         import_into = import_into.replace(PathDelimiter, 2*PathDelimiter)
+    update_flag = kwargs['update_flag']
 
-    importer = importer_for_format(file_format)()
-    # type: BaseImporter
+    importer = importer_for_format(file_format)()  # type: BaseImporter
 
     records_before = len(params.record_cache)
 
@@ -260,6 +268,7 @@ def _import(params, file_format, filename, **kwargs):
     folder_add = prepare_folder_add(params, folders, records)
     if folder_add:
         fol_rs, _ = execute_import_folder_record(params, folder_add, None)
+        _ = fol_rs
         api.sync_down(params)
 
     if folders:
@@ -268,10 +277,15 @@ def _import(params, file_format, filename, **kwargs):
             api.execute_batch(params, permissions)
             api.sync_down(params)
 
-    if records:        # create records
-        record_add = prepare_record_add(params, records)
-        if record_add:
-            _, rec_rs = execute_import_folder_record(params, None, record_add)
+    if records:
+        # create/update records
+        records_to_add, records_to_update = prepare_record_add_or_update(update_flag, params, records)
+        if records_to_add:
+            _, rec_rs = execute_import_folder_record(params, None, records_to_add)
+            _ = rec_rs
+            api.sync_down(params)
+        if records_to_update:
+            execute_update_record(params, records_to_update)
             api.sync_down(params)
 
         # ensure records are linked to folders
@@ -302,7 +316,48 @@ def _import(params, file_format, filename, **kwargs):
         logging.info("%d records imported successfully", records_after - records_before)
 
 
+def report_statuses(status_type, status_iter):
+    """Report status codes from list of folder_pb2.*Response."""
+    counter = collections.Counter(element.lower() for element in status_iter)
+    for status, count in sorted(counter.items()):
+        logging.info('%-15s %-15s %d', status_type, status, count)
+
+
+def chunks(list_, n):
+    """
+    Yield successive n-sized chunks from list_.
+
+    Based on https://stackoverflow.com/questions/312443/how-do-you-split-a-list-into-evenly-sized-chunks
+    """
+    for offset in range(0, len(list_), n):
+        yield list_[offset:offset + n]
+
+
+def execute_update_record(params, records_to_update):
+    """Interact with the API to update preexisting records: we only change the password(s)."""
+    for chunk in chunks(records_to_update, 100):
+        request = {
+            'command': 'record_update',
+            'username': params.user,
+            'session_token': params.session_token,
+            'client_version': CLIENT_VERSION,
+            'locale': api.LOCALE,
+            'pt': 'Commander',
+            'client_time': api.current_milli_time(),
+            'update_records': chunk,
+            'device_id': 'Commander',
+        }
+        result = api.communicate(params, request)
+        if isinstance(result, dict):
+            if 'result' in result:
+                # Note that this may appear more than once for an import with many password updates
+                report_statuses('update', (element['status'] for element in result['update_records']))
+            else:
+                logging.info('overall operation failed')
+
+
 def execute_import_folder_record(params, folders, records):
+    """Interact with the API to import folders and records."""
     rs_folder = []
     rs_record = []
     while folders or records:
@@ -328,15 +383,19 @@ def execute_import_folder_record(params, folders, records):
         if len(import_rs.recordResponse) > 0:
             rs_record.extend(import_rs.recordResponse)
 
+    report_statuses('folder', (element.status for element in rs_folder))
+    report_statuses('record', (element.status for element in rs_record))
+
     return rs_folder, rs_record
 
 
 def upload_attachment(params, attachments):
-    '''
+    """
+    Interact with the API to upload attachments.
+
     :param attachments:
     :type attachments: [(str, ImportAttachment)]
-    '''
-
+    """
     print('Uploading attachments:')
     while len(attachments) > 0:
         chunk = attachments[:90]
@@ -350,7 +409,7 @@ def upload_attachment(params, attachments):
             file_no += 1
             file_size += att.size or 0
 
-        #TODO check storage subscription
+        # TODO check storage subscription
         rq = {
             'command': 'request_upload',
             'file_count': file_no
@@ -464,6 +523,7 @@ def upload_attachment(params, attachments):
 
 
 def prepare_folder_add(params, folders, records):
+    """Find what folders to import (?)."""
     folder_hash = {}
     for f_uid in params.folder_cache:
         fol = params.folder_cache[f_uid]
@@ -471,7 +531,7 @@ def prepare_folder_add(params, folders, records):
         hs = '{0}|{1}'.format((fol.name or '').lower(), fol.parent_uid or '')
         h.update(hs.encode())
         shared_folder_key = None
-        if fol.type in { BaseFolderNode.SharedFolderType, BaseFolderNode.SharedFolderFolderType}:
+        if fol.type in {BaseFolderNode.SharedFolderType, BaseFolderNode.SharedFolderFolderType}:
             sf_uid = fol.shared_folder_uid if fol.type == BaseFolderNode.SharedFolderFolderType else fol.uid
             if sf_uid in params.shared_folder_cache:
                 shared_folder_key = params.shared_folder_cache[sf_uid]['shared_folder_key_unencrypted']
@@ -509,10 +569,12 @@ def prepare_folder_add(params, folders, records):
                     fol_req.encryptedFolderKey = base64.urlsafe_b64decode(api.encrypt_aes(folder_key, params.data_key) + '==')
 
                     data = {'name': comp}
-                    fol_req.folderData = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(data).encode('utf-8'), folder_key) + '==')
+                    string = api.encrypt_aes(json.dumps(data).encode('utf-8'), folder_key)
+                    fol_req.folderData = base64.urlsafe_b64decode(string + '==')
 
                     if folder_type == 'shared_folder':
-                        fol_req.sharedFolderFields.encryptedFolderName = base64.urlsafe_b64decode(api.encrypt_aes(comp.encode('utf-8'), folder_key) + '==')
+                        string2 = api.encrypt_aes(comp.encode('utf-8'), folder_key)
+                        fol_req.sharedFolderFields.encryptedFolderName = base64.urlsafe_b64decode(string2 + '==')
                         fol_req.sharedFolderFields.manageUsers = fol.manage_users
                         fol_req.sharedFolderFields.manageRecords = fol.manage_records
                         fol_req.sharedFolderFields.canEdit = fol.can_edit
@@ -565,7 +627,11 @@ def prepare_folder_add(params, folders, records):
 
                                 fol_req = folder_pb2.FolderRequest()
                                 fol_req.folderUid = base64.urlsafe_b64decode(folder_uid + '==')
-                                fol_req.folderType = 2 if folder_type == 'shared_folder' else 3 if folder_type == 'shared_folder_folder' else 1
+                                fol_req.folderType = 2 \
+                                    if folder_type == 'shared_folder' \
+                                    else 3 \
+                                    if folder_type == 'shared_folder_folder' \
+                                    else 1
 
                                 if parent_uid:
                                     fol_req.parentFolderUid = base64.urlsafe_b64decode(parent_uid + '==')
@@ -574,22 +640,27 @@ def prepare_folder_add(params, folders, records):
 
                                 folder_key = os.urandom(32)
                                 if folder_type == 'shared_folder_folder':
-                                    fol_req.encryptedFolderKey = base64.urlsafe_b64decode(api.encrypt_aes(folder_key, parent_shared_folder_key or params.data_key) + '==')
+                                    string3 = api.encrypt_aes(folder_key, parent_shared_folder_key or params.data_key)
+                                    fol_req.encryptedFolderKey = base64.urlsafe_b64decode(string3 + '==')
                                 else:
-                                    fol_req.encryptedFolderKey = base64.urlsafe_b64decode(api.encrypt_aes(folder_key, params.data_key) + '==')
+                                    string4 = api.encrypt_aes(folder_key, params.data_key)
+                                    fol_req.encryptedFolderKey = base64.urlsafe_b64decode(string4 + '==')
 
                                 data = {'name': comp}
-                                fol_req.folderData = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(data).encode('utf-8'), folder_key) + '==')
+                                string5 = api.encrypt_aes(json.dumps(data).encode('utf-8'), folder_key)
+                                fol_req.folderData = base64.urlsafe_b64decode(string5 + '==')
 
                                 if folder_type == 'shared_folder':
-                                    fol_req.sharedFolderFields.encryptedFolderName = base64.urlsafe_b64decode(api.encrypt_aes(comp.encode('utf-8'), folder_key) + '==')
+                                    string6 = api.encrypt_aes(comp.encode('utf-8'), folder_key)
+                                    fol_req.sharedFolderFields.encryptedFolderName = base64.urlsafe_b64decode(string6 + '==')
 
                                     parent_shared_folder_key = folder_key
                                     parent_shared_folder_uid = folder_uid
 
                                 elif folder_type == 'shared_folder_folder':
                                     if parent_shared_folder_uid:
-                                        fol_req.sharedFolderFolderFields.sharedFolderUid = base64.urlsafe_b64decode(parent_shared_folder_uid + '==')
+                                        fol_req.sharedFolderFolderFields.sharedFolderUid = \
+                                            base64.urlsafe_b64decode(parent_shared_folder_uid + '==')
 
                                 folder_add.append(fol_req)
                                 folder_hash[digest] = folder_uid, folder_type, parent_shared_folder_key
@@ -607,7 +678,49 @@ def prepare_folder_add(params, folders, records):
     return folder_add
 
 
-def tokenize_record(record):   # type: (Record) -> [str]
+def tokenize_partial_import_record(record):   # type: (ImportRecord) -> [str]
+    """
+    Turn a record-to-import into an iterable of str's for hashing.  This is really about import --update.
+
+    Examine just the relevant parts of the record.
+    """
+    yield record.title or ''
+    yield record.login or ''
+    yield record.login_url or ''
+
+
+def tokenize_partial_preexisting_record(record):   # type: (Record) -> [str]
+    """
+    Turn a preexisting record into an iterable of str's for hashing.
+
+    Examine just the relevant parts of the record.
+
+    For now at least, this is the same as tokenize_partial_import_record().
+    """
+    return tokenize_partial_import_record(record)
+
+
+def tokenize_full_import_record(record):   # type: (ImportRecord) -> [str]
+    """
+    Turn a record-to-import into an iterable of str's for hashing.
+
+    Examine the entire record.
+    """
+    yield record.title or ''
+    yield record.login or ''
+    yield record.password or ''
+    yield record.login_url or ''
+    yield record.notes or ''
+
+    if len(record.custom_fields) > 0:
+        keys = list(record.custom_fields.keys())
+        keys.sort()
+        for key in keys:
+            yield key + ':' + record.custom_fields[key]
+
+
+def tokenize_full_preexisting_record(record):   # type: (Record) -> [str]
+    """Turn a preexisting record into an iterable of str's for hashing."""
     yield record.title or ''
     yield record.login or ''
     yield record.password or ''
@@ -628,105 +741,204 @@ def tokenize_record(record):   # type: (Record) -> [str]
             yield key + ':' + custom[key]
 
 
-def tokenize_import_record(record):   # type: (ImportRecord) -> [str]
-    yield record.title or ''
-    yield record.login or ''
-    yield record.password or ''
-    yield record.login_url or ''
-    yield record.notes or ''
+def construct_import_rec_req(params, preexisting_record_hash, rec_to_import):
+    """Build a rec_req for rec_to_import."""
+    r_hash = build_record_hash(record=rec_to_import, tokenize_gen=tokenize_full_import_record)
 
-    if len(record.custom_fields) > 0:
-        keys = list(record.custom_fields.keys())
-        keys.sort()
-        for key in keys:
-            yield key + ':' + record.custom_fields[key]
+    if r_hash in preexisting_record_hash:
+        # Nothing to do.  We already have this identical record.
+        return None
+    else:
+        rec_to_import.uid = api.generate_record_uid()
+        preexisting_record_hash[r_hash] = rec_to_import.uid
+        record_key = os.urandom(32)
+        rec_req = folder_pb2.RecordRequest()
+        rec_req.recordUid = base64.urlsafe_b64decode(rec_to_import.uid + '==')
+        rec_req.recordType = 0
+        rec_req.encryptedRecordKey = base64.urlsafe_b64decode(api.encrypt_aes(record_key, params.data_key) + '==')
+        rec_req.howLongAgo = 0
+        rec_req.folderType = 1
+
+        folder_uid = None
+        if rec_to_import.folders:
+            folder_uid = rec_to_import.folders[0].uid
+        if folder_uid:
+            if folder_uid in params.folder_cache:
+                folder = params.folder_cache[folder_uid]
+                if folder.type in {BaseFolderNode.SharedFolderType, BaseFolderNode.SharedFolderFolderType}:
+                    rec_req.folderUid = base64.urlsafe_b64decode(folder.uid + '==')
+                    rec_req.folderType = 2 if folder.type == BaseFolderNode.SharedFolderType else 3
+
+                    sh_uid = folder.uid if folder.type == BaseFolderNode.SharedFolderType else folder.shared_folder_uid
+                    sf = params.shared_folder_cache[sh_uid]
+                    rec_req.encryptedRecordFolderKey = base64.urlsafe_b64decode(
+                        api.encrypt_aes(record_key, sf['shared_folder_key_unencrypted']) + '=='
+                    )
+                else:
+                    rec_req.folderType = 1
+                    if folder.type != BaseFolderNode.RootFolderType:
+                        rec_req.folderUid = base64.urlsafe_b64decode(folder.uid + '==')
+
+        custom_fields = []
+        totp = None
+        if rec_to_import.custom_fields:
+            for cf in rec_to_import.custom_fields:
+                if cf == TWO_FACTOR_CODE:
+                    totp = rec_to_import.custom_fields[cf]
+                else:
+                    custom_fields.append({
+                        'name': cf,
+                        'value': rec_to_import.custom_fields[cf]
+                    })
+
+        data = {
+            'title': rec_to_import.title or '',
+            'secret1': rec_to_import.login or '',
+            'secret2': rec_to_import.password or '',
+            'link': rec_to_import.login_url or '',
+            'notes': rec_to_import.notes or '',
+            'custom': custom_fields
+        }
+        rec_req.recordData = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(data).encode('utf-8'), record_key) + '==')
+        if totp:
+            extra = {
+                'fields': [
+                    {
+                        'id': api.generate_record_uid(),
+                        'field_type': 'totp',
+                        'field_title': 'Two-Factor Code',
+                        'type': 0,
+                        'data': totp
+                    }]
+            }
+            rec_req.extra = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(extra).encode('utf-8'), record_key) + '==')
+        return rec_req
 
 
-def prepare_record_add(params, records):
-    record_hash = {}
-    for r_uid in params.record_cache:
-        rec = api.get_record(params, r_uid)
-        h = hashlib.sha256()
-        for token in tokenize_record(rec):
-            h.update(token.encode())
-        record_hash[h.hexdigest()] = r_uid
+def construct_update_rec_req(params, preexisting_record_hash, rec_to_update):
+    """
+    Build a rec_req for rec_to_import.
+
+    Based on https://keeper.atlassian.net/wiki/spaces/KA/pages/13238307/record+update+-+deprecated
+    and upload_attachment(params, attachments), which appears elsewhere in this file.
+
+    We're not doing records_update yet, because it requires v3 and we don't do v3 yet.
+    """
+    # FIXME: This assert probably can be sorted out during code review.
+    assert len(rec_to_update.folders) == 1, "What should we do with records that aren't in exactly one folder?"
+    data = {
+        'folder': rec_to_update.folders[0].get_folder_path(),
+        'title': rec_to_update.title,
+        'secret1': rec_to_update.login,
+        'secret2': rec_to_update.password,
+        'link': rec_to_update.login_url,
+        # We add notes and custom a little later.
+    }
+
+    current_rec = params.record_cache[rec_to_update.uid]
+    # This should always exist, because this is an import --update.
+    preexisting_record = params.record_cache[rec_to_update.uid]
+
+    preexisting_record_fields_str = preexisting_record['data_unencrypted'].decode('utf-8')
+    preexisting_record_fields_dict = json.loads(preexisting_record_fields_str)
+
+    # These fields need to be preserved - per our design.
+    field_tuple = ('notes', 'custom')
+    for field_name in field_tuple:
+        # these need to be preserved
+        if field_name in preexisting_record_fields_dict:
+            data[field_name] = preexisting_record_fields_dict[field_name]
+
+    unencrypted_key = preexisting_record['record_key_unencrypted']
+
+    encrypted_data = api.encrypt_aes(json.dumps(data).encode('utf-8'), unencrypted_key)
+    record_key = api.encrypt_aes(unencrypted_key, params.data_key)
+    one_rec_req = {
+        'record_uid': rec_to_update.uid,
+        'record_key': record_key,
+        'record_key_unencrypted': base64.urlsafe_b64encode(unencrypted_key).decode('utf-8'),
+        'data': encrypted_data,
+        'version': 2,
+        'client_modified_time': api.current_milli_time(),
+        'revision': current_rec['revision']
+    }
+    return one_rec_req
+
+
+def build_record_hash(record, tokenize_gen):
+    """Build a sha256 hash of record using tokenize_gen."""
+    hasher = hashlib.sha256()
+    for token in tokenize_gen(record):
+        hasher.update(token.encode())
+    return hasher.hexdigest()
+
+
+def build_hash_dict(params, tokenize_gen):
+    """Return a dict of hashes to record uid's with a parameterized tokenizing generator."""
+    preexisting_record_hash = {}
+    for preexisting_r_uid in params.record_cache:
+        preexisting_rec = api.get_record(params, preexisting_r_uid)
+        preexisting_record_hash[build_record_hash(preexisting_rec, tokenize_gen)] = preexisting_r_uid
+    return preexisting_record_hash
+
+
+def prepare_record_add_or_update(update_flag, params, records):
+    """
+    Find what records to import or update.
+
+    If update_flag is False:
+        If a 100% match is found for a record, then just skip requesting anything; it doesn't need to be changed.
+        Otherwise import the record, risking creating an almost-duplicate.
+    If update_flag is True:
+       if a unique field match (on title, login, and url) is found, then request a change in password only.
+       Do not update the TOTP custom field, even if it exists.
+    """
+    recs_to_import_or_update = records
+    del records
+    preexisting_entire_record_hash = build_hash_dict(params, tokenize_full_preexisting_record)
+    preexisting_partial_record_hash = build_hash_dict(params, tokenize_partial_preexisting_record)
 
     record_adds = []
-    for rec in records:
-        h = hashlib.sha256()
-        for token in tokenize_import_record(rec):
-            h.update(token.encode())
-        r_hash = h.hexdigest()
-        if r_hash in record_hash:
-            rec.uid = record_hash[r_hash]
+    record_updates = []
+    for rec_to_import_or_update in recs_to_import_or_update:
+        perform_import_or_update = 'neither'
+
+        full_hash_of_cur_rec = build_record_hash(rec_to_import_or_update, tokenize_full_import_record)
+        partial_hash_of_cur_rec = build_record_hash(rec_to_import_or_update, tokenize_partial_import_record)
+        # Decide what kind of operation is needed.
+        if full_hash_of_cur_rec in preexisting_entire_record_hash:
+            # We do not need to do a record update; we already have this record in its entirety.
+            pass
+        elif partial_hash_of_cur_rec in preexisting_partial_record_hash and update_flag:
+            # This is a record to update instead of importing it.
+            rec_to_import_or_update.uid = preexisting_partial_record_hash[partial_hash_of_cur_rec]
+            perform_import_or_update = 'update'
         else:
-            rec.uid = api.generate_record_uid()
-            record_hash[r_hash] = rec.uid
-            record_key = os.urandom(32)
-            rec_req = folder_pb2.RecordRequest()
-            rec_req.recordUid = base64.urlsafe_b64decode(rec.uid + '==')
-            rec_req.recordType = 0
-            rec_req.encryptedRecordKey = base64.urlsafe_b64decode(api.encrypt_aes(record_key, params.data_key) + '==')
-            rec_req.howLongAgo = 0
-            rec_req.folderType = 1
+            # Create a new UID for the new record, and signal that we need to do the import.
+            # We do this conditionally for --update, and unconditionally for import without --update.
+            rec_to_import_or_update.uid = api.generate_record_uid()
+            perform_import_or_update = 'import'
 
-            folder_uid = None
-            if rec.folders:
-                folder_uid = rec.folders[0].uid
-            if folder_uid:
-                if folder_uid in params.folder_cache:
-                    folder = params.folder_cache[folder_uid]
-                    if folder.type in {BaseFolderNode.SharedFolderType, BaseFolderNode.SharedFolderFolderType}:
-                        rec_req.folderUid = base64.urlsafe_b64decode(folder.uid + '==')
-                        rec_req.folderType = 2 if folder.type == BaseFolderNode.SharedFolderType else 3
-
-                        sh_uid = folder.uid if folder.type == BaseFolderNode.SharedFolderType else folder.shared_folder_uid
-                        sf = params.shared_folder_cache[sh_uid]
-                        rec_req.encryptedRecordFolderKey = base64.urlsafe_b64decode(api.encrypt_aes(record_key, sf['shared_folder_key_unencrypted']) + '==')
-                    else:
-                        rec_req.folderType = 1
-                        if folder.type != BaseFolderNode.RootFolderType:
-                            rec_req.folderUid = base64.urlsafe_b64decode(folder.uid + '==')
-
-            custom_fields = []
-            totp = None
-            if rec.custom_fields:
-                for cf in rec.custom_fields:
-                    if cf == TWO_FACTOR_CODE:
-                        totp = rec.custom_fields[cf]
-                    else:
-                        custom_fields.append({
-                            'name': cf,
-                            'value': rec.custom_fields[cf]
-                        })
-
-            data = {
-                'title': rec.title or '',
-                'secret1': rec.login or '',
-                'secret2': rec.password or '',
-                'link': rec.login_url or '',
-                'notes': rec.notes or '',
-                'custom': custom_fields
-            }
-            rec_req.recordData = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(data).encode('utf-8'), record_key) + '==')
-            if totp:
-                extra = {
-                    'fields': [
-                        {
-                            'id': api.generate_record_uid(),
-                            'field_type': 'totp',
-                            'field_title': 'Two-Factor Code',
-                            'type': 0,
-                            'data': totp
-                        }]
-                }
-                rec_req.extra = base64.urlsafe_b64decode(api.encrypt_aes(json.dumps(extra).encode('utf-8'), record_key) + '==')
+        # Act on the selected operation.
+        if perform_import_or_update == 'update':
+            rec_req = construct_update_rec_req(params, preexisting_partial_record_hash, rec_to_import_or_update)
+            # Schedule the record for later batch-update.
+            record_updates.append(rec_req)
+        elif perform_import_or_update == 'import':
+            rec_req = construct_import_rec_req(params, preexisting_entire_record_hash, rec_to_import_or_update)
+            # Schedule the record for later batch-addition.
             record_adds.append(rec_req)
+        elif perform_import_or_update == 'neither':
+            # Nothing to do.
+            pass
+        else:
+            raise AssertionError('perform_import_or_update has a strange value: {}'.format(perform_import_or_update))
 
-    return record_adds
+    return record_adds, record_updates
 
 
 def prepare_record_link(params, records):
+    """Prepare record links to folders."""
     record_folders = {}    # type: [str, [str]]
     record_links = []
     for rec in records:
@@ -748,19 +960,21 @@ def prepare_record_link(params, records):
                         folder_ids.append(folder_uid)
                         src_folder = params.folder_cache[folder_ids[0]]
                         dst_folder = params.folder_cache[folder_uid] if folder_uid in params.folder_cache else params.root_folder
+                        ft = dst_folder.type if dst_folder.type != BaseFolderNode.RootFolderType else BaseFolderNode.UserFolderType
                         req = {
                             'command': 'move',
-                            'to_type': dst_folder.type if dst_folder.type != BaseFolderNode.RootFolderType else BaseFolderNode.UserFolderType,
+                            'to_type': ft,
                             'link': True,
                             'move': [],
                             'transition_keys': []
                         }
                         if dst_folder.type != BaseFolderNode.RootFolderType:
                             req['to_uid'] = dst_folder.uid
+                        ft = src_folder.type if src_folder.type != BaseFolderNode.RootFolderType else BaseFolderNode.UserFolderType
                         mo = {
                             'type': 'record',
                             'uid': rec.uid,
-                            'from_type': src_folder.type if src_folder.type != BaseFolderNode.RootFolderType else BaseFolderNode.UserFolderType,
+                            'from_type': ft,
                             'cascade': True
                         }
                         if src_folder.type != BaseFolderNode.RootFolderType:
@@ -796,6 +1010,7 @@ def prepare_record_link(params, records):
 
 
 def prepare_folder_permission(params, folders):    # type: (KeeperParams, list) -> list
+    """Prepare a list of API interactions for changes to folder permissions."""
     shared_folder_lookup = {}
     for shared_folder_uid in params.shared_folder_cache:
         path = get_folder_path(params, shared_folder_uid)
@@ -827,8 +1042,12 @@ def prepare_folder_permission(params, folders):    # type: (KeeperParams, list) 
         api.load_available_teams(params)
         team_uids = set()
         for t in teams:
-            team_uid = next((x.get('team_uid') for x in params.available_team_cache
-                         if x.get('team_uid') == t or x.get('team_name').casefold() == t.casefold()), None)
+            team_uid = next(
+                (
+                    x.get('team_uid')
+                    for x in params.available_team_cache
+                    if x.get('team_uid') == t or x.get('team_name').casefold() == t.casefold()
+                ), None)
             if team_uid:
                 team_uids.add(team_uid)
         if len(team_uids) > 0:
@@ -914,6 +1133,7 @@ def prepare_folder_permission(params, folders):    # type: (KeeperParams, list) 
 
 
 def prepare_record_permission(params, records):
+    """Prepare a list of API interactions for changes to record permissions."""
     shared_update = []
     for rec in records:
         if rec.folders and rec.uid:
@@ -925,7 +1145,10 @@ def prepare_record_permission(params, records):
                     if fol.uid and fol.uid in params.folder_cache:
                         folder = params.folder_cache[fol.uid]
                         if folder.type in {BaseFolderNode.SharedFolderType, BaseFolderNode.SharedFolderFolderType}:
-                            sf_uid = folder.shared_folder_uid if folder.type == BaseFolderNode.SharedFolderFolderType else folder.uid
+                            sf_uid = \
+                                folder.shared_folder_uid \
+                                if folder.type == BaseFolderNode.SharedFolderFolderType \
+                                else folder.uid
                             if sf_uid in params.shared_folder_cache:
                                 sf = params.shared_folder_cache[sf_uid]
                                 if 'records' in sf:
@@ -951,13 +1174,21 @@ def prepare_record_permission(params, records):
 
 
 class KeeperAttachment(ImportAttachment):
+    """
+    Allow opening an attachment.
+
+    Note that this may be a duplicate of keepercommander/importer/commands.py's KeeperAttachment.
+    """
+
     def __init__(self, params, record_uid,):
+        """Initialize."""
         ImportAttachment.__init__(self)
         self.params = params
         self.record_uid = record_uid
 
     @contextmanager
     def open(self):
+        """Open an attachment."""
         rq = {
             'command': 'request_download',
             'file_ids': [self.file_id],
@@ -970,4 +1201,3 @@ class KeeperAttachment(ImportAttachment):
             if 'url' in dl:
                 with requests.get(dl['url'], stream=True) as rq_http:
                     yield rq_http.raw
-

--- a/keepercommander/rest_api.py
+++ b/keepercommander/rest_api.py
@@ -135,7 +135,7 @@ def execute_rest(context, endpoint, payload):    # type: (RestApiContext, str, p
         content_type = rs.headers.get('Content-Type') or ''
         if rs.status_code == 200:
             if content_type == 'application/json':
-                return rs.json()        # type: dict
+                return rs.json()
 
             rs_body = rs.content
             if rs_body:
@@ -257,4 +257,3 @@ def v2_execute(context, rq):
 
         if type(rs_data) is dict:
             raise KeeperApiError(rs_data['error'], rs_data['message'])
-

--- a/pylintrc
+++ b/pylintrc
@@ -550,7 +550,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=
+generated-members=keepercommander\.folder_pb2\..*
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).


### PR DESCRIPTION
    go rule becomes report rule. pylint exit status is ignored

    Parse and pass around update/update_flag

    Many small linter fixes. Attempts to update records through older/import_folders_and_records and fails.  Added result status output

    Introduced PYTHON_FILES variable, rather than computing it in multiple rules

    A little refactoring to simplify matters

    import appears to work, but no --update at all.

    import --update works for a single update record

    Misc.

    Split some code out into functions.
    Decoupled import-or-update-control from the import-and-update.
    Works on import and at least one update.

    Eliminated most FIXMEs

    Improved error reporting a bit. Replaced a manual hashlib use with build_record_hash

    Added 2 FIXME's and a comment about an assert

    Added authentication data to execute_update_record. Improved some variable names

    Ignore no-member from keepercommander.folder_pb2

    Encrypt correctly, I think.  Need to preserve notes and custom fields though.

    Fixed a type comment that was perplexing pylint.  Removed the final newline

    Added targeted-report rule and some comments

    Preserve notes and custom

    Removed pudb.set_trace()

    Removed 2 pprint invocations

    Changed a comment to a FIXME

    Introduced a LOCALE global

    Downcase statuses. Use api.LOCALE. Small change to notes and custom preservation

    Eliminated pudb.set_trace()

    Deleted an internal-only URL