### PR TITLE
Fix tempfile.NamedTemporaryFile on Windows

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,7 @@
 import tempfile
 import json
 import os
+import shutil
 import warnings
 
 from unittest import TestCase, mock
@@ -74,6 +75,10 @@ class TestConnectedCommands(TestCase):
 
     def setUp(self):
         warnings.simplefilter('ignore', category=ImportWarning)
+        # Windows doesn't play nice with temp files, so create tmpdir that may fail to delete
+        self.tmpdir = os.path.join(os.path.dirname(__file__), 'tmp')
+        os.makedirs(self.tmpdir, exist_ok=True)
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
 
     def test_commands(self):
         params = TestConnectedCommands.params # type: KeeperParams
@@ -115,7 +120,7 @@ class TestConnectedCommands(TestCase):
             cli.do_command(params, 'search record')
             cli.do_command(params, 'search folder')
 
-            with tempfile.NamedTemporaryFile() as f:
+            with tempfile.NamedTemporaryFile(dir=self.tmpdir, delete=False) as f:
                 f.write(b'data')
                 f.flush()
                 cli.do_command(params, 'cd "User Folder 1"')


### PR DESCRIPTION
This is needed for https://keeper.atlassian.net/browse/KC-237

This PR fixes tempfile.NamedTemporaryFile for testing on Windows.

There are a few problems using NamedTemporaryFile on Windows:
- As indicated in the Python docs the file corresponding to the file-like object in the context manager cannot be opened again:
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows NT or later).
- There is a workaround, however, that allows NamedTemporaryFile to work on Windows, i.e. use the parameter `delete=False`. Then the temporary file needs to be cleaned up later.
- The problem with cleaning up the temporary file later on Windows is that an OSError may be returned when trying to delete the temporary file.

The above issues are addressed in this PR by:
- Using the NamedTemporaryFile parameter `delete=False`
- Setting NamedTemporaryFile parameter `dir` to a newly created directory `tmp` in the test folder
- Add cleanup of directory `tmp` to the unittest.TestCase
- Use shutil.rmtree(ignore_errors=True) for cleanup so that the test doesn't fail if directory `tmp` fails to be removed on Windows