### PR TITLE
Fix lastpass import of records without title

### DIFF
--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -62,6 +62,8 @@ class LastPassImporter(BaseImporter):
                 record.login_url = account.url.decode('utf-8')
                 if record.login_url == 'http://sn':
                     record.login_url = None
+                elif record.login_url == 'http://group':
+                    continue
             if account.notes:
                 notes = account.notes.decode('utf-8')
                 if notes:


### PR DESCRIPTION
If a Lastpass record being imported has no title then the import will crash. ~This PR adds in a default of "Lastpass Import Untitled [count]" for each untitled record being imported.~

The records that didn't have titles had "http://group" in the URL because they were folders. This PR skips those items.