### PR TITLE
Convert v2 record to v3 record (KC-308)

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -1750,64 +1750,9 @@ def get_pb2_record_update(params, rec, **kwargs):
     return record_rq
 
 
-def update_record_v3(params, rec, **kwargs):   # type: (KeeperParams, Record, ...) -> Optional[bool]
-    """ Push a record update to the cloud.
-        Takes a Record() object, converts to record JSON
-        and pushes to the Keeper cloud API
-    """
-    record_rq = get_pb2_record_update(params, rec, **kwargs)
-    ru = record_rq['pb2_record_update']
-    rq = records.RecordsUpdateRequest()
-    rq.records.append(ru)
-    #NB! 'error code (Invalid data) has occurred.' won't return proper status - throws CommunicationError
-    rs = communicate_rest(params, rq, 'vault/records_update')
-    records_modify_rs = records.RecordsModifyResponse()
-    records_modify_rs.ParseFromString(rs)
-
-    for r in records_modify_rs.records:
-        ruid = loginv3.CommonHelperMethods.bytes_to_url_safe_str(r.record_uid)
-        success = (r.status == records.RecordModifyResult.DESCRIPTOR.values_by_name['RS_SUCCESS'].number)
-        status = records.RecordModifyResult.DESCRIPTOR.values_by_number[r.status].name
-
-        if not success:
-            logging.error(bcolors.FAIL + 'Error: Record update failed with status - %s' + bcolors.ENDC, status)
-            return False
-
-        new_revision = 0
-        if success and ruid == rec.record_uid:
-            new_revision = records_modify_rs.revision
-
-        if new_revision == 0:
-            logging.error('Error: Revision not updated')
-            return False
-
-        if new_revision == record_rq['revision']:
-            logging.error('Error: Revision did not change')
-            return False
-
-        if not kwargs.get('silent'):
-            logging.info('Update record successful for record_uid=%s, revision=%d, new_revision=%s',
-                         record_rq['record_uid'], record_rq['revision'], new_revision)
-
-        record_rq['revision'] = new_revision
-
-    sync_down(params)
-    return True
-
-
-def update_records_v3(params, rec_list, **kwargs):   # type: (KeeperParams, List[Record], ...) -> Optional[bool]
-    """ Push a record update to the cloud.
-        Takes a Record() object, converts to record JSON
-        and pushes to the Keeper cloud API
-    """
-    rq = records.RecordsUpdateRequest()
-    record_rq_by_uid = {}
-    for rec in rec_list:
-        record_rq = get_pb2_record_update(params, rec, **kwargs)
-        record_rq_by_uid[rec.record_uid] = record_rq
-        rq.records.append(record_rq['pb2_record_update'])
-    #NB! 'error code (Invalid data) has occurred.' won't return proper status - throws CommunicationError
-    rs = communicate_rest(params, rq, 'vault/records_update')
+def get_record_v3_response(params, rq, endpoint, record_rq_by_uid, silent):
+    # type: (KeeperParams, records._message.Message, str, dict[dict]) -> Optional[bool]
+    rs = communicate_rest(params, rq, endpoint)
     records_modify_rs = records.RecordsModifyResponse()
     records_modify_rs.ParseFromString(rs)
 
@@ -1833,14 +1778,44 @@ def update_records_v3(params, rec_list, **kwargs):   # type: (KeeperParams, List
             logging.error('Error: Revision did not change')
             return False
 
-        if not kwargs.get('silent'):
-            logging.info('Update record successful for record_uid=%s, revision=%d, new_revision=%s',
-                        record_rq['record_uid'], record_rq['revision'], new_revision)
+        if not silent:
+            logging.info(
+                'Update record successful for record_uid=%s, revision=%d, new_revision=%s',
+                ruid, record_rq['revision'], new_revision
+            )
 
         record_rq['revision'] = new_revision
 
     sync_down(params)
     return True
+
+
+def update_record_v3(params, rec, **kwargs):   # type: (KeeperParams, Record, ...) -> Optional[bool]
+    """ Push a record update to the cloud.
+        Takes a Record() object, converts to record JSON
+        and pushes to the Keeper cloud API
+    """
+    record_rq = get_pb2_record_update(params, rec, **kwargs)
+    ru = record_rq['pb2_record_update']
+    rq = records.RecordsUpdateRequest()
+    rq.records.append(ru)
+    record_rq_by_uid = {rec.record_uid: record_rq}
+    return get_record_v3_response(params, rq, 'vault/records_update', record_rq_by_uid, silent=kwargs.get('silent'))
+
+
+def update_records_v3(params, rec_list, **kwargs):   # type: (KeeperParams, List[Record], ...) -> Optional[bool]
+    """ Push a record update to the cloud.
+        Takes a Record() object, converts to record JSON
+        and pushes to the Keeper cloud API
+    """
+    rq = records.RecordsUpdateRequest()
+    record_rq_by_uid = {}
+    for rec in rec_list:
+        record_rq = get_pb2_record_update(params, rec, **kwargs)
+        record_rq_by_uid[rec.record_uid] = record_rq
+        rq.records.append(record_rq['pb2_record_update'])
+
+    return get_record_v3_response(params, rq, 'vault/records_update', record_rq_by_uid)
 
 
 def add_record(params, record,  **kwargs):   # type: (KeeperParams, Record) -> bool

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -1525,7 +1525,8 @@ def prepare_record_v3(params, record):   # type: (KeeperParams, Record) -> Optio
                     'title': d.get('title', ''),
                     'record_type': rt_name,
                 }
-                if url: adata['url'] = url  # url will only be supplied if there is one on the record
+                if url:
+                    adata['url'] = url  # url will only be supplied if there is one on the record
                 audit_data = crypto.encrypt_ec(json.dumps(adata).encode('utf-8'), params.enterprise_ec_key)
 
         except Exception as e:

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -57,6 +57,10 @@ def register_commands(commands, aliases, command_info):
     breachwatch.register_commands(commands)
     breachwatch.register_command_info(aliases, command_info)
 
+    from . import convert
+    convert.register_commands(commands)
+    convert.register_command_info(aliases, command_info)
+
     from .utils import register_commands as misc_commands, register_command_info as misc_command_info
     misc_commands(commands)
     misc_command_info(aliases, command_info)

--- a/keepercommander/commands/convert.py
+++ b/keepercommander/commands/convert.py
@@ -34,16 +34,16 @@ def register_command_info(aliases, command_info):
 convert_parser = argparse.ArgumentParser(prog='convert', description='Convert record(s) to use record types')
 convert_parser.add_argument('-t', '--type', dest='type', action='store', help='Convert to record type')
 convert_parser.add_argument(
-    '-u', '--url', dest='url', action='store', help='Convert records with URL pattern (* for any with URL)'
+    '-u', '--url', dest='url', action='store', help='Convert records with URL pattern (* for record with any URL)'
 )
 convert_parser.add_argument(
-    '-n', '--dry-run', dest='dry_run', action='store_true', help='Display the record conversions without updating'
+    '-n', '--dry-run', dest='dry_run', action='store_true', help='Preview the record conversions without updating'
 )
 convert_parser.add_argument(
     '-r', '--recursive', dest='recursive', action='store_true', help='Convert recursively through subfolders'
 )
 convert_parser.add_argument(
-    'pattern', nargs='*', type=str, action='store', help='One or more record title/ID search patterns'
+    'record-uid-name-patterns', nargs='*', type=str, action='store', help='One or more record title/UID search patterns'
 )
 convert_parser.error = raise_parse_exception
 convert_parser.exit = suppress_exit
@@ -108,7 +108,7 @@ class ConvertCommand(Command):
             )
             return
 
-        pattern_list = kwargs.get('pattern', [])
+        pattern_list = kwargs.get('record-uid-name-patterns', [])
         if len(pattern_list) == 0:
             logging.warning(f'Please specify a record to convert')
             return

--- a/keepercommander/commands/convert.py
+++ b/keepercommander/commands/convert.py
@@ -1,0 +1,104 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2021 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+import argparse
+import fnmatch
+import logging
+import re
+
+from keepercommander import api, loginv3, record_pb2, recordv3
+from keepercommander.subfolder import try_resolve_path
+from .base import raise_parse_exception, suppress_exit, Command
+
+
+def register_commands(commands):
+    commands['convert'] = ConvertCommand()
+
+
+def register_command_info(aliases, command_info):
+    command_info[convert_parser.prog] = convert_parser.description
+
+
+convert_parser = argparse.ArgumentParser(prog='convert', description='Convert record(s) to use record types')
+convert_parser.add_argument('pattern', nargs='?', type=str, action='store', help='search pattern')
+convert_parser.error = raise_parse_exception
+convert_parser.exit = suppress_exit
+
+
+class ConvertCommand(Command):
+    def get_parser(self):
+        return convert_parser
+
+    def execute(self, params, **kwargs):
+        if params.settings and isinstance(params.settings.get('record_types_enabled'), bool):
+            v3_enabled = params.settings.get('record_types_enabled')
+        else:
+            v3_enabled = False
+        if not v3_enabled:
+            logging.warning(f'Cannot convert record(s) if record types is not enabled')
+            return
+
+        folder = params.folder_cache.get(params.current_folder, params.root_folder)
+        pattern = kwargs.get('pattern')
+        if not pattern:
+            logging.warning(f'Please specify a record to convert')
+            return
+
+        rs = try_resolve_path(params, kwargs['pattern'])
+        if rs is not None:
+            folder, pattern = rs
+
+        regex = None
+        if pattern:
+            regex = re.compile(fnmatch.translate(pattern)).match
+
+        records = []
+        folder_uid = folder.uid or ''
+        if folder_uid in params.subfolder_record_cache:
+            for uid in params.subfolder_record_cache[folder_uid]:
+                rv = params.record_cache[uid].get('version') if uid in params.record_cache else None
+                if rv > 2:
+                    continue
+                r = api.get_record(params, uid)
+                r_attrs = (r.title, r.record_uid)
+                if any(attr for attr in r_attrs if isinstance(attr, str) and len(attr) > 0 and regex(attr) is not None):
+                    records.append(r)
+
+        if len(records) == 0:
+            logging.warning(
+                f'No records that can be converted to record types can be found found for pattern "{kwargs["pattern"]}"'
+            )
+            return
+
+        rq = record_pb2.RecordsConvertToV3Request()
+        record_rq_by_uid = {}
+        for record in records:
+            if recordv3.RecordV3.convert_to_record_type(record.record_uid, params):
+                v3_record = api.get_record(params, record.record_uid)
+            else:
+                logging.warning(f'Conversion failed for {record.title} ({record.record_uid})')
+                continue
+
+            record_rq, audit_data = api.prepare_record_v3(params, v3_record)
+            record_rq_by_uid[record.record_uid] = record_rq
+
+            rc = record_pb2.RecordConvertToV3()
+            rc.record_uid = loginv3.CommonHelperMethods.url_safe_str_to_bytes(record_rq['record_uid'])
+            rc.client_modified_time = record_rq['client_modified_time']
+            rc.revision = record_rq['revision']
+            rc.data = loginv3.CommonHelperMethods.url_safe_str_to_bytes(record_rq['data'])
+            rc.audit.data = audit_data
+            rq.records.append(rc)
+
+        if len(record_rq_by_uid) > 0:
+            rq.client_time = api.current_milli_time()
+            result = api.get_record_v3_response(
+                params, rq, 'vault/records_convert3', record_rq_by_uid, silent=kwargs.get('silent')
+            )

--- a/keepercommander/commands/convert.py
+++ b/keepercommander/commands/convert.py
@@ -20,6 +20,9 @@ from .folder import get_folder_path
 from .base import raise_parse_exception, suppress_exit, Command
 
 
+DEFAULT_CONVERT_TO_V3_RECORD_TYPE = 'login'
+
+
 def register_commands(commands):
     commands['convert'] = ConvertCommand()
 
@@ -96,7 +99,7 @@ class ConvertCommand(Command):
         url_pattern = kwargs.get('url')
         url_regex = re.compile(fnmatch.translate(url_pattern)).match if url_pattern else None
 
-        record_type = kwargs.get('type') or 'general'
+        record_type = kwargs.get('type') or DEFAULT_CONVERT_TO_V3_RECORD_TYPE
         available_types = [json.loads(params.record_type_cache.get(rti)).get('$id') for rti in params.record_type_cache]
         if record_type not in available_types:
             logging.warning(

--- a/keepercommander/record_pb2.py
+++ b/keepercommander/record_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=b'\n\030com.keepersecurity.protoB\007Records',
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0crecord.proto\x12\x07Records\"\\\n\nRecordType\x12\x14\n\x0crecordTypeId\x18\x01 \x01(\x05\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\t\x12\'\n\x05scope\x18\x03 \x01(\x0e\x32\x18.Records.RecordTypeScope\"H\n\x12RecordTypesRequest\x12\x10\n\x08standard\x18\x01 \x01(\x08\x12\x0c\n\x04user\x18\x02 \x01(\x08\x12\x12\n\nenterprise\x18\x03 \x01(\x08\"\x88\x01\n\x13RecordTypesResponse\x12(\n\x0brecordTypes\x18\x01 \x03(\x0b\x32\x13.Records.RecordType\x12\x17\n\x0fstandardCounter\x18\x02 \x01(\x05\x12\x13\n\x0buserCounter\x18\x03 \x01(\x05\x12\x19\n\x11\x65nterpriseCounter\x18\x04 \x01(\x05\"A\n\x18RecordTypeModifyResponse\x12\x14\n\x0crecordTypeId\x18\x01 \x01(\x05\x12\x0f\n\x07\x63ounter\x18\x02 \x01(\x05\"=\n\x11RecordsGetRequest\x12\x13\n\x0brecord_uids\x18\x01 \x03(\x0c\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xd1\x01\n\x06Record\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12/\n\x0frecord_key_type\x18\x03 \x01(\x0e\x32\x16.Records.RecordKeyType\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\r\n\x05\x65xtra\x18\x05 \x01(\x0c\x12\x0f\n\x07version\x18\x06 \x01(\x05\x12\x1c\n\x14\x63lient_modified_time\x18\x07 \x01(\x03\x12\x10\n\x08revision\x18\x08 \x01(\x03\x12\x10\n\x08\x66ile_ids\x18\t \x03(\x0c\"M\n\x0f\x46olderRecordKey\x12\x12\n\nfolder_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_uid\x18\x02 \x01(\x0c\x12\x12\n\nrecord_key\x18\x03 \x01(\x0c\"a\n\x06\x46older\x12\x12\n\nfolder_uid\x18\x01 \x01(\x0c\x12\x12\n\nfolder_key\x18\x02 \x01(\x0c\x12/\n\x0f\x66older_key_type\x18\x03 \x01(\x0e\x32\x16.Records.RecordKeyType\"\x95\x01\n\x04Team\x12\x10\n\x08team_uid\x18\x01 \x01(\x0c\x12\x10\n\x08team_key\x18\x02 \x01(\x0c\x12\x18\n\x10team_private_key\x18\x03 \x01(\x0c\x12-\n\rteam_key_type\x18\x04 \x01(\x0e\x32\x16.Records.RecordKeyType\x12 \n\x07\x66olders\x18\x05 \x03(\x0b\x32\x0f.Records.Folder\"\xac\x01\n\x12RecordsGetResponse\x12 \n\x07records\x18\x01 \x03(\x0b\x32\x0f.Records.Record\x12\x34\n\x12\x66older_record_keys\x18\x02 \x03(\x0b\x32\x18.Records.FolderRecordKey\x12 \n\x07\x66olders\x18\x03 \x03(\x0b\x32\x0f.Records.Folder\x12\x1c\n\x05teams\x18\x04 \x03(\x0b\x32\r.Records.Team\"4\n\nRecordLink\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\",\n\x0bRecordAudit\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\"\xa0\x02\n\tRecordAdd\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x17\n\x0fnon_shared_data\x18\x05 \x01(\x0c\x12.\n\x0b\x66older_type\x18\x06 \x01(\x0e\x32\x19.Records.RecordFolderType\x12\x12\n\nfolder_uid\x18\x07 \x01(\x0c\x12\x12\n\nfolder_key\x18\x08 \x01(\x0c\x12)\n\x0crecord_links\x18\t \x03(\x0b\x32\x13.Records.RecordLink\x12#\n\x05\x61udit\x18\n \x01(\x0b\x32\x14.Records.RecordAudit\"M\n\x11RecordsAddRequest\x12#\n\x07records\x18\x01 \x03(\x0b\x32\x12.Records.RecordAdd\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xea\x01\n\x0cRecordUpdate\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x02 \x01(\x03\x12\x10\n\x08revision\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x17\n\x0fnon_shared_data\x18\x05 \x01(\x0c\x12-\n\x10record_links_add\x18\x06 \x03(\x0b\x32\x13.Records.RecordLink\x12\x1b\n\x13record_links_remove\x18\x07 \x03(\x0c\x12#\n\x05\x61udit\x18\x08 \x01(\x0b\x32\x14.Records.RecordAudit\"S\n\x14RecordsUpdateRequest\x12&\n\x07records\x18\x01 \x03(\x0b\x32\x15.Records.RecordUpdate\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\'\n\x14RecordsRemoveRequest\x12\x0f\n\x07records\x18\x01 \x03(\x0c\"f\n\x12RecordModifyStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12+\n\x06status\x18\x02 \x01(\x0e\x32\x1b.Records.RecordModifyResult\x12\x0f\n\x07message\x18\x03 \x01(\t\"W\n\x15RecordsModifyResponse\x12,\n\x07records\x18\x01 \x03(\x0b\x32\x1b.Records.RecordModifyStatus\x12\x10\n\x08revision\x18\x02 \x01(\x03\"H\n\x12RecordAddAuditData\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x10\n\x08revision\x18\x02 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\"C\n\x13\x41\x64\x64\x41uditDataRequest\x12,\n\x07records\x18\x01 \x03(\x0b\x32\x1b.Records.RecordAddAuditData\"a\n\x04\x46ile\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\x12\x10\n\x08\x66ileSize\x18\x04 \x01(\x03\x12\x11\n\tthumbSize\x18\x05 \x01(\x05\"D\n\x0f\x46ilesAddRequest\x12\x1c\n\x05\x66iles\x18\x01 \x03(\x0b\x32\r.Records.File\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xa7\x01\n\rFileAddStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12&\n\x06status\x18\x02 \x01(\x0e\x32\x16.Records.FileAddResult\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x12\n\nparameters\x18\x04 \x01(\t\x12\x1c\n\x14thumbnail_parameters\x18\x05 \x01(\t\x12\x1b\n\x13success_status_code\x18\x06 \x01(\x05\"9\n\x10\x46ilesAddResponse\x12%\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x16.Records.FileAddStatus\"f\n\x0f\x46ilesGetRequest\x12\x13\n\x0brecord_uids\x18\x01 \x03(\x0c\x12\x16\n\x0e\x66or_thumbnails\x18\x02 \x01(\x08\x12&\n\x1e\x65mergency_access_account_owner\x18\x03 \x01(\t\"u\n\rFileGetStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12&\n\x06status\x18\x02 \x01(\x0e\x32\x16.Records.FileGetResult\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x1b\n\x13success_status_code\x18\x04 \x01(\x05\"9\n\x10\x46ilesGetResponse\x12%\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x16.Records.FileGetStatus\"h\n\x15\x41pplicationAddRequest\x12\x0f\n\x07\x61pp_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c*B\n\x0fRecordTypeScope\x12\x0f\n\x0bRT_STANDARD\x10\x00\x12\x0b\n\x07RT_USER\x10\x01\x12\x11\n\rRT_ENTERPRISE\x10\x02*S\n\rRecordKeyType\x12\n\n\x06NO_KEY\x10\x00\x12\x19\n\x15\x45NCRYPTED_BY_DATA_KEY\x10\x01\x12\x1b\n\x17\x45NCRYPTED_BY_PUBLIC_KEY\x10\x02*P\n\x10RecordFolderType\x12\x0f\n\x0buser_folder\x10\x00\x12\x11\n\rshared_folder\x10\x01\x12\x18\n\x14shared_folder_folder\x10\x02*\x99\x01\n\x12RecordModifyResult\x12\x0e\n\nRS_SUCCESS\x10\x00\x12\x12\n\x0eRS_OUT_OF_SYNC\x10\x01\x12\x14\n\x10RS_ACCESS_DENIED\x10\x02\x12\x13\n\x0fRS_SHARE_DENIED\x10\x03\x12\x14\n\x10RS_RECORD_EXISTS\x10\x04\x12\x1e\n\x1aRS_OLD_RECORD_VERSION_TYPE\x10\x05*-\n\rFileAddResult\x12\x0e\n\nFA_SUCCESS\x10\x00\x12\x0c\n\x08\x46\x41_ERROR\x10\x01*C\n\rFileGetResult\x12\x0e\n\nFG_SUCCESS\x10\x00\x12\x0c\n\x08\x46G_ERROR\x10\x01\x12\x14\n\x10\x46G_ACCESS_DENIED\x10\x02\x42#\n\x18\x63om.keepersecurity.protoB\x07Recordsb\x06proto3'
+  serialized_pb=b'\n\x0crecord.proto\x12\x07Records\"\\\n\nRecordType\x12\x14\n\x0crecordTypeId\x18\x01 \x01(\x05\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\t\x12\'\n\x05scope\x18\x03 \x01(\x0e\x32\x18.Records.RecordTypeScope\"H\n\x12RecordTypesRequest\x12\x10\n\x08standard\x18\x01 \x01(\x08\x12\x0c\n\x04user\x18\x02 \x01(\x08\x12\x12\n\nenterprise\x18\x03 \x01(\x08\"\x88\x01\n\x13RecordTypesResponse\x12(\n\x0brecordTypes\x18\x01 \x03(\x0b\x32\x13.Records.RecordType\x12\x17\n\x0fstandardCounter\x18\x02 \x01(\x05\x12\x13\n\x0buserCounter\x18\x03 \x01(\x05\x12\x19\n\x11\x65nterpriseCounter\x18\x04 \x01(\x05\"A\n\x18RecordTypeModifyResponse\x12\x14\n\x0crecordTypeId\x18\x01 \x01(\x05\x12\x0f\n\x07\x63ounter\x18\x02 \x01(\x05\"=\n\x11RecordsGetRequest\x12\x13\n\x0brecord_uids\x18\x01 \x03(\x0c\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xd1\x01\n\x06Record\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12/\n\x0frecord_key_type\x18\x03 \x01(\x0e\x32\x16.Records.RecordKeyType\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\r\n\x05\x65xtra\x18\x05 \x01(\x0c\x12\x0f\n\x07version\x18\x06 \x01(\x05\x12\x1c\n\x14\x63lient_modified_time\x18\x07 \x01(\x03\x12\x10\n\x08revision\x18\x08 \x01(\x03\x12\x10\n\x08\x66ile_ids\x18\t \x03(\x0c\"M\n\x0f\x46olderRecordKey\x12\x12\n\nfolder_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_uid\x18\x02 \x01(\x0c\x12\x12\n\nrecord_key\x18\x03 \x01(\x0c\"a\n\x06\x46older\x12\x12\n\nfolder_uid\x18\x01 \x01(\x0c\x12\x12\n\nfolder_key\x18\x02 \x01(\x0c\x12/\n\x0f\x66older_key_type\x18\x03 \x01(\x0e\x32\x16.Records.RecordKeyType\"\x95\x01\n\x04Team\x12\x10\n\x08team_uid\x18\x01 \x01(\x0c\x12\x10\n\x08team_key\x18\x02 \x01(\x0c\x12\x18\n\x10team_private_key\x18\x03 \x01(\x0c\x12-\n\rteam_key_type\x18\x04 \x01(\x0e\x32\x16.Records.RecordKeyType\x12 \n\x07\x66olders\x18\x05 \x03(\x0b\x32\x0f.Records.Folder\"\xac\x01\n\x12RecordsGetResponse\x12 \n\x07records\x18\x01 \x03(\x0b\x32\x0f.Records.Record\x12\x34\n\x12\x66older_record_keys\x18\x02 \x03(\x0b\x32\x18.Records.FolderRecordKey\x12 \n\x07\x66olders\x18\x03 \x03(\x0b\x32\x0f.Records.Folder\x12\x1c\n\x05teams\x18\x04 \x03(\x0b\x32\r.Records.Team\"4\n\nRecordLink\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\",\n\x0bRecordAudit\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\"\xa0\x02\n\tRecordAdd\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x17\n\x0fnon_shared_data\x18\x05 \x01(\x0c\x12.\n\x0b\x66older_type\x18\x06 \x01(\x0e\x32\x19.Records.RecordFolderType\x12\x12\n\nfolder_uid\x18\x07 \x01(\x0c\x12\x12\n\nfolder_key\x18\x08 \x01(\x0c\x12)\n\x0crecord_links\x18\t \x03(\x0b\x32\x13.Records.RecordLink\x12#\n\x05\x61udit\x18\n \x01(\x0b\x32\x14.Records.RecordAudit\"M\n\x11RecordsAddRequest\x12#\n\x07records\x18\x01 \x03(\x0b\x32\x12.Records.RecordAdd\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xea\x01\n\x0cRecordUpdate\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x02 \x01(\x03\x12\x10\n\x08revision\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x17\n\x0fnon_shared_data\x18\x05 \x01(\x0c\x12-\n\x10record_links_add\x18\x06 \x03(\x0b\x32\x13.Records.RecordLink\x12\x1b\n\x13record_links_remove\x18\x07 \x03(\x0c\x12#\n\x05\x61udit\x18\x08 \x01(\x0b\x32\x14.Records.RecordAudit\"S\n\x14RecordsUpdateRequest\x12&\n\x07records\x18\x01 \x03(\x0b\x32\x15.Records.RecordUpdate\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\x8e\x01\n\x17RecordFileForConversion\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x14\n\x0c\x66ile_file_id\x18\x02 \x01(\x03\x12\x15\n\rthumb_file_id\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x12\n\nrecord_key\x18\x05 \x01(\x0c\x12\x10\n\x08link_key\x18\x06 \x01(\x0c\"\xda\x01\n\x11RecordConvertToV3\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x02 \x01(\x03\x12\x10\n\x08revision\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\x12\x17\n\x0fnon_shared_data\x18\x05 \x01(\x0c\x12#\n\x05\x61udit\x18\x06 \x01(\x0b\x32\x14.Records.RecordAudit\x12\x35\n\x0brecord_file\x18\x07 \x03(\x0b\x32 .Records.RecordFileForConversion\"]\n\x19RecordsConvertToV3Request\x12+\n\x07records\x18\x01 \x03(\x0b\x32\x1a.Records.RecordConvertToV3\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\'\n\x14RecordsRemoveRequest\x12\x0f\n\x07records\x18\x01 \x03(\x0c\"f\n\x12RecordModifyStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12+\n\x06status\x18\x02 \x01(\x0e\x32\x1b.Records.RecordModifyResult\x12\x0f\n\x07message\x18\x03 \x01(\t\"W\n\x15RecordsModifyResponse\x12,\n\x07records\x18\x01 \x03(\x0b\x32\x1b.Records.RecordModifyStatus\x12\x10\n\x08revision\x18\x02 \x01(\x03\"Y\n\x12RecordAddAuditData\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x10\n\x08revision\x18\x02 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\x12\x0f\n\x07version\x18\x04 \x01(\x05\"C\n\x13\x41\x64\x64\x41uditDataRequest\x12,\n\x07records\x18\x01 \x03(\x0b\x32\x1b.Records.RecordAddAuditData\"a\n\x04\x46ile\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x0c\n\x04\x64\x61ta\x18\x03 \x01(\x0c\x12\x10\n\x08\x66ileSize\x18\x04 \x01(\x03\x12\x11\n\tthumbSize\x18\x05 \x01(\x05\"D\n\x0f\x46ilesAddRequest\x12\x1c\n\x05\x66iles\x18\x01 \x03(\x0b\x32\r.Records.File\x12\x13\n\x0b\x63lient_time\x18\x02 \x01(\x03\"\xa7\x01\n\rFileAddStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12&\n\x06status\x18\x02 \x01(\x0e\x32\x16.Records.FileAddResult\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x12\n\nparameters\x18\x04 \x01(\t\x12\x1c\n\x14thumbnail_parameters\x18\x05 \x01(\t\x12\x1b\n\x13success_status_code\x18\x06 \x01(\x05\"9\n\x10\x46ilesAddResponse\x12%\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x16.Records.FileAddStatus\"f\n\x0f\x46ilesGetRequest\x12\x13\n\x0brecord_uids\x18\x01 \x03(\x0c\x12\x16\n\x0e\x66or_thumbnails\x18\x02 \x01(\x08\x12&\n\x1e\x65mergency_access_account_owner\x18\x03 \x01(\t\"u\n\rFileGetStatus\x12\x12\n\nrecord_uid\x18\x01 \x01(\x0c\x12&\n\x06status\x18\x02 \x01(\x0e\x32\x16.Records.FileGetResult\x12\x0b\n\x03url\x18\x03 \x01(\t\x12\x1b\n\x13success_status_code\x18\x04 \x01(\x05\"9\n\x10\x46ilesGetResponse\x12%\n\x05\x66iles\x18\x01 \x03(\x0b\x32\x16.Records.FileGetStatus\"h\n\x15\x41pplicationAddRequest\x12\x0f\n\x07\x61pp_uid\x18\x01 \x01(\x0c\x12\x12\n\nrecord_key\x18\x02 \x01(\x0c\x12\x1c\n\x14\x63lient_modified_time\x18\x03 \x01(\x03\x12\x0c\n\x04\x64\x61ta\x18\x04 \x01(\x0c\"\x88\x01\n\"GetRecordDataWithAccessInfoRequest\x12\x12\n\nclientTime\x18\x01 \x01(\x03\x12\x11\n\trecordUid\x18\x02 \x03(\x0c\x12;\n\x14recordDetailsInclude\x18\x03 \x01(\x0e\x32\x1d.Records.RecordDetailsInclude\"\xab\x01\n\x0eUserPermission\x12\x10\n\x08username\x18\x01 \x01(\t\x12\r\n\x05owner\x18\x02 \x01(\x08\x12\x12\n\nshareAdmin\x18\x03 \x01(\x08\x12\x10\n\x08sharable\x18\x04 \x01(\x08\x12\x10\n\x08\x65\x64itable\x18\x05 \x01(\x08\x12\x18\n\x10\x61waitingApproval\x18\x06 \x01(\x08\x12\x12\n\nexpiration\x18\x07 \x01(\x03\x12\x12\n\naccountUid\x18\x08 \x01(\x0c\"}\n\x16SharedFolderPermission\x12\x17\n\x0fsharedFolderUid\x18\x01 \x01(\x0c\x12\x12\n\nresharable\x18\x02 \x01(\x08\x12\x10\n\x08\x65\x64itable\x18\x03 \x01(\x08\x12\x10\n\x08revision\x18\x04 \x01(\x03\x12\x12\n\nexpiration\x18\x05 \x01(\x03\"\x87\x02\n\nRecordData\x12\x10\n\x08revision\x18\x01 \x01(\x03\x12\x0f\n\x07version\x18\x02 \x01(\x05\x12\x0e\n\x06shared\x18\x03 \x01(\x08\x12\x1b\n\x13\x65ncryptedRecordData\x18\x04 \x01(\t\x12\x1a\n\x12\x65ncryptedExtraData\x18\x05 \x01(\t\x12\x1a\n\x12\x63lientModifiedTime\x18\x06 \x01(\x03\x12\x16\n\x0eownerRecordUid\x18\x07 \x01(\x0c\x12 \n\x18\x65ncryptedLinkedRecordKey\x18\x08 \x01(\x0c\x12\x0e\n\x06\x66ileId\x18\t \x03(\x03\x12\x10\n\x08\x66ileSize\x18\n \x01(\x03\x12\x15\n\rthumbnailSize\x18\x0b \x01(\x03\"\xc8\x01\n\x18RecordDataWithAccessInfo\x12\x11\n\trecordUid\x18\x01 \x01(\x0c\x12\'\n\nrecordData\x18\x02 \x01(\x0b\x32\x13.Records.RecordData\x12/\n\x0euserPermission\x18\x03 \x03(\x0b\x32\x17.Records.UserPermission\x12?\n\x16sharedFolderPermission\x18\x04 \x03(\x0b\x32\x1f.Records.SharedFolderPermission\"\x89\x01\n#GetRecordDataWithAccessInfoResponse\x12\x43\n\x18recordDataWithAccessInfo\x18\x01 \x03(\x0b\x32!.Records.RecordDataWithAccessInfo\x12\x1d\n\x15noPermissionRecordUid\x18\x02 \x03(\x0c\"\xbc\x01\n\x18RecordShareUpdateRequest\x12.\n\x0f\x61\x64\x64SharedRecord\x18\x01 \x03(\x0b\x32\x15.Records.SharedRecord\x12\x31\n\x12updateSharedRecord\x18\x02 \x03(\x0b\x32\x15.Records.SharedRecord\x12\x31\n\x12removeSharedRecord\x18\x03 \x03(\x0b\x32\x15.Records.SharedRecord\x12\n\n\x02pt\x18\x04 \x01(\t\"\xd5\x01\n\x0cSharedRecord\x12\x12\n\ntoUsername\x18\x01 \x01(\t\x12\x11\n\trecordUid\x18\x02 \x01(\x0c\x12\x11\n\trecordKey\x18\x03 \x01(\x0c\x12\x17\n\x0fsharedFolderUid\x18\x04 \x01(\x0c\x12\x0f\n\x07teamUid\x18\x05 \x01(\x0c\x12\x10\n\x08\x65\x64itable\x18\x06 \x01(\x08\x12\x11\n\tshareable\x18\x07 \x01(\x08\x12\x10\n\x08transfer\x18\x08 \x01(\x08\x12\x11\n\tuseEccKey\x18\t \x01(\x08\x12\x17\n\x0fremoveVaultData\x18\n \x01(\x08\"\xd5\x01\n\x19RecordShareUpdateResponse\x12:\n\x15\x61\x64\x64SharedRecordStatus\x18\x01 \x03(\x0b\x32\x1b.Records.SharedRecordStatus\x12=\n\x18updateSharedRecordStatus\x18\x02 \x03(\x0b\x32\x1b.Records.SharedRecordStatus\x12=\n\x18removeSharedRecordStatus\x18\x03 \x03(\x0b\x32\x1b.Records.SharedRecordStatus\"Z\n\x12SharedRecordStatus\x12\x11\n\trecordUid\x18\x01 \x01(\x0c\x12\x0e\n\x06status\x18\x02 \x01(\t\x12\x0f\n\x07message\x18\x03 \x01(\t\x12\x10\n\x08username\x18\x04 \x01(\t\"G\n\x1bGetRecordPermissionsRequest\x12\x12\n\nrecordUids\x18\x01 \x03(\x0c\x12\x14\n\x0cisShareAdmin\x18\x02 \x01(\x08\"T\n\x1cGetRecordPermissionsResponse\x12\x34\n\x11recordPermissions\x18\x01 \x03(\x0b\x32\x19.Records.RecordPermission\"l\n\x10RecordPermission\x12\x11\n\trecordUid\x18\x01 \x01(\x0c\x12\r\n\x05owner\x18\x02 \x01(\x08\x12\x0f\n\x07\x63\x61nEdit\x18\x03 \x01(\x08\x12\x10\n\x08\x63\x61nShare\x18\x04 \x01(\x08\x12\x13\n\x0b\x63\x61nTransfer\x18\x05 \x01(\x08\"=\n\x16GetShareObjectsRequest\x12\x11\n\tstartWith\x18\x01 \x01(\t\x12\x10\n\x08\x63ontains\x18\x02 \x01(\t\"\x8e\x02\n\x17GetShareObjectsResponse\x12\x30\n\x12shareRelationships\x18\x01 \x03(\x0b\x32\x14.Records.ShareObject\x12.\n\x10shareFamilyUsers\x18\x02 \x03(\x0b\x32\x14.Records.ShareObject\x12\x32\n\x14shareEnterpriseUsers\x18\x03 \x03(\x0b\x32\x14.Records.ShareObject\x12(\n\nshareTeams\x18\x04 \x03(\x0b\x32\x14.Records.ShareObject\x12\x33\n\x15shareManagedCompanies\x18\x05 \x03(\x0b\x32\x14.Records.ShareObject\"\x8e\x01\n\x0bShareObject\x12\x0c\n\x04name\x18\x01 \x01(\t\x12 \n\x04type\x18\x02 \x01(\x0e\x32\x12.Records.ShareType\x12\x14\n\x0cisShareAdmin\x18\x03 \x01(\x08\x12\x13\n\x0b\x64isplayName\x18\x04 \x01(\t\x12$\n\x06status\x18\x05 \x01(\x0e\x32\x14.Records.ShareStatus*B\n\x0fRecordTypeScope\x12\x0f\n\x0bRT_STANDARD\x10\x00\x12\x0b\n\x07RT_USER\x10\x01\x12\x11\n\rRT_ENTERPRISE\x10\x02*\x93\x01\n\rRecordKeyType\x12\n\n\x06NO_KEY\x10\x00\x12\x19\n\x15\x45NCRYPTED_BY_DATA_KEY\x10\x01\x12\x1b\n\x17\x45NCRYPTED_BY_PUBLIC_KEY\x10\x02\x12\x1d\n\x19\x45NCRYPTED_BY_DATA_KEY_GCM\x10\x03\x12\x1f\n\x1b\x45NCRYPTED_BY_PUBLIC_KEY_ECC\x10\x04*P\n\x10RecordFolderType\x12\x0f\n\x0buser_folder\x10\x00\x12\x11\n\rshared_folder\x10\x01\x12\x18\n\x14shared_folder_folder\x10\x02*\xd1\x01\n\x12RecordModifyResult\x12\x0e\n\nRS_SUCCESS\x10\x00\x12\x12\n\x0eRS_OUT_OF_SYNC\x10\x01\x12\x14\n\x10RS_ACCESS_DENIED\x10\x02\x12\x13\n\x0fRS_SHARE_DENIED\x10\x03\x12\x14\n\x10RS_RECORD_EXISTS\x10\x04\x12\x1e\n\x1aRS_OLD_RECORD_VERSION_TYPE\x10\x05\x12\x1e\n\x1aRS_NEW_RECORD_VERSION_TYPE\x10\x06\x12\x16\n\x12RS_FILES_NOT_MATCH\x10\x07*-\n\rFileAddResult\x12\x0e\n\nFA_SUCCESS\x10\x00\x12\x0c\n\x08\x46\x41_ERROR\x10\x01*C\n\rFileGetResult\x12\x0e\n\nFG_SUCCESS\x10\x00\x12\x0c\n\x08\x46G_ERROR\x10\x01\x12\x14\n\x10\x46G_ACCESS_DENIED\x10\x02*J\n\x14RecordDetailsInclude\x12\x13\n\x0f\x44\x41TA_PLUS_SHARE\x10\x00\x12\r\n\tDATA_ONLY\x10\x01\x12\x0e\n\nSHARE_ONLY\x10\x02*k\n\tShareType\x12\x18\n\x14SHARING_RELATIONSHIP\x10\x00\x12\x13\n\x0f\x45NTERPRISE_USER\x10\x01\x12\x11\n\rFAMILY_MEMBER\x10\x02\x12\x08\n\x04TEAM\x10\x03\x12\x12\n\x0eMANAGE_COMPANY\x10\x04*1\n\x0bShareStatus\x12\n\n\x06\x41\x43TIVE\x10\x00\x12\t\n\x05\x42LOCK\x10\x01\x12\x0b\n\x07INVITED\x10\x02\x42#\n\x18\x63om.keepersecurity.protoB\x07Recordsb\x06proto3'
 )
 
 _RECORDTYPESCOPE = _descriptor.EnumDescriptor(
@@ -48,8 +48,8 @@ _RECORDTYPESCOPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3134,
-  serialized_end=3200,
+  serialized_start=6126,
+  serialized_end=6192,
 )
 _sym_db.RegisterEnumDescriptor(_RECORDTYPESCOPE)
 
