### PR TITLE
Improvements to AWS rotation including using v3 records and new API

### DIFF
--- a/keepercommander/plugins/aws_common.py
+++ b/keepercommander/plugins/aws_common.py
@@ -32,12 +32,12 @@ class AWSRotator:
 
     def set_iam_session(self):
         """Set session and iam properties for instance"""
-        self.session = set_session(self.aws_profile)
         try:
+            self.session = set_session(self.aws_profile)
             self.iam = boto3.client('iam')
         except Exception as e:
-            logging.error(f'Login failed using {self.profile_msg}: {e}')
+            logging.error(f'Unable to create AWS session using {self.profile_msg}: {e}')
             return False
         else:
-            logging.debug(f'Login successful using {self.profile_msg}')
+            logging.debug(f'Created AWS session using {self.profile_msg}')
             return True

--- a/keepercommander/plugins/aws_common.py
+++ b/keepercommander/plugins/aws_common.py
@@ -1,0 +1,43 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2022 Keeper Security Inc.
+import logging
+
+import boto3
+
+
+AWS_INVALID_CLIENT_MSG = 'If the AWS key for this profile was recently rotated, a delay is needed before reconnecting.'
+
+
+def set_session(profile):
+    """Create new boto3 session"""
+    session_kwargs = {}
+    if profile:
+        session_kwargs['profile_name'] = profile
+    boto3.setup_default_session(**session_kwargs)
+    return boto3.DEFAULT_SESSION
+
+
+class AWSRotator:
+    def __init__(self, profile):
+        self.aws_profile = profile
+        self.profile_msg = f'AWS profile "{profile if profile else "default"}"'
+        self.session = None
+        self.iam = None
+
+    def set_iam_session(self):
+        """Set session and iam properties for instance"""
+        self.session = set_session(self.aws_profile)
+        try:
+            self.iam = boto3.client('iam')
+        except Exception as e:
+            logging.error(f'Login failed using {self.profile_msg}: {e}')
+            return False
+        else:
+            logging.debug(f'Login successful using {self.profile_msg}')
+            return True

--- a/keepercommander/plugins/awskey/aws_accesskey.py
+++ b/keepercommander/plugins/awskey/aws_accesskey.py
@@ -6,67 +6,205 @@
 #              |_|
 #
 # Keeper Commander
-# Copyright 2016 Keeper Security Inc.
+# Copyright 2022 Keeper Security Inc.
 # Contact: ops@keepersecurity.com
 #
+import logging
+import shutil
+from configparser import RawConfigParser
+from os.path import expandvars, expanduser, isfile
 
-import subprocess
-import json
+import boto3
+from botocore.exceptions import ClientError
+
+from ..commands import update_custom_text_fields
 
 """Commander Plugin for Rotating AWS Access Keys
    Dependencies:
-       pip3 install awscli
+       pip3 install boto3
 """
 
