### PR TITLE
Add capability to display and change team membership for enterprise roles (KC-396)

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -2263,6 +2263,7 @@ class EnterpriseTeamCommand(EnterpriseCommand):
 
         matched_teams = list(matched.values())
         request_batch = []
+        non_batch_update_msgs = []
 
         if kwargs.get('add') or kwargs.get('approve'):
             queue = []
@@ -2332,8 +2333,6 @@ class EnterpriseTeamCommand(EnterpriseCommand):
                 non_batch_update_msgs = self.change_team_roles(
                     params, matched_teams, kwargs.get('add_role'), kwargs.get('remove_role')
                 )
-            else:
-                non_batch_update_msgs = []
 
             if kwargs.get('add_user') or kwargs.get('remove_user'):
                 users = {}

--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -179,12 +179,24 @@ enterprise_role_parser.add_argument('--new-user', dest='new_user', action='store
 enterprise_role_parser.add_argument('--delete', dest='delete', action='store_true', help='delete role')
 enterprise_role_parser.add_argument('--node', dest='node', action='store', help='node Name or ID')
 enterprise_role_parser.add_argument('--name', dest='name', action='store', help='role\'s new name')
-enterprise_role_parser.add_argument('--add-user', dest='add_user', action='append', metavar='EMAIL', help='add user to role')
-enterprise_role_parser.add_argument('--remove-user', dest='remove_user', action='append', metavar='EMAIL', help='remove user from role')
-enterprise_role_parser.add_argument('--enforcement', dest='enforcements', action='append', metavar='KEY:VALUE', help='sets role enforcement')
-enterprise_role_parser.add_argument('--add-admin', dest='add_admin', action='append', help='add managed node to role')
+enterprise_role_parser.add_argument('-au', '--add-user', action='append', metavar='EMAIL', help='add user to role')
+enterprise_role_parser.add_argument(
+    '-ru', '--remove-user', action='append', metavar='EMAIL', help='remove user from role'
+)
+enterprise_role_parser.add_argument('-at', '--add-team', action='append', metavar='EMAIL', help='add team to role')
+enterprise_role_parser.add_argument(
+    '-rt', '--remove-team', action='append', metavar='EMAIL', help='remove team from role'
+)
+enterprise_role_parser.add_argument(
+    '-aa', '--add-admin', dest='add_admin', action='append', help='add managed node to role'
+)
+enterprise_role_parser.add_argument(
+    '-ra', '--remove-admin', dest='remove_admin', action='append', help='remove managed node from role'
+)
+enterprise_role_parser.add_argument(
+    '--enforcement', dest='enforcements', action='append', metavar='KEY:VALUE', help='sets role enforcement'
+)
 enterprise_role_parser.add_argument('--cascade', dest='cascade', action='store', choices=['on', 'off'], help='apply to the children nodes. \'add-admin\' only')
-enterprise_role_parser.add_argument('--remove-admin', dest='remove_admin', action='append', help='remove managed node from role')
 enterprise_role_parser.add_argument('role', type=str, nargs='+', help='Role Name ID. Can be repeated.')
 enterprise_role_parser.error = raise_parse_exception
 enterprise_role_parser.exit = suppress_exit
@@ -1599,6 +1611,7 @@ class EnterpriseRoleCommand(EnterpriseCommand):
         matched_roles = list(matched.values())
 
         request_batch = []
+        non_batch_update_msgs = []
         skip_display = False
         if kwargs.get('add'):
             for role in matched_roles:
@@ -1630,83 +1643,21 @@ class EnterpriseRoleCommand(EnterpriseCommand):
             if not matched_roles:
                 return
 
+            add_team, remove_team = kwargs.get('add_team'), kwargs.get('remove_team')
+            add_user, remove_user = kwargs.get('add_user'), kwargs.get('remove_user')
+
             if kwargs.get('delete'):
                 for role in matched_roles:
                     request_batch.append({ "command": "role_delete", "role_id": role['role_id'] })
 
-            elif kwargs.get('add_user') or kwargs.get('remove_user'):
-                user_changes = {}
-                for is_add in [False, True]:
-                    ul = kwargs.get('add_user') if is_add else kwargs.get('remove_user')
-                    if ul:
-                        for u in ul:
-                            uname = u.lower()
-                            user_node = None
-                            if 'users' in params.enterprise:
-                                for user in params.enterprise['users']:
-                                    if uname in { str(user['enterprise_user_id']),
-                                                  user['username'].lower() }:
-                                        user_node = user
-                                        break
-                            if user_node:
-                                user_id = user_node['enterprise_user_id']
-                                user_changes[user_id] = is_add, user_node['username']
-                            else:
-                                logging.warning('User %s could be resolved', u)
+            elif add_team or remove_team or add_user or remove_user:
+                if add_team or remove_team:
+                    non_batch_update_msgs += self.change_role_teams(params, matched_roles, add_team, remove_team)
 
-                user_pkeys = {}
-                for role in matched_roles:
-                    role_id = role['role_id']
-                    for user_id in user_changes:
-                        is_add, email = user_changes[user_id]
-                        role_key = None
-                        is_managed_role = False
-                        if is_add:
-                            if 'managed_nodes' in params.enterprise:
-                                for mn in params.enterprise['managed_nodes']:
-                                    if mn['role_id'] == role_id:
-                                        is_managed_role = True
-                                        break
-                        if is_managed_role:
-
-                            if 'role_keys2' in params.enterprise:
-                                for rk2 in params.enterprise['role_keys2']:
-                                    if rk2['role_id'] == role_id:
-                                        encrypted_key_decoded = base64.urlsafe_b64decode(rk2['role_key'] + '==')
-                                        role_key = rest_api.decrypt_aes(encrypted_key_decoded, params.enterprise['unencrypted_tree_key'])
-                                        break
-
-                            if 'role_keys' in params.enterprise and role_key is None:
-                                for rk in params.enterprise['role_keys']:
-                                    if rk['role_id'] == role_id:
-                                        if rk['key_type'] == 'encrypted_by_data_key':
-                                            role_key = api.decrypt_data(rk['encrypted_key'], params.data_key)
-                                        elif rk['key_type'] == 'encrypted_by_public_key':
-                                            role_key = api.decrypt_rsa(rk['encrypted_key'], params.rsa_key)
-                                        break
-                        rq = {
-                            'command': 'role_user_add' if is_add else 'role_user_remove',
-                            'enterprise_user_id': user_id,
-                            'role_id': role_id
-                        }
-                        if is_managed_role:
-                            if user_id not in user_pkeys:
-                                answer = 'y' if kwargs.get('force') else user_choice('Do you want to grant administrative privileges to {0}'.format(email), 'yn', 'n')
-                                public_key = None
-                                if answer == 'y':
-                                    public_key = self.get_public_key(params, email)
-                                    if public_key is None:
-                                        logging.warning('Cannot get public key for user %s', email)
-                                user_pkeys[user_id] = public_key
-                            if user_pkeys[user_id]:
-                                encrypted_tree_key = crypto.encrypt_rsa(params.enterprise['unencrypted_tree_key'], user_pkeys[user_id])
-                                rq['tree_key'] = utils.base64_url_encode(encrypted_tree_key)
-                                if role_key:
-                                    encrypted_role_key = crypto.encrypt_rsa(role_key, user_pkeys[user_id])
-                                    rq['role_admin_key'] = utils.base64_url_encode(encrypted_role_key)
-                                request_batch.append(rq)
-                        else:
-                            request_batch.append(rq)
+                if add_user or remove_user:
+                    request_batch += self.get_role_users_change_batch(
+                        params, matched_roles, add_user, remove_user
+                    )
 
             elif kwargs.get('enforcements'):
                 skip_display = True
@@ -2073,6 +2024,10 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                     else:
                         if rs['result'] != 'success':
                             logging.warning('Error: %s', rs['message'])
+
+        if request_batch or len(non_batch_update_msgs) > 0:
+            for update_msg in non_batch_update_msgs:
+                logging.info(update_msg)
             api.query_enterprise(params)
         else:
             if kwargs.get('format') == 'json':
@@ -2103,16 +2058,20 @@ class EnterpriseRoleCommand(EnterpriseCommand):
             'node_name': self.get_node_path(params, role['node_id']),
             'cascade': role.get('visible_below', False),
             'new_user_inherit': role.get('new_user_inherit', False),
-            'users': []
+            'users': [],
+            'teams': []
         }
         if 'role_users' in params.enterprise:
-            user_ids = [x['enterprise_user_id'] for x in params.enterprise['role_users'] if x['role_id'] == role_id]
+            user_ids = [r['enterprise_user_id'] for r in params.enterprise['role_users'] if r['role_id'] == role_id]
             if len(user_ids) > 0:
-                users = {x['enterprise_user_id']: x['username'] for x in params.enterprise['users']}
-                ret['users'] = [{
-                    'user_id': x,
-                    'username': users[x]
-                } for x in user_ids if x in users]
+                users = {u['enterprise_user_id']: u['username'] for u in params.enterprise['users']}
+                ret['users'] = [{'user_id': i, 'username': users[i]} for i in user_ids if i in users]
+
+        if 'role_teams' in params.enterprise:
+            team_ids = [r['team_uid'] for r in params.enterprise['role_teams'] if r['role_id'] == role_id]
+            if len(team_ids) > 0:
+                teams = {t['team_uid']: t['name'] for t in params.enterprise['teams']}
+                ret['teams'] = [{'team_id': i, 'team_name': teams[i]} for i in team_ids if i in teams]
 
         if 'managed_nodes' in params.enterprise:
             node_ids = [x['managed_node_id'] for x in params.enterprise['managed_nodes'] if x['role_id'] == role_id]
@@ -2175,15 +2134,24 @@ class EnterpriseRoleCommand(EnterpriseCommand):
         print('{0:>24s}: {1}'.format('Cascade?', 'Yes' if role['visible_below'] else 'No'))
         print('{0:>24s}: {1}'.format('New user?', 'Yes' if role['new_user_inherit'] else 'No'))
         if 'role_users' in params.enterprise:
-            user_ids = [x['enterprise_user_id'] for x in params.enterprise['role_users'] if x['role_id'] == role_id]
+            user_ids = [r['enterprise_user_id'] for r in params.enterprise['role_users'] if r['role_id'] == role_id]
             if len(user_ids) > 0:
-                users = {}
-                for user in params.enterprise['users']:
-                    users[user['enterprise_user_id']] = user['username']
+                users = {u['enterprise_user_id']: u['username'] for u in params.enterprise['users']}
                 user_ids.sort(key=lambda x: users[x])
-                for i in range(len(user_ids)):
-                    user_id = user_ids[i]
-                    print('{0:>24s}: {1:<32s} {2}'.format('User(s)' if i == 0 else '', users[user_id], user_id if is_verbose else ''))
+                for i, user_id in enumerate(user_ids):
+                    print('{0:>24s} {1:<32s} {2}'.format(
+                        'User(s):' if i == 0 else '', users[user_id], user_id if is_verbose else ''
+                    ))
+
+        if 'role_teams' in params.enterprise:
+            team_ids = [r['team_uid'] for r in params.enterprise['role_teams'] if r['role_id'] == role_id]
+            if len(team_ids) > 0:
+                teams = {t['team_uid']: t['name'] for t in params.enterprise['teams']}
+                team_ids.sort(key=lambda x: teams[x])
+                for i, team_id in enumerate(team_ids):
+                    print('{0:>24s} {1:<32s} {2}'.format(
+                        'Team(s):' if i == 0 else '', teams[team_id], team_id if is_verbose else ''
+                    ))
 
         if 'managed_nodes' in params.enterprise:
             node_ids = [x['managed_node_id'] for x in params.enterprise['managed_nodes'] if x['role_id'] == role_id]

--- a/keepercommander/commands/enterprise_common.py
+++ b/keepercommander/commands/enterprise_common.py
@@ -9,12 +9,24 @@
 # Contact: ops@keepersecurity.com
 #
 