@@ -76,11 +76,21 @@ _RECORDKEYTYPE = _descriptor.EnumDescriptor(
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='ENCRYPTED_BY_DATA_KEY_GCM', index=3, number=3,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='ENCRYPTED_BY_PUBLIC_KEY_ECC', index=4, number=4,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3202,
-  serialized_end=3285,
+  serialized_start=6195,
+  serialized_end=6342,
 )
 _sym_db.RegisterEnumDescriptor(_RECORDKEYTYPE)
 
@@ -110,8 +120,8 @@ _RECORDFOLDERTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3287,
-  serialized_end=3367,
+  serialized_start=6344,
+  serialized_end=6424,
 )
 _sym_db.RegisterEnumDescriptor(_RECORDFOLDERTYPE)
 
@@ -153,11 +163,21 @@ _RECORDMODIFYRESULT = _descriptor.EnumDescriptor(
       serialized_options=None,
       type=None,
       create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='RS_NEW_RECORD_VERSION_TYPE', index=6, number=6,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='RS_FILES_NOT_MATCH', index=7, number=7,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3370,
-  serialized_end=3523,
+  serialized_start=6427,
+  serialized_end=6636,
 )
 _sym_db.RegisterEnumDescriptor(_RECORDMODIFYRESULT)
 
@@ -182,8 +202,8 @@ _FILEADDRESULT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3525,
-  serialized_end=3570,
+  serialized_start=6638,
+  serialized_end=6683,
 )
 _sym_db.RegisterEnumDescriptor(_FILEADDRESULT)
 
@@ -213,18 +233,123 @@ _FILEGETRESULT = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3572,
-  serialized_end=3639,
+  serialized_start=6685,
+  serialized_end=6752,
 )
 _sym_db.RegisterEnumDescriptor(_FILEGETRESULT)
 
 FileGetResult = enum_type_wrapper.EnumTypeWrapper(_FILEGETRESULT)
+_RECORDDETAILSINCLUDE = _descriptor.EnumDescriptor(
+  name='RecordDetailsInclude',
+  full_name='Records.RecordDetailsInclude',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='DATA_PLUS_SHARE', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='DATA_ONLY', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='SHARE_ONLY', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=6754,
+  serialized_end=6828,
+)
+_sym_db.RegisterEnumDescriptor(_RECORDDETAILSINCLUDE)
+
+RecordDetailsInclude = enum_type_wrapper.EnumTypeWrapper(_RECORDDETAILSINCLUDE)
+_SHARETYPE = _descriptor.EnumDescriptor(
+  name='ShareType',
+  full_name='Records.ShareType',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='SHARING_RELATIONSHIP', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='ENTERPRISE_USER', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='FAMILY_MEMBER', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='TEAM', index=3, number=3,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='MANAGE_COMPANY', index=4, number=4,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=6830,
+  serialized_end=6937,
+)
+_sym_db.RegisterEnumDescriptor(_SHARETYPE)
+
+ShareType = enum_type_wrapper.EnumTypeWrapper(_SHARETYPE)
+_SHARESTATUS = _descriptor.EnumDescriptor(
+  name='ShareStatus',
+  full_name='Records.ShareStatus',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='ACTIVE', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='BLOCK', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='INVITED', index=2, number=2,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=6939,
+  serialized_end=6988,
+)
+_sym_db.RegisterEnumDescriptor(_SHARESTATUS)
+
+ShareStatus = enum_type_wrapper.EnumTypeWrapper(_SHARESTATUS)
 RT_STANDARD = 0
 RT_USER = 1
 RT_ENTERPRISE = 2
 NO_KEY = 0
 ENCRYPTED_BY_DATA_KEY = 1
 ENCRYPTED_BY_PUBLIC_KEY = 2
+ENCRYPTED_BY_DATA_KEY_GCM = 3
+ENCRYPTED_BY_PUBLIC_KEY_ECC = 4
 user_folder = 0
 shared_folder = 1
 shared_folder_folder = 2
@@ -234,11 +359,24 @@ RS_ACCESS_DENIED = 2
 RS_SHARE_DENIED = 3
 RS_RECORD_EXISTS = 4
 RS_OLD_RECORD_VERSION_TYPE = 5
+RS_NEW_RECORD_VERSION_TYPE = 6
+RS_FILES_NOT_MATCH = 7
 FA_SUCCESS = 0
 FA_ERROR = 1
 FG_SUCCESS = 0
 FG_ERROR = 1
 FG_ACCESS_DENIED = 2
+DATA_PLUS_SHARE = 0
+DATA_ONLY = 1
+SHARE_ONLY = 2
+SHARING_RELATIONSHIP = 0
+ENTERPRISE_USER = 1
+FAMILY_MEMBER = 2
+TEAM = 3
+MANAGE_COMPANY = 4
+ACTIVE = 0
+BLOCK = 1
+INVITED = 2
 
 
 
@@ -1090,6 +1228,186 @@ _RECORDSUPDATEREQUEST = _descriptor.Descriptor(
 )
 
 
+_RECORDFILEFORCONVERSION = _descriptor.Descriptor(
+  name='RecordFileForConversion',
+  full_name='Records.RecordFileForConversion',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='record_uid', full_name='Records.RecordFileForConversion.record_uid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='file_file_id', full_name='Records.RecordFileForConversion.file_file_id', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='thumb_file_id', full_name='Records.RecordFileForConversion.thumb_file_id', index=2,
+      number=3, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='data', full_name='Records.RecordFileForConversion.data', index=3,
+      number=4, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='record_key', full_name='Records.RecordFileForConversion.record_key', index=4,
+      number=5, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='link_key', full_name='Records.RecordFileForConversion.link_key', index=5,
+      number=6, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1972,
+  serialized_end=2114,
+)
+
+
+_RECORDCONVERTTOV3 = _descriptor.Descriptor(
+  name='RecordConvertToV3',
+  full_name='Records.RecordConvertToV3',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='record_uid', full_name='Records.RecordConvertToV3.record_uid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='client_modified_time', full_name='Records.RecordConvertToV3.client_modified_time', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='revision', full_name='Records.RecordConvertToV3.revision', index=2,
+      number=3, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='data', full_name='Records.RecordConvertToV3.data', index=3,
+      number=4, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='non_shared_data', full_name='Records.RecordConvertToV3.non_shared_data', index=4,
+      number=5, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='audit', full_name='Records.RecordConvertToV3.audit', index=5,
+      number=6, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='record_file', full_name='Records.RecordConvertToV3.record_file', index=6,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2117,
+  serialized_end=2335,
+)
+
+
+_RECORDSCONVERTTOV3REQUEST = _descriptor.Descriptor(
+  name='RecordsConvertToV3Request',
+  full_name='Records.RecordsConvertToV3Request',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='records', full_name='Records.RecordsConvertToV3Request.records', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='client_time', full_name='Records.RecordsConvertToV3Request.client_time', index=1,
+      number=2, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2337,
+  serialized_end=2430,
+)
+
+
 _RECORDSREMOVEREQUEST = _descriptor.Descriptor(
   name='RecordsRemoveRequest',
   full_name='Records.RecordsRemoveRequest',
@@ -1117,8 +1435,8 @@ _RECORDSREMOVEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1971,
-  serialized_end=2010,
+  serialized_start=2432,
+  serialized_end=2471,
 )
 
 
@@ -1163,8 +1481,8 @@ _RECORDMODIFYSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2012,
-  serialized_end=2114,
+  serialized_start=2473,
+  serialized_end=2575,
 )
 
 
@@ -1202,8 +1520,8 @@ _RECORDSMODIFYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2116,
-  serialized_end=2203,
+  serialized_start=2577,
+  serialized_end=2664,
 )
 
 
@@ -1236,6 +1554,13 @@ _RECORDADDAUDITDATA = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='Records.RecordAddAuditData.version', index=3,
+      number=4, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -1248,8 +1573,8 @@ _RECORDADDAUDITDATA = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2205,
-  serialized_end=2277,
+  serialized_start=2666,
+  serialized_end=2755,
 )
 
 
@@ -1280,8 +1605,8 @@ _ADDAUDITDATAREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2279,
-  serialized_end=2346,
+  serialized_start=2757,
+  serialized_end=2824,
 )
 
 
@@ -1340,8 +1665,8 @@ _FILE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2348,
-  serialized_end=2445,
+  serialized_start=2826,
+  serialized_end=2923,
 )
 
 
@@ -1379,8 +1704,8 @@ _FILESADDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2447,
-  serialized_end=2515,
+  serialized_start=2925,
+  serialized_end=2993,
 )
 
 
@@ -1446,8 +1771,8 @@ _FILEADDSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2518,
-  serialized_end=2685,
+  serialized_start=2996,
+  serialized_end=3163,
 )
 
 
@@ -1478,8 +1803,8 @@ _FILESADDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2687,
-  serialized_end=2744,
+  serialized_start=3165,
+  serialized_end=3222,
 )
 
 
@@ -1524,8 +1849,8 @@ _FILESGETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2746,
-  serialized_end=2848,
+  serialized_start=3224,
+  serialized_end=3326,
 )
 
 
@@ -1577,8 +1902,8 @@ _FILEGETSTATUS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2850,
-  serialized_end=2967,
+  serialized_start=3328,
+  serialized_end=3445,
 )
 
 
@@ -1609,8 +1934,8 @@ _FILESGETRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2969,
-  serialized_end=3026,
+  serialized_start=3447,
+  serialized_end=3504,
 )
 
 
@@ -1662,8 +1987,926 @@ _APPLICATIONADDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3028,
-  serialized_end=3132,
+  serialized_start=3506,
+  serialized_end=3610,
+)
+
+
+_GETRECORDDATAWITHACCESSINFOREQUEST = _descriptor.Descriptor(
+  name='GetRecordDataWithAccessInfoRequest',
+  full_name='Records.GetRecordDataWithAccessInfoRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='clientTime', full_name='Records.GetRecordDataWithAccessInfoRequest.clientTime', index=0,
+      number=1, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recordUid', full_name='Records.GetRecordDataWithAccessInfoRequest.recordUid', index=1,
+      number=2, type=12, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recordDetailsInclude', full_name='Records.GetRecordDataWithAccessInfoRequest.recordDetailsInclude', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3613,
+  serialized_end=3749,
+)
+
+
+_USERPERMISSION = _descriptor.Descriptor(
+  name='UserPermission',
+  full_name='Records.UserPermission',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='username', full_name='Records.UserPermission.username', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='owner', full_name='Records.UserPermission.owner', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareAdmin', full_name='Records.UserPermission.shareAdmin', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='sharable', full_name='Records.UserPermission.sharable', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='editable', full_name='Records.UserPermission.editable', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='awaitingApproval', full_name='Records.UserPermission.awaitingApproval', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='expiration', full_name='Records.UserPermission.expiration', index=6,
+      number=7, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='accountUid', full_name='Records.UserPermission.accountUid', index=7,
+      number=8, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3752,
+  serialized_end=3923,
+)
+
+
+_SHAREDFOLDERPERMISSION = _descriptor.Descriptor(
+  name='SharedFolderPermission',
+  full_name='Records.SharedFolderPermission',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='sharedFolderUid', full_name='Records.SharedFolderPermission.sharedFolderUid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='resharable', full_name='Records.SharedFolderPermission.resharable', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='editable', full_name='Records.SharedFolderPermission.editable', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='revision', full_name='Records.SharedFolderPermission.revision', index=3,
+      number=4, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='expiration', full_name='Records.SharedFolderPermission.expiration', index=4,
+      number=5, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3925,
+  serialized_end=4050,
+)
+
+
+_RECORDDATA = _descriptor.Descriptor(
+  name='RecordData',
+  full_name='Records.RecordData',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='revision', full_name='Records.RecordData.revision', index=0,
+      number=1, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='version', full_name='Records.RecordData.version', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shared', full_name='Records.RecordData.shared', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryptedRecordData', full_name='Records.RecordData.encryptedRecordData', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryptedExtraData', full_name='Records.RecordData.encryptedExtraData', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='clientModifiedTime', full_name='Records.RecordData.clientModifiedTime', index=5,
+      number=6, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='ownerRecordUid', full_name='Records.RecordData.ownerRecordUid', index=6,
+      number=7, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='encryptedLinkedRecordKey', full_name='Records.RecordData.encryptedLinkedRecordKey', index=7,
+      number=8, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='fileId', full_name='Records.RecordData.fileId', index=8,
+      number=9, type=3, cpp_type=2, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='fileSize', full_name='Records.RecordData.fileSize', index=9,
+      number=10, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='thumbnailSize', full_name='Records.RecordData.thumbnailSize', index=10,
+      number=11, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4053,
+  serialized_end=4316,
+)
+
+
+_RECORDDATAWITHACCESSINFO = _descriptor.Descriptor(
+  name='RecordDataWithAccessInfo',
+  full_name='Records.RecordDataWithAccessInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordUid', full_name='Records.RecordDataWithAccessInfo.recordUid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recordData', full_name='Records.RecordDataWithAccessInfo.recordData', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='userPermission', full_name='Records.RecordDataWithAccessInfo.userPermission', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='sharedFolderPermission', full_name='Records.RecordDataWithAccessInfo.sharedFolderPermission', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4319,
+  serialized_end=4519,
+)
+
+
+_GETRECORDDATAWITHACCESSINFORESPONSE = _descriptor.Descriptor(
+  name='GetRecordDataWithAccessInfoResponse',
+  full_name='Records.GetRecordDataWithAccessInfoResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordDataWithAccessInfo', full_name='Records.GetRecordDataWithAccessInfoResponse.recordDataWithAccessInfo', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='noPermissionRecordUid', full_name='Records.GetRecordDataWithAccessInfoResponse.noPermissionRecordUid', index=1,
+      number=2, type=12, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4522,
+  serialized_end=4659,
+)
+
+
+_RECORDSHAREUPDATEREQUEST = _descriptor.Descriptor(
+  name='RecordShareUpdateRequest',
+  full_name='Records.RecordShareUpdateRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='addSharedRecord', full_name='Records.RecordShareUpdateRequest.addSharedRecord', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='updateSharedRecord', full_name='Records.RecordShareUpdateRequest.updateSharedRecord', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='removeSharedRecord', full_name='Records.RecordShareUpdateRequest.removeSharedRecord', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='pt', full_name='Records.RecordShareUpdateRequest.pt', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4662,
+  serialized_end=4850,
+)
+
+
+_SHAREDRECORD = _descriptor.Descriptor(
+  name='SharedRecord',
+  full_name='Records.SharedRecord',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='toUsername', full_name='Records.SharedRecord.toUsername', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recordUid', full_name='Records.SharedRecord.recordUid', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='recordKey', full_name='Records.SharedRecord.recordKey', index=2,
+      number=3, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='sharedFolderUid', full_name='Records.SharedRecord.sharedFolderUid', index=3,
+      number=4, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='teamUid', full_name='Records.SharedRecord.teamUid', index=4,
+      number=5, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='editable', full_name='Records.SharedRecord.editable', index=5,
+      number=6, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareable', full_name='Records.SharedRecord.shareable', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='transfer', full_name='Records.SharedRecord.transfer', index=7,
+      number=8, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='useEccKey', full_name='Records.SharedRecord.useEccKey', index=8,
+      number=9, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='removeVaultData', full_name='Records.SharedRecord.removeVaultData', index=9,
+      number=10, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=4853,
+  serialized_end=5066,
+)
+
+
+_RECORDSHAREUPDATERESPONSE = _descriptor.Descriptor(
+  name='RecordShareUpdateResponse',
+  full_name='Records.RecordShareUpdateResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='addSharedRecordStatus', full_name='Records.RecordShareUpdateResponse.addSharedRecordStatus', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='updateSharedRecordStatus', full_name='Records.RecordShareUpdateResponse.updateSharedRecordStatus', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='removeSharedRecordStatus', full_name='Records.RecordShareUpdateResponse.removeSharedRecordStatus', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5069,
+  serialized_end=5282,
+)
+
+
+_SHAREDRECORDSTATUS = _descriptor.Descriptor(
+  name='SharedRecordStatus',
+  full_name='Records.SharedRecordStatus',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordUid', full_name='Records.SharedRecordStatus.recordUid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='Records.SharedRecordStatus.status', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='message', full_name='Records.SharedRecordStatus.message', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='username', full_name='Records.SharedRecordStatus.username', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5284,
+  serialized_end=5374,
+)
+
+
+_GETRECORDPERMISSIONSREQUEST = _descriptor.Descriptor(
+  name='GetRecordPermissionsRequest',
+  full_name='Records.GetRecordPermissionsRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordUids', full_name='Records.GetRecordPermissionsRequest.recordUids', index=0,
+      number=1, type=12, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='isShareAdmin', full_name='Records.GetRecordPermissionsRequest.isShareAdmin', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5376,
+  serialized_end=5447,
+)
+
+
+_GETRECORDPERMISSIONSRESPONSE = _descriptor.Descriptor(
+  name='GetRecordPermissionsResponse',
+  full_name='Records.GetRecordPermissionsResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordPermissions', full_name='Records.GetRecordPermissionsResponse.recordPermissions', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5449,
+  serialized_end=5533,
+)
+
+
+_RECORDPERMISSION = _descriptor.Descriptor(
+  name='RecordPermission',
+  full_name='Records.RecordPermission',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='recordUid', full_name='Records.RecordPermission.recordUid', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='owner', full_name='Records.RecordPermission.owner', index=1,
+      number=2, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='canEdit', full_name='Records.RecordPermission.canEdit', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='canShare', full_name='Records.RecordPermission.canShare', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='canTransfer', full_name='Records.RecordPermission.canTransfer', index=4,
+      number=5, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5535,
+  serialized_end=5643,
+)
+
+
+_GETSHAREOBJECTSREQUEST = _descriptor.Descriptor(
+  name='GetShareObjectsRequest',
+  full_name='Records.GetShareObjectsRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='startWith', full_name='Records.GetShareObjectsRequest.startWith', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='contains', full_name='Records.GetShareObjectsRequest.contains', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5645,
+  serialized_end=5706,
+)
+
+
+_GETSHAREOBJECTSRESPONSE = _descriptor.Descriptor(
+  name='GetShareObjectsResponse',
+  full_name='Records.GetShareObjectsResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='shareRelationships', full_name='Records.GetShareObjectsResponse.shareRelationships', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareFamilyUsers', full_name='Records.GetShareObjectsResponse.shareFamilyUsers', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareEnterpriseUsers', full_name='Records.GetShareObjectsResponse.shareEnterpriseUsers', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareTeams', full_name='Records.GetShareObjectsResponse.shareTeams', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shareManagedCompanies', full_name='Records.GetShareObjectsResponse.shareManagedCompanies', index=4,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5709,
+  serialized_end=5979,
+)
+
+
+_SHAREOBJECT = _descriptor.Descriptor(
+  name='ShareObject',
+  full_name='Records.ShareObject',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='Records.ShareObject.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='type', full_name='Records.ShareObject.type', index=1,
+      number=2, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='isShareAdmin', full_name='Records.ShareObject.isShareAdmin', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='displayName', full_name='Records.ShareObject.displayName', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='Records.ShareObject.status', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=5982,
+  serialized_end=6124,
 )
 
 _RECORDTYPE.fields_by_name['scope'].enum_type = _RECORDTYPESCOPE
