### PR TITLE
Fix "convert" command error handling and update output

### DIFF
--- a/keepercommander/commands/convert.py
+++ b/keepercommander/commands/convert.py
@@ -158,7 +158,12 @@ class ConvertCommand(Command):
                     logging.warning(f'Conversion failed for {record.title} ({record.record_uid})')
                     continue
 
-                record_rq, audit_data = api.prepare_record_v3(params, v3_record)
+                prepare_result = api.prepare_record_v3(params, v3_record)
+                if prepare_result:
+                    record_rq, audit_data = prepare_result
+                else:
+                    logging.warning(f'Conversion failed for {record.title} ({record.record_uid})')
+                    continue
                 record_rq_by_uid[record.record_uid] = record_rq
 
                 rc = record_pb2.RecordConvertToV3()


### PR DESCRIPTION
This PR does the following with the "convert" command:
- Fixes the error handling of an attempt to convert a read-only record to v3.
- Updates the output of the "convert" command by giving a count of records matched and successfully converted along with a list of successfully converted records.
- Adds a --quiet option to suppress output besides warnings and errors