### PR TITLE
Improve "run-batch" error handling

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 from collections import OrderedDict
 
 from prompt_toolkit import PromptSession
@@ -405,13 +406,14 @@ def runcommands(params, commands=None, command_delay=0, quiet=False):
                 logging.info('Executing [%s]...', command)
             try:
                 do_command(params, command)
+            except CommandError as e:
+                logging.error(f'Error in command "{command}": {e.message}')
             except CommunicationError as e:
-                logging.error("Communication Error: %s", e.message)
+                logging.error(f'Communication Error: {e.message}')
             except AuthenticationError as e:
-                logging.error("AuthenticationError Error: %s", e.message)
-            except Exception as e:
-                logging.debug(e, exc_info=True)
-                logging.error('An unexpected error occurred: %s', sys.exc_info()[0])
+                logging.error(f'AuthenticationError Error: {e.message}')
+            except Exception:
+                logging.error(traceback.format_exc())
 
         if timedelay == 0:
             keep_running = False

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,12 @@
 norecursedirs = venv
 # unit-tests/test_command_utils.py fails due to circular import
 # unit-tests/test_login.py fails due to connection errors
-addopts = --disable-warnings -m "not cross_enterprise" --ignore unit-tests/test_command_utils.py --ignore unit-tests/test_login.py
+addopts =
+    --disable-warnings
+    -m "not cross_enterprise"
+    -k "not test_convert_to_folders"
+    --ignore unit-tests/test_command_utils.py
+    --ignore unit-tests/test_login.py
 markers =
     quicktest: at the moment an alias for the "keeper_imports" marker
     keeper_imports: smoke test to make sure all packages and modules in keeper can be imported


### PR DESCRIPTION
This PR improves the error handling of "run-batch" in the following ways:
- A warning is given if a Commander batch file is not found for the provided file pattern
- There are numerous improvements to the help and logging messages
- keepercommander.cli.runcommands is updated with a separate exception clause for CommandError exceptions to provide better reporting of the Commander specific error
- keepercommander.cli.runcommands is also updated to print the traceback for unexpected exceptions when running Commander commands