### PR TITLE
Store Lastpass shared folder teams in LastpassSharedFolder

### DIFF
--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -961,10 +961,10 @@ def prepare_folder_add(params, folders, records):
                     if folder_type == 'shared_folder':
                         string2 = api.encrypt_aes(comp.encode('utf-8'), folder_key)
                         fol_req.sharedFolderFields.encryptedFolderName = base64.urlsafe_b64decode(string2 + '==')
-                        fol_req.sharedFolderFields.manageUsers = fol.manage_users
-                        fol_req.sharedFolderFields.manageRecords = fol.manage_records
-                        fol_req.sharedFolderFields.canEdit = fol.can_edit
-                        fol_req.sharedFolderFields.canShare = fol.can_share
+                        fol_req.sharedFolderFields.manageUsers = fol.manage_users or False
+                        fol_req.sharedFolderFields.manageRecords = fol.manage_records or False
+                        fol_req.sharedFolderFields.canEdit = fol.can_edit or False
+                        fol_req.sharedFolderFields.canShare = fol.can_share or False
 
                     folder_add.append(fol_req)
                     folder_hash[digest] = folder_uid, folder_type, folder_key if folder_type == 'shared_folder' else None

--- a/keepercommander/importer/lastpass/fetcher.py
+++ b/keepercommander/importer/lastpass/fetcher.py
@@ -57,11 +57,10 @@ def fetch_shared_folder_members(session, shareid, web_client=http):
 
     if response.status_code != requests.codes.ok:
         error = f'HTTP {response.status_code}, {response.reason}'
-        return [], error
+        return [], [], error
 
     response_dict = json.loads(response.content.decode('utf-8'))
     if 'users' in response_dict:
-        # We're only returning the users that have access to the share and not the groups
         shared_folder_members = response_dict['users']
         error = None
     elif 'error' in response_dict:
@@ -72,7 +71,7 @@ def fetch_shared_folder_members(session, shareid, web_client=http):
     else:
         shared_folder_members = []
         error = 'Unknown response from Lastpass'
-    return shared_folder_members, error
+    return shared_folder_members, response_dict.get('groups', []), error
 
 
 def request_iteration_count(username, web_client=http):

--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -131,10 +131,6 @@ class LastPassImporter(BaseImporter):
         for shared_folder in vault.shared_folders:
             folder = SharedFolder()
             folder.path = shared_folder.name
-            folder.manage_users = False
-            folder.manage_records = False
-            folder.can_edit = True
-            folder.can_share = True
             folder.permissions = []
             for member in shared_folder.members:
                 perm = Permission()

--- a/keepercommander/importer/lastpass/shared_folder.py
+++ b/keepercommander/importer/lastpass/shared_folder.py
@@ -1,5 +1,6 @@
 class LastpassSharedFolder:
-    def __init__(self, id, name, members):
+    def __init__(self, id, name, members, teams):
         self.id = id
         self.name = name
         self.members = members
+        self.teams = teams

--- a/keepercommander/importer/lastpass/shared_folder.py
+++ b/keepercommander/importer/lastpass/shared_folder.py
@@ -1,5 +1,5 @@
 class LastpassSharedFolder:
-    def __init__(self, id, name, members, teams):
+    def __init__(self, id, name, members=None, teams=None):
         self.id = id
         self.name = name
         self.members = members

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -12,14 +12,15 @@ class Vault(object):
         session = fetcher.login(username, password, multifactor_password, client_id)
         blob = fetcher.fetch(session)
         encryption_key = blob.encryption_key(username, password)
-        return cls(blob, encryption_key, session)
+        vault = cls(blob, encryption_key, session)
+        fetcher.logout(session)
+        return vault
 
     @classmethod
     def open_local(cls, blob_filename, username, password):
         """Creates a vault from a locally stored blob"""
         # TODO: read the blob here
         raise NotImplementedError()
-
 
     def __init__(self, blob, encryption_key, session):
         """This more of an internal method, use one of the static constructors instead"""
@@ -30,12 +31,25 @@ class Vault(object):
 
         self.errors = set()
         self.shared_folders = []
-        self.accounts = self.parse_accounts(chunks, encryption_key, session)
+        self.accounts = self.parse_accounts(chunks, encryption_key)
+
+        try:
+            if self.shared_folders and len(self.shared_folders) < 50:
+                for shared_folder in self.shared_folders:
+                    members, teams, error = fetcher.fetch_shared_folder_members(session, shared_folder.id)
+                    if error:
+                        self.errors.add(error)
+                        break
+                    else:
+                        shared_folder.members = members
+                        shared_folder.teams = teams
+        except:
+            pass
 
     def is_complete(self, chunks):
         return len(chunks) > 0 and chunks[-1].id == b'ENDM' and chunks[-1].payload == b'OK'
 
-    def parse_accounts(self, chunks, encryption_key, session):
+    def parse_accounts(self, chunks, encryption_key):
         accounts = []
 
         key = encryption_key
@@ -54,11 +68,7 @@ class Vault(object):
                 share = parser.parse_SHAR(i, encryption_key, rsa_private_key)
                 key = share['encryption_key']
                 shareid = share['id'].decode('utf-8')
-                members, teams, error = fetcher.fetch_shared_folder_members(session, shareid)
-                if error:
-                    self.errors.add(error)
-                shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), members, teams)
+                shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'))
                 self.shared_folders.append(shared_folder)
 
-        fetcher.logout(session)
         return accounts

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -54,10 +54,10 @@ class Vault(object):
                 share = parser.parse_SHAR(i, encryption_key, rsa_private_key)
                 key = share['encryption_key']
                 shareid = share['id'].decode('utf-8')
-                shared_folder_members, error = fetcher.fetch_shared_folder_members(session, shareid)
+                members, teams, error = fetcher.fetch_shared_folder_members(session, shareid)
                 if error:
                     self.errors.add(error)
-                shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), shared_folder_members)
+                shared_folder = LastpassSharedFolder(shareid, share['name'].decode('utf-8'), members, teams)
                 self.shared_folders.append(shared_folder)
 
         fetcher.logout(session)


### PR DESCRIPTION
This PR returns the team names as well as users that have access to the shared folder being imported. The team permissions are added as an attribute to the LastpassSharedFolder, but the permissions for the teams are still not being imported into Keeper.