### PR TITLE
Keep custom tmpdir and use existing Lastpass attachments

### DIFF
--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -119,7 +119,8 @@ class LastPassImporter(BaseImporter):
 
     def cleanup(self):
         """Cleanup should be performed when finished with encrypted attachment files"""
-        if self.vault:
+        # Don't remove custom specified tmpdir
+        if self.vault and self.tmpdir is None:
             self.vault.cleanup()
 
         old_tmpdir = glob(f'{tempfile.gettempdir()}/{TMPDIR_PREFIX}*')
@@ -129,6 +130,7 @@ class LastPassImporter(BaseImporter):
             logging.warning(warn_msg)
 
     def do_import(self, name, users_only=False, old_domain=None, new_domain=None, tmpdir=None, **kwargs):
+        self.tmpdir = tmpdir
         username = name
         password = getpass.getpass(prompt='...' + 'LastPass Password'.rjust(30) + ': ', stream=None)
         print('Press <Enter> if account is not protected with Multifactor Authentication')

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -109,12 +109,15 @@ class Vault(object):
                     os.makedirs(tmpdir)
                 self.tmpdir = os.path.abspath(tmpdir)
 
-        print(f'Downloading {attach_cnt} LastPass attachments:')
+        print(f'Processing {attach_cnt} LastPass attachments:')
         for i, attachment in enumerate(self.attachments):
-            tmp_filename = f'{str(i+1).zfill(attach_cnt_digits)}of{attach_cnt}_{attachment.file_id}'
+            tmp_filename = f'{str(i + 1).zfill(attach_cnt_digits)}of{attach_cnt}_{attachment.file_id}'
             attachment.tmpfile = os.path.join(self.tmpdir, tmp_filename)
-            with fetcher.stream_attachment(session, attachment) as r:
-                with open(attachment.tmpfile, 'wb') as f:
-                    print(f'{i+1}. {attachment.name} ... ', end='', flush=True)
-                    shutil.copyfileobj(r.raw, f)
-                    print('Done')
+            if os.path.isfile(attachment.tmpfile) and os.path.getsize(attachment.tmpfile) == attachment.size:
+                print(f'{i + 1}. Found {attachment.name}')
+            else:
+                with fetcher.stream_attachment(session, attachment) as r:
+                    with open(attachment.tmpfile, 'wb') as f:
+                        print(f'{i + 1}. Downloading {attachment.name} ... ', end='', flush=True)
+                        shutil.copyfileobj(r.raw, f)
+                        print('Done')


### PR DESCRIPTION
This PR makes the following changes:
- Don't cleanup the temporary directory for Lastpass file attachments if the directory is specified on the commandline
- If the Lastpass file attachment already exists, use the existing attachment rather than downloading again