### PR TITLE
Add generate password rules options to add and edit commands (KC-388)

### DIFF
--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -86,6 +86,10 @@ command_group.add_argument(
     '-gr', '--generate-rules', dest='generate_rules', action='store',
     help='generate a random password with comma separated complexity integers (uppercase, lowercase, numbers, symbols)'
 )
+add_parser.add_argument(
+    '-gl', '--generate-length', type=int, dest='generate_length', action='store',
+    help='generate password with given length'
+)
 add_parser.add_argument('--url', dest='url', action='store', help='url')
 add_parser.add_argument('--notes', dest='notes', action='store', help='notes')
 add_parser.add_argument('--custom', dest='custom', action='store', help='add custom fields. JSON or name:value pairs separated by comma. CSV Example: --custom "name1: value1, name2: value2". JSON Example: --custom \'{"name1":"value1", "name2":"value: 2,3,4"}\'')
@@ -111,6 +115,10 @@ command_group.add_argument('-g', '--generate', dest='generate', action='store_tr
 command_group.add_argument(
     '-gr', '--generate-rules', dest='generate_rules', action='store',
     help='generate a random password with comma separated complexity integers (uppercase, lowercase, numbers, symbols)'
+)
+edit_parser.add_argument(
+    '-gl', '--generate-length', type=int, dest='generate_length', action='store',
+    help='generate password with given length'
 )
 edit_parser.add_argument('--url', dest='url', action='store', help='url')
 edit_parser.add_argument('--notes', dest='notes', action='store', help='set or replace the notes. Use a plus sign (+) in front appends to existing notes')
@@ -269,14 +277,14 @@ file_report_parser.error = raise_parse_exception
 file_report_parser.exit = suppress_exit
 
 
-def get_password_from_rules(generate_rules):
+def get_password_from_rules(generate_rules, generate_length):
     if generate_rules:
-        kpg = generator.KeeperPasswordGenerator.create_from_rules(generate_rules)
+        kpg = generator.KeeperPasswordGenerator.create_from_rules(generate_rules, length=generate_length)
         if kpg is None:
             logging.warning('Using default password complexity rules')
-            kpg = generator.KeeperPasswordGenerator(DEFAULT_GENERATE_PASSWORD_LENGTH)
+            kpg = generator.KeeperPasswordGenerator(generate_length or DEFAULT_GENERATE_PASSWORD_LENGTH)
     else:
-        kpg = generator.KeeperPasswordGenerator(DEFAULT_GENERATE_PASSWORD_LENGTH)
+        kpg = generator.KeeperPasswordGenerator(generate_length or DEFAULT_GENERATE_PASSWORD_LENGTH)
     return kpg.generate()
 
 
@@ -539,8 +547,8 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
         # For compatibility w/ legacy: --password overides --generate AND --generate overrides dataJSON/option
         # dataJSON/option < kwargs: --generate < kwargs: --password
         password = kwargs.get('password')
-        if not password and (kwargs.get('generate') or kwargs.get('generate_rules')):
-            password = get_password_from_rules(kwargs.get('generate_rules'))
+        if not password and (kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length')):
+            password = get_password_from_rules(kwargs.get('generate_rules'), kwargs.get('generate_length'))
         if password:
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
@@ -746,7 +754,8 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
         data_json = str(kwargs['data']).strip() if 'data' in kwargs and kwargs['data'] else None
         data_file = str(kwargs['data_file']).strip() if 'data_file' in kwargs and kwargs['data_file'] else None
         data_opts = recordv3.RecordV3.convert_options_to_json(params, record_data, rt_def, kwargs) if rt_def else None
-        if not (data_json or data_file or data_opts or kwargs.get('generate')):
+        generate = kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length')
+        if not (data_json or data_file or data_opts or generate):
             logging.error(bcolors.FAIL + "Please provide valid record data as a JSON string, options or file name." + bcolors.ENDC)
             self.get_parser().print_help()
             return
@@ -765,7 +774,7 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
             if not data_opts.get('errors'):
                 rec = data_opts.get('record')
                 data = json.dumps(rec) if rec else ''
-        if kwargs.get('generate') and not data:
+        if generate and not data:
             data = record_data
 
         data = data.strip() if data else None
@@ -776,8 +785,8 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
         # For compatibility w/ legacy: --password overides --generate AND --generate overrides dataJSON/option
         # dataJSON/option < kwargs: --generate < kwargs: --password
         password = kwargs.get('password')
-        if not password and (kwargs.get('generate') or kwargs.get('generate_rules')):
-            password = get_password_from_rules(kwargs.get('generate_rules'))
+        if not password and generate:
+            password = get_password_from_rules(kwargs.get('generate_rules'), kwargs.get('generate_length'))
         if password:
             record.password = password
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -518,7 +518,7 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
         # dataJSON/option < kwargs: --generate < kwargs: --password
         password = kwargs.get('password')
         if not password and kwargs.get('generate'):
-            password = generator.generate(16)
+            password = generator.KeeperPasswordGenerator(16).generate()
         if password:
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
@@ -755,7 +755,7 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
         # dataJSON/option < kwargs: --generate < kwargs: --password
         password = kwargs.get('password')
         if not password and kwargs.get('generate'):
-            password = generator.generate(16)
+            password = generator.KeeperPasswordGenerator(16).generate()
         if password:
             record.password = password
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -11,16 +11,13 @@ import logging
 import os
 import random
 import string
+from typing import Optional
 from secrets import choice
 
 from Cryptodome.Random.random import shuffle
 
 
 DEFAULT_LENGTH = 32
-DEFAULT_SYMBOLS = 8
-DEFAULT_DIGITS = 8
-DEFAULT_CAPS = 8
-DEFAULT_LOWER = 8
 PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
 
 
@@ -96,12 +93,18 @@ def generate(length=64):
 
 
 class KeeperPasswordGenerator:
-    def __init__(self, length: int = DEFAULT_LENGTH, symbols: int = DEFAULT_SYMBOLS, digits: int = DEFAULT_DIGITS,
-                 caps: int = DEFAULT_CAPS, lower: int = DEFAULT_LOWER, special_characters: str = PW_SPECIAL_CHARACTERS):
-        sum_categories = sum(
-            (symbols if symbols > 0 else 0, digits if digits > 0 else 0, caps if caps > 0 else 0, lower if lower > 0 else 0)
-        )
-        if sum_categories == 0:
+    def __init__(self, length: int = DEFAULT_LENGTH, symbols: Optional[int] = None, digits: Optional[int] = None,
+                 caps: Optional[int] = None, lower: Optional[int] = None,
+                 special_characters: str = PW_SPECIAL_CHARACTERS):
+        none_count = (symbols, digits, caps, lower).count(None)
+        sum_categories = sum(0 if i is None or i <= 0 else i for i in (symbols, digits, caps, lower))
+        if none_count > 0:
+            # remaining length of password will be divided among unspecified categories
+            extra_count = length - sum_categories if length > sum_categories else 0
+            new_none_value = extra_count // none_count
+            symbols, digits, caps, lower = (new_none_value if i is None else i for i in (symbols, digits, caps, lower))
+            sum_categories += new_none_value * none_count
+        elif sum_categories == 0:
             symbols, digits, caps, lower, sum_categories = 1, 1, 1, 1, 4
         extra_count = length - sum_categories if length > sum_categories else 0
         self.category_map = [

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -17,7 +17,7 @@ from secrets import choice
 from Cryptodome.Random.random import shuffle
 
 
-DEFAULT_LENGTH = 32
+DEFAULT_PASSWORD_LENGTH = 32
 PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
 
 
@@ -93,8 +93,8 @@ def generate(length=64):
 
 
 class KeeperPasswordGenerator:
-    def __init__(self, length: int = DEFAULT_LENGTH, symbols: Optional[int] = None, digits: Optional[int] = None,
-                 caps: Optional[int] = None, lower: Optional[int] = None,
+    def __init__(self, length: int = DEFAULT_PASSWORD_LENGTH, symbols: Optional[int] = None,
+                 digits: Optional[int] = None, caps: Optional[int] = None, lower: Optional[int] = None,
                  special_characters: str = PW_SPECIAL_CHARACTERS):
         none_count = (symbols, digits, caps, lower).count(None)
         sum_categories = sum(0 if i is None or i <= 0 else i for i in (symbols, digits, caps, lower))
@@ -122,3 +122,24 @@ class KeeperPasswordGenerator:
             password_list.extend(choice(chars) for i in range(count))
         shuffle(password_list)
         return ''.join(password_list)
+
+    @classmethod
+    def create_from_rules(cls, rule_string: str, length: Optional[int] = None,
+                          special_characters: str = PW_SPECIAL_CHARACTERS):
+        """Create instance of class from rules string
+
+        rule_string: comma separated integer character counts of uppercase, lowercase, numbers, symbols
+        length: length of password
+        special_characters: set of characters used to generate password symbols
+        """
+        rule_list = [s.strip() for s in rule_string.split(',')]
+        if len(rule_list) != 4 or not all(n.isnumeric() for n in rule_list):
+            logging.warning(
+                'Invalid rules to generate password. Format is "upper, lower, digits, symbols"'
+            )
+            return None
+        else:
+            rule_list = [int(n) for n in rule_list]
+            upper, lower, digits, symbols = rule_list
+            length = sum(rule_list) if length is None else length
+            return cls(length=length, caps=upper, lower=lower, digits=digits, symbols=symbols)

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -142,4 +142,7 @@ class KeeperPasswordGenerator:
             rule_list = [int(n) for n in rule_list]
             upper, lower, digits, symbols = rule_list
             length = sum(rule_list) if length is None else length
-            return cls(length=length, caps=upper, lower=lower, digits=digits, symbols=symbols)
+            return cls(
+                length=length, caps=upper, lower=lower, digits=digits, symbols=symbols,
+                special_characters=special_characters
+            )

--- a/keepercommander/plugins/commands.py
+++ b/keepercommander/plugins/commands.py
@@ -121,11 +121,10 @@ def get_new_password(plugin, rules=None):
         pw_special_characters = generator.PW_SPECIAL_CHARACTERS
     if rules:
         logging.debug("Rules found for record")
-        upper, lower, digits, symbols = (int(n) for n in rules.split(','))
-        kpg = generator.KeeperPasswordGenerator(
-            length=upper + lower + digits + symbols, symbols=symbols, digits=digits, caps=upper, lower=lower,
-            special_characters=pw_special_characters
-        )
+        kpg = generator.KeeperPasswordGenerator.create_from_rules(rules, special_characters=pw_special_characters)
+        if kpg is None:
+            logging.warning('Using default password complexity rules')
+            kpg = generator.KeeperPasswordGenerator(special_characters=pw_special_characters)
     else:
         logging.debug("No rules, just generate")
         kpg = generator.KeeperPasswordGenerator(special_characters=pw_special_characters)

--- a/keepercommander/plugins/commands.py
+++ b/keepercommander/plugins/commands.py
@@ -48,7 +48,10 @@ rotate_parser.add_argument(
 rotate_parser.add_argument('--plugin', dest='plugin', action='store', help='Force rotation plugin (optional)')
 rotate_parser.add_argument('--host', dest='host', action='store', help='Optional host (override record value)')
 rotate_parser.add_argument('--port', dest='port', action='store', help='Optional port (override record value)')
-rotate_parser.add_argument('--rules', dest='rules', action='store', help='Optional rules (override record value)')
+rotate_parser.add_argument('-r', '--rules', dest='rules', action='store', help='Optional rules (override record value)')
+rotate_parser.add_argument(
+    '-l', '--length', type=int, dest='length', action='store', help='Optional password length (override record value)'
+)
 rotate_parser.add_argument('--password', dest='password', action='store', help='Optional new password')
 rotate_parser.add_argument(
     '--force', dest='force', action='store_true', help='force all matches to rotate without prompt'
@@ -112,7 +115,7 @@ def update_password(params, record, new_password, plugin):
         return True
 
 
-def get_new_password(plugin, rules=None):
+def get_new_password(plugin, rules=None, length=None):
     if hasattr(plugin, 'disallow_special_characters'):
         pw_special_characters = generator.PW_SPECIAL_CHARACTERS.translate(
             str.maketrans('', '', plugin.disallow_special_characters)
@@ -121,13 +124,19 @@ def get_new_password(plugin, rules=None):
         pw_special_characters = generator.PW_SPECIAL_CHARACTERS
     if rules:
         logging.debug("Rules found for record")
-        kpg = generator.KeeperPasswordGenerator.create_from_rules(rules, special_characters=pw_special_characters)
+        kpg = generator.KeeperPasswordGenerator.create_from_rules(
+            rules, length=length, special_characters=pw_special_characters
+        )
         if kpg is None:
             logging.warning('Using default password complexity rules')
-            kpg = generator.KeeperPasswordGenerator(special_characters=pw_special_characters)
+            if length is None:
+                length = generator.DEFAULT_PASSWORD_LENGTH
+            kpg = generator.KeeperPasswordGenerator(length=length, special_characters=pw_special_characters)
     else:
         logging.debug("No rules, just generate")
-        kpg = generator.KeeperPasswordGenerator(special_characters=pw_special_characters)
+        if length is None:
+            length = generator.DEFAULT_PASSWORD_LENGTH
+        kpg = generator.KeeperPasswordGenerator(length=length, special_characters=pw_special_characters)
     new_password = kpg.generate()
 
     # ensure password starts with alpha numeric character
@@ -142,7 +151,7 @@ def get_new_password(plugin, rules=None):
 
 
 def rotate_password(params, record_uid, rotate_name=None, plugin_name=None, host=None, port=None, rules=None,
-                    new_password=None):
+                    length=None, new_password=None):
     """ Rotate the password for the specified record """
     api.sync_down(params)
     record = KeeperRecord.load(params, record_uid)
@@ -160,7 +169,9 @@ def rotate_password(params, record_uid, rotate_name=None, plugin_name=None, host
     if new_password is None:
         if not rules:
             rules = plugin_kwargs.get('rules')
-        new_password = get_new_password(plugin, rules)
+        if not length:
+            length = plugin_kwargs.get('length')
+        new_password = get_new_password(plugin, rules, length)
 
     if plugin_kwargs.get('password') == new_password:
         logging.warning('Rotation aborted because the old and new passwords are the same.')
@@ -252,7 +263,7 @@ class RecordRotateCommand(Command):
                 rotate_password(
                     params, record_uid, rotate_name=rotate_name, plugin_name=kwargs.get('plugin'),
                     host=kwargs.get('host'), port=kwargs.get('port'), rules=kwargs.get('rules'),
-                    new_password=kwargs.get('password')
+                    length=kwargs.get('length'), new_password=kwargs.get('password')
                 )
                 if print_result:
                     record = api.get_record(params, record_uid)

--- a/keepercommander/plugins/plugin_manager.py
+++ b/keepercommander/plugins/plugin_manager.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 from . import noop
 
 
+CONVERT_KWARG_TO_INT = ('port', 'length')
 REQUIRED_PLUGIN_KWARGS = {
     'awskey': ['login', 'aws_key_id'],
     'awspswd': ['login'],
@@ -178,11 +179,17 @@ def get_plugin(record, rotate_name, plugin_name=None, host=None, port=None):
         plugin_kwargs['host'] = host
     if port:
         plugin_kwargs['port'] = port
-    if 'port' in plugin_kwargs:
-        if plugin_kwargs['port'].isnumeric():
-            plugin_kwargs['port'] = int(plugin_kwargs['port'])
-        else:
-            plugin_kwargs.pop('port')
+
+    for convert_kwarg in CONVERT_KWARG_TO_INT:
+        if convert_kwarg in plugin_kwargs:
+            if plugin_kwargs[convert_kwarg].isnumeric():
+                plugin_kwargs[convert_kwarg] = int(plugin_kwargs[convert_kwarg])
+            else:
+                logging.warning(
+                    f'Argument "{convert_kwarg}", value "{plugin_kwargs[convert_kwarg]}"'
+                    ' ignored because unable to convert to integer'
+                )
+                plugin_kwargs.pop(convert_kwarg)
 
     if plugin_name is None:
         if port and port in PORT_TO_PLUGIN:


### PR DESCRIPTION
This PR does the following:
- Update KeeperPasswordGenerator to split count of password categories over remaining length when categories aren't specified
- Add class method to KeeperPasswordGenerator for getting instance from rules string
- Add --generate-rules and --generate-length option to `add` and `edit` commands
- Add --rules option to generate command as well
- Add --length or `cmdr:length` option to rotation plugins as well