### PR TITLE
Update audit-report --syntax-help to list all available columns and event types (KC-216)

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -3057,7 +3057,7 @@ Filters                 Supported: '=', '>', '<', '>=', '<=', 'IN(<>,<>,<>)'. De
                         where value is UTC date or epoch time in seconds
 --username              Email
 --to-username
---record-uid	        Record UID
+--record-uid            Record UID
 --shared-folder-uid     Shared Folder UID
 --event-type            Audit Event Type.  Value is event type id or event type name
 '''


### PR DESCRIPTION
This PR updates the `--syntax-help` option of the `audit-report` command in the following ways:
- `--report-type` is no longer required with the `--syntax-help` option
- Newly available columns are added
- Event type ids and event type names are added to the end of `--syntax-help`