@@ -1683,6 +2926,9 @@ _RECORDSADDREQUEST.fields_by_name['records'].message_type = _RECORDADD
 _RECORDUPDATE.fields_by_name['record_links_add'].message_type = _RECORDLINK
 _RECORDUPDATE.fields_by_name['audit'].message_type = _RECORDAUDIT
 _RECORDSUPDATEREQUEST.fields_by_name['records'].message_type = _RECORDUPDATE
+_RECORDCONVERTTOV3.fields_by_name['audit'].message_type = _RECORDAUDIT
+_RECORDCONVERTTOV3.fields_by_name['record_file'].message_type = _RECORDFILEFORCONVERSION
+_RECORDSCONVERTTOV3REQUEST.fields_by_name['records'].message_type = _RECORDCONVERTTOV3
 _RECORDMODIFYSTATUS.fields_by_name['status'].enum_type = _RECORDMODIFYRESULT
 _RECORDSMODIFYRESPONSE.fields_by_name['records'].message_type = _RECORDMODIFYSTATUS
 _ADDAUDITDATAREQUEST.fields_by_name['records'].message_type = _RECORDADDAUDITDATA
@@ -1691,6 +2937,25 @@ _FILEADDSTATUS.fields_by_name['status'].enum_type = _FILEADDRESULT
 _FILESADDRESPONSE.fields_by_name['files'].message_type = _FILEADDSTATUS
 _FILEGETSTATUS.fields_by_name['status'].enum_type = _FILEGETRESULT
 _FILESGETRESPONSE.fields_by_name['files'].message_type = _FILEGETSTATUS
+_GETRECORDDATAWITHACCESSINFOREQUEST.fields_by_name['recordDetailsInclude'].enum_type = _RECORDDETAILSINCLUDE
+_RECORDDATAWITHACCESSINFO.fields_by_name['recordData'].message_type = _RECORDDATA
+_RECORDDATAWITHACCESSINFO.fields_by_name['userPermission'].message_type = _USERPERMISSION
+_RECORDDATAWITHACCESSINFO.fields_by_name['sharedFolderPermission'].message_type = _SHAREDFOLDERPERMISSION
+_GETRECORDDATAWITHACCESSINFORESPONSE.fields_by_name['recordDataWithAccessInfo'].message_type = _RECORDDATAWITHACCESSINFO
+_RECORDSHAREUPDATEREQUEST.fields_by_name['addSharedRecord'].message_type = _SHAREDRECORD
+_RECORDSHAREUPDATEREQUEST.fields_by_name['updateSharedRecord'].message_type = _SHAREDRECORD
+_RECORDSHAREUPDATEREQUEST.fields_by_name['removeSharedRecord'].message_type = _SHAREDRECORD
+_RECORDSHAREUPDATERESPONSE.fields_by_name['addSharedRecordStatus'].message_type = _SHAREDRECORDSTATUS
+_RECORDSHAREUPDATERESPONSE.fields_by_name['updateSharedRecordStatus'].message_type = _SHAREDRECORDSTATUS
+_RECORDSHAREUPDATERESPONSE.fields_by_name['removeSharedRecordStatus'].message_type = _SHAREDRECORDSTATUS
+_GETRECORDPERMISSIONSRESPONSE.fields_by_name['recordPermissions'].message_type = _RECORDPERMISSION
+_GETSHAREOBJECTSRESPONSE.fields_by_name['shareRelationships'].message_type = _SHAREOBJECT
+_GETSHAREOBJECTSRESPONSE.fields_by_name['shareFamilyUsers'].message_type = _SHAREOBJECT
+_GETSHAREOBJECTSRESPONSE.fields_by_name['shareEnterpriseUsers'].message_type = _SHAREOBJECT
+_GETSHAREOBJECTSRESPONSE.fields_by_name['shareTeams'].message_type = _SHAREOBJECT
+_GETSHAREOBJECTSRESPONSE.fields_by_name['shareManagedCompanies'].message_type = _SHAREOBJECT
+_SHAREOBJECT.fields_by_name['type'].enum_type = _SHARETYPE
+_SHAREOBJECT.fields_by_name['status'].enum_type = _SHARESTATUS
 DESCRIPTOR.message_types_by_name['RecordType'] = _RECORDTYPE
 DESCRIPTOR.message_types_by_name['RecordTypesRequest'] = _RECORDTYPESREQUEST
 DESCRIPTOR.message_types_by_name['RecordTypesResponse'] = _RECORDTYPESRESPONSE
@@ -1707,6 +2972,9 @@ DESCRIPTOR.message_types_by_name['RecordAdd'] = _RECORDADD
 DESCRIPTOR.message_types_by_name['RecordsAddRequest'] = _RECORDSADDREQUEST
 DESCRIPTOR.message_types_by_name['RecordUpdate'] = _RECORDUPDATE
 DESCRIPTOR.message_types_by_name['RecordsUpdateRequest'] = _RECORDSUPDATEREQUEST
+DESCRIPTOR.message_types_by_name['RecordFileForConversion'] = _RECORDFILEFORCONVERSION
+DESCRIPTOR.message_types_by_name['RecordConvertToV3'] = _RECORDCONVERTTOV3
+DESCRIPTOR.message_types_by_name['RecordsConvertToV3Request'] = _RECORDSCONVERTTOV3REQUEST
 DESCRIPTOR.message_types_by_name['RecordsRemoveRequest'] = _RECORDSREMOVEREQUEST
 DESCRIPTOR.message_types_by_name['RecordModifyStatus'] = _RECORDMODIFYSTATUS
 DESCRIPTOR.message_types_by_name['RecordsModifyResponse'] = _RECORDSMODIFYRESPONSE
@@ -1720,12 +2988,31 @@ DESCRIPTOR.message_types_by_name['FilesGetRequest'] = _FILESGETREQUEST
 DESCRIPTOR.message_types_by_name['FileGetStatus'] = _FILEGETSTATUS
 DESCRIPTOR.message_types_by_name['FilesGetResponse'] = _FILESGETRESPONSE
 DESCRIPTOR.message_types_by_name['ApplicationAddRequest'] = _APPLICATIONADDREQUEST
+DESCRIPTOR.message_types_by_name['GetRecordDataWithAccessInfoRequest'] = _GETRECORDDATAWITHACCESSINFOREQUEST
+DESCRIPTOR.message_types_by_name['UserPermission'] = _USERPERMISSION
+DESCRIPTOR.message_types_by_name['SharedFolderPermission'] = _SHAREDFOLDERPERMISSION
+DESCRIPTOR.message_types_by_name['RecordData'] = _RECORDDATA
+DESCRIPTOR.message_types_by_name['RecordDataWithAccessInfo'] = _RECORDDATAWITHACCESSINFO
+DESCRIPTOR.message_types_by_name['GetRecordDataWithAccessInfoResponse'] = _GETRECORDDATAWITHACCESSINFORESPONSE
+DESCRIPTOR.message_types_by_name['RecordShareUpdateRequest'] = _RECORDSHAREUPDATEREQUEST
+DESCRIPTOR.message_types_by_name['SharedRecord'] = _SHAREDRECORD
+DESCRIPTOR.message_types_by_name['RecordShareUpdateResponse'] = _RECORDSHAREUPDATERESPONSE
+DESCRIPTOR.message_types_by_name['SharedRecordStatus'] = _SHAREDRECORDSTATUS
+DESCRIPTOR.message_types_by_name['GetRecordPermissionsRequest'] = _GETRECORDPERMISSIONSREQUEST
+DESCRIPTOR.message_types_by_name['GetRecordPermissionsResponse'] = _GETRECORDPERMISSIONSRESPONSE
+DESCRIPTOR.message_types_by_name['RecordPermission'] = _RECORDPERMISSION
+DESCRIPTOR.message_types_by_name['GetShareObjectsRequest'] = _GETSHAREOBJECTSREQUEST
+DESCRIPTOR.message_types_by_name['GetShareObjectsResponse'] = _GETSHAREOBJECTSRESPONSE
+DESCRIPTOR.message_types_by_name['ShareObject'] = _SHAREOBJECT
 DESCRIPTOR.enum_types_by_name['RecordTypeScope'] = _RECORDTYPESCOPE
 DESCRIPTOR.enum_types_by_name['RecordKeyType'] = _RECORDKEYTYPE
 DESCRIPTOR.enum_types_by_name['RecordFolderType'] = _RECORDFOLDERTYPE
 DESCRIPTOR.enum_types_by_name['RecordModifyResult'] = _RECORDMODIFYRESULT
 DESCRIPTOR.enum_types_by_name['FileAddResult'] = _FILEADDRESULT
 DESCRIPTOR.enum_types_by_name['FileGetResult'] = _FILEGETRESULT
+DESCRIPTOR.enum_types_by_name['RecordDetailsInclude'] = _RECORDDETAILSINCLUDE
+DESCRIPTOR.enum_types_by_name['ShareType'] = _SHARETYPE
+DESCRIPTOR.enum_types_by_name['ShareStatus'] = _SHARESTATUS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 RecordType = _reflection.GeneratedProtocolMessageType('RecordType', (_message.Message,), {
@@ -1840,6 +3127,27 @@ RecordsUpdateRequest = _reflection.GeneratedProtocolMessageType('RecordsUpdateRe
   })
 _sym_db.RegisterMessage(RecordsUpdateRequest)
 
+RecordFileForConversion = _reflection.GeneratedProtocolMessageType('RecordFileForConversion', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDFILEFORCONVERSION,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordFileForConversion)
+  })
+_sym_db.RegisterMessage(RecordFileForConversion)
+
+RecordConvertToV3 = _reflection.GeneratedProtocolMessageType('RecordConvertToV3', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDCONVERTTOV3,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordConvertToV3)
+  })
+_sym_db.RegisterMessage(RecordConvertToV3)
+
+RecordsConvertToV3Request = _reflection.GeneratedProtocolMessageType('RecordsConvertToV3Request', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDSCONVERTTOV3REQUEST,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordsConvertToV3Request)
+  })
+_sym_db.RegisterMessage(RecordsConvertToV3Request)
+
 RecordsRemoveRequest = _reflection.GeneratedProtocolMessageType('RecordsRemoveRequest', (_message.Message,), {
   'DESCRIPTOR' : _RECORDSREMOVEREQUEST,
   '__module__' : 'record_pb2'
@@ -1930,6 +3238,118 @@ ApplicationAddRequest = _reflection.GeneratedProtocolMessageType('ApplicationAdd
   # @@protoc_insertion_point(class_scope:Records.ApplicationAddRequest)
   })
 _sym_db.RegisterMessage(ApplicationAddRequest)
+
+GetRecordDataWithAccessInfoRequest = _reflection.GeneratedProtocolMessageType('GetRecordDataWithAccessInfoRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETRECORDDATAWITHACCESSINFOREQUEST,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetRecordDataWithAccessInfoRequest)
+  })
+_sym_db.RegisterMessage(GetRecordDataWithAccessInfoRequest)
+
+UserPermission = _reflection.GeneratedProtocolMessageType('UserPermission', (_message.Message,), {
+  'DESCRIPTOR' : _USERPERMISSION,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.UserPermission)
+  })
+_sym_db.RegisterMessage(UserPermission)
+
+SharedFolderPermission = _reflection.GeneratedProtocolMessageType('SharedFolderPermission', (_message.Message,), {
+  'DESCRIPTOR' : _SHAREDFOLDERPERMISSION,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.SharedFolderPermission)
+  })
+_sym_db.RegisterMessage(SharedFolderPermission)
+
+RecordData = _reflection.GeneratedProtocolMessageType('RecordData', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDDATA,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordData)
+  })
+_sym_db.RegisterMessage(RecordData)
+
+RecordDataWithAccessInfo = _reflection.GeneratedProtocolMessageType('RecordDataWithAccessInfo', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDDATAWITHACCESSINFO,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordDataWithAccessInfo)
+  })
+_sym_db.RegisterMessage(RecordDataWithAccessInfo)
+
+GetRecordDataWithAccessInfoResponse = _reflection.GeneratedProtocolMessageType('GetRecordDataWithAccessInfoResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETRECORDDATAWITHACCESSINFORESPONSE,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetRecordDataWithAccessInfoResponse)
+  })
+_sym_db.RegisterMessage(GetRecordDataWithAccessInfoResponse)
+
+RecordShareUpdateRequest = _reflection.GeneratedProtocolMessageType('RecordShareUpdateRequest', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDSHAREUPDATEREQUEST,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordShareUpdateRequest)
+  })
+_sym_db.RegisterMessage(RecordShareUpdateRequest)
+
+SharedRecord = _reflection.GeneratedProtocolMessageType('SharedRecord', (_message.Message,), {
+  'DESCRIPTOR' : _SHAREDRECORD,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.SharedRecord)
+  })
+_sym_db.RegisterMessage(SharedRecord)
+
+RecordShareUpdateResponse = _reflection.GeneratedProtocolMessageType('RecordShareUpdateResponse', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDSHAREUPDATERESPONSE,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordShareUpdateResponse)
+  })
+_sym_db.RegisterMessage(RecordShareUpdateResponse)
+
+SharedRecordStatus = _reflection.GeneratedProtocolMessageType('SharedRecordStatus', (_message.Message,), {
+  'DESCRIPTOR' : _SHAREDRECORDSTATUS,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.SharedRecordStatus)
+  })
+_sym_db.RegisterMessage(SharedRecordStatus)
+
+GetRecordPermissionsRequest = _reflection.GeneratedProtocolMessageType('GetRecordPermissionsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETRECORDPERMISSIONSREQUEST,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetRecordPermissionsRequest)
+  })
+_sym_db.RegisterMessage(GetRecordPermissionsRequest)
+
+GetRecordPermissionsResponse = _reflection.GeneratedProtocolMessageType('GetRecordPermissionsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETRECORDPERMISSIONSRESPONSE,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetRecordPermissionsResponse)
+  })
+_sym_db.RegisterMessage(GetRecordPermissionsResponse)
+
+RecordPermission = _reflection.GeneratedProtocolMessageType('RecordPermission', (_message.Message,), {
+  'DESCRIPTOR' : _RECORDPERMISSION,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.RecordPermission)
+  })
+_sym_db.RegisterMessage(RecordPermission)
+
+GetShareObjectsRequest = _reflection.GeneratedProtocolMessageType('GetShareObjectsRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETSHAREOBJECTSREQUEST,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetShareObjectsRequest)
+  })
+_sym_db.RegisterMessage(GetShareObjectsRequest)
+
+GetShareObjectsResponse = _reflection.GeneratedProtocolMessageType('GetShareObjectsResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETSHAREOBJECTSRESPONSE,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.GetShareObjectsResponse)
+  })
+_sym_db.RegisterMessage(GetShareObjectsResponse)
+
+ShareObject = _reflection.GeneratedProtocolMessageType('ShareObject', (_message.Message,), {
+  'DESCRIPTOR' : _SHAREOBJECT,
+  '__module__' : 'record_pb2'
+  # @@protoc_insertion_point(class_scope:Records.ShareObject)
+  })
+_sym_db.RegisterMessage(ShareObject)
 
 
 DESCRIPTOR._options = None

--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -23,1740 +23,1793 @@ from .record import get_totp_code
 
 
 class RecordV3:
-  """Defines a user-friendly Keeper Record v3 for display purposes"""
+    """Defines a user-friendly Keeper Record v3 for display purposes"""
 
-  def __init__(self, record_uid='', folder='', title = '', type = '', fields=None, custom_fields=None, notes = '', revision = '', data = ''):
-      self.record_uid = record_uid
-      self.folder = folder
-      self.title = title
-      self.type = type
-      self.fields = custom_fields or []
-      self.custom_fields = custom_fields or []
-      self.notes = notes
-      self.revision = revision
-      self.data = data
+    def __init__(self, record_uid='', folder='', title='', type='', fields=None, custom_fields=None, notes='',
+                 revision='', data=''):
+        self.record_uid = record_uid
+        self.folder = folder
+        self.title = title
+        self.type = type
+        self.fields = custom_fields or []
+        self.custom_fields = custom_fields or []
+        self.notes = notes
+        self.revision = revision
+        self.data = data
 
+    @staticmethod
+    def is_valid_record_type(record_type_json: str, rt_definition_json: str) -> dict:
+        # validate record type (a.k.a. record v3) data
+        # https://github.com/Keeper-Security/record-templates/tree/master/standard_templates
+        rt = {}
+        try:
+            rt = json.loads(record_type_json)
+        except ValueError:
+            return {'is_valid': False, 'error': 'Invalid record type JSON'}
+        except Exception:
+            return {'is_valid': False, 'error': 'Invalid record type'}
 
-  @staticmethod
-  def is_valid_record_type(record_type_json: str, rt_definition_json: str) -> dict:
-    # validate record type (a.k.a. record v3) data
-    # https://github.com/Keeper-Security/record-templates/tree/master/standard_templates
-    rt = {}
-    try:
-      rt = json.loads(record_type_json)
-    except ValueError:
-      return { 'is_valid': False, 'error': 'Invalid record type JSON' }
-    except Exception:
-      return { 'is_valid': False, 'error': 'Invalid record type' }
+        res = RecordV3.is_valid_record_type_definition(rt_definition_json)
+        if not res.get('is_valid'):
+            return res
+        rtd = json.loads(rt_definition_json)
 
-    res = RecordV3.is_valid_record_type_definition(rt_definition_json)
-    if not res.get('is_valid'):
-      return res
-    rtd = json.loads(rt_definition_json)
+        # Implicit fields - always present on any record, no need to be specified in the template: title, custom, notes
+        rtd_type = rtd.get('$id') or ''
+        rt_type = rt.get('type') or ''
+        rt_title = rt.get('title') or ''
+        rt_notes = rt.get('notes') or ''
+        rt_fields = rt.get('fields') or []
+        rt_custom = rt.get('custom') or []
 
-    # Implicit fields - always present on any record, no need to be specified in the template: title, custom, notes
-    rtd_type = rtd.get('$id') or ''
-    rt_type = rt.get('type') or ''
-    rt_title = rt.get('title') or ''
-    rt_notes = rt.get('notes') or ''
-    rt_fields = rt.get('fields') or []
-    rt_custom = rt.get('custom') or []
+        if not isinstance(rt_type, str):
+            return {'is_valid': False, 'error': 'Record type "type" should be string: ' + str(rt_type)}
+        if not isinstance(rt_title, str):
+            return {'is_valid': False, 'error': 'Record type "title" should be string: ' + str(rt_title)}
+        if not isinstance(rt_notes, str):
+            return {'is_valid': False, 'error': 'Record type "notes" should be string: ' + str(rt_notes)}
+        if not isinstance(rt_fields, list):
+            return {'is_valid': False, 'error': 'Record type "fields" should be array: ' + str(rt_fields)}
+        if not isinstance(rt_custom, list):
+            return {'is_valid': False, 'error': 'Record type "custom" should be array: ' + str(rt_custom)}
 
-    if not isinstance(rt_type, str):
-      return { 'is_valid': False, 'error': 'Record type "type" should be string: ' + str(rt_type) }
-    if not isinstance(rt_title, str):
-      return { 'is_valid': False, 'error': 'Record type "title" should be string: ' + str(rt_title) }
-    if not isinstance(rt_notes, str):
-      return { 'is_valid': False, 'error': 'Record type "notes" should be string: ' + str(rt_notes) }
-    if not isinstance(rt_fields, list):
-      return { 'is_valid': False, 'error': 'Record type "fields" should be array: ' + str(rt_fields) }
-    if not isinstance(rt_custom, list):
-      return { 'is_valid': False, 'error': 'Record type "custom" should be array: ' + str(rt_custom) }
+        if not rt_type or not rt_type.strip():
+            return {'is_valid': False, 'error': 'Missing record type type'}
+        if rt_type.strip() != rtd_type.strip():
+            return {'is_valid': False,
+                    'error': 'Type mistmatch - RT "type" should match "$id" in RT definition: ' + rt_type + " != " + rtd_type}
 
-    if not rt_type or not rt_type.strip():
-      return { 'is_valid': False, 'error': 'Missing record type type' }
-    if rt_type.strip() != rtd_type.strip():
-      return { 'is_valid': False, 'error': 'Type mistmatch - RT "type" should match "$id" in RT definition: ' + rt_type + " != " + rtd_type }
+        if not rt_title or not rt_title.strip():
+            return {'is_valid': False, 'error': 'Missing record type title'}
 
-    if not rt_title or not rt_title.strip():
-      return { 'is_valid': False, 'error': 'Missing record type title' }
+        # Top level RT attributes - unknown attribute(s) generate error
+        # All known attribute(s) from RT definition that don't belong to RT data also generate error
+        tlod = [x for x in rtd]
+        tlor = [x for x in rt]
+        rtdef_only = ('$id', 'categories', 'description', 'label')  # these are in RT definitions only
+        ilist = [x for x in tlor if x in rtdef_only]
+        if ilist:
+            return {'is_valid': False,
+                    'error': 'Record has atributes that should be present in record type definitions only: ' + str(
+                        ilist)}
 
-    # Top level RT attributes - unknown attribute(s) generate error
-    # All known attribute(s) from RT definition that don't belong to RT data also generate error
-    tlod = [x for x in rtd]
-    tlor = [x for x in rt]
-    rtdef_only = ('$id', 'categories', 'description', 'label') # these are in RT definitions only
-    ilist = [x for x in tlor if x in rtdef_only]
-    if ilist:
-      return { 'is_valid': False, 'error': 'Record has atributes that should be present in record type definitions only: ' + str(ilist) }
+        # ulist = [x for x in tlor if x not in ('type', 'title', 'notes', 'fields', 'custom')]
+        ulist = [x for x in tlor if x not in tlod + [*RecordV3.record_fields.keys()]]
+        if ulist:
+            return {'is_valid': False, 'error': 'Unknown record type attribute(s): ' + str(ulist)}
 
-    #ulist = [x for x in tlor if x not in ('type', 'title', 'notes', 'fields', 'custom')]
-    ulist = [x for x in tlor if x not in tlod + [*RecordV3.record_fields.keys()]]
-    if ulist:
-      return { 'is_valid': False, 'error': 'Unknown record type attribute(s): ' + str(ulist) }
+        # Allow only valid/known field types - field types are case sensitive?
+        badf = [x for x in rt_fields if not RecordV3.field_types.__contains__(x.get('type'))]
+        if badf:
+            return {'is_valid': False, 'error': 'Unknown field types in "fields": ' + str(badf)}
+        badf = [x for x in rt_custom if not RecordV3.field_types.__contains__(x.get('type'))]
+        if badf:
+            return {'is_valid': False, 'error': 'Unknown field types in "custom": ' + str(badf)}
 
