### PR TITLE
Don't fail if file attachments are missing for existing record for import

### DIFF
--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -803,7 +803,9 @@ def _import(params, file_format, filename, **kwargs):
                     existing_data = json.loads(existing_record['data_unencrypted'])
                     filerefs = [f for f in existing_data.get('fields', []) if f['type'] == 'fileRef']
                     if len(filerefs) > 0:
-                        existing_attachments = [params.record_cache[uid] for uid in filerefs[0].get('value') or []]
+                        existing_attachments = [
+                            params.record_cache[u] for u in filerefs[0].get('value') or [] if u in params.record_cache
+                        ]
                         attachment_data = [json.loads(a['data_unencrypted']) for a in existing_attachments]
                     else:
                         attachment_data = []


### PR DESCRIPTION
This fixes an issue with the following traceback:
```
Traceback (most recent call last):
  File "keepercommander/cli.py", line 547, in loop
  File "keepercommander/cli.py", line 369, in do_command
  File "keepercommander/importer/commands.py", line 123, in execute_args
  File "keepercommander/commands/base.py", line 250, in execute_args
  File "keepercommander/importer/commands.py", line 167, in execute
  File "keepercommander/importer/imp_exp.py", line 806, in _import
  File "keepercommander/importer/imp_exp.py", line 806, in <listcomp>
KeyError: 'FiTacTpxdnPXQLbXbAjtAg'
An unexpected error occurred: 'FiTacTpxdnPXQLbXbAjtAg'. Toggle debug to print traceback
My Vault>
```
This issue occurs when an importing a record that already exists but is missing the file attachment.