+import base64
 import collections
+import logging
 
-from .base import Command
-from .. import api, utils, crypto
+from .base import Command, user_choice
+from .. import api, utils, crypto, rest_api
 from ..error import CommandError
 from ..params import KeeperParams
+from ..proto.enterprise_pb2 import RoleTeam, RoleTeams
+
+
+def decrypt_role_key(params, role_key):
+    if role_key['key_type'] == 'encrypted_by_data_key':
+        return api.decrypt_data(role_key['encrypted_key'], params.data_key)
+    elif role_key['key_type'] == 'encrypted_by_public_key':
+        return api.decrypt_rsa(role_key['encrypted_key'], params.rsa_key)
+    else:
+        return None
 
 
 class EnterpriseCommand(Command):
@@ -96,6 +108,139 @@ class EnterpriseCommand(Command):
         if team_key is not None:
             self.team_keys[team_uid] = team_key
         return team_key
+
+    def get_role_users_change_batch(self, params, roles, add_user, remove_user, force=False):
+        """Get batch of requests for changing enterprise role users"""
+        request_batch = []
+        user_changes = {}
+        for is_add in (False, True):
+            ul = add_user if is_add else remove_user
+            if ul:
+                for u in ul:
+                    user_node = next((
+                        user for user in params.enterprise.get('users', [])
+                        if u.lower() in (str(user['enterprise_user_id']), user['username'].lower())
+                    ), None)
+                    if user_node:
+                        user_id = user_node['enterprise_user_id']
+                        user_changes[user_id] = is_add, user_node['username']
+                    else:
+                        logging.warning('User %s could be resolved', u)
+
+        user_pkeys = {}
+        for role in roles:
+            role_id = role['role_id']
+            for user_id in user_changes:
+                is_add, email = user_changes[user_id]
+                role_key = None
+                if is_add:
+                    is_managed_role = next((
+                        True for mn in params.enterprise.get('managed_nodes', []) if mn['role_id'] == role_id
+                    ), False)
+                else:
+                    is_managed_role = False
+
+                if is_managed_role:
+                    role_keys2 = params.enterprise.get('role_keys2', [])
+                    role_key = next((rk2['role_key'] for rk2 in role_keys2 if rk2['role_id'] == role_id), None)
+                    if role_key:
+                        encrypted_key_decoded = base64.urlsafe_b64decode(role_key + '==')
+                        role_key = rest_api.decrypt_aes(
+                            encrypted_key_decoded, params.enterprise['unencrypted_tree_key']
+                        )
+                    else:
+                        role_keys = params.enterprise.get('role_keys', [])
+                        role_key = next((
+                            decrypt_role_key(params, rk) for rk in role_keys if rk['role_id'] == role_id
+                        ), None)
+                rq = {
+                    'command': 'role_user_add' if is_add else 'role_user_remove',
+                    'enterprise_user_id': user_id,
+                    'role_id': role_id
+                }
+                if is_managed_role:
+                    if user_id not in user_pkeys:
+                        answer = 'y' if force else user_choice(
+                            'Do you want to grant administrative privileges to {0}'.format(email), 'yn', 'n')
+                        public_key = None
+                        if answer == 'y':
+                            public_key = self.get_public_key(params, email)
+                            if public_key is None:
+                                logging.warning('Cannot get public key for user %s', email)
+                        user_pkeys[user_id] = public_key
+                    if user_pkeys[user_id]:
+                        encrypted_tree_key = crypto.encrypt_rsa(params.enterprise['unencrypted_tree_key'],
+                                                                user_pkeys[user_id])
+                        rq['tree_key'] = utils.base64_url_encode(encrypted_tree_key)
+                        if role_key:
+                            encrypted_role_key = crypto.encrypt_rsa(role_key, user_pkeys[user_id])
+                            rq['role_admin_key'] = utils.base64_url_encode(encrypted_role_key)
+                        request_batch.append(rq)
+                else:
+                    request_batch.append(rq)
+        return request_batch
+
+    @staticmethod
+    def decrypt_role_key(params, rk):
+        if rk['key_type'] == 'encrypted_by_data_key':
+            return api.decrypt_data(rk['encrypted_key'], params.data_key)
+        elif rk['key_type'] == 'encrypted_by_public_key':
+            return api.decrypt_rsa(rk['encrypted_key'], params.rsa_key)
+        else:
+            return None
+
+    @staticmethod
+    def change_role_teams(params, roles, add_team, remove_team):
+        """Change enterprise role teams"""
+        update_msgs = []
+        add_teams = None
+        remove_teams = None
+        team_changes = {}
+        for is_add in (False, True):
+            team_list = add_team if is_add else remove_team
+            if team_list:
+                if is_add:
+                    add_teams = RoleTeams()
+                else:
+                    remove_teams = RoleTeams()
+                for team in team_list:
+                    team_node = next((
+                        t for t in params.enterprise.get('teams', []) if team in (t['team_uid'], t['name'])
+                    ), None)
+                    if team_node:
+                        team_changes[team_node['team_uid']] = is_add, team_node['name']
+                    else:
+                        logging.warning('Team %s could be resolved', team)
+
+        for role in roles:
+            role_id = role['role_id']
+            for team_id in team_changes:
+                is_add, team_name = team_changes[team_id]
+                if is_add:
+                    is_managed_role = next((
+                        True for mn in params.enterprise.get('managed_nodes', []) if mn['role_id'] == role_id
+                    ), False)
+                else:
+                    is_managed_role = False
+
+                if is_managed_role:
+                    logging.warning('Teams cannot be assigned to roles with administrative permissions.')
+                else:
+                    role_team = RoleTeam()
+                    role_team.role_id = role_id
+                    role_team.teamUid = utils.base64_url_decode(team_id)
+                    role_name = role['data']['displayname']
+                    if is_add:
+                        add_teams.role_team.append(role_team)
+                        update_msgs.append(f"'{role_name}' role assigned to team '{team_name}'")
+                    else:
+                        remove_teams.role_team.append(role_team)
+                        update_msgs.append(f"'{role_name}' role removed from team '{team_name}'")
+        if remove_teams:
+            api.communicate_rest(params, remove_teams, 'enterprise/role_team_remove')
+        if add_teams:
+            api.communicate_rest(params, add_teams, 'enterprise/role_team_add')
+        return update_msgs
 
     @staticmethod
     def get_enterprise_id(params):