-    # Allow only valid/known field types - field types are case sensitive?
-    badf = [x for x in rt_fields if not RecordV3.field_types.__contains__(x.get('type'))]
-    if badf:
-      return { 'is_valid': False, 'error': 'Unknown field types in "fields": ' + str(badf) }
-    badf = [x for x in rt_custom if not RecordV3.field_types.__contains__(x.get('type'))]
-    if badf:
-      return { 'is_valid': False, 'error': 'Unknown field types in "custom": ' + str(badf) }
+        # only one FT of type password allowed in record v3
+        pwdf = [x for x in rt_fields if x.get('type') == 'password']
+        pwdc = [x for x in rt_custom if x.get('type') == 'password']
+        pwds = pwdf + pwdc
+        if len(pwds) > 1:
+            return {'is_valid': False, 'error': 'Error: Only one password allowed per record! ' + str(pwds)}
+        elif len(pwds) == 1:
+            rtdp = next((True for x in (rtd.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'), False)
+            if rtdp:
+                if pwdc: return {'is_valid': False,
+                                 'error': 'Password must be in fields[] section as defined by record type! ' + str(
+                                     pwds)}
+            else:
+                if pwdf: return {'is_valid': False,
+                                 'error': 'Password must be in custom[] section - this record type does not allow password in fields[]! ' + str(
+                                     pwds)}
 
-    # only one FT of type password allowed in record v3
-    pwdf = [x for x in rt_fields if x.get('type') == 'password']
-    pwdc = [x for x in rt_custom if x.get('type') == 'password']
-    pwds = pwdf + pwdc
-    if len(pwds) > 1:
-      return { 'is_valid': False, 'error': 'Error: Only one password allowed per record! ' + str(pwds) }
-    elif len(pwds) == 1:
-      rtdp = next((True for x in (rtd.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'), False)
-      if rtdp:
-        if pwdc: return { 'is_valid': False, 'error': 'Password must be in fields[] section as defined by record type! ' + str(pwds) }
-      else:
-        if pwdf: return { 'is_valid': False, 'error': 'Password must be in custom[] section - this record type does not allow password in fields[]! ' + str(pwds) }
+        # All fields in fields[] must be in record type definition
+        rtdf = [x.get('$ref') for x in (rtd.get('fields') or []) if '$ref' in x]
+        badf = [x for x in rt_fields if x.get('type') not in rtdf]
+        if badf:
+            return {'is_valid': False,
+                    'error': 'This record type doesn\'t allow these in fields[] (move to custom): ' + str(badf)}
 
-    # All fields in fields[] must be in record type definition
-    rtdf = [x.get('$ref') for x in (rtd.get('fields') or []) if '$ref' in x]
-    badf = [x for x in rt_fields if x.get('type') not in rtdf]
-    if badf:
-      return { 'is_valid': False, 'error': 'This record type doesn\'t allow these in fields[] (move to custom): ' + str(badf) }
+        # fileRef use upload-attachment/delete-attachment commands
+        # remove from validation to allow for cros referencing same fileRef from multiple records v3
+        # refs = [x for x in rt_fields + rt_custom if x.get('type') == 'fileRef' and x.get('value')]
+        # if refs:
+        #   return { 'is_valid': False, 'error': 'File reference manipulations are disabled here. Use upload-attachment/delete-attachment commands instead. ' + str(refs) }
 
-    # fileRef use upload-attachment/delete-attachment commands
-    # remove from validation to allow for cros referencing same fileRef from multiple records v3
-    # refs = [x for x in rt_fields + rt_custom if x.get('type') == 'fileRef' and x.get('value')]
-    # if refs:
-    #   return { 'is_valid': False, 'error': 'File reference manipulations are disabled here. Use upload-attachment/delete-attachment commands instead. ' + str(refs) }
+        # fields[] must contain all 'requried' fields (and requried value parts) - custom[] is not in RT definition
+        reqd = [x.get('$ref') for x in (rtd.get('fields') or []) if '$ref' in x and 'required' in x]
+        reqf = [x for x in rt_fields if x.get('type') in reqd]
+        regf = [x for x in rt_fields if x.get('type') not in reqd] + rt_custom
 
-    # fields[] must contain all 'requried' fields (and requried value parts) - custom[] is not in RT definition
-    reqd = [x.get('$ref') for x in (rtd.get('fields') or []) if '$ref' in x and 'required' in x]
-    reqf = [x for x in rt_fields if x.get('type') in reqd]
-    regf = [x for x in rt_fields if x.get('type') not in reqd] + rt_custom
+        # all fields required by RT definition must be present
+        miss = set(reqd) - set([x.get('type') for x in reqf])
+        if miss:
+            return {'is_valid': False, 'error': 'Missing requried fields: ' + str(miss)}
 
-    # all fields required by RT definition must be present
-    miss = set(reqd) - set([x.get('type') for x in reqf])
-    if miss:
-      return { 'is_valid': False, 'error': 'Missing requried fields: ' + str(miss) }
+        # validate field values
+        fver = []
+        for fld in reqf:
+            err = RecordV3.is_valid_field_data(fld, True)
+            fver.extend(err)
+        if fver:
+            return {'is_valid': False, 'error': 'Error(s) validating requried fields: ' + str(fver)}
 
-    # validate field values
-    fver = []
-    for fld in reqf:
-      err = RecordV3.is_valid_field_data(fld, True)
-      fver.extend(err)
-    if fver:
-      return { 'is_valid': False, 'error': 'Error(s) validating requried fields: ' + str(fver) }
+        for fld in regf:
+            err = RecordV3.is_valid_field_data(fld, False)
+            fver.extend(err)
+        if fver:
+            return {'is_valid': False, 'error': 'Error(s) validating fields: ' + str(fver)}
 
-    for fld in regf:
-      err = RecordV3.is_valid_field_data(fld, False)
-      fver.extend(err)
-    if fver:
-      return { 'is_valid': False, 'error': 'Error(s) validating fields: ' + str(fver) }
+        return {'is_valid': True, 'error': ''}
 
-    return { 'is_valid': True, 'error': '' }
+    @staticmethod
+    def is_valid_record_type_definition(record_type_definition_json: str) -> dict:
+        # validate record type (a.k.a. record v3) definition
+        # https://github.com/Keeper-Security/record-templates/tree/master/standard_templates
 
+        rt = {}
+        try:
+            rt = json.loads(record_type_definition_json)
+        except ValueError:
+            return {'is_valid': False, 'error': 'Invalid record type JSON'}
+        except Exception:
+            return {'is_valid': False, 'error': 'Invalid record type definition'}
 
-  @staticmethod
-  def is_valid_record_type_definition(record_type_definition_json: str) -> dict:
-    # validate record type (a.k.a. record v3) definition
-    # https://github.com/Keeper-Security/record-templates/tree/master/standard_templates
+        rtid = rt.get('$id') or ''
+        if not rtid or not rtid.strip():
+            return {'is_valid': False, 'error': 'Missing record type name'}
 
-    rt = {}
-    try:
-      rt = json.loads(record_type_definition_json)
-    except ValueError:
-      return { 'is_valid': False, 'error': 'Invalid record type JSON' }
-    except Exception:
-      return { 'is_valid': False, 'error': 'Invalid record type definition' }
+        # Min RT definition: {"$id": "Name"} - allows only implicit (custom) fields
+        # Max RT definition: {"$id": "Name", "categories": ["note"], "description": "Description", "fields":[]}
+        # Implicit fields - always present on any record, no need to be specified in the template: title, custom, notes
+        implicit_field_names = [x for x in RecordV3.record_implicit_fields]
+        implicit_fields = [r for r in rt if r in implicit_field_names]
+        if implicit_fields:
+            return {'is_valid': False,
+                    'error': 'Implicit fields not allowed in record type definition: ' + str(implicit_fields)}
 
-    rtid = rt.get('$id') or ''
-    if not rtid or not rtid.strip():
-      return { 'is_valid': False, 'error': 'Missing record type name' }
+        rt_attributes = ('$id', 'categories', 'description', 'fields')
+        bada = [r for r in rt if r not in rt_attributes and r not in implicit_field_names]
+        if bada:
+            return {'is_valid': False, 'error': 'Unknown attributes in record type definition: ' + str(bada)}
 
-    # Min RT definition: {"$id": "Name"} - allows only implicit (custom) fields
-    # Max RT definition: {"$id": "Name", "categories": ["note"], "description": "Description", "fields":[]}
-    # Implicit fields - always present on any record, no need to be specified in the template: title, custom, notes
-    implicit_field_names = [x for x in RecordV3.record_implicit_fields]
-    implicit_fields = [r for r in rt if r in implicit_field_names]
-    if implicit_fields:
-      return { 'is_valid': False, 'error': 'Implicit fields not allowed in record type definition: ' + str(implicit_fields) }
+        # Allow only valid/known field types - field types are case sensitive?
+        flds = rt.get('fields') or []
+        # Record type definitions without fields are OK? They still have title and custom[]
+        # if not flds:
+        #   return { 'is_valid': False, 'error': 'Missing fields list' }
 
-    rt_attributes = ('$id', 'categories', 'description', 'fields')
-    bada = [r for r in rt if r not in rt_attributes and r not in implicit_field_names]
-    if bada:
-      return { 'is_valid': False, 'error': 'Unknown attributes in record type definition: ' + str(bada) }
+        badf = [x for x in flds if not x.get('$ref')]
+        if badf:
+            return {'is_valid': False, 'error': 'Missing field type reference (ex. {"$ref": "login"}): ' + str(badf)}
 
-    # Allow only valid/known field types - field types are case sensitive?
-    flds = rt.get('fields') or []
-    # Record type definitions without fields are OK? They still have title and custom[]
-    # if not flds:
-    #   return { 'is_valid': False, 'error': 'Missing fields list' }
+        badf = [x for x in flds if not RecordV3.field_types.__contains__(x.get('$ref'))]
+        if badf:
+            return {'is_valid': False, 'error': 'Unknown field types: ' + str(badf)}
 
-    badf = [x for x in flds if not x.get('$ref')]
-    if badf:
-      return { 'is_valid': False, 'error': 'Missing field type reference (ex. {"$ref": "login"}): ' + str(badf) }
+        known_ft_atributes = {'$ref', 'label', 'required'}
+        unknown_ft_atributes = [x for x in flds if not set(x.keys()).issubset(known_ft_atributes)]
+        if unknown_ft_atributes:
+            return {'is_valid': False, 'error': 'Unknown field atributes: ' + str(unknown_ft_atributes)}
 
-    badf = [x for x in flds if not RecordV3.field_types.__contains__(x.get('$ref'))]
-    if badf:
-      return { 'is_valid': False, 'error': 'Unknown field types: ' + str(badf) }
+        badf = [x for x in flds if not RecordV3.is_valid_field_type_ref(json.dumps(x))]
+        if badf:
+            return {'is_valid': False, 'error': 'Invalid field types: ' + str(badf)}
 
-    known_ft_atributes = {'$ref', 'label', 'required'}
-    unknown_ft_atributes = [x for x in flds if not set(x.keys()).issubset(known_ft_atributes)]
-    if unknown_ft_atributes:
-      return { 'is_valid': False, 'error': 'Unknown field atributes: ' + str(unknown_ft_atributes) }
+        return {'is_valid': True, 'error': ''}
 
-    badf = [x for x in flds if not RecordV3.is_valid_field_type_ref(json.dumps(x))]
-    if badf:
-      return { 'is_valid': False, 'error': 'Invalid field types: ' + str(badf) }
-
-    return { 'is_valid': True, 'error': '' }
-
-
-  # Implicit fields - The following fields are always present on any record and do not need to be specified in the template:
-  record_implicit_fields = {
-    'title': '',  # string
-    'custom': [], # Array of Field Data objects
-    'notes': ''   # string
-  }
-
-  record_fields = {
-    'title': '',  # string - Record Title
-    'type': '',   # string - Record Type (either one of the standard types or a custom type)
-    'fields': [], # Array of Field Data objects
-    'custom': [], # Array of Field Data objects
-    'notes': ''   # string
-  }
-
-  # Fields are client-side defined. Fields are defined with a Field Type. All Field Types are fixed.  
-  # Meaning, although we may implement new field types, the client cannot arbitrarily add field types,
-  # nor display/edit field types that are not pre programmed into the client.  
-  # Once the client is updated to understand the new field type, the data may then be displayed and edited. 
-
-  # TODO: translatable labels
-  # NB! Allow only one login/password field per v3 record. Allow in custom[] only if RT definition doesn't have them
-  # Standard RT definitions: always required - type, title
-  record_types = {
-    'login': { 'label': 'Login' },
-    # def.  {"$id":"login","categories":["login"],"description":"Login template","fields":[{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"securityQuestion"},{"$ref":"fileRef"},{"$ref":"oneTimeCode"}]}
-    # ex.   {"title":"Title","type":"login","fields":[{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"securityQuestion","value":[]},{"type":"fileRef","value":[]},{"type":"oneTimeCode","value":[]}],"custom":[]}
-
-    'bankAccount': { 'label': 'Bank Account' }, # { "$ref": "bankAccount", "required": true }
-    # def.  {"$id":"bankAccount","description":"Bank account template","fields":[{"$ref":"bankAccount","required":true},{"$ref":"name"},{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"cardRef"},{"$ref":"fileRef"},{"$ref":"oneTimeCode"}]}
-    # ex.   {"title":"Title","type":"bankAccount","fields":[{"type":"bankAccount","value":[{"accountType":"","routingNumber":"","accountNumber":"1234","otherType":""}],"required":true},{"type":"name","value":[{"first":"John","last":"Doe"}]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"cardRef","value":[]},{"type":"fileRef","value":[]},{"type":"oneTimeCode","value":[]}],"custom":[]}
-
-    'address': { 'label': 'Address' },
-    # def.  {"$id":"address","categories":["address"],"description":"Address template","fields":[{"$ref":"address"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"address","fields":[{"type":"address","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'bankCard': { 'label': 'Payment Card' },
-    # def.  {"$id":"bankCard","categories":["payment"],"description":"Bank card template","fields":[{"$ref":"paymentCard"},{"$ref":"text","label":"cardholderName"},{"$ref":"pinCode"},{"$ref":"addressRef"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"bankCard","fields":[{"type":"paymentCard","value":[]},{"type":"text","label":"Cardholder Name","value":[]},{"type":"pinCode","value":[]},{"type":"addressRef","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'birthCertificate': { 'label': 'Birth Certificate' },
-    # def.  {"$id":"birthCertificate","categories":["ids"],"description":"Birth certificate template","fields":[{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"birthCertificate","fields":[{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'contact': { 'label': 'Contact' }, # { "$ref": "name", "required": true }
-    # def.  {"$id":"contact","categories":["address"],"description":"Contact template","fields":[{"$ref":"name","required":true},{"$ref":"text","label":"company"},{"$ref":"email"},{"$ref":"phone"},{"$ref":"addressRef"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"contact","fields":[{"type":"name","value":[{"first":"John","last":"Doe"}],"required":true},{"type":"text","label":"Company","value":[]},{"type":"email","value":[]},{"type":"phone","value":[]},{"type":"addressRef","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'driverLicense': { 'label': 'Driver\'s License' },
-    # def.  {"$id":"driverLicense","categories":["ids"],"description":"Driver license template","fields":[{"$ref":"accountNumber","label":"dlNumber"},{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"addressRef"},{"$ref":"expirationDate"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"driverLicense","fields":[{"type":"accountNumber","label":"Driver's License Number","value":[]},{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"addressRef","value":[]},{"type":"expirationDate","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'encryptedNotes': { 'label': 'Secure Note' },
-    # def.  {"$id":"encryptedNotes","categories":["note"],"description":"Encrypted note template","fields":[{"$ref":"note"},{"$ref":"date"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"encryptedNotes","fields":[{"type":"note","value":[]},{"type":"date","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'file': { 'label': 'File Attachment' },
-    # def.  {"$id":"file","categories":["file"],"description":"File template","fields":[{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"file","fields":[{"type":"fileRef","value":[]}],"custom":[]}
-
-    'healthInsurance': { 'label': 'Health Insurance' },
-    # def.  {"$id":"healthInsurance","categories":["ids"],"description":"Health insurance template","fields":[{"$ref":"accountNumber"},{"$ref":"name","label":"insuredsName"},{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
-    # ex.   {"title":"Title","type":"healthInsurance","fields":[{"type":"accountNumber","value":[]},{"type":"name","label":"Insured's Name","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
-
-    'membership': { 'label': 'Membership' },
-    # def.  {"$id":"membership","categories":["ids"],"description":"Membership template","fields":[{"$ref":"accountNumber"},{"$ref":"name"},{"$ref":"password"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
-    # ex.   {"title":"Title","type":"membership","fields":[{"type":"accountNumber","value":[]},{"type":"name","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
-
-    'passport': { 'label': 'Passport' },
-    # def.  {"$id":"passport","categories":["ids"],"description":"Passport template","fields":[{"$ref":"accountNumber","label":"passportNumber"},{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"addressRef"},{"$ref":"expirationDate"},{"$ref":"date","label":"dateIssued"},{"$ref":"password"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"passport","fields":[{"type":"accountNumber","label":"Passport Number","value":[]},{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"addressRef","value":[]},{"type":"expirationDate","value":[]},{"type":"date","label":"Date Issued","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'photo': { 'label': 'Photo' },
-    # def.  {"$id":"photo","categories":["file"],"description":"Photo template","fields":[{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"photo","fields":[{"type":"fileRef","value":[]}],"custom":[]}
-
-    'serverCredentials': { 'label': 'Server' },
-    # def.  {"$id":"serverCredentials","categories":["login"],"description":"Server credentials template","fields":[{"$ref":"host"},{"$ref":"login"},{"$ref":"password"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"serverCredentials","fields":[{"type":"host","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'softwareLicense': { 'label': 'Software License' },
-    # def.  {"$id":"softwareLicense","categories":["note"],"description":"Software license template","fields":[{"$ref":"licenseNumber"},{"$ref":"expirationDate"},{"$ref":"date","label":"dateActive"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
-    # ex.   {"title":"Title","type":"softwareLicense","fields":[{"type":"licenseNumber","value":[]},{"type":"expirationDate","value":[]},{"type":"date","label":"Date Active","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
-
-    'ssnCard': { 'label': 'Identity Card' },
-    # def.  {"$id":"ssnCard","categories":["ids"],"description":"Identity card template","fields":[{"$ref":"accountNumber","label":"identityNumber"},{"$ref":"name"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"ssnCard","fields":[{"type":"accountNumber","label":"Identity Number","value":[]},{"type":"name","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-
-    'general': { 'label': 'Legacy Record' },
-    # def.  {"$id":"general","categories":["login"],"description":"Legacy template","fields":[{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"oneTimeCode"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"general","fields":[{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"oneTimeCode","value":[]},{"type":"fileRef","value":[]}],"custom":[],"notes":""}
-
-    'sshKeys': { 'label': 'SSH Key' },
-    # def.  {"$id":"sshKeys","categories":["login"],"description":"SSH key template","fields":[{"$ref":"login"},{"$ref":"keyPair"},{"$ref":"text","label":"passphrase"},{"$ref":"host"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
-    # ex.   {"title":"Title","type":"sshKeys","fields":[{"type":"login","value":[]},{"type":"keyPair","value":[]},{"type":"text","label":"Passphrase","value":[]},{"type":"host","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
-
-    'databaseCredentials': { 'label': 'Database' }
-    # def.  {"$id":"databaseCredentials","categories":["login"],"description":"Database credentials template","fields":[{"$ref":"text","label":"type"},{"$ref":"host"},{"$ref":"login"},{"$ref":"password"},{"$ref":"fileRef"}]}
-    # ex.   {"title":"Title","type":"databaseCredentials","fields":[{"type":"text","label":"Type","value":[]},{"type":"host","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
-  }
-
-  # A field definition consists from:
-  #   $id - ex. 'title', used to reference the field definitions and to translate the field labels
-  #   type|$type - used to tell the UI how to render and edit the field
-  #   lookup - optional flag: lookup values are shared based on the field reference. 
-  #     ex. all 'login' fields will share the same set of lookup values but will not see the lookup values from 'company' field
-  #   multiple - optional flag: If specified, the UI should allow populating multiple instances of the field on the record
-  #   label - optional modifier: If specified, the UI display the label instead of the translated value
-  #   default - optional modifier: Defines the default value for the field
-  #   readonly -  flag: restrict editable field to be readonly or relax readonly field to be editable
-  #   required - optional flag: Can be used to make the field required
-  #   hidden - optional flag. Can be used to hide a field from the base template
-
-  # https://github.com/Keeper-Security/record-templates/blob/master/fields.json
-  # NB! All field_types must have corresponding field_values
-  field_types = {
-    # 2021-05-06 FT 'text' added for compatibility with web vault
-    'text': {
-      '$id': 'text',
-      'type': 'text'
-    },
-    # 2021-06-24 One RT added new FT 'secret' - type is yet unknown
-    'secret': {
-      '$id': 'secret',
-      'type': 'text'
-    },
-    'title': {
-      '$id': 'title',
-      'type': 'text'
-    },
-    'login': {
-      '$id': 'login',
-      'type': 'login',
-      'lookup': 'login'
-    },
-    'password': {
-      '$id': 'password',
-      'type': 'password'
-    },
-    'name': {
-      '$id': 'name',
-      'type': 'name',
-      'lookup': 'name'
-    },
-    'company': {
-      '$id': 'company',
-      'type': 'text',
-      'lookup': 'company'
-    },
-    'phone': {
-      '$id': 'phone',
-      'type': 'phone',
-      'multiple': 'optional',
-      'lookup': 'phone'
-    },
-    'email': {
-      '$id': 'email',
-      'type': 'email',
-      'multiple': 'optional',
-      'lookup': 'email'
-    },
-    'address': {
-      '$id': 'address',
-      'type': 'address',
-      'label': 'Street Address'
-    },
-    'addressRef': {
-      '$id': 'addressRef',
-      'type': 'addressRef',
-      'lookup': 'addressRef'
-    },
-    # 'cardNumber': {
-    #   '$id': 'cardNumber',
-    #   'type': 'cardNumber'  # undefined - probably replaced by paymentCard
-    # },
-    'date': {
-      '$id': 'date',
-      'type': 'date'
-    },
-    # 2021-06-18 One RT added new FT expirationDate probably just a date value
-    'expirationDate': {
-      '$id': 'expirationDate',
-      'type': 'date'
-    },
-    'birthDate': {
-      '$id': 'birthDate',
-      'type': 'date'
-    },
-    'paymentCard': {
-      '$id': 'paymentCard',
-      'type': 'paymentCard'
-    },
-    'accountNumber': {
-      '$id': 'accountNumber',
-      'type': 'text',
-      'lookup': 'accountNumber',
-      'label': 'Account Number'
-    },
-    'groupNumber': {
-      '$id': 'groupNumber',
-      'type': 'text'
-    },
-    'bankAccount': {
-      '$id': 'bankAccount',
-      'type': 'bankAccount',
-      'lookup': 'accountNumber'
-    },
-    'cardRef': {
-      '$id': 'cardRef',
-      'type': 'cardRef',
-      'lookup': 'bankCard',
-      'multiple': 'default'
-    },
-    'note': {
-      '$id': 'note',
-      'type': 'multiline'
-    },
-    'url': {
-      '$id': 'url',
-      'type': 'url',
-      'multiple': 'optional'
-    },
-    # 2021-05-06 Unused photo, file - removed for compatibility with web vault
-    # 'photo': {
-    #   '$id': 'photo',
-    #   'type': 'file'
-    # },
-    # 'file': {
-    #   '$id': 'file',
-    #   'type': 'file'
-    # },
-    'fileRef': {
-      '$id': 'fileRef',
-      'type': 'fileRef',
-      'multiple': 'default'
-    },
-    'host': {
-      '$id': 'host',
-      'type': 'host',
-      'lookup': 'host',
-      'multiple': 'optional'
-    },
-    'securityQuestion': {
-      '$id': 'securityQuestion',
-      'type': 'securityQuestion',
-      'multiple': 'default'
-    },
-    'pinCode': {
-      '$id': 'pinCode',
-      'type': 'secret'
-    },
-    'oneTimeCode': {
-      '$id': 'oneTimeCode',
-      'type': 'otp'
-    },
-    'keyPair': {
-      '$id': 'keyPair',
-      'type': 'privateKey'
-    },
-    'licenseNumber': {
-      '$id': 'licenseNumber',
-      'type': 'multiline'
+    # Implicit fields - The following fields are always present on any record and do not need to be specified in the template:
+    record_implicit_fields = {
+        'title': '',  # string
+        'custom': [],  # Array of Field Data objects
+        'notes': ''  # string
     }
-    # 'custom: {
-    #   '$id': 'custom',
-    #   'type': 'custom'
-    # }
-  }
 
-  # https://github.com/Keeper-Security/record-templates/blob/master/field-types.json
-  # Record labels override default field type labels
-  field_values = {
-    'text': {
-      'type': 'text',
-      'value_description': 'plain text',
-      'value': '' # string
-    },
-    'url': {
-      'type': 'url',
-      'value_description': 'url string, can be clicked',
-      'value': '' # string
-    },
-    'multiline': {
-      'type': 'multiline',
-      'value_description': 'multiline text',
-      'value': '' # string
-    },
-    # 2021-05-06 Unused file type - removed for compatibility with web vault
-    # 'file': {
-    #   'type': 'file',
-    #   'value_description': 'large binary object, picture or other file',
-    #   'value': '' # ???
-    # },
-    'fileRef': {
-      'type': 'fileRef',
-      'value_description': 'reference to the file field on another record',
-      'value': '' # string (record v4 UID)
-    },
-    'email': {
-      'type': 'email',
-      'value_description': 'valid email address plus tag',
-      'value': '' # string
-    },
-    'host': {
-      'type': 'host',
-      'value_description': 'multiple fields to capture host information',
-      'value': {        # object
-        'hostName': '', # string
-        'port': ''      # string
-      }
-    },
-    'phone': {
-      'type': 'phone',
-      'value_description': 'numbers and symbols only plus tag',
-      'value': {      # object
-        'region': '', # string
-        'number': '', # string
-        'ext': '',    # string
-        'type': ('Mobile', 'Home', 'Work')
-      }
-    },
-    'name': {
-      'type': 'name',
-      'value_description': 'multiple fields to capture name',
-      'value': {          # object
-        'first': '',  # string
-        'middle': '', # string
-        'last': ''    # string
-      },
-      'required': ['first', 'last'] # required parts of field value - enforced only when RT specify that field is required
-      # 2021-04-01 use reference implementation (webVault - above) != from documentation (Record+Format+V3+draft - below)
-      # 'value': {          # object
-      #   'firstName': '',  # string
-      #   'middleName': '', # string
-      #   'lastName': ''    # string
-      # },
-      # 'required': ['firstName', 'lastName']
-    },
-    'address': {
-      'type': 'address',
-      'value_description': 'multiple fields to capture address',
-      'value': {        # object
-        'street1': '',  # string
-        'street2': '',  # string
-        'city': '',     # string
-        'state': '',    # string
-        'zip': '',      # string
-        'country': ''   # string
-      }
-    },
-    'addressRef': {
-      'type': 'addressRef',
-      'value_description': 'reference to the address field on another record',
-      'value': '' # string
-    },
-    'cardRef': {
-      'type': 'cardRef',
-      'value_description': 'reference to the bankCard field on another record',
-      'value': '' # string (record UID)
-    },
-    'secret': {
-      'type': 'secret',
-      'value_description': 'the field value is masked',
-      'value': '' # string
-    },
-    'login': {
-      'type': 'login',
-      'value_description': 'Login field, detected as the website login for browser extension or KFFA.',
-      'value': '' # string?
-    },
-    'password': {
-      'type': 'password',
-      'value_description': 'Field value is masked and allows for generation. Also complexity enforcements.',
-      'value': '' # string
-    },
-    'securityQuestion': {
-      'type': 'securityQuestion',
-      'value_description': 'Security Question and Answer',
-      'value': {        # object
-        'question': '', # string
-        'answer': ''    # string
-      }
-    },
-    'otp': {
-      'type': 'otp',
-      'value_description': 'captures the seed, displays QR code',
-      'value': '' # string
-    },
-    'paymentCard': {
-      'type': 'paymentCard',
-      'value_description': 'Field consisting of validated card number, expiration date and security code.',
-      'value': {                    # object
-          'cardNumber': '',         # string
-          'cardExpirationDate': '', # string
-          'cardSecurityCode': ''    # string
+    record_fields = {
+        'title': '',  # string - Record Title
+        'type': '',  # string - Record Type (either one of the standard types or a custom type)
+        'fields': [],  # Array of Field Data objects
+        'custom': [],  # Array of Field Data objects
+        'notes': ''  # string
+    }
+
+    # Fields are client-side defined. Fields are defined with a Field Type. All Field Types are fixed.
+    # Meaning, although we may implement new field types, the client cannot arbitrarily add field types,
+    # nor display/edit field types that are not pre programmed into the client.
+    # Once the client is updated to understand the new field type, the data may then be displayed and edited.
+
+    # TODO: translatable labels
+    # NB! Allow only one login/password field per v3 record. Allow in custom[] only if RT definition doesn't have them
+    # Standard RT definitions: always required - type, title
+    record_types = {
+        'login': {'label': 'Login'},
+        # def.  {"$id":"login","categories":["login"],"description":"Login template","fields":[{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"securityQuestion"},{"$ref":"fileRef"},{"$ref":"oneTimeCode"}]}
+        # ex.   {"title":"Title","type":"login","fields":[{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"securityQuestion","value":[]},{"type":"fileRef","value":[]},{"type":"oneTimeCode","value":[]}],"custom":[]}
+
+        'bankAccount': {'label': 'Bank Account'},  # { "$ref": "bankAccount", "required": true }
+        # def.  {"$id":"bankAccount","description":"Bank account template","fields":[{"$ref":"bankAccount","required":true},{"$ref":"name"},{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"cardRef"},{"$ref":"fileRef"},{"$ref":"oneTimeCode"}]}
+        # ex.   {"title":"Title","type":"bankAccount","fields":[{"type":"bankAccount","value":[{"accountType":"","routingNumber":"","accountNumber":"1234","otherType":""}],"required":true},{"type":"name","value":[{"first":"John","last":"Doe"}]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"cardRef","value":[]},{"type":"fileRef","value":[]},{"type":"oneTimeCode","value":[]}],"custom":[]}
+
+        'address': {'label': 'Address'},
+        # def.  {"$id":"address","categories":["address"],"description":"Address template","fields":[{"$ref":"address"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"address","fields":[{"type":"address","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'bankCard': {'label': 'Payment Card'},
+        # def.  {"$id":"bankCard","categories":["payment"],"description":"Bank card template","fields":[{"$ref":"paymentCard"},{"$ref":"text","label":"cardholderName"},{"$ref":"pinCode"},{"$ref":"addressRef"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"bankCard","fields":[{"type":"paymentCard","value":[]},{"type":"text","label":"Cardholder Name","value":[]},{"type":"pinCode","value":[]},{"type":"addressRef","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'birthCertificate': {'label': 'Birth Certificate'},
+        # def.  {"$id":"birthCertificate","categories":["ids"],"description":"Birth certificate template","fields":[{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"birthCertificate","fields":[{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'contact': {'label': 'Contact'},  # { "$ref": "name", "required": true }
+        # def.  {"$id":"contact","categories":["address"],"description":"Contact template","fields":[{"$ref":"name","required":true},{"$ref":"text","label":"company"},{"$ref":"email"},{"$ref":"phone"},{"$ref":"addressRef"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"contact","fields":[{"type":"name","value":[{"first":"John","last":"Doe"}],"required":true},{"type":"text","label":"Company","value":[]},{"type":"email","value":[]},{"type":"phone","value":[]},{"type":"addressRef","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'driverLicense': {'label': 'Driver\'s License'},
+        # def.  {"$id":"driverLicense","categories":["ids"],"description":"Driver license template","fields":[{"$ref":"accountNumber","label":"dlNumber"},{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"addressRef"},{"$ref":"expirationDate"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"driverLicense","fields":[{"type":"accountNumber","label":"Driver's License Number","value":[]},{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"addressRef","value":[]},{"type":"expirationDate","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'encryptedNotes': {'label': 'Secure Note'},
+        # def.  {"$id":"encryptedNotes","categories":["note"],"description":"Encrypted note template","fields":[{"$ref":"note"},{"$ref":"date"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"encryptedNotes","fields":[{"type":"note","value":[]},{"type":"date","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'file': {'label': 'File Attachment'},
+        # def.  {"$id":"file","categories":["file"],"description":"File template","fields":[{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"file","fields":[{"type":"fileRef","value":[]}],"custom":[]}
+
+        'healthInsurance': {'label': 'Health Insurance'},
+        # def.  {"$id":"healthInsurance","categories":["ids"],"description":"Health insurance template","fields":[{"$ref":"accountNumber"},{"$ref":"name","label":"insuredsName"},{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
+        # ex.   {"title":"Title","type":"healthInsurance","fields":[{"type":"accountNumber","value":[]},{"type":"name","label":"Insured's Name","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
+
+        'membership': {'label': 'Membership'},
+        # def.  {"$id":"membership","categories":["ids"],"description":"Membership template","fields":[{"$ref":"accountNumber"},{"$ref":"name"},{"$ref":"password"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
+        # ex.   {"title":"Title","type":"membership","fields":[{"type":"accountNumber","value":[]},{"type":"name","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
+
+        'passport': {'label': 'Passport'},
+        # def.  {"$id":"passport","categories":["ids"],"description":"Passport template","fields":[{"$ref":"accountNumber","label":"passportNumber"},{"$ref":"name"},{"$ref":"birthDate"},{"$ref":"addressRef"},{"$ref":"expirationDate"},{"$ref":"date","label":"dateIssued"},{"$ref":"password"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"passport","fields":[{"type":"accountNumber","label":"Passport Number","value":[]},{"type":"name","value":[]},{"type":"birthDate","value":[]},{"type":"addressRef","value":[]},{"type":"expirationDate","value":[]},{"type":"date","label":"Date Issued","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'photo': {'label': 'Photo'},
+        # def.  {"$id":"photo","categories":["file"],"description":"Photo template","fields":[{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"photo","fields":[{"type":"fileRef","value":[]}],"custom":[]}
+
+        'serverCredentials': {'label': 'Server'},
+        # def.  {"$id":"serverCredentials","categories":["login"],"description":"Server credentials template","fields":[{"$ref":"host"},{"$ref":"login"},{"$ref":"password"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"serverCredentials","fields":[{"type":"host","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'softwareLicense': {'label': 'Software License'},
+        # def.  {"$id":"softwareLicense","categories":["note"],"description":"Software license template","fields":[{"$ref":"licenseNumber"},{"$ref":"expirationDate"},{"$ref":"date","label":"dateActive"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
+        # ex.   {"title":"Title","type":"softwareLicense","fields":[{"type":"licenseNumber","value":[]},{"type":"expirationDate","value":[]},{"type":"date","label":"Date Active","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
+
+        'ssnCard': {'label': 'Identity Card'},
+        # def.  {"$id":"ssnCard","categories":["ids"],"description":"Identity card template","fields":[{"$ref":"accountNumber","label":"identityNumber"},{"$ref":"name"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"ssnCard","fields":[{"type":"accountNumber","label":"Identity Number","value":[]},{"type":"name","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+
+        'general': {'label': 'Legacy Record'},
+        # def.  {"$id":"general","categories":["login"],"description":"Legacy template","fields":[{"$ref":"login"},{"$ref":"password"},{"$ref":"url"},{"$ref":"oneTimeCode"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"general","fields":[{"type":"login","value":[]},{"type":"password","value":[]},{"type":"url","value":[]},{"type":"oneTimeCode","value":[]},{"type":"fileRef","value":[]}],"custom":[],"notes":""}
+
+        'sshKeys': {'label': 'SSH Key'},
+        # def.  {"$id":"sshKeys","categories":["login"],"description":"SSH key template","fields":[{"$ref":"login"},{"$ref":"keyPair"},{"$ref":"text","label":"passphrase"},{"$ref":"host"},{"$ref":"fileRef"},{"$ref":"securityQuestion"}]}
+        # ex.   {"title":"Title","type":"sshKeys","fields":[{"type":"login","value":[]},{"type":"keyPair","value":[]},{"type":"text","label":"Passphrase","value":[]},{"type":"host","value":[]},{"type":"fileRef","value":[]},{"type":"securityQuestion","value":[]}],"custom":[]}
+
+        'databaseCredentials': {'label': 'Database'}
+        # def.  {"$id":"databaseCredentials","categories":["login"],"description":"Database credentials template","fields":[{"$ref":"text","label":"type"},{"$ref":"host"},{"$ref":"login"},{"$ref":"password"},{"$ref":"fileRef"}]}
+        # ex.   {"title":"Title","type":"databaseCredentials","fields":[{"type":"text","label":"Type","value":[]},{"type":"host","value":[]},{"type":"login","value":[]},{"type":"password","value":[]},{"type":"fileRef","value":[]}],"custom":[]}
+    }
+
+    # A field definition consists from:
+    #   $id - ex. 'title', used to reference the field definitions and to translate the field labels
+    #   type|$type - used to tell the UI how to render and edit the field
+    #   lookup - optional flag: lookup values are shared based on the field reference.
+    #     ex. all 'login' fields will share the same set of lookup values but will not see the lookup values from 'company' field
+    #   multiple - optional flag: If specified, the UI should allow populating multiple instances of the field on the record
+    #   label - optional modifier: If specified, the UI display the label instead of the translated value
+    #   default - optional modifier: Defines the default value for the field
+    #   readonly -  flag: restrict editable field to be readonly or relax readonly field to be editable
+    #   required - optional flag: Can be used to make the field required
+    #   hidden - optional flag. Can be used to hide a field from the base template
+
+    # https://github.com/Keeper-Security/record-templates/blob/master/fields.json
+    # NB! All field_types must have corresponding field_values
+    field_types = {
+        # 2021-05-06 FT 'text' added for compatibility with web vault
+        'text': {
+            '$id': 'text',
+            'type': 'text'
+        },
+        # 2021-06-24 One RT added new FT 'secret' - type is yet unknown
+        'secret': {
+            '$id': 'secret',
+            'type': 'text'
+        },
+        'title': {
+            '$id': 'title',
+            'type': 'text'
+        },
+        'login': {
+            '$id': 'login',
+            'type': 'login',
+            'lookup': 'login'
+        },
+        'password': {
+            '$id': 'password',
+            'type': 'password'
+        },
+        'name': {
+            '$id': 'name',
+            'type': 'name',
+            'lookup': 'name'
+        },
+        'company': {
+            '$id': 'company',
+            'type': 'text',
+            'lookup': 'company'
+        },
+        'phone': {
+            '$id': 'phone',
+            'type': 'phone',
+            'multiple': 'optional',
+            'lookup': 'phone'
+        },
+        'email': {
+            '$id': 'email',
+            'type': 'email',
+            'multiple': 'optional',
+            'lookup': 'email'
+        },
+        'address': {
+            '$id': 'address',
+            'type': 'address',
+            'label': 'Street Address'
+        },
+        'addressRef': {
+            '$id': 'addressRef',
+            'type': 'addressRef',
+            'lookup': 'addressRef'
+        },
+        # 'cardNumber': {
+        #   '$id': 'cardNumber',
+        #   'type': 'cardNumber'  # undefined - probably replaced by paymentCard
+        # },
+        'date': {
+            '$id': 'date',
+            'type': 'date'
+        },
+        # 2021-06-18 One RT added new FT expirationDate probably just a date value
+        'expirationDate': {
+            '$id': 'expirationDate',
+            'type': 'date'
+        },
+        'birthDate': {
+            '$id': 'birthDate',
+            'type': 'date'
+        },
+        'paymentCard': {
+            '$id': 'paymentCard',
+            'type': 'paymentCard'
+        },
+        'accountNumber': {
+            '$id': 'accountNumber',
+            'type': 'text',
+            'lookup': 'accountNumber',
+            'label': 'Account Number'
+        },
+        'groupNumber': {
+            '$id': 'groupNumber',
+            'type': 'text'
+        },
+        'bankAccount': {
+            '$id': 'bankAccount',
+            'type': 'bankAccount',
+            'lookup': 'accountNumber'
+        },
+        'cardRef': {
+            '$id': 'cardRef',
+            'type': 'cardRef',
+            'lookup': 'bankCard',
+            'multiple': 'default'
+        },
+        'note': {
+            '$id': 'note',
+            'type': 'multiline'
+        },
+        'url': {
+            '$id': 'url',
+            'type': 'url',
+            'multiple': 'optional'
+        },
+        # 2021-05-06 Unused photo, file - removed for compatibility with web vault
+        # 'photo': {
+        #   '$id': 'photo',
+        #   'type': 'file'
+        # },
+        # 'file': {
+        #   '$id': 'file',
+        #   'type': 'file'
+        # },
+        'fileRef': {
+            '$id': 'fileRef',
+            'type': 'fileRef',
+            'multiple': 'default'
+        },
+        'host': {
+            '$id': 'host',
+            'type': 'host',
+            'lookup': 'host',
+            'multiple': 'optional'
+        },
+        'securityQuestion': {
+            '$id': 'securityQuestion',
+            'type': 'securityQuestion',
+            'multiple': 'default'
+        },
+        'pinCode': {
+            '$id': 'pinCode',
+            'type': 'secret'
+        },
+        'oneTimeCode': {
+            '$id': 'oneTimeCode',
+            'type': 'otp'
+        },
+        'keyPair': {
+            '$id': 'keyPair',
+            'type': 'privateKey'
+        },
+        'licenseNumber': {
+            '$id': 'licenseNumber',
+            'type': 'multiline'
         }
-    },
-    'date': {
-      'type': 'date',
-      'value_description': 'calendar date with validation, stored as unix milliseconds',
-      'value': 0 # number (long)
-    },
-    'bankAccount': {
-      'type': 'bankAccount',
-      'value_description': 'bank account information',
-      'value': {              # object
-        'accountType': ('Checking', 'Savings', 'Other'),
-        'otherType': '',      # string
-        'routingNumber': '',  # string
-        'accountNumber': ''   # string (required for RT bankAccount)
-      },
-      'required': ['accountNumber'] # required parts of field value - enforced only when RT specify that field is required
-    },
-    'privateKey': {
-      'type': 'privateKey',
-      'value_description': 'private key in ASN.1 format',
-      'value': {   # object
-        'publicKey': '', # string
-        'privateKey': '' # string
-      }
+        # 'custom: {
+        #   '$id': 'custom',
+        #   'type': 'custom'
+        # }
     }
-  }
-  # field_values w/o field_type - probably migrated to different types
-  # 'pinCode': '',       # string - currently v3.pinCode.type == secret /string/
-  # 'keyPair': {         # object - currently v3.keyPair.type == privateKey /string (PEM encoded)/
-  #     'publicKey': '', # string
-  #     'privateKey': '' # string
-  #   },
-  # 'note': ''           # string - currently v3.note.type == multiline /string/
 
+    # https://github.com/Keeper-Security/record-templates/blob/master/field-types.json
+    # Record labels override default field type labels
+    field_values = {
+        'text': {
+            'type': 'text',
+            'value_description': 'plain text',
+            'value': ''  # string
+        },
+        'url': {
+            'type': 'url',
+            'value_description': 'url string, can be clicked',
+            'value': ''  # string
+        },
+        'multiline': {
+            'type': 'multiline',
+            'value_description': 'multiline text',
+            'value': ''  # string
+        },
+        # 2021-05-06 Unused file type - removed for compatibility with web vault
+        # 'file': {
+        #   'type': 'file',
+        #   'value_description': 'large binary object, picture or other file',
+        #   'value': '' # ???
+        # },
+        'fileRef': {
+            'type': 'fileRef',
+            'value_description': 'reference to the file field on another record',
+            'value': ''  # string (record v4 UID)
+        },
+        'email': {
+            'type': 'email',
+            'value_description': 'valid email address plus tag',
+            'value': ''  # string
+        },
+        'host': {
+            'type': 'host',
+            'value_description': 'multiple fields to capture host information',
+            'value': {  # object
+                'hostName': '',  # string
+                'port': ''  # string
+            }
+        },
+        'phone': {
+            'type': 'phone',
+            'value_description': 'numbers and symbols only plus tag',
+            'value': {  # object
+                'region': '',  # string
+                'number': '',  # string
+                'ext': '',  # string
+                'type': ('Mobile', 'Home', 'Work')
+            }
+        },
+        'name': {
+            'type': 'name',
+            'value_description': 'multiple fields to capture name',
+            'value': {  # object
+                'first': '',  # string
+                'middle': '',  # string
+                'last': ''  # string
+            },
+            'required': ['first', 'last']
+            # required parts of field value - enforced only when RT specify that field is required
+            # 2021-04-01 use reference implementation (webVault - above) != from documentation (Record+Format+V3+draft - below)
+            # 'value': {          # object
+            #   'firstName': '',  # string
+            #   'middleName': '', # string
+            #   'lastName': ''    # string
+            # },
+            # 'required': ['firstName', 'lastName']
+        },
+        'address': {
+            'type': 'address',
+            'value_description': 'multiple fields to capture address',
+            'value': {  # object
+                'street1': '',  # string
+                'street2': '',  # string
+                'city': '',  # string
+                'state': '',  # string
+                'zip': '',  # string
+                'country': ''  # string
+            }
+        },
+        'addressRef': {
+            'type': 'addressRef',
+            'value_description': 'reference to the address field on another record',
+            'value': ''  # string
+        },
+        'cardRef': {
+            'type': 'cardRef',
+            'value_description': 'reference to the bankCard field on another record',
+            'value': ''  # string (record UID)
+        },
+        'secret': {
+            'type': 'secret',
+            'value_description': 'the field value is masked',
+            'value': ''  # string
+        },
+        'login': {
+            'type': 'login',
+            'value_description': 'Login field, detected as the website login for browser extension or KFFA.',
+            'value': ''  # string?
+        },
+        'password': {
+            'type': 'password',
+            'value_description': 'Field value is masked and allows for generation. Also complexity enforcements.',
+            'value': ''  # string
+        },
+        'securityQuestion': {
+            'type': 'securityQuestion',
+            'value_description': 'Security Question and Answer',
+            'value': {  # object
+                'question': '',  # string
+                'answer': ''  # string
+            }
+        },
+        'otp': {
+            'type': 'otp',
+            'value_description': 'captures the seed, displays QR code',
+            'value': ''  # string
+        },
+        'paymentCard': {
+            'type': 'paymentCard',
+            'value_description': 'Field consisting of validated card number, expiration date and security code.',
+            'value': {  # object
+                'cardNumber': '',  # string
+                'cardExpirationDate': '',  # string
+                'cardSecurityCode': ''  # string
+            }
+        },
+        'date': {
+            'type': 'date',
+            'value_description': 'calendar date with validation, stored as unix milliseconds',
+            'value': 0  # number (long)
+        },
+        'bankAccount': {
+            'type': 'bankAccount',
+            'value_description': 'bank account information',
+            'value': {  # object
+                'accountType': ('Checking', 'Savings', 'Other'),
+                'otherType': '',  # string
+                'routingNumber': '',  # string
+                'accountNumber': ''  # string (required for RT bankAccount)
+            },
+            'required': ['accountNumber']
+            # required parts of field value - enforced only when RT specify that field is required
+        },
+        'privateKey': {
+            'type': 'privateKey',
+            'value_description': 'private key in ASN.1 format',
+            'value': {  # object
+                'publicKey': '',  # string
+                'privateKey': ''  # string
+            }
+        }
+    }
 
-  @classmethod
-  def is_valid_field(cls, field_json):
-    ft_dict = {}
-    if field_json:
-      try: ft_dict = json.loads(field_json)
-      except: ft_dict = {}
+    # field_values w/o field_type - probably migrated to different types
+    # 'pinCode': '',       # string - currently v3.pinCode.type == secret /string/
+    # 'keyPair': {         # object - currently v3.keyPair.type == privateKey /string (PEM encoded)/
+    #     'publicKey': '', # string
+    #     'privateKey': '' # string
+    #   },
+    # 'note': ''           # string - currently v3.note.type == multiline /string/
 
-    ft = ft_dict.get('type')
-    fv = ft_dict.get('value') or []
-    valid_type = RecordV3.is_valid_field_type(ft)
-    valid_value = RecordV3.is_valid_field_value(ft, fv)
-    result = valid_type and valid_value
-    return result
+    @classmethod
+    def is_valid_field(cls, field_json):
+        ft_dict = {}
+        if field_json:
+            try:
+                ft_dict = json.loads(field_json)
+            except:
+                ft_dict = {}
 
+        ft = ft_dict.get('type')
+        fv = ft_dict.get('value') or []
+        valid_type = RecordV3.is_valid_field_type(ft)
+        valid_value = RecordV3.is_valid_field_value(ft, fv)
+        result = valid_type and valid_value
+        return result
 
-  @classmethod
-  def is_valid_field_type(cls, field_type):
-    result = True if field_type and cls.field_types.get(field_type) else False
-    return result
+    @classmethod
+    def is_valid_field_type(cls, field_type):
+        result = True if field_type and cls.field_types.get(field_type) else False
+        return result
 
+    @classmethod
+    def is_valid_field_value(cls, field_type, field_value):
+        result = False
+        if field_type and RecordV3.is_valid_field_type(field_type):
+            # empty value is OK
+            if field_value == []:
+                result = True
 
-  @classmethod
-  def is_valid_field_value(cls, field_type, field_value):
-    result = False
-    if field_type and RecordV3.is_valid_field_type(field_type):
-      # empty value is OK
-      if field_value == []:
-        result = True
+            if not result and isinstance(field_value, list):
+                fdef = cls.field_types.get(field_type) or {}
+                ftyp = fdef.get('type')
+                fvt = cls.field_values.get(ftyp)
+                fval = fvt.get('value')
+                results = True
+                if ftyp in ('fileRef', 'cardRef', 'addressRef'):
+                    for fv in field_value:
+                        results = results and RecordV3.is_valid_ref_uid(fv)
+                elif isinstance(fval, int):
+                    for fv in field_value:
+                        results = results and (isinstance(fv, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(fv))))
+                elif isinstance(fval, str):
+                    for fv in field_value:
+                        results = results and isinstance(fv, str) and bool(fv)
+                elif isinstance(fval, tuple):
+                    for fv in field_value:
+                        results = results and fval.__contains__(str(fv).strip())
+                elif isinstance(fval, dict):
+                    for fv in field_value:
+                        results = results and isinstance(fv, dict)
+                        if not results: break
+                        for fvv in fv:
+                            val1 = fval.get(fvv)
+                            val2 = fv.get(fvv)
+                            res = bool(val2)
+                            if isinstance(val1, int):
+                                res = res and (
+                                            isinstance(val2, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(val2))))
+                            elif isinstance(val1, str):
+                                res = res and isinstance(val2, str) and bool(val2)
+                            elif isinstance(val1, tuple):
+                                res = res and val1.__contains__(str(val2).strip())
+                            else:
+                                res = False
+                            results = results and res
+                else:
+                    results = False
+                result = results
 
-      if not result and isinstance(field_value, list):
-        fdef = cls.field_types.get(field_type) or {}
-        ftyp = fdef.get('type')
-        fvt = cls.field_values.get(ftyp)
-        fval = fvt.get('value')
-        results = True
-        if ftyp in ('fileRef', 'cardRef', 'addressRef'):
-          for fv in field_value:
-            results = results and RecordV3.is_valid_ref_uid(fv)
-        elif isinstance(fval, int):
-          for fv in field_value:
-            results = results and (isinstance(fv, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(fv))))
-        elif isinstance(fval, str):
-          for fv in field_value:
-            results = results and isinstance(fv, str) and bool(fv)
-        elif isinstance(fval, tuple):
-          for fv in field_value:
-            results = results and fval.__contains__(str(fv).strip())
-        elif isinstance(fval, dict):
-          for fv in field_value:
-            results = results and isinstance(fv, dict)
-            if not results: break
-            for fvv in fv:
-              val1 = fval.get(fvv)
-              val2 = fv.get(fvv)
-              res = bool(val2)
-              if isinstance(val1, int):
-                res = res and (isinstance(val2, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(val2))))
-              elif isinstance(val1, str):
-                res = res and isinstance(val2, str) and bool(val2)
-              elif isinstance(val1, tuple):
-                res = res and val1.__contains__(str(val2).strip())
-              else:
-                res = False
-              results = results and res
+        return result
+
+    @classmethod
+    def is_valid_field_data(cls, field_data, required=False):
+        errors = []
+
+        # ex. {"type": "name", "value": [{"first": "", "middle": "", "last": ""}]}
+        ft = field_data if isinstance(field_data, dict) else RecordV3.record_type_to_dict(field_data)
+        ftype = ft.get('type')
+        fvalue = ft.get('value') or []
+        reqd = required or bool(ft.get('required')) or False
+        if ftype and RecordV3.is_valid_field_type(ftype):
+            # empty value is OK for non-required fields
+            if not fvalue:
+                if reqd:
+                    errors.append('Field missing required value: ' + str(field_data))
+                return errors
+
+            if isinstance(fvalue, list):
+                fdef = cls.field_types.get(ftype) or {}
+                ftyp = fdef.get('type')
+                fvt = cls.field_values.get(ftyp) or {}
+                fval = fvt.get('value')
+                freq = (fvt.get('required') or []) if reqd else []
+                # warnings.append('Couldn\'t find requried fields for field type: ' + str(ftyp))
+
+                if ftyp in ('fileRef', 'cardRef', 'addressRef'):
+                    for fv in fvalue:
+                        # if reqd and not fv: errors.append('Missing required Ref UID: ' + fv)
+                        if fv and not RecordV3.is_valid_ref_uid(fv):
+                            errors.append('Invalid Ref UID: ' + fv)
+                elif isinstance(fval, int):
+                    for fv in fvalue:
+                        # if reqd and not fv: errors.append('Missing required integer value: ' + fv)
+                        if not ((isinstance(fv, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(fv))))):
+                            errors.append('Invalid integer value: ' + fv)
+                elif isinstance(fval, str):
+                    for fv in fvalue:
+                        # if reqd and not fv: errors.append('Missing required string value: ' + fv)
+                        if not isinstance(fv, str):  # and bool(fv)
+                            errors.append('Invalid string value: ' + fv)
+                elif isinstance(fval, tuple):
+                    for fv in fvalue:
+                        # if reqd and not fv: errors.append('Missing required enum value: ' + fv)
+                        if not fval.__contains__(str(fv).strip()):
+                            errors.append('Invalid enum value: ' + fv)
+                elif isinstance(fval, dict):
+                    for fv in fvalue:
+                        if not isinstance(fv, dict):
+                            errors.append('Invalid object value: ' + fv)
+                        if errors: break
+                        for fvv in fv:
+                            val1 = fval.get(fvv)
+                            val2 = fv.get(fvv)
+                            res = bool(val2)
+                            if reqd and fvv in freq and not res:
+                                errors.append('Missing required object field value: ' + fvv)
+                            if not errors:
+                                if isinstance(val1, int):
+                                    if not (
+                                    (isinstance(val2, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(val2))))):
+                                        errors.append('Invalid integer object value: ' + fvv)
+                                elif isinstance(val1, str):
+                                    if not isinstance(val2, str):  # and bool(val2)
+                                        errors.append('Invalid string object value: ' + fvv)
+                                elif isinstance(val1, tuple):
+                                    if not val1.__contains__(str(val2).strip()):
+                                        errors.append('Invalid enum object value: ' + fvv)
+                                else:
+                                    errors.append('Invalid object value type: ' + fvv)
+                else:
+                    errors.append('Invalid value type: ' + fval)
+            else:
+                errors.append('Expected an array of field values: ' + str(ftype))
         else:
-          results = False
-        result = results
+            errors.append('Field has unknown type: ' + str(ftype))
 
-    return result
-
-
-  @classmethod
-  def is_valid_field_data(cls, field_data, required=False):
-    errors = []
-
-    # ex. {"type": "name", "value": [{"first": "", "middle": "", "last": ""}]}
-    ft = field_data if isinstance(field_data, dict) else RecordV3.record_type_to_dict(field_data)
-    ftype = ft.get('type')
-    fvalue = ft.get('value') or []
-    reqd = required or bool(ft.get('required')) or False
-    if ftype and RecordV3.is_valid_field_type(ftype):
-      # empty value is OK for non-required fields
-      if not fvalue:
-        if reqd:
-          errors.append('Field missing required value: ' + str(field_data))
         return errors
 
-      if isinstance(fvalue, list):
-        fdef = cls.field_types.get(ftype) or {}
-        ftyp = fdef.get('type')
-        fvt = cls.field_values.get(ftyp) or {}
-        fval = fvt.get('value')
-        freq = (fvt.get('required') or []) if reqd else []
-        # warnings.append('Couldn\'t find requried fields for field type: ' + str(ftyp))
+    @classmethod
+    def is_valid_field_type_ref(cls, field_type_json):
+        # field ref inside record type definition - ex. {"$ref":"name", "required":true, "label":"placeName"}
+        # 2021-04-26 currently the only used options in field ref are - $ref, label, requried
+        result = False
+        if field_type_json:
+            try:
+                ft = json.loads(field_type_json)
+            except:
+                ft = {}
+            ref = ft.get('$ref')
+            result = RecordV3.is_valid_field_type(ref)
 
-        if ftyp in ('fileRef', 'cardRef', 'addressRef'):
-          for fv in fvalue:
-            # if reqd and not fv: errors.append('Missing required Ref UID: ' + fv)
-            if fv and not RecordV3.is_valid_ref_uid(fv):
-              errors.append('Invalid Ref UID: ' + fv)
-        elif isinstance(fval, int):
-          for fv in fvalue:
-            # if reqd and not fv: errors.append('Missing required integer value: ' + fv)
-            if not((isinstance(fv, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(fv))))):
-              errors.append('Invalid integer value: ' + fv)
-        elif isinstance(fval, str):
-          for fv in fvalue:
-            # if reqd and not fv: errors.append('Missing required string value: ' + fv)
-            if not isinstance(fv, str): # and bool(fv)
-              errors.append('Invalid string value: ' + fv)
-        elif isinstance(fval, tuple):
-          for fv in fvalue:
-            # if reqd and not fv: errors.append('Missing required enum value: ' + fv)
-            if not fval.__contains__(str(fv).strip()):
-              errors.append('Invalid enum value: ' + fv)
-        elif isinstance(fval, dict):
-          for fv in fvalue:
-            if not isinstance(fv, dict):
-              errors.append('Invalid object value: ' + fv)
-            if errors: break
-            for fvv in fv:
-              val1 = fval.get(fvv)
-              val2 = fv.get(fvv)
-              res = bool(val2)
-              if reqd and fvv in freq and not res:
-                errors.append('Missing required object field value: ' + fvv)
-              if not errors:
-                if isinstance(val1, int):
-                  if not((isinstance(val2, int) or bool(re.match(r'^\s*[-+]?\s*\d+\s*$', str(val2))))):
-                    errors.append('Invalid integer object value: ' + fvv)
-                elif isinstance(val1, str):
-                  if not isinstance(val2, str): # and bool(val2)
-                    errors.append('Invalid string object value: ' + fvv)
-                elif isinstance(val1, tuple):
-                  if not val1.__contains__(str(val2).strip()):
-                    errors.append('Invalid enum object value: ' + fvv)
+            known_keys = ('$ref', 'label', 'required')
+            unknown_keys = [x for x in ft if x.lower() not in known_keys]
+            if unknown_keys:
+                logging.warning('Unknown attributes in field reference: ' + str(unknown_keys))
+
+        return result
+
+    @classmethod
+    def is_valid_field_type_data(cls, field_type_json):
+        # field data inside record type - ex. {"type":"name","value":[{"first":"John","last":"Doe"}],"required":true, "label":"personName"}
+        # 2021-04-26 currently the only used options in fields are - type, label, requried, value[]
+        result = False
+        if field_type_json:
+            try:
+                ft = json.loads(field_type_json)
+            except:
+                ft = {}
+            ref = ft.get('type')
+            result = True if ref and cls.field_types.get(ref) else False
+
+            known_keys = ('type', 'label', 'requried')
+            unknown_keys = [x for x in ft if x.lower() not in known_keys]
+            if unknown_keys:
+                logging.warning('Unknown attributes in field type data: ' + str(unknown_keys))
+        return result
+
+    @staticmethod
+    def get_custom_list(custom_list):
+        # parse a list of key-value pairs - accepted formats: json, csv, list
+        custom = []
+        error = ''
+        if custom_list:
+            if type(custom_list) == str:
+                if custom_list[0] == '{' and custom_list[-1] == '}':
+                    try:
+                        custom_json = json.loads(custom_list)
+                        for k, v in custom_json.items():
+                            custom.append({
+                                'name': k,
+                                'value': str(v)
+                            })
+                    except ValueError as e:
+                        error = 'Invalid custom fields JSON input for {0}, Error: {1}'.format(custom_list, e)
                 else:
-                  errors.append('Invalid object value type: ' + fvv)
-        else:
-          errors.append('Invalid value type: ' + fval)
-      else:
-        errors.append('Expected an array of field values: ' + str(ftype))
-    else:
-      errors.append('Field has unknown type: ' + str(ftype))
+                    pairs = custom_list.split(',')
+                    for pair in pairs:
+                        idx = pair.find(':')
+                        if idx > 0:
+                            custom.append({
+                                'name': pair[:idx].strip(),
+                                'value': pair[idx + 1:].strip()
+                            })
+                        else:
+                            error = 'Invalid custom fields input for {0}. Expected: "Key:Value". Got: "{1}"'.format(
+                                custom_list, pair)
+            elif type(custom_list) == list:
+                for c in custom_list:
+                    if type(c) == dict:
+                        name = c.get('name')
+                        value = c.get('value')
+                        if name and value:
+                            custom.append({'name': name, 'value': value})
+        result = {'custom_list': custom, 'error': error}
+        return result
 
-    return errors
+    @staticmethod
+    def get_record_password(rt_data):
+        # Records v3 allow only one password to be stored either in fields[] or in custom[]
+        rt = RecordV3.record_type_to_dict(rt_data)
+        flds = (rt.get('fields') or []) + (rt.get('custom') or [])
+        passwords = [x.get('value') or [] for x in flds if isinstance(x, dict) and x.get('type') == 'password']
+        result = passwords[0][0] if passwords and passwords[0] else None
+        return result
 
+    @staticmethod
+    def get_record_field_value(rt_data, field_name, printable=True):
+        rt = RecordV3.record_type_to_dict(rt_data)
+        flds = (rt.get('fields') or []) + (rt.get('custom') or [])
+        values = [x.get('value') or [] for x in flds if isinstance(x, dict) and x.get('type') == field_name]
+        result = values[0][0] if values and values[0] else ''
+        if printable:
+            result = str(result)
+        return result
 
-  @classmethod
-  def is_valid_field_type_ref(cls, field_type_json):
-    # field ref inside record type definition - ex. {"$ref":"name", "required":true, "label":"placeName"}
-    # 2021-04-26 currently the only used options in field ref are - $ref, label, requried
-    result = False
-    if field_type_json:
-      try: ft = json.loads(field_type_json)
-      except: ft = {}
-      ref = ft.get('$ref')
-      result = RecordV3.is_valid_field_type(ref)
+    @staticmethod
+    def get_record_type_name(rt_data):
+        result = None
 
-      known_keys = ('$ref', 'label', 'required')
-      unknown_keys = [x for x in ft if x.lower() not in known_keys]
-      if unknown_keys:
-        logging.warning('Unknown attributes in field reference: ' + str(unknown_keys))
+        rt = rt_data if isinstance(rt_data, dict) else {}
+        if rt_data and (isinstance(rt_data, str) or isinstance(rt_data, bytes)):
+            try:
+                rt = json.loads(rt_data or '{}')
+            except:
+                logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_data) + bcolors.ENDC)
 
