### PR TITLE
Import shared folder members with shared folder (KC-286)

### DIFF
--- a/keepercommander/importer/lastpass/fetcher.py
+++ b/keepercommander/importer/lastpass/fetcher.py
@@ -58,8 +58,12 @@ def fetch_shared_folder_members(session, shareid, web_client=http):
     if response.status_code != requests.codes.ok:
         raise NetworkError()
 
-    # We're only returning the users that have access to the share and not the groups
-    shared_folder_members = json.loads(response.content.decode('utf-8'))['users']
+    response_dict = json.loads(response.content.decode('utf-8'))
+    if 'users' in response_dict:
+        # We're only returning the users that have access to the share and not the groups
+        shared_folder_members = response_dict['users']
+    else:
+        shared_folder_members = []
     return shared_folder_members
 
 

--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -229,7 +229,7 @@ class LastPassImporter(BaseImporter):
             if account.group or account.shared_folder:
                 fol = Folder()
                 if account.shared_folder:
-                    fol.domain = account.shared_folder.decode('utf-8')
+                    fol.domain = account.shared_folder.name
                 if account.group:
                     fol.path = account.group.decode('utf-8')
                 record.folders = [fol]

--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -123,6 +123,10 @@ class LastPassImporter(BaseImporter):
         except LastPassUnknownError as lpe:
             logging.warning(lpe)
             return
+        else:
+            if len(vault.errors) > 0:
+                err_list = '\n'.join(vault.errors)
+                logging.warning(f'The following errors occurred retrieving Lastpass shared folder members:\n{err_list}')
 
         for shared_folder in vault.shared_folders:
             folder = SharedFolder()

--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -8,17 +8,17 @@
 # Copyright 2021 Keeper Security Inc.
 # Contact: ops@keepersecurity.com
 #
+import calendar
+import datetime
+import getpass
 import json
 import logging
-
 from typing import Optional, List
-from ..importer import BaseImporter, Record, Folder, RecordField, RecordReferences, SharedFolder, Permission
-import calendar, datetime
-import getpass
 
-from .vault import Vault
+from ..importer import BaseImporter, Record, Folder, RecordField, RecordReferences, SharedFolder, Permission
 from .account import Account
 from .exceptions import LastPassUnknownError
+from .vault import Vault
 
 
 class LastPassImporter(BaseImporter):

--- a/keepercommander/importer/lastpass/shared_folder.py
+++ b/keepercommander/importer/lastpass/shared_folder.py
@@ -1,4 +1,4 @@
-class SharedFolder:
+class LastpassSharedFolder:
     def __init__(self, id, name, members):
         self.id = id
         self.name = name

--- a/keepercommander/importer/lastpass/shared_folder.py
+++ b/keepercommander/importer/lastpass/shared_folder.py
@@ -1,0 +1,5 @@
+class SharedFolder:
+    def __init__(self, id, name, members):
+        self.id = id
+        self.name = name
+        self.members = members

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -28,6 +28,7 @@ class Vault(object):
         if not self.is_complete(chunks):
             raise InvalidResponseError('Blob is truncated')
 
+        self.shared_folders = []
         self.accounts = self.parse_accounts(chunks, encryption_key, session)
 
     def is_complete(self, chunks):
@@ -54,6 +55,7 @@ class Vault(object):
                 shareid = share['id'].decode('utf-8')
                 shared_folder_members = fetcher.fetch_shared_folder_members(session, shareid)
                 shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), shared_folder_members)
+                self.shared_folders.append(shared_folder)
 
         fetcher.logout(session)
         return accounts

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -28,6 +28,7 @@ class Vault(object):
         if not self.is_complete(chunks):
             raise InvalidResponseError('Blob is truncated')
 
+        self.errors = set()
         self.shared_folders = []
         self.accounts = self.parse_accounts(chunks, encryption_key, session)
 
@@ -53,7 +54,9 @@ class Vault(object):
                 share = parser.parse_SHAR(i, encryption_key, rsa_private_key)
                 key = share['encryption_key']
                 shareid = share['id'].decode('utf-8')
-                shared_folder_members = fetcher.fetch_shared_folder_members(session, shareid)
+                shared_folder_members, error = fetcher.fetch_shared_folder_members(session, shareid)
+                if error:
+                    self.errors.add(error)
                 shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), shared_folder_members)
                 self.shared_folders.append(shared_folder)
 

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -2,7 +2,7 @@
 from . import fetcher
 from . import parser
 from .exceptions import InvalidResponseError
-from .shared_folder import SharedFolder
+from .shared_folder import LastpassSharedFolder
 
 
 class Vault(object):
@@ -53,7 +53,7 @@ class Vault(object):
                 key = share['encryption_key']
                 shareid = share['id'].decode('utf-8')
                 shared_folder_members = fetcher.fetch_shared_folder_members(session, shareid)
-                shared_folder = SharedFolder(shareid, share['name'].decode('utf-8'), shared_folder_members)
+                shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), shared_folder_members)
 
         fetcher.logout(session)
         return accounts


### PR DESCRIPTION
This PR does the following:
- Adds class LastpassSharedFolder to store shared folder name with permissions for shared folder imported from Lastpass.
- Makes API call to Lastpass to retrieve shared folder permissions which are stored in Vault.shared_folders as list of LastpassSharedFolder.
- Yield list of importer.SharedFolder to the Keeper import with permissions populated from the lastpass shared folders.