### PR TITLE
Import updates

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -1708,9 +1708,16 @@ def get_pb2_record_update(params, rec, **kwargs):
     if record_rq is None:
         return
 
-    links = kwargs.get('record_links') or {}
-    links_add = links.get('record_links_add') or []
-    links_remove = links.get('record_links_remove') or []
+    links_by_uid = kwargs.get('record_links_by_uid')
+    if links_by_uid:
+        links_add_by_uid = links_by_uid.get('record_links_add') or {}
+        links_add = links_add_by_uid.get(rec.record_uid) or []
+        links_del_by_uid = links_by_uid.get('record_links_remove') or {}
+        links_remove = links_del_by_uid.get(rec.record_uid) or []
+    else:
+        links = kwargs.get('record_links') or {}
+        links_add = links.get('record_links_add') or []
+        links_remove = links.get('record_links_remove') or []
 
     record_links_add = []
     for link in links_add:

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -802,7 +802,6 @@ def _import(params, file_format, filename, **kwargs):
                             missing_attachments.append(a)
 
                     if found_attachments:
-                        # found_names = ', '.join((a.name for a in found_attachments))
                         found = len(found_attachments)
                         total = len(r.attachments)
                         print(f'Found {found} of {total} attachments in record {r.title}.')

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -951,10 +951,10 @@ def upload_v3_attachments(params, records_with_attachments):
     """Interact with the API to upload v3 attachments"""
     print('Uploading v3 attachments:')
 
+    rq = record_pb2.FilesAddRequest()
+    uid_to_attachment = {}
     for parent_record in records_with_attachments:
         parent_uid = parent_record.uid
-        rq = record_pb2.FilesAddRequest()
-        uid_to_attachment = {}
         for atta in parent_record.attachments:
             if atta.size > 100 * 2 ** 20:  # hard limit at 100MB for upload
                 logging.warning(f'Upload of {atta.name} failed: File size of {atta.size} exceeds the 100MB maximum.')
@@ -975,6 +975,7 @@ def upload_v3_attachments(params, records_with_attachments):
             uid = api.generate_record_uid()
             atta.record_uid = loginv3.CommonHelperMethods.url_safe_str_to_bytes(uid)
             atta.encrypted_key = api.encrypt_aes_plain(atta.key, params.data_key)
+            atta.parent_uid = parent_uid
 
             rf = record_pb2.File()
             rf.record_uid = atta.record_uid
@@ -984,62 +985,72 @@ def upload_v3_attachments(params, records_with_attachments):
             rq.files.append(rf)
             uid_to_attachment[atta.record_uid] = atta
 
-        rq.client_time = api.current_milli_time()
-        rs = api.communicate_rest(params, rq, 'vault/files_add')
-        files_add_rs = record_pb2.FilesAddResponse()
-        files_add_rs.ParseFromString(rs)
+    rq.client_time = api.current_milli_time()
+    rs = api.communicate_rest(params, rq, 'vault/files_add')
+    files_add_rs = record_pb2.FilesAddResponse()
+    files_add_rs.ParseFromString(rs)
 
-        new_attachment_uids = []
-        record_links_add = []
-        for f in files_add_rs.files:
-            atta = uid_to_attachment[f.record_uid]
-            status = record_pb2.FileAddResult.DESCRIPTOR.values_by_number[f.status].name
-            success = (f.status == record_pb2.FileAddResult.DESCRIPTOR.values_by_name['FA_SUCCESS'].number)
+    new_attachments_by_parent_uid = {}
+    for f in files_add_rs.files:
+        atta = uid_to_attachment[f.record_uid]
+        status = record_pb2.FileAddResult.DESCRIPTOR.values_by_number[f.status].name
+        success = (f.status == record_pb2.FileAddResult.DESCRIPTOR.values_by_name['FA_SUCCESS'].number)
 
-            if not success:
-                logging.warning(f'{bcolors.FAIL}Upload of {atta.name} failed with status: {status}{bcolors.ENDC}')
-                continue
+        if not success:
+            logging.warning(f'{bcolors.FAIL}Upload of {atta.name} failed with status: {status}{bcolors.ENDC}')
+            continue
 
