### PR TITLE
Fix ksm (KC-256)

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -180,7 +180,7 @@ def do_command(params, command_line):
     if command_line.startswith('ksm'):
         try:
             which_cmd = 'where' if sys.platform.startswith('win') else 'which'
-            subprocess.check_call([which_cmd, 'ksm'])
+            subprocess.check_call([which_cmd, 'ksm'], stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             logging.error(
                 'Please install the ksm application to run ksm commands.\n'

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -9,36 +9,36 @@
 # Contact: ops@keepersecurity.com
 #
 
-import os
-import sys
-import getpass
 import datetime
-import time
-import threading
 import functools
+import getpass
 import logging
+import os
 import re
 import shlex
 import subprocess
-
+import sys
+import threading
+import time
 from collections import OrderedDict
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.enums import EditingMode
+from prompt_toolkit.shortcuts import CompleteStyle
 
+from . import api, display, loginv3, ttk
+from .autocomplete import CommandCompleter
+from .commands import (
+    register_commands, register_enterprise_commands, register_msp_commands,
+    aliases, commands, command_info, enterprise_commands, msp_commands
+)
 from .commands.msp import get_mc_by_name_or_id
-
-from .params import KeeperParams
-from . import display, loginv3, api
-# from .api import sync_down, login, communicate, query_enterprise, query_msp, login_and_get_mc_params, login_and_get_mc_params_login_v3
+from .constants import OS_WHICH_CMD
 from .error import AuthenticationError, CommunicationError, CommandError
+from .params import KeeperParams
 from .recordv3 import init_recordv3_commands
 from .subfolder import BaseFolderNode
-from .autocomplete import CommandCompleter
-from .commands import register_commands, register_enterprise_commands, register_msp_commands, aliases, commands, \
-    command_info, enterprise_commands, msp_commands
-from . import ttk
+
 
 stack = []
 command_info = OrderedDict()
@@ -179,8 +179,7 @@ def do_command(params, command_line):
 
     if command_line.startswith('ksm'):
         try:
-            which_cmd = 'where' if sys.platform.startswith('win') else 'which'
-            subprocess.check_call([which_cmd, 'ksm'], stdout=subprocess.DEVNULL)
+            subprocess.check_call([OS_WHICH_CMD, 'ksm'], stdout=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             logging.error(
                 'Please install the ksm application to run ksm commands.\n'

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -18,6 +18,7 @@ import threading
 import functools
 import logging
 import re
+import shlex
 import subprocess
 
 from collections import OrderedDict
@@ -183,7 +184,10 @@ def do_command(params, command_line):
         except subprocess.CalledProcessError:
             logging.error('Please install the ksm application to run ksm commands.')
         else:
-            subprocess.check_call(command_line)
+            if sys.platform.startswith('win'):
+                subprocess.check_call(command_line)
+            else:
+                subprocess.check_call(shlex.split(command_line))
         return
     elif '-h' in command_line.lower():
         if command_line.lower().startswith('h ') or command_line.lower().startswith('history '):

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -182,7 +182,12 @@ def do_command(params, command_line):
             which_cmd = 'where' if sys.platform.startswith('win') else 'which'
             subprocess.check_call([which_cmd, 'ksm'])
         except subprocess.CalledProcessError:
-            logging.error('Please install the ksm application to run ksm commands.')
+            logging.error(
+                'Please install the ksm application to run ksm commands.\n'
+                'See https://docs.keeper.io/secrets-manager/secrets-manager'
+                '/secrets-manager-command-line-interface'
+                '#secrets-manager-cli-installation'
+            )
         else:
             if sys.platform.startswith('win'):
                 subprocess.check_call(command_line)

--- a/keepercommander/constants.py
+++ b/keepercommander/constants.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 
+# Timeout constants
 # Set to default value by using timedelta of 0
 TIMEOUT_DEFAULT = timedelta(0)
 TIMEOUT_MIN = timedelta(minutes=1)
@@ -8,6 +9,7 @@ TIMEOUT_MAX = timedelta(days=30)
 TIMEOUT_DEFAULT_UNIT = 'minutes'
 TIMEOUT_ALLOWED_UNITS = ('days', 'hours', 'minutes')
 
+# Enforcement constants
 _ENFORCEMENTS = [
     ("MASTER_PASSWORD_MINIMUM_LENGTH", 10, "LONG"),
     ("MASTER_PASSWORD_MINIMUM_SPECIAL", 11, "LONG"),
@@ -111,3 +113,10 @@ _ENFORCEMENTS = [
 ENFORCEMENTS = {}
 for e in _ENFORCEMENTS:
     ENFORCEMENTS[e[0].lower()] = e[2].lower()
+
+# OS dependent constants
+if sys.platform.startswith('win'):
+        OS_WHICH_CMD = 'where'
+    else:
+        OS_WHICH_CMD = 'which'
+


### PR DESCRIPTION
This PR does the following:
- Fix the ksm command by using shlex.split on the command line that is passed to subprocess.check_call (This is only needed on non-Windows platforms)
- Add more info to the error message that is returned if ksm is not installed, i.e. a URL that provides installation instructions for ksm
- Don't display the output of the `which ksm` or `where ksm` that is used to determine if ksm is installed