### PR TITLE
Fix TOTP parse error

### DIFF
--- a/keepercommander/importer/lastpass/parser.py
+++ b/keepercommander/importer/lastpass/parser.py
@@ -79,12 +79,16 @@ def parse_ACCT(chunk, encryption_key, shared_folder):
         attach_key = None
 
     skip_item(io, 11)
-    totp_secret = decode_aes256_plain_auto(read_item(io), encryption_key).decode('utf-8')
-    if totp_secret:
-        totp_query_string = urlencode([('secret', totp_secret)] + TOTP_URL_QUERY_MAPPING)
-        totp_url = urlunsplit((TOTP_URL_SCHEME, TOTP_URL_NETLOC, TOTP_URL_PATH, totp_query_string, ''))
-    else:
+    try:
+        totp_secret = decode_aes256_plain_auto(read_item(io), encryption_key).decode('utf-8')
+    except Exception:
         totp_url = None
+    else:
+        if totp_secret:
+            totp_query_string = urlencode([('secret', totp_secret)] + TOTP_URL_QUERY_MAPPING)
+            totp_url = urlunsplit((TOTP_URL_SCHEME, TOTP_URL_NETLOC, TOTP_URL_PATH, totp_query_string, ''))
+        else:
+            totp_url = None
 
     # Parse secure note
     if secure_note == b'1':


### PR DESCRIPTION
This is an untested fix for an error report with the following traceback:
![image](https://user-images.githubusercontent.com/2257487/153640234-a954f569-98c7-448d-8e6e-e02b1be223e5.png)