-    return result
-
-
-  @classmethod
-  def is_valid_field_type_data(cls, field_type_json):
-    # field data inside record type - ex. {"type":"name","value":[{"first":"John","last":"Doe"}],"required":true, "label":"personName"}
-    # 2021-04-26 currently the only used options in fields are - type, label, requried, value[]
-    result = False
-    if field_type_json:
-      try: ft = json.loads(field_type_json)
-      except: ft = {}
-      ref = ft.get('type')
-      result = True if ref and cls.field_types.get(ref) else False
-
-      known_keys = ('type', 'label', 'requried')
-      unknown_keys = [x for x in ft if x.lower() not in known_keys]
-      if unknown_keys:
-        logging.warning('Unknown attributes in field type data: ' + str(unknown_keys))
-    return result
-
-
-  @staticmethod
-  def get_custom_list(custom_list):
-    # parse a list of key-value pairs - accepted formats: json, csv, list
-    custom = []
-    error = ''
-    if custom_list:
-        if type(custom_list) == str:
-            if custom_list[0] == '{' and custom_list[-1] == '}':
-                try:
-                    custom_json = json.loads(custom_list)
-                    for k,v in custom_json.items():
-                        custom.append({
-                            'name': k,
-                            'value': str(v)
-                        })
-                except ValueError as e:
-                    error = 'Invalid custom fields JSON input for {0}, Error: {1}'.format(custom_list, e)
+        if rt and isinstance(rt, dict):
+            rtt = rt.get('type')
+            if rtt:
+                result = rtt
             else:
-                pairs = custom_list.split(',')
-                for pair in pairs:
-                    idx = pair.find(':')
-                    if idx > 0:
-                        custom.append({
-                            'name': pair[:idx].strip(),
-                            'value': pair[idx+1:].strip()
-                        })
-                    else:
-                        error = 'Invalid custom fields input for {0}. Expected: "Key:Value". Got: "{1}"'.format(custom_list, pair)
-        elif type(custom_list) == list:
-            for c in custom_list:
-                if type(c) == dict:
-                    name = c.get('name')
-                    value = c.get('value')
-                    if name and value:
-                        custom.append({ 'name': name, 'value': value })
-    result = { 'custom_list': custom, 'error': error }
-    return result
-
-
-  @staticmethod
-  def get_record_password(rt_data):
-    # Records v3 allow only one password to be stored either in fields[] or in custom[]
-    rt = RecordV3.record_type_to_dict(rt_data)
-    flds = (rt.get('fields') or []) + (rt.get('custom') or [])
-    passwords = [x.get('value') or [] for x in flds if isinstance(x, dict) and x.get('type') == 'password']
-    result = passwords[0][0] if passwords and passwords[0] else None
-    return result
-
-
-  @staticmethod
-  def get_record_field_value(rt_data, field_name, printable = True):
-    rt = RecordV3.record_type_to_dict(rt_data)
-    flds = (rt.get('fields') or []) + (rt.get('custom') or [])
-    values = [x.get('value') or [] for x in flds if isinstance(x, dict) and x.get('type') == field_name]
-    result = values[0][0] if values and values[0] else ''
-    if printable:
-      result = str(result)
-    return result
-
-
-  @staticmethod
-  def get_record_type_name(rt_data):
-    result = None
-
-    rt = rt_data if isinstance(rt_data, dict) else {}
-    if rt_data and (isinstance(rt_data, str) or isinstance(rt_data, bytes)):
-      try: rt = json.loads(rt_data or '{}')
-      except: logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_data) + bcolors.ENDC)
-
-    if rt and isinstance(rt, dict):
-      rtt = rt.get('type')
-      if rtt:
-        result = rtt
-      else:
-        logging.error(bcolors.FAIL + 'Unable to find record type type - JSON: ' + str(rt_data) + bcolors.ENDC)
-
-    return result
-
-
-  @staticmethod
-  def get_record_type_title(rt_data):
-    result = None
-
-    rt = rt_data if isinstance(rt_data, dict) else {}
-    if rt_data and (isinstance(rt_data, str) or isinstance(rt_data, bytes)):
-      try: rt = json.loads(rt_data or '{}')
-      except: logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_data) + bcolors.ENDC)
-
-    if rt and isinstance(rt, dict):
-      rtt = rt.get('title')
-      if rtt:
-        result = rtt
-      else:
-        logging.error(bcolors.FAIL + 'Unable to find record type title - JSON: ' + str(rt_data) + bcolors.ENDC)
-
-    return result
-
-  @staticmethod
-  def resolve_record_type_by_name(params, record_type_name):
-    record_type_info = None
-    if record_type_name:
-      if params.record_type_cache:
-        for v in params.record_type_cache.values():
-          dict = json.loads(v)
-          # TODO: Is 'type' case sensitive
-          if dict and dict.get('$id').lower() == record_type_name.lower():
-            record_type_info = v
-            break
-
-    return record_type_info
-
-  @staticmethod
-  def change_record_type(params, rt_data, new_rt_name):
-    # Converts rt_data (dict or JSON) from one valid record type to another
-    # by moving required fields between fields[] and custom[]
-
-    result = {
-      'errors': [],
-      'warnings': [],
-      'record': {}
-    }
-
-    r = rt_data if isinstance(rt_data, dict) else {}
-    if isinstance(rt_data, str) or isinstance(rt_data, bytes):
-      try: r = json.loads(rt_data)
-      except: result['errors'].append('Unable to parse record type data JSON: ' + str(rt_data))
-
-    newrtd = {}
-    rt_def = RecordV3.resolve_record_type_by_name(params, new_rt_name)
-    if rt_def:
-      try: newrtd = json.loads(rt_def)
-      except: result['errors'].append('Unable to parse record type definition JSON: ' + str(rt_def))
-    else:
-      result['errors'].append('Record type definition not found for type: ' + str(new_rt_name) + ' - to get list of all available record types use: record-type-info -lr')
-    if result['errors']: return result
-
-    rt = copy.deepcopy(r)
-    newf = newrtd.get('fields') or []
-    newf = [x.get('$ref') for x in newf if isinstance(x, dict)]
-    flds = rt.get('fields') or []
-    cust = rt.get('custom') or []
-
-    keep = [x for x in flds if isinstance(x, dict) and x.get('type') in newf]
-    move = [x for x in flds if isinstance(x, dict) and x.get('type') not in newf]
-    del flds[:]
-    flds.extend(keep)
-    cust.extend(move)
-
-    cmove = [x for x in cust if isinstance(x, dict) and x.get('type') in newf]
-    ckeep = [x for x in cust if isinstance(x, dict) and x.get('type') not in newf]
-    cset = {x.get('type') for x in cmove if isinstance(x, dict) and x.get('type')}
-    # move only first/one instance per field type
-    cmoved = []
-    for x in cmove:
-      if x.get('type') in cset:
-        cmoved.append(x)
-        cset.remove(x.get('type'))
-      else:
-        ckeep.append(x)
-    del cust[:]
-    flds.extend(cmoved)
-    cust.extend(ckeep)
-
-    rt['fields'] = flds
-    rt['custom'] = cust
-    rt['type'] = new_rt_name
-
-    if not result['errors']:
-      r = rt
-
-    result['record'] = r
-    return result
-
-
-  @staticmethod
-  def is_valid_ref_uid(uid: str) -> bool:
-    # UID length is 22 and all characters are valid base64 urlsafe characters
-    result = bool(re.search('^[A-Za-z0-9-_]{22}$', uid or ''))
-    return result
-
-  @staticmethod
-  def convert_options_to_json(params, rt_json, rt_def, kwargs):
-    # Converts dot notation options string to JSON string representing a valid record type
-    # NB! Currently duplicate field types cannot be added or edited using dot notation syntax
-    # Use JSON representation for full add/edit capabilites
-
-    result = {
-      'errors': [],
-      'warnings': [],
-      'record': {}
-    }
-
-    is_edit = True if rt_json else False
-
-    rt = {}
-    if rt_json:
-      try: rt = json.loads(rt_json or '{}')
-      except: result['errors'].append('Unable to parse record type JSON: ' + str(rt_json))
-
-    rtdef = {}
-    if rt_def:
-      try: rtdef = json.loads(rt_def)
-      except: result['errors'].append('Unable to parse record type definition JSON: ' + str(rt_def))
-    if result['errors']: return result
-
-    options = kwargs.get('option') or []
-    opts = [(x or '').split("=", 1) for x in options]
-    if not options and not kwargs.get('custom_list'):
-      return result
-
-    # normalize prefixes: f. -> fields., c. -> custom.
-    # so f.name.first is treated as duplicate of fields.name.first
-    for x in opts:
-      if x and x[0]:
-        x[0] = re.sub(r'^\s*fields\.', 'fields.', x[0], 1, flags=re.IGNORECASE)
-        x[0] = re.sub(r'^\s*custom\.', 'custom.', x[0], 1, flags=re.IGNORECASE)
-        x[0] = re.sub(r'^\s*f\.', 'fields.', x[0], 1, flags=re.IGNORECASE)
-        x[0] = re.sub(r'^\s*c\.', 'custom.', x[0], 1, flags=re.IGNORECASE)
-
-    # check for duplicate keys or keys with more than one value
-    dupes = [x for x in opts if x and len(x) != 2] # keys with multiple values
-    if dupes:
-      result['errors'].append('Found keys with multiple values: ' + str(dupes))
-    groups = {} # duplicate key(s)
-    for x, *values in opts: groups[x] = 1 + (groups.get(x) or 0)
-    multi = [{x: groups[x]} for x in groups if groups[x] > 1]
-    if multi:
-      result['errors'].append('Found duplicate keys/values: ' + str(multi))
-    if result['errors']: return result
-
-    rt_type = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'type'), None)
-    if not rt_type and is_edit and isinstance(rt, dict): rt_type = rt.get('type')
-    rt_title = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'title'), None)
-    rt_notes = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'notes'), None)
-    rt_fields = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'fields'), None)
-    rt_custom = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'custom'), None)
-
-    if not rt_type:
-      result['errors'].append('Record types "type" is requried')
-    if rt_fields or rt_custom:
-      result['errors'].append('Array types fields[] and custom[] cannot be assigned directly')
-    if result['errors']: return result
-
-    # Top level RT options - unknown attribute(s) generate error
-    # All known attribute(s) /from RT definition/ generate а warning and are silently ignored
-    tlo = [x for x in opts if x and not x[0].__contains__('.')]
-    ignored = ('$id', 'categories', 'description', 'label') # these are in RT definitions only
-    ilist = [x for x in tlo if x and x[0] in ignored]
-    if ilist:
-      tlo = [x for x in tlo if x not in ilist]
-      result['warnings'].append('Removed record type attributes that should be present in record type definitions only: ' + str(ilist))
-
-    ulist = [x for x in tlo if x and x[0].strip() not in ('type', 'title', 'notes')]
-    if ulist:
-      result['errors'].append('Unknown top level attributes: ' + str(ulist))
-
-    # field type options - ex. -o field.name.first=Jane -o f.name.last=Doe
-    flo = [x for x in opts if x and x[0].__contains__('.')]
-
-    # All fields must be either in fields[] or custom[] arrays
-    badg = [x for x in flo if x[0].split('.', 1)[0].strip().lower() not in ('fields', 'custom') ]
-    if badg:
-      result['errors'].append('Unknown field group (not fields[] and not custom[]): ' + str(badg))
-
-    # Allow only valid/known field types - field types are case sensitive?
-    badf = [x for x in flo if not RecordV3.field_types.__contains__(x[0].split('.', 2)[1].strip())]
-    if badf:
-      result['errors'].append('Unknown field types: ' + str(badf))
-    if result['errors']: return result
-
-    # only one FT of type password allowed in record v3
-    pwds = [x for x in flo if x and x[0].startswith(('fields.password','f.password','custom.password','c.password'))]
-    if len(pwds) > 1:
-      result['errors'].append('Error: Only one password allowed per record! ' + str(pwds))
-    elif len(pwds) == 1:
-      rtdp = next((True for x in (rtdef.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'), False)
-      pwdc = pwds[0][0] and pwds[0][0].lower().startswith('custom.')
-      if rtdp:
-        if pwdc: result['errors'].append('Password must be in fields[] section as defined by record type! ' + str(pwds))
-      else:
-        if not pwdc: result['errors'].append('Password must be in custom[] section - record type does not allow password in fields[]! ' + str(pwds))
-    if result['errors']: return result
-
-    # All fields with prefix f./fields. must be in record type definition
-    # Don't move f./fields. not in RT definition to custom[] - undefined order on duplicates, might break scripts
-    rtdf = [x.get('$ref') for x in (rtdef.get('fields') or []) if '$ref' in x]
-    flds = [x for x in flo if x and x[0].startswith(('fields.','f.'))]
-    cust = [x for x in flo if x and x[0].startswith(('custom.','c.'))]
-    badf = [x for x in flds if not x[0].split('.', 2)[1].strip() in rtdf]
-    if badf:
-      result['errors'].append('This record type doesn\'t allow "fields." prefix for these (move to custom): ' + str(badf))
-    # fileRef must use upload-attachment/delete-attachment commands instead
-    refs = [x for x in flds + cust if x[0].split('.', 2)[1].strip().lower() == 'fileref']
-    if refs:
-      result['errors'].append('File reference manipulations are disabled here. Use upload-attachment/delete-attachment commands instead. ' + str(refs))
-    if result['errors']: return result
-
-    # edit command: JSON validation before update
-    # add command: fields[] must contain all 'requried' fields (and requried value parts)
-    if not is_edit:
-      reqd = [x.get('$ref') for x in (rtdef.get('fields') or []) if '$ref' in x and 'required' in x]
-      for fld in reqd:
-        ft = (RecordV3.field_types.get(fld) or {}).get('type')
-        ftr = (RecordV3.field_values.get(ft) or {}).get('required') or []
-        if ftr:
-          ftr = ['fields.' + fld + '.' + x for x in ftr]
-          flon = [x[0] for x in flo if x and x[0]]
-          ftrm = [x for x in ftr if x not in flon]
-          if ftrm:
-            result['errors'].append('Missing requried fields: ' + str(ftrm) + '   Use `rti -lf field_name --example` to generate valid field sample.')
-        else:
-          result['warnings'].append('Couldn\'t find requried fields for the field type: ' + str(ft))
-    if result['errors']: return result
-
-    # NB! cmdline labels override RT definition labels which override FT definition labels
-    r = {}
-    if is_edit and rt_type != rt.get('type'):
-      res = RecordV3.change_record_type(params, rt_json, rt_type)
-      if not res.get('errors'):
-        r = res.get('record') or r
-      if res.get('errors'): result['errors'].extend(res['errors'])
-      if res.get('warnings'): result['warnings'].extend(res['warnings'])
-    else:
-      r = copy.deepcopy(rt) # for edited or deleted items
-      if not r: r = { 'type': rt_type } # add command
-      if rt_title: r['title'] = rt_title
-      if is_edit and rt_title == '': r['title'] = '' # edit: delete title
-      if rt_notes: r['notes'] = rt_notes
-      if is_edit and rt_notes == '': r['notes'] = '' # edit: delete notes
-      if not 'fields' in r: r['fields'] = []
-      if not 'custom' in r: r['custom'] = []
-      for lst in [flds, cust]:
-        for f in lst:
-          if f and len(f) == 2:
-            val = f[1]
-            path = f[0].split('.')
-            forc = path[0].strip() if path else '' # fields or custom
-            fname = path[1].strip() if path and len(path) > 1 else ''  # field name
-            fvname = path[2].strip() if path and len(path) > 2 else '' # field attribute (if any)
-            if fname:
-              if not forc in r: r[forc] = [] # create fields[] or custom[]
-              fv = next((x for x in r[forc] if isinstance(x, dict) and x.get('type') == fname), {})
-              if not fv:
-                fv = { 'type': fname, 'value': [] }
-                r[forc].append(fv)
-              if 'value' not in fv: fv['value'] = []
-              if fvname:
-                # NB! required:true/false comes from RT definition and should not be re/set here
-                if fvname.lower() == 'required':
-                  result['warnings'].append('Skipped "required" field attribute which comes from record type definition and should not be set here! ' + str(f))
-                  continue
-                # check if fvname is FT attribute vs FT value object parts - ex. c.name.label vs. c.name.first
-                if fvname.lower() == 'label':
-                  fv['label'] = val
-                elif is_edit and not val: # delete
-                  if forc in r:
-                    v = next((x.get('value') or [] for x in r[forc] if isinstance(x, dict) and x.get('type') == fname), [])
-                    # v = next((x for x in v if isinstance(x, dict) and fvname in x), {})
-                    v = next((x for x in v if isinstance(x, dict)), {})
-                    v.pop(fvname, None)
-                elif bool(val):  # upsert
-                  # v = next((x for x in fv['value'] if isinstance(x, dict) and fvname in x), None)
-                  v = next((x for x in fv['value'] if isinstance(x, dict)), None)
-                  if v: v[fvname] = val
-                  else: fv['value'].append({fvname: val})
-                  ok = RecordV3.is_valid_field_value(fname, [{fvname: val}])
-                  if not ok: result['errors'].append('Invalid field value: ' + str({fname: [{fvname: val}]}))
-                else:
-                  result['warnings'].append('Skipped empty field value: ' + str(f))
-              else: # simple value str/int assign directly - ex. c.login=MyLogin
-                if bool(val):
-                  del fv['value'][:]
-                  fv['value'].append(val)
-                elif 'value' in fv and isinstance(fv['value'], list): # delete
-                  del fv['value'][:]
-          else:
-            result['errors'].append('Miltiple field values per single option aren\'t allowed. Use multiple options: -o f.name.first=A -o f.name.last=B ' + str(f))
-
-    # add command could pass multiple custom options - ex. --custom='{"name1":"value1", "name2":"value: 2,3,4"}'
-    # since dot format can't handle duplicate keys we pass these as kwargs['custom_list']
-    custom_list = kwargs.get('custom_list') or []
-    custom = [ {
-      'type': 'text',
-      'label': x.get('name') or '',
-      'value': [x.get('value')] if x.get('value') else []
-    } for x in custom_list if x.get('name') or x.get('value') ]
-    if custom:
-      r['custom'] = (r.get('custom') or [])
-      if is_edit:
-        # update value of existing custom field or insert new one
-        for cr in custom:
-          cold = next((x for x in r['custom'] if x.get('type') == 'text' and x.get('label') == cr.get('label') and cr.get('label') is not None), None)
-          if cold:
-            cold['value'] = cr.get('value')
-          else:
-            r['custom'].append(cr)
-      else:
-        r['custom'] = r['custom'] + custom
-
-    if r and not result['errors']:
-      if not r.get('custom'): r.pop('custom', None)
-      if not r.get('fields'): r.pop('fields', None)
-      rt = r
-
-    if not result['errors']:
-      result['record'] = rt
-
-    return result
-
-  @staticmethod
-  def convert_to_record_type(record_uid, params):
-    # Converts records v2 to v3
-    result = False
-
-    if not (record_uid and params and params.record_cache and record_uid in params.record_cache):
-      logging.error(bcolors.FAIL + 'Record %s not found.' + bcolors.ENDC, record_uid)
-      return result
-
-    record = params.record_cache[record_uid]
-    version = record.get('version') or 0
-    if version != 2:
-      logging.error(bcolors.FAIL + 'Record %s is not version 2.' + bcolors.ENDC, record_uid)
-      return result
-
-    udata = record.get('udata')
-    data = record.get('data_unencrypted')
-    extra = record.get('extra_unencrypted')
-    # extra contains: files, fields, (favicon_url - deprecated, smartfill - deprecated)
-
-    udata = udata if isinstance(udata, dict) else json.loads(udata or '{}')
-    data = data if isinstance(data, dict) else json.loads(data or '{}')
-    extra = extra if isinstance(extra, dict) else json.loads(extra or '{}')
-
-    file_ids = udata.get('file_ids') or []
-    files = extra.get('files') or []
-    has_files = len(file_ids) > 0 or len(files) > 0
-    if has_files:
-      logging.error(bcolors.FAIL + 'Record %s has file atachments. Not convertible.' + bcolors.ENDC, record_uid)
-      return result
-
-    # check for other non-convertible data - ex. fields[] has "field_type" != "totp" if present
-    fields = extra.get('fields') or []
-    otps = [x for x in fields if 'totp' == (x.get('field_type') or '')]
-    if bool(data.get('folder')) or len(fields) != len(otps):
-      logging.error(bcolors.FAIL + 'Record %s has unknown extra fields.' + bcolors.ENDC, record_uid)
-      return result
-
-    otp = otps[0] if otps else {}
-    totp = otp.get('data') or ''
-    # label = otp.get('field_title') or ''
-
-    title = data.get('title') or ''
-    login = data.get('secret1') or ''
-    password = data.get('secret2') or ''
-    url = data.get('link') or ''
-
-    notes = data.get('notes') or ''
-    custom2 = data.get('custom') or []
-    # custom.type	- Always "text" for legacy reasons.
-    custom = [ {
-      'type': 'text',
-      'label': x.get('name') or '',
-      'value': [x.get('value')] if x.get('value') else []
-    } for x in custom2 if x.get('name') or x.get('value') ]
-
-    # Add any remaining TOTP codes to custom[]
-    if len(otps) > 1:
-      otps.pop(0)
-      otp2 = [ {
-        'type': 'oneTimeCode',
-        'value': [x.get('data')]
-      } for x in otps if x.get('data') ]
-      if otp2: custom.extend(otp2)
-
-    rt = {
-      'title': title,
-      'type': 'general',
-      'fields': [
-        { 'type': 'login', 'value': [login] if login else []},
-        { 'type': 'password', 'value': [password] if password else []},
-        { 'type': 'url', 'value': [url] if url else []},
-        { 'type': 'oneTimeCode', 'value': [totp] if totp else [] },
-        { 'type': 'fileRef', 'value': []}
-      ],
-      'custom': custom,
-      'notes': notes
-    }
-
-    record['version'] = 3
-    record.pop('udata', None)
-    record.pop('extra', None)
-    record.pop('extra_unencrypted', None)
-    record['data_unencrypted'] = json.dumps(rt)
-    record['client_modified_time'] = api.current_milli_time()
-    result = True
-    return result
-
-  @staticmethod
-  def values_to_lowerstring(data_json):
-    return RecordV3.values_to_string(data_json).lower()
-
-  @staticmethod
-  def values_to_string(data_json):
-    result = ''
-
-    rt = RecordV3.record_type_to_dict(data_json)
-    result += rt.get('title') or ''
-    result += rt.get('notes') or ''
-
-    fields = rt.get('fields') or []
-    custom = rt.get('custom') or []
-    values = [x.get('value') for x in fields + custom if x.get('value')]
-    values = [x if not isinstance(x[0], dict) else ';'.join(str(v) for v in x[0].values()) for x in values if len(x) > 0]
-    result += str(values)
-
-    return result
-
-  @staticmethod
-  def record_type_to_dict(rt_json):
-    rt = {}
-    if rt_json:
-      try:
-        rt = json.loads(rt_json or '{}')
-      except:
-        rt = {}
-        logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_json) + bcolors.ENDC)
-    return rt
-
-  @staticmethod
-  def update_password(password, rt_json, rt_def):
-    # Delete if pass is empty, Upsert if pass is present:
-    # Check if there's password field in fields[], custom[] and replace first instance
-    # If no password in RT but RT definition has a password field - add to fields[]
-    # else add to custom[]
-    result = rt_json
-
-    rt = {}
-    if rt_json:
-      try: rt = json.loads(rt_json or '{}')
-      except: logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_json) + bcolors.ENDC)
-
-    rtdef = {}
-    if rt_def:
-      try: rtdef = json.loads(rt_def)
-      except: logging.error(bcolors.FAIL + 'Unable to parse record type definition JSON: ' + str(rt_def) + bcolors.ENDC)
-
-    if not rt or not rtdef:
-      logging.error(bcolors.FAIL + 'Failed to update password field!' + bcolors.ENDC)
-      return result
-
-    rtt = rt.get('type')
-    rtdt = rtdef.get('$id')
-    if not rtt or rtt != rtdt:
-      logging.error(bcolors.FAIL + 'Record type missing or doesn\'t match definition! ' + str([rtt, rtdt]) + bcolors.ENDC)
-      return result
-
-    # Look for existing password in fields[] then custom[] and replace
-    fields = rt.get('fields') or []
-    custom = rt.get('custom') or []
-    rtfp = [x for x in fields if 'type' in x and x.get('type') == 'password']
-    rtcp = [x for x in custom if 'type' in x and x.get('type') == 'password']
-    changed = False
-    if rtfp:
-      rtfp[0]['value'] = [password] if password else []
-      changed = True
-    elif rtcp:
-      rtcp[0]['value'] = [password] if password else []
-      changed = True
-    elif password:
-      # no existing password - add to fields[] (if RT definition allows) or to custom[]
-      rtdp = next((True for x in (rtdef.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'), False)
-      if rtdp:
-        if 'fields' not in rt:
-          rt['fields'] = []
-        rt['fields'].append({'type': 'password', 'value':[password]})
-      else:
-        if 'custom' not in rt:
-          rt['custom'] = []
-        rt['custom'].append({'type': 'password', 'value':[password]})
-      changed = True
-
-    if changed:
-      result = json.dumps(rt)
-
-    return result
-
-  @staticmethod
-  def get_field_types():
-    ftypes = [ { **RecordV3.field_types.get(fkey), **RecordV3.field_values.get(vkey) }
-        for fkey in RecordV3.field_types
-          for vkey in RecordV3.field_values
-            if (RecordV3.field_types.get(fkey) or {}).get('type') == vkey
-    ]
-    rows = [] # (id, type, lookup, multiple, description)
-    for ft in ftypes:
-      field_id = ft.get('$id') or ''
-      field_type = ft.get('type') or ''
-      lookup = ft.get('lookup') or ''
-      multiple = ft.get('multiple') or ''
-      description = ft.get('value_description') or ''
-      rows.append((field_id, field_type, lookup, multiple, description))
-    return rows
-
-  @staticmethod
-  def get_field_type(id):
-    STR_VALUE = 'text'
-    ftypes = [ { **RecordV3.field_types.get(fkey), **RecordV3.field_values.get(vkey) }
-        for fkey in RecordV3.field_types
-          for vkey in RecordV3.field_values
-            if (RecordV3.field_types.get(fkey) or {}).get('type') == vkey
-    ]
-    ids = [ft for ft in ftypes if id and (id == ft.get('$id'))]
-    result = ids[0] if ids else {}
-    if result:
-      val = result.get('value')
-      vtype = ('integer' if isinstance(val, int)
-        else 'string' if isinstance(val, str)
-        else 'enum' if isinstance(val, tuple)
-        else 'object' if isinstance(val, dict)
-        else 'unknown')
-      obj = val if vtype != 'object' else {
-        x: val[x] if not isinstance(val[x], tuple) else " | ".join(str(t) for t in val[x])
-        for x in val
-      }
-      obj_sample = val if vtype != 'object' else {
-        x: 0 if isinstance(val[x], int)
-          else STR_VALUE if isinstance(val[x], str)
-          else val[x][0] if isinstance(val[x], tuple)
-          else val
-        for x in val
-      }
-      value = (0 if vtype == 'integer'
-        else '' if vtype == 'string'
-        else val[0] if vtype == 'enum'
-        else obj if vtype == 'object'
-        else '')
-      sample = (0 if vtype == 'integer'
-        else STR_VALUE if vtype == 'string'
-        else val[0] if vtype == 'enum'
-        else obj_sample if vtype == 'object'
-        else '')
-
-      result = {
-        'id': result.get('$id') or '',
-        'type': result.get('type') or '',
-        'valueType': vtype,
-        'value': value,
-        'sample': sample
-      }
-    return result
-
-  @staticmethod
-  def get_record_type_example(params, rt_name: str) -> str:
-    STR_VALUE = 'text'
-
-    result = ''
-    rte = {}
-    rt_def = RecordV3.resolve_record_type_by_name(params, rt_name)
-    if rt_def:
-      rtdd = RecordV3.record_type_to_dict(rt_def)
-      rtdf = rtdd.get('fields') or []
-
-      rte = {
-        'type': rt_name,
-        'title': STR_VALUE,
-        'notes': STR_VALUE,
-        'fields': [],
-        'custom': []
-      }
-
-      rtdef= {}
-      try:
-        rtdef = json.loads(rt_def)
-      except:
-        logging.error(bcolors.FAIL + 'Unable to parse record type definition JSON: ' + str(rt_def) + bcolors.ENDC)
-
-      fields = rtdef.get('fields') or []
-      fields = [x.get('$ref') for x in fields]
-      for fname in fields:
-        ft = RecordV3.get_field_type(fname)
-        if not ft or not ft.get('id'):
-          logging.error(bcolors.FAIL + 'Error - Unknown field type: ' + fname + bcolors.ENDC)
-          continue
-
-        val = {
-          'type': fname,
-          'value': []
+                logging.error(bcolors.FAIL + 'Unable to find record type type - JSON: ' + str(rt_data) + bcolors.ENDC)
+
+        return result
+
+    @staticmethod
+    def get_record_type_title(rt_data):
+        result = None
+
+        rt = rt_data if isinstance(rt_data, dict) else {}
+        if rt_data and (isinstance(rt_data, str) or isinstance(rt_data, bytes)):
+            try:
+                rt = json.loads(rt_data or '{}')
+            except:
+                logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_data) + bcolors.ENDC)
+
+        if rt and isinstance(rt, dict):
+            rtt = rt.get('title')
+            if rtt:
+                result = rtt
+            else:
+                logging.error(bcolors.FAIL + 'Unable to find record type title - JSON: ' + str(rt_data) + bcolors.ENDC)
+
+        return result
+
+    @staticmethod
+    def resolve_record_type_by_name(params, record_type_name):
+        record_type_info = None
+        if record_type_name:
+            if params.record_type_cache:
+                for v in params.record_type_cache.values():
+                    dict = json.loads(v)
+                    # TODO: Is 'type' case sensitive
+                    if dict and dict.get('$id').lower() == record_type_name.lower():
+                        record_type_info = v
+                        break
+
+        return record_type_info
+
+    @staticmethod
+    def change_record_type(params, rt_data, new_rt_name):
+        # Converts rt_data (dict or JSON) from one valid record type to another
+        # by moving required fields between fields[] and custom[]
+
+        result = {
+            'errors': [],
+            'warnings': [],
+            'record': {}
         }
 
-        if fname not in ('fileRef', 'addressRef', 'cardRef'):
-          # Fix for webVault - fails if phone's region is not valid country code
-          if fname == 'phone' and 'sample' in ft and 'region' in ft['sample']:
-            ft['sample']['region'] = 'US'
+        r = rt_data if isinstance(rt_data, dict) else {}
+        if isinstance(rt_data, str) or isinstance(rt_data, bytes):
+            try:
+                r = json.loads(rt_data)
+            except:
+                result['errors'].append('Unable to parse record type data JSON: ' + str(rt_data))
 
-          val['value'].append(ft.get('sample'))
-          required = next((x.get('required') for x in rtdf if x.get('$ref') == fname), None)
-          if required:
-            val['required'] = required
-          label = next((x.get('label') for x in rtdf if x.get('$ref') == fname), None)
-          if label:
-            val['label'] = label
-
-        rte['fields'].append(val)
-    else:
-      logging.error(bcolors.FAIL + 'Unable to find record type definition for type: ' + str(rt_name) +
-        '   To show available record types definitions use `record-type-info --list-record *` command'+ bcolors.ENDC)
-
-    result = json.dumps(rte) if rte else ''
-    return result
-
-  @staticmethod
-  def display(r, **kwargs):
-    record_uid = r['record_uid']
-    print('')
-    # print('{0:>20s}: https://keepersecurity.com/vault#detail/{1}'.format('Link', record_uid))
-    print('{0:>20s}: {1:<20s}'.format('UID', record_uid))
-    # if 'version' in r: print('{0:>20s}: {1:<20s}'.format('Version', str(r['version'])))
-    params = None
-    if 'params' in kwargs:
-        params = kwargs['params']
-        folders = [get_folder_path(params, x) for x in find_folders(params, record_uid)]
-        for i in range(len(folders)):
-            print('{0:>21s} {1:<20s}'.format('Folder:' if i == 0 else '', folders[i]))
-
-    data = {}
-    if 'data_unencrypted' in r:
-      data = r['data_unencrypted'].decode() if isinstance(r['data_unencrypted'], bytes) else r['data_unencrypted']
-      data = json.loads(data)
-    fields = data.get('fields') or []
-    custom = data.get('custom') or []
-    
-    print('{0:>20s}: {1:<20s}'.format('Type', str(data['type']) if 'type' in data else ''))
-    print('{0:>20s}: {1:<20s}'.format('Title', str(data['title']) if 'title' in data else ''))
-    # NB! General notes here - fields[] might provide their own notes
-    if 'notes' in data: print('{0:>20s}: {1:<20s}'.format('Notes', str(data['notes'])))
-    # fields[] * print Field# NN - atrib: value
-
-    for c in fields + custom:
-      ftyp = c.get('type') or ''
-      flab = c.get('label') or ''
-      flds = c.get('value') or []
-      fval = flds
-      if len(flds) == 1 and flds[0]:
-        if isinstance(flds[0], dict):
-          if ftyp.lower() == 'name':
-            fval = ' '.join(flds[0].values())
-          else:
-            fval = ' | '.join(flds[0].values())
-        elif RecordV3.get_field_type(ftyp).get('type') == 'date' and flds[0] and bool(re.match('^[+-]?[0-9]+$', str(flds[0]).strip())):
-          dt = datetime.datetime.fromtimestamp(flds[0]/1000.0)
-          fval = str(dt)
+        newrtd = {}
+        rt_def = RecordV3.resolve_record_type_by_name(params, new_rt_name)
+        if rt_def:
+            try:
+                newrtd = json.loads(rt_def)
+            except:
+                result['errors'].append('Unable to parse record type definition JSON: ' + str(rt_def))
         else:
-          fval = flds[0]
-      if fval:
-        if ftyp in ('fileRef', 'cardRef', 'addressRef'):
-          RecordV3.display_ref(ftyp, fval, **kwargs)
+            result['errors'].append('Record type definition not found for type: ' + str(
+                new_rt_name) + ' - to get list of all available record types use: record-type-info -lr')
+        if result['errors']: return result
+
+        rt = copy.deepcopy(r)
+        newf = newrtd.get('fields') or []
+        newf = [x.get('$ref') for x in newf if isinstance(x, dict)]
+        flds = rt.get('fields') or []
+        cust = rt.get('custom') or []
+
+        keep = [x for x in flds if isinstance(x, dict) and x.get('type') in newf]
+        move = [x for x in flds if isinstance(x, dict) and x.get('type') not in newf]
+        del flds[:]
+        flds.extend(keep)
+        cust.extend(move)
+
+        cmove = [x for x in cust if isinstance(x, dict) and x.get('type') in newf]
+        ckeep = [x for x in cust if isinstance(x, dict) and x.get('type') not in newf]
+        cset = {x.get('type') for x in cmove if isinstance(x, dict) and x.get('type')}
+        # move only first/one instance per field type
+        cmoved = []
+        for x in cmove:
+            if x.get('type') in cset:
+                cmoved.append(x)
+                cset.remove(x.get('type'))
+            else:
+                ckeep.append(x)
+        del cust[:]
+        flds.extend(cmoved)
+        cust.extend(ckeep)
+
+        rt['fields'] = flds
+        rt['custom'] = cust
+        rt['type'] = new_rt_name
+
+        if not result['errors']:
+            r = rt
+
+        result['record'] = r
+        return result
+
+    @staticmethod
+    def is_valid_ref_uid(uid: str) -> bool:
+        # UID length is 22 and all characters are valid base64 urlsafe characters
+        result = bool(re.search('^[A-Za-z0-9-_]{22}$', uid or ''))
+        return result
+
+    @staticmethod
+    def convert_options_to_json(params, rt_json, rt_def, kwargs):
+        # Converts dot notation options string to JSON string representing a valid record type
+        # NB! Currently duplicate field types cannot be added or edited using dot notation syntax
+        # Use JSON representation for full add/edit capabilites
+
+        result = {
+            'errors': [],
+            'warnings': [],
+            'record': {}
+        }
+
+        is_edit = True if rt_json else False
+
+        rt = {}
+        if rt_json:
+            try:
+                rt = json.loads(rt_json or '{}')
+            except:
+                result['errors'].append('Unable to parse record type JSON: ' + str(rt_json))
+
+        rtdef = {}
+        if rt_def:
+            try:
+                rtdef = json.loads(rt_def)
+            except:
+                result['errors'].append('Unable to parse record type definition JSON: ' + str(rt_def))
+        if result['errors']: return result
+
+        options = kwargs.get('option') or []
+        opts = [(x or '').split("=", 1) for x in options]
+        if not options and not kwargs.get('custom_list'):
+            return result
+
+        # normalize prefixes: f. -> fields., c. -> custom.
+        # so f.name.first is treated as duplicate of fields.name.first
+        for x in opts:
+            if x and x[0]:
+                x[0] = re.sub(r'^\s*fields\.', 'fields.', x[0], 1, flags=re.IGNORECASE)
+                x[0] = re.sub(r'^\s*custom\.', 'custom.', x[0], 1, flags=re.IGNORECASE)
+                x[0] = re.sub(r'^\s*f\.', 'fields.', x[0], 1, flags=re.IGNORECASE)
+                x[0] = re.sub(r'^\s*c\.', 'custom.', x[0], 1, flags=re.IGNORECASE)
+
+        # check for duplicate keys or keys with more than one value
+        dupes = [x for x in opts if x and len(x) != 2]  # keys with multiple values
+        if dupes:
+            result['errors'].append('Found keys with multiple values: ' + str(dupes))
+        groups = {}  # duplicate key(s)
+        for x, *values in opts: groups[x] = 1 + (groups.get(x) or 0)
+        multi = [{x: groups[x]} for x in groups if groups[x] > 1]
+        if multi:
+            result['errors'].append('Found duplicate keys/values: ' + str(multi))
+        if result['errors']: return result
+
+        rt_type = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'type'), None)
+        if not rt_type and is_edit and isinstance(rt, dict): rt_type = rt.get('type')
+        rt_title = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'title'), None)
+        rt_notes = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'notes'), None)
+        rt_fields = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'fields'), None)
+        rt_custom = next((x[1] for x in opts if x and len(x) == 2 and x[0].lower() == 'custom'), None)
+
+        if not rt_type:
+            result['errors'].append('Record types "type" is requried')
+        if rt_fields or rt_custom:
+            result['errors'].append('Array types fields[] and custom[] cannot be assigned directly')
+        if result['errors']: return result
+
+        # Top level RT options - unknown attribute(s) generate error
+        # All known attribute(s) /from RT definition/ generate а warning and are silently ignored
+        tlo = [x for x in opts if x and not x[0].__contains__('.')]
+        ignored = ('$id', 'categories', 'description', 'label')  # these are in RT definitions only
+        ilist = [x for x in tlo if x and x[0] in ignored]
+        if ilist:
+            tlo = [x for x in tlo if x not in ilist]
+            result['warnings'].append(
+                'Removed record type attributes that should be present in record type definitions only: ' + str(ilist))
+
+        ulist = [x for x in tlo if x and x[0].strip() not in ('type', 'title', 'notes')]
+        if ulist:
+            result['errors'].append('Unknown top level attributes: ' + str(ulist))
+
+        # field type options - ex. -o field.name.first=Jane -o f.name.last=Doe
+        flo = [x for x in opts if x and x[0].__contains__('.')]
+
+        # All fields must be either in fields[] or custom[] arrays
+        badg = [x for x in flo if x[0].split('.', 1)[0].strip().lower() not in ('fields', 'custom')]
+        if badg:
+            result['errors'].append('Unknown field group (not fields[] and not custom[]): ' + str(badg))
+
+        # Allow only valid/known field types - field types are case sensitive?
+        badf = [x for x in flo if not RecordV3.field_types.__contains__(x[0].split('.', 2)[1].strip())]
+        if badf:
+            result['errors'].append('Unknown field types: ' + str(badf))
+        if result['errors']: return result
+
+        # only one FT of type password allowed in record v3
+        pwds = [x for x in flo if
+                x and x[0].startswith(('fields.password', 'f.password', 'custom.password', 'c.password'))]
+        if len(pwds) > 1:
+            result['errors'].append('Error: Only one password allowed per record! ' + str(pwds))
+        elif len(pwds) == 1:
+            rtdp = next((True for x in (rtdef.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'),
+                        False)
+            pwdc = pwds[0][0] and pwds[0][0].lower().startswith('custom.')
+            if rtdp:
+                if pwdc: result['errors'].append(
+                    'Password must be in fields[] section as defined by record type! ' + str(pwds))
+            else:
+                if not pwdc: result['errors'].append(
+                    'Password must be in custom[] section - record type does not allow password in fields[]! ' + str(
+                        pwds))
+        if result['errors']: return result
+
+        # All fields with prefix f./fields. must be in record type definition
+        # Don't move f./fields. not in RT definition to custom[] - undefined order on duplicates, might break scripts
+        rtdf = [x.get('$ref') for x in (rtdef.get('fields') or []) if '$ref' in x]
+        flds = [x for x in flo if x and x[0].startswith(('fields.', 'f.'))]
+        cust = [x for x in flo if x and x[0].startswith(('custom.', 'c.'))]
+        badf = [x for x in flds if not x[0].split('.', 2)[1].strip() in rtdf]
+        if badf:
+            result['errors'].append(
+                'This record type doesn\'t allow "fields." prefix for these (move to custom): ' + str(badf))
+        # fileRef must use upload-attachment/delete-attachment commands instead
+        refs = [x for x in flds + cust if x[0].split('.', 2)[1].strip().lower() == 'fileref']
+        if refs:
+            result['errors'].append(
+                'File reference manipulations are disabled here. Use upload-attachment/delete-attachment commands instead. ' + str(
+                    refs))
+        if result['errors']: return result
+
+        # edit command: JSON validation before update
+        # add command: fields[] must contain all 'requried' fields (and requried value parts)
+        if not is_edit:
+            reqd = [x.get('$ref') for x in (rtdef.get('fields') or []) if '$ref' in x and 'required' in x]
+            for fld in reqd:
+                ft = (RecordV3.field_types.get(fld) or {}).get('type')
+                ftr = (RecordV3.field_values.get(ft) or {}).get('required') or []
+                if ftr:
+                    ftr = ['fields.' + fld + '.' + x for x in ftr]
+                    flon = [x[0] for x in flo if x and x[0]]
+                    ftrm = [x for x in ftr if x not in flon]
+                    if ftrm:
+                        result['errors'].append('Missing requried fields: ' + str(
+                            ftrm) + '   Use `rti -lf field_name --example` to generate valid field sample.')
+                else:
+                    result['warnings'].append('Couldn\'t find requried fields for the field type: ' + str(ft))
+        if result['errors']: return result
+
+        # NB! cmdline labels override RT definition labels which override FT definition labels
+        r = {}
+        if is_edit and rt_type != rt.get('type'):
+            res = RecordV3.change_record_type(params, rt_json, rt_type)
+            if not res.get('errors'):
+                r = res.get('record') or r
+            if res.get('errors'): result['errors'].extend(res['errors'])
+            if res.get('warnings'): result['warnings'].extend(res['warnings'])
         else:
-          fkey = '{} ({})'.format(flab, ftyp)
-          print('{0:>20s}: {1:<s}'.format(str(fkey), str(fval)))
+            r = copy.deepcopy(rt)  # for edited or deleted items
+            if not r: r = {'type': rt_type}  # add command
+            if rt_title: r['title'] = rt_title
+            if is_edit and rt_title == '': r['title'] = ''  # edit: delete title
+            if rt_notes: r['notes'] = rt_notes
+            if is_edit and rt_notes == '': r['notes'] = ''  # edit: delete notes
+            if not 'fields' in r: r['fields'] = []
+            if not 'custom' in r: r['custom'] = []
+            for lst in [flds, cust]:
+                for f in lst:
+                    if f and len(f) == 2:
+                        val = f[1]
+                        path = f[0].split('.')
+                        forc = path[0].strip() if path else ''  # fields or custom
+                        fname = path[1].strip() if path and len(path) > 1 else ''  # field name
+                        fvname = path[2].strip() if path and len(path) > 2 else ''  # field attribute (if any)
+                        if fname:
+                            if not forc in r: r[forc] = []  # create fields[] or custom[]
+                            fv = next((x for x in r[forc] if isinstance(x, dict) and x.get('type') == fname), {})
+                            if not fv:
+                                fv = {'type': fname, 'value': []}
+                                r[forc].append(fv)
+                            if 'value' not in fv: fv['value'] = []
+                            if fvname:
+                                # NB! required:true/false comes from RT definition and should not be re/set here
+                                if fvname.lower() == 'required':
+                                    result['warnings'].append(
+                                        'Skipped "required" field attribute which comes from record type definition and should not be set here! ' + str(
+                                            f))
+                                    continue
+                                # check if fvname is FT attribute vs FT value object parts - ex. c.name.label vs. c.name.first
+                                if fvname.lower() == 'label':
+                                    fv['label'] = val
+                                elif is_edit and not val:  # delete
+                                    if forc in r:
+                                        v = next((x.get('value') or [] for x in r[forc] if
+                                                  isinstance(x, dict) and x.get('type') == fname), [])
+                                        # v = next((x for x in v if isinstance(x, dict) and fvname in x), {})
+                                        v = next((x for x in v if isinstance(x, dict)), {})
+                                        v.pop(fvname, None)
+                                elif bool(val):  # upsert
+                                    # v = next((x for x in fv['value'] if isinstance(x, dict) and fvname in x), None)
+                                    v = next((x for x in fv['value'] if isinstance(x, dict)), None)
+                                    if v:
+                                        v[fvname] = val
+                                    else:
+                                        fv['value'].append({fvname: val})
+                                    ok = RecordV3.is_valid_field_value(fname, [{fvname: val}])
+                                    if not ok: result['errors'].append(
+                                        'Invalid field value: ' + str({fname: [{fvname: val}]}))
+                                else:
+                                    result['warnings'].append('Skipped empty field value: ' + str(f))
+                            else:  # simple value str/int assign directly - ex. c.login=MyLogin
+                                if bool(val):
+                                    del fv['value'][:]
+                                    fv['value'].append(val)
+                                elif 'value' in fv and isinstance(fv['value'], list):  # delete
+                                    del fv['value'][:]
+                    else:
+                        result['errors'].append(
+                            'Miltiple field values per single option aren\'t allowed. Use multiple options: -o f.name.first=A -o f.name.last=B ' + str(
+                                f))
 
-    totp = next((t.get('value') for t in fields if t['type'] == 'oneTimeCode'), None)
-    totp = totp[0] if totp else totp
-    if totp:
-      code, remain, _ = get_totp_code(totp)
-      if code: print('{0:>20s}: {1:<20s} valid for {2} sec'.format('Two Factor Code', code, remain))
+        # add command could pass multiple custom options - ex. --custom='{"name1":"value1", "name2":"value: 2,3,4"}'
+        # since dot format can't handle duplicate keys we pass these as kwargs['custom_list']
+        custom_list = kwargs.get('custom_list') or []
+        custom = [{
+            'type': 'text',
+            'label': x.get('name') or '',
+            'value': [x.get('value')] if x.get('value') else []
+        } for x in custom_list if x.get('name') or x.get('value')]
+        if custom:
+            r['custom'] = (r.get('custom') or [])
+            if is_edit:
+                # update value of existing custom field or insert new one
+                for cr in custom:
+                    cold = next((x for x in r['custom'] if
+                                 x.get('type') == 'text' and x.get('label') == cr.get('label') and cr.get(
+                                     'label') is not None), None)
+                    if cold:
+                        cold['value'] = cr.get('value')
+                    else:
+                        r['custom'].append(cr)
+            else:
+                r['custom'] = r['custom'] + custom
 
-    if params is not None:
-        if record_uid in params.record_cache:
-            rec = params.record_cache[record_uid]
-            if 'shares' in rec:
-                no = 0
-                if 'user_permissions' in rec['shares']:
-                    perm = rec['shares']['user_permissions'].copy()
-                    perm.sort(key=lambda r: (' 1' if r.get('owner') else ' 2' if r.get(
-                        'editable') else ' 3' if r.get('sharable') else '') + r.get('username'))
-                    for uo in perm:
-                        flags = ''
-                        if uo.get('owner'):
-                            flags = 'Owner'
-                        elif uo.get('awaiting_approval'):
-                            flags = 'Awaiting Approval'
-                        else:
-                            if uo.get('editable'):
+        if r and not result['errors']:
+            if not r.get('custom'): r.pop('custom', None)
+            if not r.get('fields'): r.pop('fields', None)
+            rt = r
+
+        if not result['errors']:
+            result['record'] = rt
+
+        return result
+
+    @staticmethod
+    def convert_to_record_type(record_uid, params):
+        # Converts records v2 to v3
+        result = False
+
+        if not (record_uid and params and params.record_cache and record_uid in params.record_cache):
+            logging.error(bcolors.FAIL + 'Record %s not found.' + bcolors.ENDC, record_uid)
+            return result
+
+        record = params.record_cache[record_uid]
+        version = record.get('version') or 0
+        if version != 2:
+            logging.error(bcolors.FAIL + 'Record %s is not version 2.' + bcolors.ENDC, record_uid)
+            return result
+
+        udata = record.get('udata')
+        data = record.get('data_unencrypted')
+        extra = record.get('extra_unencrypted')
+        # extra contains: files, fields, (favicon_url - deprecated, smartfill - deprecated)
+
+        udata = udata if isinstance(udata, dict) else json.loads(udata or '{}')
+        data = data if isinstance(data, dict) else json.loads(data or '{}')
+        extra = extra if isinstance(extra, dict) else json.loads(extra or '{}')
+
+        file_ids = udata.get('file_ids') or []
+        files = extra.get('files') or []
+        has_files = len(file_ids) > 0 or len(files) > 0
+        if has_files:
+            logging.error(bcolors.FAIL + 'Record %s has file atachments. Not convertible.' + bcolors.ENDC, record_uid)
+            return result
+
+        # check for other non-convertible data - ex. fields[] has "field_type" != "totp" if present
+        fields = extra.get('fields') or []
+        otps = [x for x in fields if 'totp' == (x.get('field_type') or '')]
+        if bool(data.get('folder')) or len(fields) != len(otps):
+            logging.error(bcolors.FAIL + 'Record %s has unknown extra fields.' + bcolors.ENDC, record_uid)
+            return result
+
+        otp = otps[0] if otps else {}
+        totp = otp.get('data') or ''
+        # label = otp.get('field_title') or ''
+
+        title = data.get('title') or ''
+        login = data.get('secret1') or ''
+        password = data.get('secret2') or ''
+        url = data.get('link') or ''
+
+        notes = data.get('notes') or ''
+        custom2 = data.get('custom') or []
+        # custom.type	- Always "text" for legacy reasons.
+        custom = [{
+            'type': 'text',
+            'label': x.get('name') or '',
+            'value': [x.get('value')] if x.get('value') else []
+        } for x in custom2 if x.get('name') or x.get('value')]
+
+        # Add any remaining TOTP codes to custom[]
+        if len(otps) > 1:
+            otps.pop(0)
+            otp2 = [{
+                'type': 'oneTimeCode',
+                'value': [x.get('data')]
+            } for x in otps if x.get('data')]
+            if otp2: custom.extend(otp2)
+
+        rt = {
+            'title': title,
+            'type': 'general',
+            'fields': [
+                {'type': 'login', 'value': [login] if login else []},
+                {'type': 'password', 'value': [password] if password else []},
+                {'type': 'url', 'value': [url] if url else []},
+                {'type': 'oneTimeCode', 'value': [totp] if totp else []},
+                {'type': 'fileRef', 'value': []}
+            ],
+            'custom': custom,
+            'notes': notes
+        }
+
+        record['version'] = 3
+        record.pop('udata', None)
+        record.pop('extra', None)
+        record.pop('extra_unencrypted', None)
+        record['data_unencrypted'] = json.dumps(rt)
+        record['client_modified_time'] = api.current_milli_time()
+        result = True
+        return result
+
+    @staticmethod
+    def values_to_lowerstring(data_json):
+        return RecordV3.values_to_string(data_json).lower()
+
+    @staticmethod
+    def values_to_string(data_json):
+        result = ''
+
+        rt = RecordV3.record_type_to_dict(data_json)
+        result += rt.get('title') or ''
+        result += rt.get('notes') or ''
+
+        fields = rt.get('fields') or []
+        custom = rt.get('custom') or []
+        values = [x.get('value') for x in fields + custom if x.get('value')]
+        values = [x if not isinstance(x[0], dict) else ';'.join(str(v) for v in x[0].values()) for x in values if
+                  len(x) > 0]
+        result += str(values)
+
+        return result
+
+    @staticmethod
+    def record_type_to_dict(rt_json):
+        rt = {}
+        if rt_json:
+            try:
+                rt = json.loads(rt_json or '{}')
+            except:
+                rt = {}
+                logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_json) + bcolors.ENDC)
+        return rt
+
+    @staticmethod
+    def update_password(password, rt_json, rt_def):
+        # Delete if pass is empty, Upsert if pass is present:
+        # Check if there's password field in fields[], custom[] and replace first instance
+        # If no password in RT but RT definition has a password field - add to fields[]
+        # else add to custom[]
+        result = rt_json
+
+        rt = {}
+        if rt_json:
+            try:
+                rt = json.loads(rt_json or '{}')
+            except:
+                logging.error(bcolors.FAIL + 'Unable to parse record type JSON: ' + str(rt_json) + bcolors.ENDC)
+
+        rtdef = {}
+        if rt_def:
+            try:
+                rtdef = json.loads(rt_def)
+            except:
+                logging.error(
+                    bcolors.FAIL + 'Unable to parse record type definition JSON: ' + str(rt_def) + bcolors.ENDC)
+
+        if not rt or not rtdef:
+            logging.error(bcolors.FAIL + 'Failed to update password field!' + bcolors.ENDC)
+            return result
+
+        rtt = rt.get('type')
+        rtdt = rtdef.get('$id')
+        if not rtt or rtt != rtdt:
+            logging.error(
+                bcolors.FAIL + 'Record type missing or doesn\'t match definition! ' + str([rtt, rtdt]) + bcolors.ENDC)
+            return result
+
+        # Look for existing password in fields[] then custom[] and replace
+        fields = rt.get('fields') or []
+        custom = rt.get('custom') or []
+        rtfp = [x for x in fields if 'type' in x and x.get('type') == 'password']
+        rtcp = [x for x in custom if 'type' in x and x.get('type') == 'password']
+        changed = False
+        if rtfp:
+            rtfp[0]['value'] = [password] if password else []
+            changed = True
+        elif rtcp:
+            rtcp[0]['value'] = [password] if password else []
+            changed = True
+        elif password:
+            # no existing password - add to fields[] (if RT definition allows) or to custom[]
+            rtdp = next((True for x in (rtdef.get('fields') or []) if '$ref' in x and x.get('$ref') == 'password'),
+                        False)
+            if rtdp:
+                if 'fields' not in rt:
+                    rt['fields'] = []
+                rt['fields'].append({'type': 'password', 'value': [password]})
+            else:
+                if 'custom' not in rt:
+                    rt['custom'] = []
+                rt['custom'].append({'type': 'password', 'value': [password]})
+            changed = True
+
+        if changed:
+            result = json.dumps(rt)
+
+        return result
+
+    @staticmethod
+    def get_field_types():
+        ftypes = [{**RecordV3.field_types.get(fkey), **RecordV3.field_values.get(vkey)}
+                  for fkey in RecordV3.field_types
+                  for vkey in RecordV3.field_values
+                  if (RecordV3.field_types.get(fkey) or {}).get('type') == vkey
+                  ]
+        rows = []  # (id, type, lookup, multiple, description)
+        for ft in ftypes:
+            field_id = ft.get('$id') or ''
+            field_type = ft.get('type') or ''
+            lookup = ft.get('lookup') or ''
+            multiple = ft.get('multiple') or ''
+            description = ft.get('value_description') or ''
+            rows.append((field_id, field_type, lookup, multiple, description))
+        return rows
+
+    @staticmethod
+    def get_field_type(id):
+        STR_VALUE = 'text'
+        ftypes = [{**RecordV3.field_types.get(fkey), **RecordV3.field_values.get(vkey)}
+                  for fkey in RecordV3.field_types
+                  for vkey in RecordV3.field_values
+                  if (RecordV3.field_types.get(fkey) or {}).get('type') == vkey
+                  ]
+        ids = [ft for ft in ftypes if id and (id == ft.get('$id'))]
+        result = ids[0] if ids else {}
+        if result:
+            val = result.get('value')
+            vtype = ('integer' if isinstance(val, int)
+                     else 'string' if isinstance(val, str)
+            else 'enum' if isinstance(val, tuple)
+            else 'object' if isinstance(val, dict)
+            else 'unknown')
+            obj = val if vtype != 'object' else {
+                x: val[x] if not isinstance(val[x], tuple) else " | ".join(str(t) for t in val[x])
+                for x in val
+            }
+            obj_sample = val if vtype != 'object' else {
+                x: 0 if isinstance(val[x], int)
+                else STR_VALUE if isinstance(val[x], str)
+                else val[x][0] if isinstance(val[x], tuple)
+                else val
+                for x in val
+            }
+            value = (0 if vtype == 'integer'
+                     else '' if vtype == 'string'
+            else val[0] if vtype == 'enum'
+            else obj if vtype == 'object'
+            else '')
+            sample = (0 if vtype == 'integer'
+                      else STR_VALUE if vtype == 'string'
+            else val[0] if vtype == 'enum'
+            else obj_sample if vtype == 'object'
+            else '')
+
+            result = {
+                'id': result.get('$id') or '',
+                'type': result.get('type') or '',
+                'valueType': vtype,
+                'value': value,
+                'sample': sample
+            }
+        return result
+
+    @staticmethod
+    def get_record_type_example(params, rt_name: str) -> str:
+        STR_VALUE = 'text'
+
+        result = ''
+        rte = {}
+        rt_def = RecordV3.resolve_record_type_by_name(params, rt_name)
+        if rt_def:
+            rtdd = RecordV3.record_type_to_dict(rt_def)
+            rtdf = rtdd.get('fields') or []
+
+            rte = {
+                'type': rt_name,
+                'title': STR_VALUE,
+                'notes': STR_VALUE,
+                'fields': [],
+                'custom': []
+            }
+
+            rtdef = {}
+            try:
+                rtdef = json.loads(rt_def)
+            except:
+                logging.error(
+                    bcolors.FAIL + 'Unable to parse record type definition JSON: ' + str(rt_def) + bcolors.ENDC)
+
+            fields = rtdef.get('fields') or []
+            fields = [x.get('$ref') for x in fields]
+            for fname in fields:
+                ft = RecordV3.get_field_type(fname)
+                if not ft or not ft.get('id'):
+                    logging.error(bcolors.FAIL + 'Error - Unknown field type: ' + fname + bcolors.ENDC)
+                    continue
+
+                val = {
+                    'type': fname,
+                    'value': []
+                }
+
+                if fname not in ('fileRef', 'addressRef', 'cardRef'):
+                    # Fix for webVault - fails if phone's region is not valid country code
+                    if fname == 'phone' and 'sample' in ft and 'region' in ft['sample']:
+                        ft['sample']['region'] = 'US'
+
+                    val['value'].append(ft.get('sample'))
+                    required = next((x.get('required') for x in rtdf if x.get('$ref') == fname), None)
+                    if required:
+                        val['required'] = required
+                    label = next((x.get('label') for x in rtdf if x.get('$ref') == fname), None)
+                    if label:
+                        val['label'] = label
+
+                rte['fields'].append(val)
+        else:
+            logging.error(bcolors.FAIL + 'Unable to find record type definition for type: ' + str(rt_name) +
+                          '   To show available record types definitions use `record-type-info --list-record *` command' + bcolors.ENDC)
+
+        result = json.dumps(rte) if rte else ''
+        return result
+
+    @staticmethod
+    def display(r, **kwargs):
+        record_uid = r['record_uid']
+        print('')
+        # print('{0:>20s}: https://keepersecurity.com/vault#detail/{1}'.format('Link', record_uid))
+        print('{0:>20s}: {1:<20s}'.format('UID', record_uid))
+        # if 'version' in r: print('{0:>20s}: {1:<20s}'.format('Version', str(r['version'])))
+        params = None
+        if 'params' in kwargs:
+            params = kwargs['params']
+            folders = [get_folder_path(params, x) for x in find_folders(params, record_uid)]
+            for i in range(len(folders)):
+                print('{0:>21s} {1:<20s}'.format('Folder:' if i == 0 else '', folders[i]))
+
+        data = {}
+        if 'data_unencrypted' in r:
+            data = r['data_unencrypted'].decode() if isinstance(r['data_unencrypted'], bytes) else r['data_unencrypted']
+            data = json.loads(data)
+        fields = data.get('fields') or []
+        custom = data.get('custom') or []
+
+        print('{0:>20s}: {1:<20s}'.format('Type', str(data['type']) if 'type' in data else ''))
+        print('{0:>20s}: {1:<20s}'.format('Title', str(data['title']) if 'title' in data else ''))
+        # NB! General notes here - fields[] might provide their own notes
+        if 'notes' in data: print('{0:>20s}: {1:<20s}'.format('Notes', str(data['notes'])))
+        # fields[] * print Field# NN - atrib: value
+
+        for c in fields + custom:
+            ftyp = c.get('type') or ''
+            flab = c.get('label') or ''
+            flds = c.get('value') or []
+            fval = flds
+            if len(flds) == 1 and flds[0]:
+                if isinstance(flds[0], dict):
+                    if ftyp.lower() == 'name':
+                        fval = ' '.join(flds[0].values())
+                    else:
+                        fval = ' | '.join(flds[0].values())
+                elif RecordV3.get_field_type(ftyp).get('type') == 'date' and flds[0] and bool(
+                        re.match('^[+-]?[0-9]+$', str(flds[0]).strip())):
+                    dt = datetime.datetime.fromtimestamp(flds[0] / 1000.0)
+                    fval = str(dt)
+                else:
+                    fval = flds[0]
+            if fval:
+                if ftyp in ('fileRef', 'cardRef', 'addressRef'):
+                    RecordV3.display_ref(ftyp, fval, **kwargs)
+                else:
+                    fkey = '{} ({})'.format(flab, ftyp)
+                    print('{0:>20s}: {1:<s}'.format(str(fkey), str(fval)))
+
+        totp = next((t.get('value') for t in fields if t['type'] == 'oneTimeCode'), None)
+        totp = totp[0] if totp else totp
+        if totp:
+            code, remain, _ = get_totp_code(totp)
+            if code: print('{0:>20s}: {1:<20s} valid for {2} sec'.format('Two Factor Code', code, remain))
+
+        if params is not None:
+            if record_uid in params.record_cache:
+                rec = params.record_cache[record_uid]
+                if 'shares' in rec:
+                    no = 0
+                    if 'user_permissions' in rec['shares']:
+                        perm = rec['shares']['user_permissions'].copy()
+                        perm.sort(key=lambda r: (' 1' if r.get('owner') else ' 2' if r.get(
+                            'editable') else ' 3' if r.get('sharable') else '') + r.get('username'))
+                        for uo in perm:
+                            flags = ''
+                            if uo.get('owner'):
+                                flags = 'Owner'
+                            elif uo.get('awaiting_approval'):
+                                flags = 'Awaiting Approval'
+                            else:
+                                if uo.get('editable'):
+                                    flags = 'Edit'
+                                if uo.get('sharable'):
+                                    if flags:
+                                        flags = flags + ', '
+                                    flags = flags + 'Share'
+                            if not flags:
+                                flags = 'View'
+
+                            print('{0:>21s} {1} ({2}) {3}'.format('Shared Users:' if no == 0 else '', uo['username'],
+                                                                  flags,
+                                                                  'self' if uo['username'] == params.user else ''))
+                            no = no + 1
+                    no = 0
+                    if 'shared_folder_permissions' in rec['shares']:
+                        for sfo in rec['shares']['shared_folder_permissions']:
+                            flags = ''
+                            if sfo.get('editable'):
                                 flags = 'Edit'