-            with atta.open() as src:
-                with EncryptionReader.get_buffered_reader(src, atta.key) as encrypted_src:
-                    form_files = {'file': (atta.name, encrypted_src, 'application/octet-stream')}
-                    form_params = json.loads(f.parameters)
-                    print(f'{atta.name} ... ', end='', flush=True)
-                    response = requests.post(f.url, data=form_params, files=form_files)
+        with atta.open() as src:
+            with EncryptionReader.get_buffered_reader(src, atta.key) as encrypted_src:
+                form_files = {'file': (atta.name, encrypted_src, 'application/octet-stream')}
+                form_params = json.loads(f.parameters)
+                print(f'{atta.name} ... ', end='', flush=True)
+                response = requests.post(f.url, data=form_params, files=form_files)
 
-            if str(response.status_code) == form_params.get('success_action_status'):
-                print('Done')
-                rl = {'record_uid': atta.record_uid, 'record_key': atta.encrypted_key}
-                record_links_add.append(rl)
-                new_attachment_uids.append(atta.record_uid)
+        if str(response.status_code) == form_params.get('success_action_status'):
+            print('Done')
+            new_attachments = new_attachments_by_parent_uid.get(atta.parent_uid)
+            if new_attachments:
+                new_attachments.append(atta)
             else:
-                print('Failed')
+                new_attachments_by_parent_uid[atta.parent_uid] = [atta]
+        else:
+            print('Failed')
 
-        if new_attachment_uids:
-            new_attachments = [loginv3.CommonHelperMethods.bytes_to_url_safe_str(a) for a in new_attachment_uids]
+    rec_list = []
+    record_links_add = {}
+    for parent_uid, attachments in new_attachments_by_parent_uid.items():
+        new_attachments_uids = [
+            loginv3.CommonHelperMethods.bytes_to_url_safe_str(a.record_uid) for a in attachments
+        ]
 
-            record_data = params.record_cache[parent_uid].get('data_unencrypted')
-            if record_data:
-                if isinstance(record_data, bytes):
-                    record_data = record_data.decode('utf-8')
-                data = json.loads(record_data.strip())
-            else:
-                data = {}
-            if 'fields' not in data:
-                data['fields'] = []
+        record_data = params.record_cache[parent_uid].get('data_unencrypted')
+        if record_data:
+            if isinstance(record_data, bytes):
+                record_data = record_data.decode('utf-8')
+            data = json.loads(record_data.strip())
+        else:
+            data = {}
+        if 'fields' not in data:
+            data['fields'] = []
 
-            # find first fileRef or create new fileRef if missing
-            file_ref = next((ft for ft in data['fields'] if ft['type'] == 'fileRef'), None)
-            if file_ref:
-                file_ref['value'] = file_ref.get('value', []) + new_attachments
-            else:
-                data['fields'].append({'type': 'fileRef', 'value': new_attachments})
+        # find first fileRef or create new fileRef if missing
+        file_ref = next((ft for ft in data['fields'] if ft['type'] == 'fileRef'), None)
+        if file_ref:
+            file_ref['value'] = file_ref.get('value', []) + new_attachments_uids
+        else:
+            data['fields'].append({'type': 'fileRef', 'value': new_attachments_uids})
 
-            new_data = json.dumps(data)
-            params.record_cache[parent_uid]['data_unencrypted'] = new_data
-            params.sync_data = True
-            rec = api.get_record(params, parent_uid)
-            api.update_record_v3(params, rec, record_links={'record_links_add': record_links_add}, silent=True)
+        new_data = json.dumps(data)
+        params.record_cache[parent_uid]['data_unencrypted'] = new_data
+        params.sync_data = True
+        rec = api.get_record(params, parent_uid)
+        rec_list.append(rec)
+        record_links_add[parent_uid] = [
+            {'record_uid': a.record_uid, 'record_key': a.encrypted_key} for a in attachments
+        ]
+
+    api.update_records_v3(params, rec_list, record_links_by_uid={'record_links_add': record_links_add}, silent=True)
 
 
 def upload_attachment(params, attachments):

