### PR TITLE
Add --copy-uid option to clipboard-copy (KC-253)

### DIFF
--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -1479,7 +1479,7 @@ class ClipboardCommand(Command):
                 pyperclip.copy(txt)
                 logging.info(f'{copy_item} copied to clipboard')
             else:
-                print(f'{copy_item}:\n{txt}')
+                print(txt)
             if copy_item == 'Password':
                 params.queue_audit_event('copy_password', record_uid=record_uid)
 

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -1480,7 +1480,7 @@ class ClipboardCommand(Command):
                 logging.info(f'{copy_item} copied to clipboard')
             else:
                 print(f'{copy_item}:\n{txt}')
-            if not kwargs.get('login') and not kwargs.get('copy_uid'):
+            if copy_item == 'Password':
                 params.queue_audit_event('copy_password', record_uid=record_uid)
 
 

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -193,7 +193,7 @@ delete_attachment_parser.error = raise_parse_exception
 delete_attachment_parser.exit = suppress_exit
 
 
-clipboard_copy_parser = argparse.ArgumentParser(prog='find-password|clipboard-copy', description='Retrieve the password for a specific record')
+clipboard_copy_parser = argparse.ArgumentParser(prog='find-password|clipboard-copy|cc', description='Retrieve the password for a specific record')
 clipboard_copy_parser.add_argument('--username', dest='username', action='store', help='match login name (optional)')
 clipboard_copy_parser.add_argument('--output', dest='output', choices=['clipboard', 'stdout'], default='clipboard', action='store', help='password output destination')
 clipboard_copy_parser.add_argument('-l', '--login', dest='login', action='store_true', help='output login name instead of password')


### PR DESCRIPTION
This PR does the following:
- Update the help for clipboard-copy to show the alias "cc"
- Add the "--copy-uid/-cu" option to copy the record UID
- Add better output to the clipboard-copy to show what was copied to clipboard, i.e. "Password", "Login", or "Record UID"