-                            if uo.get('sharable'):
+                            if sfo.get('reshareable'):
                                 if flags:
                                     flags = flags + ', '
                                 flags = flags + 'Share'
-                        if not flags:
-                            flags = 'View'
+                            if not flags:
+                                flags = 'View'
+                            sf_uid = sfo['shared_folder_uid']
+                            for f_uid in find_folders(params, record_uid):
+                                if f_uid in params.subfolder_cache:
+                                    fol = params.folder_cache[f_uid]
+                                    if fol.type in {BaseFolderNode.SharedFolderType,
+                                                    BaseFolderNode.SharedFolderFolderType}:
+                                        sfid = fol.uid if fol.type == BaseFolderNode.SharedFolderType else fol.shared_folder_uid
+                                        if sf_uid == sfid:
+                                            print('{0:>21s} {1:<20s}'.format('Shared Folders:' if no == 0 else '',
+                                                                             fol.name))
+                                            no = no + 1
 
-                        print('{0:>21s} {1} ({2}) {3}'.format('Shared Users:' if no == 0 else '', uo['username'],
-                                                              flags,
-                                                              'self' if uo['username'] == params.user else ''))
-                        no = no + 1
-                no = 0
-                if 'shared_folder_permissions' in rec['shares']:
-                    for sfo in rec['shares']['shared_folder_permissions']:
-                        flags = ''
-                        if sfo.get('editable'):
-                            flags = 'Edit'
-                        if sfo.get('reshareable'):
-                            if flags:
-                                flags = flags + ', '
-                            flags = flags + 'Share'
-                        if not flags:
-                            flags = 'View'
-                        sf_uid = sfo['shared_folder_uid']
-                        for f_uid in find_folders(params, record_uid):
-                            if f_uid in params.subfolder_cache:
-                                fol = params.folder_cache[f_uid]
-                                if fol.type in {BaseFolderNode.SharedFolderType,
-                                                BaseFolderNode.SharedFolderFolderType}:
-                                    sfid = fol.uid if fol.type == BaseFolderNode.SharedFolderType else fol.shared_folder_uid
-                                    if sf_uid == sfid:
-                                        print('{0:>21s} {1:<20s}'.format('Shared Folders:' if no == 0 else '',
-                                                                          fol.name))
-                                        no = no + 1
+        if kwargs.get('format') == 'detail':
+            if 'shared' in r: print('{0:>20s}: {1:<20s}'.format('Shared', str(r['shared'])))
+            if 'client_modified_time' in r:
+                dt = datetime.datetime.fromtimestamp(r['client_modified_time'] / 1000.0)
+                print('{0:>20s}: {1:<20s}'.format('Last Modified', dt.strftime('%Y-%m-%d %H:%M:%S')))
+            if 'revision' in r: print('{0:>20s}: {1:<20s}'.format('Revision', str(r['revision'])))
 