--- a/keepercommander/commands/enterprise_create_user.py
+++ b/keepercommander/commands/enterprise_create_user.py
@@ -69,7 +69,8 @@ class CreateEnterpriseUserCommand(EnterpriseCommand, RecordMixin):
 
             verification_code = ''
             try:
-                data = {'displayname': email}
+                displayname = kwargs.get('name',email)
+                data = {'displayname': displayname}
                 rq = {
                     'command': 'enterprise_user_add',
                     'enterprise_user_id': EnterpriseCommand.get_enterprise_id(params),

--- a/unit-tests/test_command_enterprise.py
+++ b/unit-tests/test_command_enterprise.py
@@ -142,7 +142,7 @@ class TestEnterprise(TestCase):
         with mock.patch('builtins.print'):
             cmd.execute(params, role=[ent_env.role1_name])
 
-        with mock.patch('keepercommander.commands.enterprise.user_choice') as mock_choice:
+        with mock.patch('keepercommander.commands.enterprise_common.user_choice') as mock_choice:
             mock_choice.return_value = 'y'
             TestEnterprise.expected_commands = ['role_user_add']
             cmd.execute(params, add_user=[ent_env.user2_email], role=[ent_env.role1_id])


### PR DESCRIPTION
This PR makes the following enterprise command changes:
- Add options `--add-team` (`-at`) and `--remove-team` (`-rt`) to the `enterprise-role` command
- Show teams output for the `enterprise-role` command with both `--format` options of both `json` and `text`
- Add options `--add-role` (`-ar`) and `--remove-role` (`-rr`) to the `enterprise-team` command
- Show roles output for the `enterprise-team` command