### PR TITLE
Convert v2 to v3 fields (KC-308)

### DIFF
--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -29,7 +29,7 @@ def get_v3_field_type(field_value):
         if is_url(field_value):
             return_type = 'url'
         if len(field_value) > 128:
-            return_type = 'multiline'
+            return_type = 'note'
     return return_type
 
 

--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -20,6 +20,17 @@ from . import api
 from .display import bcolors
 from .subfolder import get_folder_path, find_folders, BaseFolderNode
 from .record import get_totp_code
+from keepercommander.utils import is_url
+
+
+def get_v3_field_type(field_value):
+    return_type = 'text'
+    if field_value:
+        if is_url(field_value):
+            return_type = 'url'
+        if len(field_value) > 128:
+            return_type = 'multiline'
+    return return_type
 
 
 class RecordV3:
@@ -1363,7 +1374,7 @@ class RecordV3:
         custom2 = data.get('custom') or []
         # custom.type	- Always "text" for legacy reasons.
         custom = [{
-            'type': 'text',
+            'type': get_v3_field_type(x.get('value')),
             'label': x.get('name') or '',
             'value': [x.get('value')] if x.get('value') else []
         } for x in custom2 if x.get('name') or x.get('value')]

--- a/keepercommander/utils.py
+++ b/keepercommander/utils.py
@@ -10,12 +10,14 @@
 #
 
 import base64
-import itertools
 import math
 import time
 from urllib.parse import urlparse
 
 from . import crypto
+
+
+VALID_URL_SCHEME_CHARS = '+-.:'
 
 
 def generate_uid():             # type: () -> str
@@ -85,6 +87,18 @@ def create_auth_verifier(password, salt, iterations):   # type: (str, bytes, int
     enc_iter = int.to_bytes(iterations, length=3, byteorder='big', signed=False)
     auth_ver = b'\x01' + enc_iter + salt + derived_key
     return base64_url_encode(auth_ver)
+
+
+def is_url(test_str):   # type: (str) -> bool
+    if not isinstance(test_str, str):
+        return False
+    url_parts = test_str.split('://')
+    url_scheme = url_parts[0]
+    valid_scheme = all(c.isalnum or c in VALID_URL_SCHEME_CHARS for c in url_scheme)
+    if len(test_str.split()) == 1 and len(url_parts) > 1 and valid_scheme:
+        return True
+    else:
+        return False
 
 
 def url_strip(url):   # type: (str) -> str


### PR DESCRIPTION
Convert v2 field values matching a URL pattern to a v3 `url` field type and v2 field values over 128 characters to a v3 `multiline` field type.