### PR TITLE
KC-172: Give a nicer error message when we hit login timeout

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -503,8 +503,10 @@ def loop(params):  # type: (KeeperParams) -> int
         except CommunicationError as e:
 
             if e.result_code == 'restricted_client_type':
-
-                logging.error("Error code: %s\n%s" % e.result_code, loginv3.permissions_error_msg)
+                logging.error("Error code: %s\n%s" % (e.result_code, loginv3.permissions_error_msg))
+            elif e.result_code == 'session_token':
+                msg = 'Session token error: if authorized, please log in to the Web Vault and fix all errors there'
+                logging.error("Error code: %s\n%s" % (e.result_code, msg))
             else:
                 logging.error("Error code: %s\nCommunication Error: %s" % (e.result_code, e.message))
 

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -221,7 +221,7 @@ class Command:
                 return self.execute(params, **d)
             except KeeperApiError as exc:
                 if exc.result_code == 'session_token':
-                    logging.error('Session token error: account is inactive')
+                    logging.error('Session token error: if authorized, please log in to the Web Vault and fix all errors there')
                     return
                 raise
         except ParseError as e:

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -18,7 +18,6 @@ import functools
 import os
 import json
 
-
 from .. import api, display
 from ..subfolder import BaseFolderNode, try_resolve_path, find_folders
 from ..record import Record
@@ -143,14 +142,14 @@ class FolderListCommand(Command):
         folders = []
         records = []
 
-        if show_folders:
+        if show_folders and folder is not None:
             for uid in folder.subfolders:
                 f = params.folder_cache[uid]
                 if any(filter(lambda x: regex(x) is not None, FolderListCommand.folder_match_strings(f))) if regex is not None else True:
                     folders.append(f)
 
         v3_enabled = params.settings.get('record_types_enabled') if params.settings and isinstance(params.settings.get('record_types_enabled'), bool) else False
-        if show_records:
+        if show_records and folder is not None:
             folder_uid = folder.uid or ''
             if folder_uid in params.subfolder_record_cache:
                 for uid in params.subfolder_record_cache[folder_uid]:

--- a/keepercommander/loginv3.py
+++ b/keepercommander/loginv3.py
@@ -770,7 +770,12 @@ class LoginV3API:
             login_resp.ParseFromString(rs)
             return login_resp
         else:
-            raise KeeperApiError(rs['error'], "Account validation error.\n" + rs['message'])
+            # rs['message'] is almost relevant here.
+            list_ = [
+                "Account validation error: probable bad username or password.",
+                "If authorized, please run login within the keeper shell to try again."
+            ]
+            raise KeeperApiError(rs['error'], '\n'.join(list_))
 
     @staticmethod
     def twoFactorValidateMessage(params: KeeperParams, encryptedLoginToken: bytes, otp_code: str, tfa_expire_in, twoFactorValueType=None):


### PR DESCRIPTION
Added a FIXME. Check for KeeperApiError.result_code and give a better error message

No more tracebacks on no folders

Reworded an error message

Changed error message wording again