### PR TITLE
Use actual file size for vault/files_add API call

### DIFF
--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -1006,14 +1006,6 @@ def upload_v3_attachments(params, records_with_attachments):  # type: (KeeperPar
                 rf.record_key = crypto.encrypt_aes_v2(file_key, params.data_key)
                 rf.data = crypto.encrypt_aes_v2(rdata, file_key)
                 rf.fileSize = IV_LEN + atta.size + GCM_TAG_LEN
-                if 'bytes_total' in params.license and 'bytes_used' in params.license:
-                    try:
-                        bytes_left = int(params.license['bytes_total']) - int(params.license['bytes_used'])
-                        if bytes_left > 2000000000:
-                            bytes_left = 2000000000
-                        rf.fileSize = bytes_left
-                    except:
-                        pass
                 rq.files.append(rf)
                 uid_to_attachment[file_uid] = (atta, parent_uid, file_key)
 


### PR DESCRIPTION
I confirmed that this fixes errors that return the following output:
```
Error code: files_upload_fail
Communication Error: file size limit exceeded
```