### PR TITLE
Make libkeepass a default dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     'asciitree',
     'colorama',
     'cryptography>=3.4.8',
+    'libkeepass',
     'prompt_toolkit>=2.0.4,<=2.0.10',
     'protobuf>=3.13.0',
     'pycryptodomex>=3.7.2',
@@ -21,7 +22,6 @@ install_requires = [
     'tabulate',
 ]
 adpasswd_requires = ['ldap3']
-keepass_requires = ['libkeepass']
 test_requires = ['pytest', 'testfixtures']
 
 setup(
@@ -52,8 +52,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'adpasswd': adpasswd_requires,
-        'keepass': keepass_requires,
         'test': test_requires,
-        'all': adpasswd_requires + keepass_requires + test_requires
+        'all': adpasswd_requires + test_requires
     }
 )


### PR DESCRIPTION
This is a follow-up to #487 and #490

This PR re-adds libkeepass to the install_requires parameter in setup.py and removes the extras_require keepass option.

It had previously been discussed that libkeepass should be installed with keepercommander by default.