-def delete_aws_key(user, key_id):
-    pipe = subprocess.Popen(['aws',
-                             'iam',
-                             'delete-access-key',
-                             '--user-name={0}'.format(user),
-                             '--access-key-id={0}'.format(key_id)
-                             ],
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
 
-    (output1, error1) = pipe.communicate(timeout=3)
-#    if pipe.poll() != 0:
-#        if error1 is not None:
-#            print("Warning: Delete AWS access key for user {1}: {0}".format(error1.decode(), user))
+AWS_SYNC_CREDENTIAL_METHOD = 'shared-credentials-file'
+AWS_CREDS_FILE_KEY_ID_OPTION = 'aws_access_key_id'
+AWS_CREDS_FILE_KEY_SECRET_OPTION = 'aws_secret_access_key'
+AWS_CREDS_FILE_BACKUP_EXTENSION = '.keeper.bak'
+AWS_NEW_KEY_ID_FIELD = 'cmdr:aws_key_id'
+AWS_NEW_SECRET_FIELD = 'cmdr:aws_key_secret'
 
 
-def rotate(record, newpassword):
-    """
-    @type record: Record
-    """
-    try:
-        old_key_id = record.get("cmdr:aws_key_id")
-        if old_key_id:
-            delete_aws_key(record.login,old_key_id)
+class Rotator:
+    def __init__(self, login, aws_key_id, aws_key_secret=None, aws_profile=None, aws_sync_profile=None, **kwargs):
+        self.login = login
+        self.aws_key_id = aws_key_id
+        self.aws_key_secret = aws_key_secret
+        self.aws_profile = aws_profile
+        self.aws_sync_profile = aws_sync_profile
 
-        pipe = subprocess.Popen(['aws',
-                                 'iam',
-                                 'create-access-key',
-                                 '--user-name={0}'.format(record.login)],
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        (output1, error1) = pipe.communicate(timeout=3)
-        if pipe.poll() == 0:
-            ret = json.loads(output1.decode())
-            key = ret["AccessKey"]
-            if key is not None:
-                new_key_id = key["AccessKeyId"]
-                new_key_secret = key["SecretAccessKey"]
-                record.set_field("cmdr:aws_key_id", new_key_id)
-                record.set_field("cmdr:aws_key_secret", new_key_secret)
+        self.new_key_id = None
+        self.new_secret = None
+        self.iam = None
+        self.old_key_deleted = False
 
-                return True
+    def rotate_start_msg(self):
+        """Display msg before starting rotation"""
+        logging.info(
+            f'Rotating AWS access key id "{self.aws_key_id}" for user "{self.login}"'
+        )
+
+    def revert(self, record, new_password):
+        """Revert rotation of an AWS access key"""
+        if self.old_key_deleted:
+            if self.aws_sync_profile:
+                if self.sync_with_creds_file():
+                    logging.info(
+                        f'New key id "{self.new_key_id}" was updated in profile "{self.aws_sync_profile}"'
+                        ' of AWS credentials file, but failed to update in Keeper record.'
+                    )
+                else:
+                    logging.info(
+                        f'New key id {self.new_key_id} failed to update in profile "{self.aws_sync_profile}"'
+                        ' of AWS credentials file, and also failed to update in Keeper record.'
+                    )
+            return False
         else:
-            if error1 is not None:
-                print("Error: Create AWS access key for user {1}: {0}".format(error1.decode(), record.login))
+            self.delete_key(new_key=True)
 
-    except Exception as e:
-        print(e)
+    def revert_failed_msg(self):
+        # Printed failure messages in revert method
+        pass
 
-    return False
+    def update_password(self, record, new_password):
+        update_custom_text_fields(
+            record, {AWS_NEW_KEY_ID_FIELD: self.new_key_id, AWS_NEW_SECRET_FIELD: self.new_secret}
+        )
+
+    def sync_password(self):
+        if self.aws_sync_profile:
+            if not self.sync_with_creds_file():
+                logging.warning(f'Failed to update {self.aws_sync_profile} in AWS credentials file.')
+        if not self.old_key_deleted:
+            self.delete_key()
+
+    def delete_key(self, new_key=False):
+        if new_key:
+            key_type = 'new'
+            key_id = self.new_key_id
+        else:
+            key_type = 'old'
+            key_id = self.aws_key_id
+        try:
+            self.iam.delete_access_key(UserName=self.login, AccessKeyId=key_id)
+        except Exception as e:
+            logging.error(f'Error deleting {key_type} key id "{key_id}" for user "{self.login}"')
+            return False
+        else:
+            if not new_key:
+                self.old_key_deleted = True
+            logging.debug(f'Deleted {key_type} key id "{key_id}" for user "{self.login}"')
+            return True
+
+    def sync_with_creds_file(self):
+        sync_profile = self.aws_sync_profile
+        session = boto3._get_default_session()
+        botocore_session = session._session
+        credential_method = session.get_credentials().method
+        if credential_method == AWS_SYNC_CREDENTIAL_METHOD:
+            providers = botocore_session._components.get_component('credential_provider').providers
+            credential_provider = next((p for p in providers if p.METHOD == credential_method), None)
+            creds_filename = expanduser(expandvars(credential_provider._creds_filename))
+            if not isfile(creds_filename):
+                logging.warning(f'Unable to find credentials file "{creds_filename}" for syncing.')
+                return False
+            cp = RawConfigParser()
+            try:
+                cp.read([creds_filename])
+            except Exception as e:
+                logging.warning(f'Unable to parse credentials file "{creds_filename}" for syncing.')
+                return False
+            if not cp.has_section(sync_profile):
+                cp.add_section(sync_profile)
+            elif cp.has_option(sync_profile, AWS_CREDS_FILE_KEY_ID_OPTION):
+                old_key_id_option = cp.get(sync_profile, AWS_CREDS_FILE_KEY_ID_OPTION)
+                if old_key_id_option != self.aws_key_id:
+                    logging.warning(
+                        f'Another key id already exists for sync profile "{sync_profile}" in file "{creds_filename}".'
+                    )
+                    return False
+            cp.set(sync_profile, AWS_CREDS_FILE_KEY_ID_OPTION, self.new_key_id)
+            cp.set(sync_profile, AWS_CREDS_FILE_KEY_SECRET_OPTION, self.new_secret)
+            backup_file = f'{creds_filename}{AWS_CREDS_FILE_BACKUP_EXTENSION}'
+            shutil.copy2(creds_filename, backup_file)
+            with open(creds_filename, 'w') as f:
+                cp.write(f)
+            logging.info(
+                f'Synced AWS key rotation with AWS credential file "{creds_filename}"'
+                f' and backed up original file to "{backup_file}"'
+            )
+            return True
+
+    def rotate(self, record, new_password, revert=False):
+        """Rotate an AWS access key"""
+        profile = self.aws_profile
+        try:
+            if profile:
+                boto3.setup_default_session(profile_name=profile)
+            self.iam = boto3.client('iam')
+        except Exception as e:
+            logging.error(f'Login failed using aws profile "{profile if profile else "default"}": {e}')
+            return False
+        else:
+            logging.debug(f'Login successful using aws profile "{profile if profile else "default"}"')
+
+        try:
+            list_response = self.iam.list_access_keys(UserName=self.login)
+        except Exception as e:
+            logging.error(f'Error listing existing AWS keys for user "{self.login}": {e}')
+            return False
+        if isinstance(list_response, dict) and isinstance(list_response.get('AccessKeyMetadata'), list):
+            found_key_id = next(
+                (m for m in list_response['AccessKeyMetadata'] if m.get('AccessKeyId') == self.aws_key_id), None
+            )
+            if found_key_id is None:
+                logging.error(f'Unable to find AWS key id "{self.aws_key_id}" to rotate for user "{self.login}"')
+                return False
+        else:
+            logging.error(f'Invalid response listing existing AWS keys for user "{self.login}": {list_response}')
+            return False
+
+        create_response = None
+        # Try create_access_key again for LimitExceededException
+        for i in range(2):
+            try:
+                create_response = self.iam.create_access_key(UserName=self.login)
+            except ClientError as e:
+                if e.response.get('Error', {}).get('Code') == 'LimitExceeded' and not self.old_key_deleted:
+                    # Continue with loop and try again
+                    pass
+                else:
+                    logging.error(f'Error creating new key for user "{self.login}": {e}')
+                    return False
+            except Exception as e:
+                logging.error(f'Error creating new key for user "{self.login}": {e}')
+                return False
+            else:
+                # Successfully created key so no further action necessary
+                break
+            # The maximum number of keys has already been created, have to delete first
+            if not self.delete_key():
+                return False
+
+        if isinstance(create_response, dict) and isinstance(create_response.get('AccessKey'), dict):
+            access_key = create_response['AccessKey']
+            check_response = all(k in access_key for k in ('UserName', 'Status', 'AccessKeyId', 'SecretAccessKey'))
+            if check_response and access_key['UserName'] == self.login and access_key['Status'] == 'Active':
+                self.new_key_id = access_key['AccessKeyId']
+                self.new_secret = access_key['SecretAccessKey']
+                return True
+            else:
+                logging.error(f'Invalid response creating new key for {self.login}: {create_response}')
+                return False
+        else:
+            logging.error(f'Invalid response creating new key for {self.login}: {create_response}')
+            return False
+

--- a/keepercommander/plugins/awskey/aws_accesskey.py
+++ b/keepercommander/plugins/awskey/aws_accesskey.py
@@ -143,12 +143,14 @@ class Rotator:
             )
             return True
 
-    def rotate(self, record, new_password, revert=False):
+    def rotate(self, record, new_password):
         """Rotate an AWS access key"""
         profile = self.aws_profile
         try:
+            session_kwargs = {}
             if profile:
-                boto3.setup_default_session(profile_name=profile)
+                session_kwargs['profile_name'] = profile
+            boto3.setup_default_session(**session_kwargs)
             self.iam = boto3.client('iam')
         except Exception as e:
             logging.error(f'Login failed using aws profile "{profile if profile else "default"}": {e}')

--- a/keepercommander/plugins/awskey/aws_accesskey.py
+++ b/keepercommander/plugins/awskey/aws_accesskey.py
@@ -144,14 +144,7 @@ class Rotator:
             return True
 
     def set_session(self):
-        """Make sure any existing session has the same AWS key id or start new session"""
-        default_session = boto3.DEFAULT_SESSION
-        if default_session:
-            session_key_id = default_session.get_credentials().access_key
-            if session_key_id == self.aws_key_id:
-                # Use existing session
-                return
-        # Create new session
+        """Create new boto3 session"""
         session_kwargs = {}
         if self.aws_profile:
             session_kwargs['profile_name'] = self.aws_profile

--- a/keepercommander/plugins/awspswd/aws_passwd.py
+++ b/keepercommander/plugins/awspswd/aws_passwd.py
@@ -6,51 +6,66 @@
 #              |_|
 #
 # Keeper Commander
-# Copyright 2016 Keeper Security Inc.
+# Copyright 2022 Keeper Security Inc.
 # Contact: ops@keepersecurity.com
 #
+import logging
 
-import subprocess
+from botocore.exceptions import ClientError
+
+from ..aws_common import AWSRotator, AWS_INVALID_CLIENT_MSG
 
 """Commander Plugin for Rotating AWS passwords
    Dependencies:
-       pip3 install awscli
+       pip3 install boto3
 """
 
-def rotate(record, newpassword):
-    """
-    @type record: Record
-    """
-    try:
-        pipe = subprocess.Popen(['aws',
-                                 'iam',
-                                 'update-login-profile',
-                                 '--user-name={0}'.format(record.login),
-                                 '--password={0}'.format(newpassword)],
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
 
-        (output1, error1) = pipe.communicate(timeout=3)
-        if pipe.poll() == 0:
-            record.password = newpassword
+class Rotator(AWSRotator):
+    def __init__(self, login, password=None, aws_profile=None, **kwargs):
+        self.login = login
+        self.password = password
+        super().__init__(aws_profile)
+
+    def revert(self, record, new_password):
+        """Revert rotation of an AWS console login password"""
+        self.rotate(record, new_password, revert=True)
+
+    def create_login(self, new_password):
+        """Create AWS login profile and return (success, response)"""
+        try:
+            create_response = self.iam.create_login_profile(UserName=self.login, Password=new_password)
+        except Exception as e:
+            logging.error(f'Error creating AWS login for user "{self.login}": {e}')
+            return False, None
+        else:
+            return True, create_response
+
+    def rotate(self, record, new_password, revert=False):
+        """Rotate an AWS console login password"""
+        if revert:
+            if self.password:
+                new_password = self.password
+            else:
+                return False
+
+        if not self.set_iam_session():
+            return False
+        try:
+            update_response = self.iam.update_login_profile(UserName=self.login, Password=new_password)
+        except ClientError as e:
+            client_error_code = e.response.get('Error', {}).get('Code')
+            if client_error_code == 'InvalidClientTokenId':
+                logging.error(f'Unable to connect using {self.profile_msg}. {AWS_INVALID_CLIENT_MSG}')
+                return False
+            elif client_error_code == 'NoSuchEntity':
+                create_success, create_response = self.create_login(new_password)
+                return create_success
+            else:
+                logging.error(f'Error updating AWS login for user "{self.login}": {e}')
+                return False
+        except Exception as e:
+            logging.error(f'Error updating AWS login for user "{self.login}": {e}')
+            return False
+        else:
             return True
-
-        pipe = subprocess.Popen(['aws',
-                                 'iam',
-                                 'create-login-profile',
-                                 '--user-name={0}'.format(record.login),
-                                 '--password={0}'.format(newpassword)],
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-
-        (output1, error1) = pipe.communicate(timeout=3)
-        if pipe.poll() == 0:
-            record.password = newpassword
-            return True
-
-    except Exception as e:
-        print(e)
-
-    return False

--- a/keepercommander/plugins/plugin_manager.py
+++ b/keepercommander/plugins/plugin_manager.py
@@ -16,6 +16,7 @@ from . import noop
 
 
 REQUIRED_PLUGIN_KWARGS = {
+    'awskey': ['login', 'aws_key_id'],
     'mssql': ['login', 'password'],
     'mysql': ['host', 'login', 'password'],
     'oracle': ['login', 'password'],

--- a/keepercommander/plugins/plugin_manager.py
+++ b/keepercommander/plugins/plugin_manager.py
@@ -17,6 +17,7 @@ from . import noop
 
 REQUIRED_PLUGIN_KWARGS = {
     'awskey': ['login', 'aws_key_id'],
+    'awspswd': ['login'],
     'mssql': ['login', 'password'],
     'mysql': ['host', 'login', 'password'],
     'oracle': ['login', 'password'],

--- a/keepercommander/plugins/plugin_manager.py
+++ b/keepercommander/plugins/plugin_manager.py
@@ -168,10 +168,8 @@ def get_plugin(record, rotate_name, plugin_name=None, host=None, port=None):
     if plugin_name is None and len(cmdr_kwargs) > 0:
         rotate_value = cmdr_kwargs.get(f'plugin:{rotate_name}') if rotate_name else None
         plugin_name = rotate_value if rotate_value else cmdr_kwargs.get('plugin')
-        plugin_kwargs = {k: v for k, v in cmdr_kwargs.items() if ':' not in v}
-    else:
-        plugin_kwargs = {}
 
+    plugin_kwargs = {k: v for k, v in cmdr_kwargs.items() if ':' not in v}
     plugin_kwargs.update({
         k[1:-1]: v for k, v in record.enumerate_fields() if k in ('(login)', '(password)', '(url)') and v
     })

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_requires = [
     'keeper-secrets-manager-core>=16.2.0'
 ]
 adpasswd_requires = ['ldap3']
+aws_requires = ['boto3']
 test_requires = ['pytest', 'testfixtures']
 
 setup(
@@ -58,7 +59,8 @@ setup(
     install_requires=install_requires,
     extras_require={
         'adpasswd': adpasswd_requires,
+        'aws': aws_requires,
         'test': test_requires,
-        'all': adpasswd_requires + test_requires
+        'all': adpasswd_requires + aws_requires + test_requires
     }
 )


### PR DESCRIPTION
This PR does the following:
- Use boto3 instead of subprocess call to AWS CLI
- Allow for custom update_password method for plugins not using password stored in record password field or newly generated password
- Add option "cmdr:aws_profile" to use custom profile for connection
- Add option "cmdr:aws_sync_profile" to allow for synchronizing the new key with a profile in the AWS credentials file