### PR TITLE
Better handling of missing title

### DIFF
--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -172,6 +172,7 @@ class LastPassImporter(BaseImporter):
 
             yield folder
 
+        missing_titles = 0
         for account in vault.accounts:  # type: Account
             record = Record()
             is_secure_note = False
@@ -179,6 +180,14 @@ class LastPassImporter(BaseImporter):
                 record.uid = account.id
             if account.name:
                 record.title = account.name.decode('utf-8')
+                if not record.title:
+                    missing_titles += 1
+                    new_title = f'Missing Title {missing_titles}'
+                    logging.warning(
+                        f'Missing title {record.title}({account.name}) in record from LastPass. '
+                        f'Assigning title "{new_title}"'
+                    )
+                    record.title = new_title
             if account.username:
                 record.login = account.username.decode('utf-8')
             if account.password:


### PR DESCRIPTION
There was a case of a missing title in an import from LastPass which crashed the import. This PR prevents the import from crashing by assigning a new title "Missing Title x" where x is the number of the missing title.