--- a/keepercommander/importer/lastpass/attachment.py
+++ b/keepercommander/importer/lastpass/attachment.py
@@ -1,25 +1,26 @@
 from contextlib import contextmanager
 
-from .decryption_reader import DecryptionReader
+from .attachment_reader import LastpassAttachmentReader
 
 
 class LastpassAttachment:
-    def __init__(self, id, parent, mimetype, storagekey, size, filename):
+    def __init__(self, id, parent, mimetype, storagekey, lastpass_size, filename):
         self.file_id = id
         self.parent = parent
         self.mime = mimetype
         self.storagekey = storagekey
-        self.size = size
+        self.lastpass_size = lastpass_size
         self.name = filename
         self.tmpfile = None
+        self.size = None  # Decrypted size to pass to importer
         self.key = None  # This lets the importer know to re-encrypt with a new Keeper key
 
     @contextmanager
     def open(self):
-        with DecryptionReader.get_buffered_reader(self.tmpfile, self.parent.attach_key) as reader:
+        with LastpassAttachmentReader.get_buffered_reader(self) as reader:
             yield reader
 
     @contextmanager
     def open_text(self):
-        with DecryptionReader.get_text_reader(self.tmpfile, self.parent.attach_key, encoding='utf-8-sig') as reader:
+        with LastpassAttachmentReader.get_text_reader(self, encoding='utf-8-sig') as reader:
             yield reader

--- a/keepercommander/importer/lastpass/lastpass.py
+++ b/keepercommander/importer/lastpass/lastpass.py
@@ -176,6 +176,14 @@ class LastPassImporter(BaseImporter):
         for account in vault.accounts:  # type: Account
             record = Record()
             is_secure_note = False
+            if account.url:
+                record.login_url = account.url.decode('utf-8')
+                if record.login_url == 'http://sn':
+                    is_secure_note = True
+                    record.login_url = None
+                elif record.login_url == 'http://group':
+                    continue
+
             if account.id:
                 record.uid = account.id
             if account.name:
@@ -192,13 +200,6 @@ class LastPassImporter(BaseImporter):
                 record.login = account.username.decode('utf-8')
             if account.password:
                 record.password = account.password.decode('utf-8')
-            if account.url:
-                record.login_url = account.url.decode('utf-8')
-                if record.login_url == 'http://sn':
-                    is_secure_note = True
-                    record.login_url = None
-                elif record.login_url == 'http://group':
-                    continue
             if len(account.attachments) > 0:
                 if record.attachments is None:
                     record.attachments = []

--- a/keepercommander/importer/lastpass/parser.py
+++ b/keepercommander/importer/lastpass/parser.py
@@ -127,7 +127,7 @@ def parse_ATTA(chunk, accounts):
     parent_id = read_item(io).decode('utf-8')
     mimetype = read_item(io).decode('utf-8')
     storagekey = read_item(io).decode('utf-8')
-    size = int(read_item(io))
+    lastpass_size = int(read_item(io))
     filename_encrypted = read_item(io)
 
     parents = [a for a in accounts if a.id == parent_id]
@@ -135,7 +135,7 @@ def parse_ATTA(chunk, accounts):
         parent = parents[0]
         if parent.attach_key:
             filename = decode_aes256_base64_auto(filename_encrypted, parent.attach_key).decode('utf-8')
-            attachment = LastpassAttachment(id, parent, mimetype, storagekey, size, filename)
+            attachment = LastpassAttachment(id, parent, mimetype, storagekey, lastpass_size, filename)
             parent.attachments.append(attachment)
 
     return attachment

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import json
 import os
 import shutil
 from tempfile import mkdtemp
@@ -10,6 +11,7 @@ from .shared_folder import LastpassSharedFolder
 
 
 TMPDIR_PREFIX = 'keepercommander_lastpass_import_'
+DECRYPTED_SIZE_FILENAME = 'decrypted_file_sizes.json'
 
 
 class Vault(object):
