### PR TITLE
Fix logging level when using "-lwsc=true" (KC-290)

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -209,7 +209,8 @@ def main(from_package=False):
         if opts.command == '?' or not params.commands:
             usage('')
 
-    logging.basicConfig(level=logging.WARNING if params.batch_mode else logging.INFO, format='%(message)s')
+    logging.basicConfig(format='%(message)s')
+    logging.getLogger().setLevel(logging.WARNING if params.batch_mode else logging.INFO)
 
     if params.timedelay >= 1 and params.commands:
         cli.runcommands(params)

--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -209,8 +209,7 @@ def main(from_package=False):
         if opts.command == '?' or not params.commands:
             usage('')
 
-    logging.basicConfig(format='%(message)s')
-    logging.getLogger().setLevel(logging.WARNING if params.batch_mode else logging.INFO)
+    logging.basicConfig(level=logging.WARNING if params.batch_mode else logging.INFO, format='%(message)s', force=True)
 
     if params.timedelay >= 1 and params.commands:
         cli.runcommands(params)


### PR DESCRIPTION
This PR fixes the logging level when using the option `-lwsc=true`. For some reason when this option is true, `logging.basicConfig` does not set the logging level according to the `level` parameter that is passed. The workaround is to use a separate `logging.getLogger().setLevel` to set the correct logging level.

On further investigation, the reason `logging.basicConfig` doesn't work in some situations is because of the following in the documentation:
>This function does nothing if the root logger already has handlers configured, unless the keyword argument force is set to True.
