### PR TITLE
Skip http://group records before checking for missing title

### DIFF
--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -176,6 +176,14 @@ class LastPassImporter(BaseImporter):
         for account in vault.accounts:  # type: Account
             record = Record()
             is_secure_note = False
+            if account.url:
+                record.login_url = account.url.decode('utf-8')
+                if record.login_url == 'http://sn':
+                    is_secure_note = True
+                    record.login_url = None
+                elif record.login_url == 'http://group':
+                    continue
+
             if account.id:
                 record.uid = account.id
             if account.name:
@@ -188,13 +196,6 @@ class LastPassImporter(BaseImporter):
                 record.login = account.username.decode('utf-8')
             if account.password:
                 record.password = account.password.decode('utf-8')
-            if account.url:
-                record.login_url = account.url.decode('utf-8')
-                if record.login_url == 'http://sn':
-                    is_secure_note = True
-                    record.login_url = None
-                elif record.login_url == 'http://group':
-                    continue
             if len(account.attachments) > 0:
                 if record.attachments is None:
                     record.attachments = []


### PR DESCRIPTION
This is another fix for checking for LastPass records without a title. There are records from LastPass with a URL `http://group` and no title that we skip anyway. These records should be skipped before checking for a missing title.