@@ -101,7 +103,6 @@ class Vault(object):
     def process_attachments(self, session, tmpdir=None):
         attach_cnt = len(self.attachments)
         if attach_cnt > 0:
-            attach_cnt_digits = len(str(attach_cnt))
             if tmpdir is None:
                 self.tmpdir = mkdtemp(prefix=TMPDIR_PREFIX)
             else:
@@ -110,10 +111,19 @@ class Vault(object):
                 self.tmpdir = os.path.abspath(tmpdir)
 
         print(f'Processing {attach_cnt} LastPass attachments:')
+
+        decrypted_size_file = os.path.join(self.tmpdir, DECRYPTED_SIZE_FILENAME)
+        if os.path.exists(decrypted_size_file):
+            with open(decrypted_size_file) as f:
+                decrypted_file_sizes = json.loads(f.read())
+        else:
+            decrypted_file_sizes = {}
+        update_decrypted_file_sizes = False
+
         for i, attachment in enumerate(self.attachments):
             tmp_filename = attachment.file_id
             attachment.tmpfile = os.path.join(self.tmpdir, tmp_filename)
-            if os.path.isfile(attachment.tmpfile) and os.path.getsize(attachment.tmpfile) == attachment.size:
+            if os.path.isfile(attachment.tmpfile) and os.path.getsize(attachment.tmpfile) == attachment.lastpass_size:
                 print(f'{i + 1}. Found {attachment.name}')
             else:
                 attachment_stream = fetcher.stream_attachment(session, attachment)
@@ -123,3 +133,16 @@ class Vault(object):
                             print(f'{i + 1}. Downloading {attachment.name} ... ', end='', flush=True)
                             shutil.copyfileobj(r.raw, f)
                             print('Done')
+
+            if attachment.file_id in decrypted_file_sizes:
+                attachment.size = decrypted_file_sizes[attachment.file_id]
+            else:
+                with attachment.open() as atta:
+                    with open(os.devnull, 'wb') as devnull:
+                        shutil.copyfileobj(atta.raw, devnull)
+                update_decrypted_file_sizes = True
+                decrypted_file_sizes[attachment.file_id] = attachment.size
+
+        if update_decrypted_file_sizes:
+            with open(decrypted_size_file, 'w') as f:
+                f.write(json.dumps(decrypted_file_sizes))

--- a/keepercommander/importer/lastpass/vault.py
+++ b/keepercommander/importer/lastpass/vault.py
@@ -111,7 +111,7 @@ class Vault(object):
 
         print(f'Processing {attach_cnt} LastPass attachments:')
         for i, attachment in enumerate(self.attachments):
-            tmp_filename = f'{str(i + 1).zfill(attach_cnt_digits)}of{attach_cnt}_{attachment.file_id}'
+            tmp_filename = attachment.file_id
             attachment.tmpfile = os.path.join(self.tmpdir, tmp_filename)
             if os.path.isfile(attachment.tmpfile) and os.path.getsize(attachment.tmpfile) == attachment.size:
                 print(f'{i + 1}. Found {attachment.name}')


### PR DESCRIPTION
This PR makes the following updates for imports:
- Create a new `api.update_records_v3` that updates multiple records in one API call and shares functionality with `api.update_record_v3`
- Update the `upload_v3_attachments` to use one `vault/files_add` API request for every chunk of file attachments to be uploaded with a default chunk size of 100.
- Update the `upload_v3_attachments` to use one `api.update_records_v3` call for attaching the files to records corresponding with the uploaded file attachments.
- Update the LastPass import to skip `http://group` records before checking for a missing title
- Updates the name of the temporary attachment file in the file-cache directory to be just the attachment file id which should eliminate re-downloading if there a different number or ordering of attachments.
- Fixes a bug in the encryption of the attachment key in parent record link
- Adds ability to force permission for "manage users" or "manage records" with `--permissions` set to "u" or "r"
- Adds ability to force restriction for "manage users" or "manage records" with `--restrictions` set to "u" or "r"
- Use decrypted file size for size of file attachments imported from Lastpass