### PR TITLE
Minor cleanup fix

### DIFF
--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -124,7 +124,8 @@ class LastPassImporter(BaseImporter):
 
     def cleanup(self):
         """Cleanup should be performed when finished with encrypted attachment files"""
-        self.vault.cleanup()
+        if self.vault:
+            self.vault.cleanup()
 
     def do_import(self, name, users_only=False, old_domain=None, new_domain=None, tmpdir=None, **kwargs):
         username = name

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -98,9 +98,9 @@ class Vault(object):
             if tmpdir is None:
                 self.tmpdir = mkdtemp()
             else:
+                if not os.path.exists(tmpdir):
+                    os.makedirs(tmpdir)
                 self.tmpdir = os.path.abspath(tmpdir)
-                if not os.path.exists(self.tmpdir):
-                    os.makedirs(self.tmpdir)
 
         for i, attachment in enumerate(self.attachments):
             tmp_filename = f'{str(i).zfill(attach_cnt_digits)}of{attach_cnt}_{attachment.file_id}'


### PR DESCRIPTION
This is a minor fix for an issue that I saw. The self.vault.cleanup() should not be called if self.vault doesn't exist. This could occur if there was an error (like incorrect password in my case) and the vault never got created.