-    if kwargs.get('format') == 'detail':
-      if 'shared' in r: print('{0:>20s}: {1:<20s}'.format('Shared', str(r['shared'])))
-      if 'client_modified_time' in r:
-        dt = datetime.datetime.fromtimestamp(r['client_modified_time']/1000.0)
-        print('{0:>20s}: {1:<20s}'.format('Last Modified', dt.strftime('%Y-%m-%d %H:%M:%S')))
-      if 'revision' in r: print('{0:>20s}: {1:<20s}'.format('Revision', str(r['revision'])))
+        if params.breach_watch:
+            bw_status = params.breach_watch.get_record_status(params, record_uid)
+            if bw_status and 'status' in bw_status:
+                status = bw_status['status']
+                if status:
+                    if status in {'WEAK', 'BREACHED'}:
+                        status = 'High-Risk Password'
+                    elif status == 'IGNORE':
+                        status = 'Ignored'
+                    print('{0:>20s}: {1:<20s}'.format('Breach Watch', status))
 
-    if params.breach_watch:
-      bw_status = params.breach_watch.get_record_status(params, record_uid)
-      if bw_status and 'status' in bw_status:
-        status = bw_status['status']
-        if status:
-          if status in {'WEAK', 'BREACHED'}:
-            status = 'High-Risk Password'
-          elif status == 'IGNORE':
-            status = 'Ignored'
-          print('{0:>20s}: {1:<20s}'.format('Breach Watch', status))
+        print('')
 
-    print('')
+    @staticmethod
+    def display_ref(ftype, fvalue, **kwargs):
+        # fileRef can hold multiple references - convert single value to list for compatibility
+        fvalue = fvalue if isinstance(fvalue, list) else [fvalue]
+        params = kwargs.get('params')
+        if ftype == 'fileRef':
+            for fuid in fvalue:
+                frec = params.record_cache.get(fuid) or {}
+                fdat = frec.get('data_unencrypted') or '{}'
+                fdic = RecordV3.record_type_to_dict(fdat)
+                name = fdic.get('name') or ''
+                size = fdic.get('size') or ''
+                if isinstance(size, str) and size.isdigit():
+                    size = int(size)
+                size = HumanBytes.format(size or 0) if isinstance(size, int) else size
+                print('{0:>20s}: {1:>22s}   {2:<12s}   {3:<s}'.format(str(ftype), str(fuid), str(size), str(name)))
+        elif ftype == 'cardRef':
+            for fuid in fvalue:
+                frec = params.record_cache.get(fuid) or {}
+                fdat = frec.get('data_unencrypted') or '{}'
+                fdic = RecordV3.record_type_to_dict(fdat)
+                title = RecordV3.get_record_type_title(fdat) or ''
+                name = RecordV3.get_record_field_value(fdat, 'text', False) or ''
+                pin = RecordV3.get_record_field_value(fdat, 'pinCode', False) or ''
+                card = RecordV3.get_record_field_value(fdat, 'paymentCard', False) or '{}'
+                card_line = 'Name: ' + name + ' | ' + ' Pin: ' + pin + ' | Card: ' + ' | '.join(
+                    str(x) for x in card.values())
+                print('{0:>20s}: {1:<s}'.format('address.' + str(title), str(card_line)))
+        elif ftype == 'addressRef':
+            for fuid in fvalue:
+                frec = params.record_cache.get(fuid) or {}
+                fdat = frec.get('data_unencrypted') or '{}'
+                fdic = RecordV3.record_type_to_dict(fdat)
+                title = RecordV3.get_record_type_title(fdat) or ''
+                addr = RecordV3.get_record_field_value(fdat, 'address', False) or '{}'
+                addr = addr if isinstance(addr, dict) else RecordV3.record_type_to_dict(addr)
+                addr_line = ' | '.join(str(x) for x in addr.values())
+                print('{0:>20s}: {1:<s}'.format('address.' + str(title), str(addr_line)))
+        else:
+            logging.error(
+                bcolors.FAIL + 'Unknown field reference type: ' + str(ftype) + ' for ' + str(fvalue) + bcolors.ENDC)
 
-  @staticmethod
-  def display_ref(ftype, fvalue, **kwargs):
-    # fileRef can hold multiple references - convert single value to list for compatibility
-    fvalue = fvalue if isinstance(fvalue, list) else [fvalue]
-    params = kwargs.get('params')
-    if ftype == 'fileRef':
-      for fuid in fvalue:
-        frec = params.record_cache.get(fuid) or {}
-        fdat = frec.get('data_unencrypted') or '{}'
-        fdic = RecordV3.record_type_to_dict(fdat)
-        name = fdic.get('name') or ''
-        size = fdic.get('size') or ''
-        if isinstance(size, str) and size.isdigit():
-          size = int(size)
-        size = HumanBytes.format(size or 0) if isinstance(size, int) else size
-        print('{0:>20s}: {1:>22s}   {2:<12s}   {3:<s}'.format(str(ftype), str(fuid), str(size), str(name)))
-    elif ftype == 'cardRef':
-      for fuid in fvalue:
-        frec = params.record_cache.get(fuid) or {}
-        fdat = frec.get('data_unencrypted') or '{}'
-        fdic = RecordV3.record_type_to_dict(fdat)
-        title = RecordV3.get_record_type_title(fdat) or ''
-        name = RecordV3.get_record_field_value(fdat, 'text', False) or ''
-        pin = RecordV3.get_record_field_value(fdat, 'pinCode', False) or ''
-        card = RecordV3.get_record_field_value(fdat, 'paymentCard', False) or '{}'
-        card_line = 'Name: ' + name + ' | ' + ' Pin: ' + pin + ' | Card: ' + ' | '.join(str(x) for x in card.values())
-        print('{0:>20s}: {1:<s}'.format('address.' + str(title), str(card_line)))
-    elif ftype == 'addressRef':
-      for fuid in fvalue:
-        frec = params.record_cache.get(fuid) or {}
-        fdat = frec.get('data_unencrypted') or '{}'
-        fdic = RecordV3.record_type_to_dict(fdat)
-        title = RecordV3.get_record_type_title(fdat) or ''
-        addr = RecordV3.get_record_field_value(fdat, 'address', False) or '{}'
-        addr = addr if isinstance(addr, dict) else RecordV3.record_type_to_dict(addr)
-        addr_line = ' | '.join(str(x) for x in addr.values())
-        print('{0:>20s}: {1:<s}'.format('address.' + str(title), str(addr_line)))
-    else:
-      logging.error(bcolors.FAIL + 'Unknown field reference type: ' + str(ftype) + ' for ' + str(fvalue) + bcolors.ENDC)
+    @staticmethod
+    def validate_access(params: KeeperParams, ruid: str):
+        if ruid:
+            v3_enabled = False
+            if params and params.settings and isinstance(params.settings.get('record_types_enabled'), bool):
+                v3_enabled = params.settings.get('record_types_enabled')
+            if not v3_enabled:
+                if params and params.record_cache and ruid in params.record_cache:
+                    rv = params.record_cache[ruid].get('version') or None
+                    if rv and rv in (3, 4):
+                        raise TypeError('Record ' + ruid + ' not found. You don\'t have Record Types enabled.')
 
+    @staticmethod
+    def custom_options_to_list(options_list: str) -> list:
+        custom = []
+        if options_list:
+            if type(options_list) == str:
+                if options_list[0] == '{' and options_list[-1] == '}':
+                    try:
+                        custom_json = json.loads(options_list)
+                        for k, v in custom_json.items():
+                            custom.append({
+                                'name': k,
+                                'value': str(v)
+                            })
+                    except ValueError as e:
+                        raise TypeError('Invalid custom fields JSON input: {0}'.format(e))
+                else:
+                    pairs = options_list.split(',')
+                    for pair in pairs:
+                        idx = pair.find(':')
+                        if idx > 0:
+                            custom.append({
+                                'name': pair[:idx].strip(),
+                                'value': pair[idx + 1:].strip()
+                            })
+                        else:
+                            raise TypeError(
+                                'Invalid custom fields input. Expected: "Key:Value". Got: "{0}"'.format(pair))
 
-  @staticmethod
-  def validate_access(params: KeeperParams, ruid: str):
-    if ruid:
-      v3_enabled = False
-      if params and params.settings and isinstance(params.settings.get('record_types_enabled'), bool):
-        v3_enabled = params.settings.get('record_types_enabled')
-      if not v3_enabled:
-        if params and params.record_cache and ruid in params.record_cache:
-          rv = params.record_cache[ruid].get('version') or None
-          if rv and rv in (3, 4):
-            raise TypeError('Record ' + ruid + ' not found. You don\'t have Record Types enabled.')
+            elif type(options_list) == list:
+                for c in options_list:
+                    if type(c) == dict:
+                        name = c.get('name')
+                        value = c.get('value')
+                        if name and value:
+                            custom.append({
+                                'name': name,
+                                'value': value
+                            })
+        return custom
 
-  @staticmethod
-  def custom_options_to_list(options_list: str) -> list:
-    custom = []
-    if options_list:
-        if type(options_list) == str:
-            if options_list[0] == '{' and options_list[-1] == '}':
-                try:
-                    custom_json = json.loads(options_list)
-                    for k,v in custom_json.items():
-                        custom.append({
-                            'name': k,
-                            'value': str(v)
-                        })
-                except ValueError as e:
-                    raise TypeError('Invalid custom fields JSON input: {0}'.format(e))
-            else:
-                pairs = options_list.split(',')
-                for pair in pairs:
-                    idx = pair.find(':')
-                    if idx > 0:
-                        custom.append({
-                            'name': pair[:idx].strip(),
-                            'value': pair[idx+1:].strip()
-                        })
-                    else:
-                        raise TypeError('Invalid custom fields input. Expected: "Key:Value". Got: "{0}"'.format(pair))
-
-        elif type(options_list) == list:
-            for c in options_list:
-                if type(c) == dict:
-                    name = c.get('name')
-                    value = c.get('value')
-                    if name and value:
-                        custom.append({
-                            'name': name,
-                            'value': value
-                        })
-    return custom
 
 class HumanBytes:
     # Human-readable formatting of bytes, using binary (powers of 1024) or metric (powers of 1000) representation.
@@ -1766,7 +1819,7 @@ class HumanBytes:
     PRECISION_FORMATS = ["{}{:.0f} {}", "{}{:.1f} {}", "{}{:.2f} {}", "{}{:.3f} {}"]
 
     @classmethod
-    def format(cls, num,  metric=False, precision=1) -> str:
+    def format(cls, num, metric=False, precision=1) -> str:
         assert isinstance(precision, int) and precision >= 0 and precision <= 3, "precision must be an int (range 0-3)"
         unit_labels = cls.METRIC_LABELS if metric else cls.BINARY_LABELS
         last_label = unit_labels[-1]
@@ -1776,7 +1829,7 @@ class HumanBytes:
         is_negative = num < 0
         if is_negative:
             num = abs(num)
-        if num < unit_step: # return exact bytes when size is too small
+        if num < unit_step:  # return exact bytes when size is too small
             return cls.PRECISION_FORMATS[0].format('-' if is_negative else '', num, unit_labels[0])
         for unit in unit_labels:
             if num < unit_step_thresh:
@@ -1787,108 +1840,108 @@ class HumanBytes:
 
 
 def init_recordv3_commands(params):
-  from .commands import commands, command_info, aliases
-  v3_commands = {}
+    from .commands import commands, command_info, aliases
+    v3_commands = {}
 
-  def init_v3_commands():
-    from .commands.record import RecordAddCommand, RecordEditCommand, add_parser, edit_parser
-    global v3_commands
-    if v3_commands:
-      return
-    v3_commands = {
-      'record-type': {},
-      'record-type-info': {},
-      'add': {
-        'substitute': {
-          'command': RecordAddCommand(),
-          'parser': add_parser,
-          'command_info': {add_parser.prog: add_parser.description},
-          'alias': {'a': 'add'}
+    def init_v3_commands():
+        from .commands.record import RecordAddCommand, RecordEditCommand, add_parser, edit_parser
+        global v3_commands
+        if v3_commands:
+            return
+        v3_commands = {
+            'record-type': {},
+            'record-type-info': {},
+            'add': {
+                'substitute': {
+                    'command': RecordAddCommand(),
+                    'parser': add_parser,
+                    'command_info': {add_parser.prog: add_parser.description},
+                    'alias': {'a': 'add'}
+                }
+            },
+            'edit': {
+                'substitute': {
+                    'command': RecordEditCommand(),
+                    'parser': edit_parser,
+                    'command_info': {edit_parser.prog: edit_parser.description},
+                    'alias': {}
+                }
+            }
         }
-      },
-      'edit': {
-        'substitute': {
-          'command': RecordEditCommand(),
-          'parser': edit_parser,
-          'command_info': {edit_parser.prog: edit_parser.description},
-          'alias': {}
-        }
-      }
-    }
 
-  try:
-    # parse v3 commands
-    init_v3_commands()
+    try:
+        # parse v3 commands
+        init_v3_commands()
 
-    for cmd in v3_commands:
-      if not v3_commands[cmd].get('command') and cmd in commands:
-        prog = commands[cmd].get_parser().prog
-        parts = prog.split('|')
-        alias = parts[-1] if len(parts) == 2 else None
-        v3_commands[cmd]['command'] = {cmd: commands[cmd]}
-        if prog in command_info:
-          v3_commands[cmd]['command_info'] = {prog: command_info[prog]}
-        if alias in aliases:
-          v3_commands[cmd]['alias'] = {alias: aliases[alias]}
+        for cmd in v3_commands:
+            if not v3_commands[cmd].get('command') and cmd in commands:
+                prog = commands[cmd].get_parser().prog
+                parts = prog.split('|')
+                alias = parts[-1] if len(parts) == 2 else None
+                v3_commands[cmd]['command'] = {cmd: commands[cmd]}
+                if prog in command_info:
+                    v3_commands[cmd]['command_info'] = {prog: command_info[prog]}
+                if alias in aliases:
+                    v3_commands[cmd]['alias'] = {alias: aliases[alias]}
 
-    v3_enabled = params.settings.get('record_types_enabled') if params.settings and isinstance(
-      params.settings.get('record_types_enabled'), bool) else False
-    if v3_enabled:
+        v3_enabled = params.settings.get('record_types_enabled') if params.settings and isinstance(
+            params.settings.get('record_types_enabled'), bool) else False
+        if v3_enabled:
 
-      # add/replace v3 commands
-      modified = []
-      for cmd in v3_commands:
-        cdic = v3_commands[cmd].get('command') or {}
-        cname = next(iter(cdic), None)
-        cmdc = commands.get(cmd) or 2
-        cmdv = ((v3_commands.get(cmd) or {}).get('command') or {}).get(cmd) or 3
-        if cname and (cname not in commands or cmdc != cmdv):
-          modified.append(cname)
-          commands[cname] = cdic[cname]
-          ciname = next(iter(v3_commands[cmd].get('command_info') or {}), None)
-          if ciname:
-            command_info[ciname] = v3_commands[cmd]['command_info'][ciname]
-          aname = next(iter(v3_commands[cmd].get('alias') or {}), None)
-          if aname:
-            aliases[aname] = v3_commands[cmd]['alias'][aname]
+            # add/replace v3 commands
+            modified = []
+            for cmd in v3_commands:
+                cdic = v3_commands[cmd].get('command') or {}
+                cname = next(iter(cdic), None)
+                cmdc = commands.get(cmd) or 2
+                cmdv = ((v3_commands.get(cmd) or {}).get('command') or {}).get(cmd) or 3
+                if cname and (cname not in commands or cmdc != cmdv):
+                    modified.append(cname)
+                    commands[cname] = cdic[cname]
+                    ciname = next(iter(v3_commands[cmd].get('command_info') or {}), None)
+                    if ciname:
+                        command_info[ciname] = v3_commands[cmd]['command_info'][ciname]
+                    aname = next(iter(v3_commands[cmd].get('alias') or {}), None)
+                    if aname:
+                        aliases[aname] = v3_commands[cmd]['alias'][aname]
 
-      # RT activation during live session - only a full sync will pull any pre-existing v3 records
-      # full_sync = response_json.get('full_sync') or False
-      # if modified and not full_sync:
-      #     logging.warning(bcolors.WARNING + 'Record types - enabled. Please logout and login again if you have existing v3 records.' + bcolors.ENDC)
-    else:
-      # remove/replace v3 commands
-      for cmd in v3_commands:
-        cdic = v3_commands[cmd].get('command') or {}
-        cname = next(iter(cdic), None)
-        if cname and cname in commands:
-          subs = v3_commands[cmd].get('substitute')
-          subs = subs if isinstance(subs, dict) else {}
-          sub_class = subs.get('command')
-          if sub_class:
-            commands[cname] = sub_class
-          else:
-            commands.pop(cname)
+            # RT activation during live session - only a full sync will pull any pre-existing v3 records
+            # full_sync = response_json.get('full_sync') or False
+            # if modified and not full_sync:
+            #     logging.warning(bcolors.WARNING + 'Record types - enabled. Please logout and login again if you have existing v3 records.' + bcolors.ENDC)
+        else:
+            # remove/replace v3 commands
+            for cmd in v3_commands:
+                cdic = v3_commands[cmd].get('command') or {}
+                cname = next(iter(cdic), None)
+                if cname and cname in commands:
+                    subs = v3_commands[cmd].get('substitute')
+                    subs = subs if isinstance(subs, dict) else {}
+                    sub_class = subs.get('command')
+                    if sub_class:
+                        commands[cname] = sub_class
+                    else:
+                        commands.pop(cname)
 
-          ciname = next(iter(v3_commands[cmd].get('command_info') or {}), None)
-          sub_ciname = next(iter(subs.get('command_info') or {}), None)
-          if ciname:
-            if ciname == sub_ciname:
-              command_info[ciname] = subs['command_info'][sub_ciname]
-            else:
-              command_info.pop(ciname)
-              if sub_ciname and subs['command_info'][sub_ciname]:
-                command_info[sub_ciname] = subs['command_info'][sub_ciname]
+                    ciname = next(iter(v3_commands[cmd].get('command_info') or {}), None)
+                    sub_ciname = next(iter(subs.get('command_info') or {}), None)
+                    if ciname:
+                        if ciname == sub_ciname:
+                            command_info[ciname] = subs['command_info'][sub_ciname]
+                        else:
+                            command_info.pop(ciname)
+                            if sub_ciname and subs['command_info'][sub_ciname]:
+                                command_info[sub_ciname] = subs['command_info'][sub_ciname]
 
-          aname = next(iter(v3_commands[cmd].get('alias') or {}), None)
-          sub_aname = next(iter(subs.get('alias') or {}), None)
-          if aname:
-            if aname == sub_aname:
-              aliases[aname] = subs['alias'][sub_aname]
-            else:
-              aliases.pop(aname)
-              if sub_aname and subs['alias'][sub_aname]:
-                aliases[aname] = subs['alias'][sub_aname]
+                    aname = next(iter(v3_commands[cmd].get('alias') or {}), None)
+                    sub_aname = next(iter(subs.get('alias') or {}), None)
+                    if aname:
+                        if aname == sub_aname:
+                            aliases[aname] = subs['alias'][sub_aname]
+                        else:
+                            aliases.pop(aname)
+                            if sub_aname and subs['alias'][sub_aname]:
+                                aliases[aname] = subs['alias'][sub_aname]
 
-  except Exception as e:
-    logging.debug(e)
+    except Exception as e:
+        logging.debug(e)

--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -1277,7 +1277,7 @@ class RecordV3:
         return result
 
     @staticmethod
-    def convert_to_record_type(record_uid, params):
+    def convert_to_record_type(record_uid, params, record_type='general'):
         # Converts records v2 to v3
         result = False
 
@@ -1343,7 +1343,7 @@ class RecordV3:
 
         rt = {
             'title': title,
-            'type': 'general',
+            'type': record_type,
             'fields': [
                 {'type': 'login', 'value': [login] if login else []},
                 {'type': 'password', 'value': [password] if password else []},

--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -191,7 +191,7 @@ class RecordV3:
         rt_attributes = ('$id', 'categories', 'description', 'fields')
         bada = [r for r in rt if r not in rt_attributes and r not in implicit_field_names]
         if bada:
-            return {'is_valid': False, 'error': 'Unknown attributes in record type definition: ' + str(bada)}
+            logging.debug(f'Unknown attributes in record type definition: {bada}')
 
         # Allow only valid/known field types - field types are case sensitive?
         flds = rt.get('fields') or []


### PR DESCRIPTION
This adds a new command "convert" to convert v2 records to v3 records.

The command has the following features:
- Multiple arguments are allowed
- Each argument is a pattern to match either the title or UID of a record
- Option `--type (-t)` for specifying the type of the converted record
- Option `--dry-run (-n)` for previewing what changes would be made
- Option `--recursive (-r)` for applying recursively to subdirectories
- Option `--url (-u)` for filtering based on a pattern to match a URL or `*` for all records with a URL