### PR TITLE
Failing mkdir test

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -263,7 +263,7 @@ class FolderMakeCommand(Command):
             if rs is not None:
                 base_folder, name = rs
                 if len(name) == 0:
-                    logging.info('mkdir: Folder "%s" already exists', kwargs['folder'])
+                    logging.warning('mkdir: Folder "%s" already exists', kwargs['folder'])
                     return
 
         shared_folder = kwargs['shared_folder'] if 'shared_folder' in kwargs else None

--- a/unit-tests/test_command_folder.py
+++ b/unit-tests/test_command_folder.py
@@ -1,4 +1,5 @@
 from unittest import TestCase, mock
+import logging
 
 from data_vault import get_synced_params
 from helper import KeeperApiHelper
@@ -81,7 +82,7 @@ class TestFolder(TestCase):
                 self.assertTrue(KeeperApiHelper.is_expect_empty())
 
         shared_folder = next(iter([x for x in params.folder_cache.values() if x.type == 'shared_folder']))
-        with self.assertRaises(CommandError):
+        with self.assertLogs(level=logging.WARNING):
             cmd.execute(params, folder=shared_folder.name)
 
         params.current_folder = shared_folder.uid


### PR DESCRIPTION

Make the mkdir of a preexisting directory log a warning instead of an info, and change the corresponding unit test to match.
