### PR TITLE
Finish PR tests (KC-244)

### DIFF
--- a/.github/workflows/test-with-pytest.yml
+++ b/.github/workflows/test-with-pytest.yml
@@ -29,4 +29,4 @@ jobs:
         run: pip install .[all]
 
       - name: Run import tests
-        run: pytest tests/test_imports.py
+        run: pytest -m "not integration"

--- a/.github/workflows/test-with-pytest.yml
+++ b/.github/workflows/test-with-pytest.yml
@@ -1,7 +1,10 @@
 name: Test with pytest
 
 on:
-#   pull_request
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-with-pytest.yml
+++ b/.github/workflows/test-with-pytest.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Install package with test dependencies
         run: pip install .[all]
 
-      - name: Run import tests
+      - name: Run non-integration tests
         run: pytest -m "not integration"

--- a/.github/workflows/test-with-pytest.yml
+++ b/.github/workflows/test-with-pytest.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package with test dependencies
-        run: pip install .[test]
+        run: pip install .[all]
 
       - name: Run import tests
         run: pytest tests/test_imports.py

--- a/.github/workflows/test-with-pytest.yml
+++ b/.github/workflows/test-with-pytest.yml
@@ -14,7 +14,7 @@ jobs:
   test-with-pytest:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.9]
 
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'prompt_toolkit>=2.0.4,<=2.0.10',
     'protobuf>=3.13.0',
     'pycryptodomex>=3.7.2',
-    'pyperclip'
+    'pyperclip',
     'requests',
     'tabulate',
 ]


### PR DESCRIPTION
This is a follow up to #487 for KC-244

This PR does the following:
- Fix an error in the setup.py from #487 
- Update the GitHub actions to install all Commander dependencies and run all non-integration tests
- Run the GitHub actions on all pull requests and pushes to master
- Also run the tests on Windows

There is still the need to add a Keeper account in order to run the integration tests. This can happen in another PR.

I'm not running the tests on Mac because as far as I understand it is much more expensive. Perhaps we want a custom Github action test runner for this?