### PR TITLE
added unit-test for calling simple commands (no opts/args) via cli.do…

### DIFF
--- a/unit-tests/test_cli.py
+++ b/unit-tests/test_cli.py
@@ -3,6 +3,8 @@ import sys
 from unittest import TestCase, mock
 
 from keepercommander.commands import base
+from keepercommander.cli import do_command
+from data_vault import get_connected_params
 
 
 class TestCommandLineInterface(TestCase):
@@ -38,3 +40,12 @@ class TestCommandLineInterface(TestCase):
             self.assertEqual(s, r'command --output=d:\1\2\aaa')            
         finally:
             sys.platform = saved_platform
+
+    def test_do_command_no_opts(self):
+        params = get_connected_params()
+        params.sync_data = False
+        with mock.patch('keepercommander.commands.utils.ThisDeviceCommand.print_device_info') \
+                as mock_print_dev:
+            mock_print_dev.return_value = 'test device info'
+            do_command(params, 'this-device')
+            mock_print_dev.assert_called()


### PR DESCRIPTION
…_command()