### PR TITLE
compliance-report readability/export fixes: 

### DIFF
--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -1770,16 +1770,18 @@ class ComplianceReportCommand(EnterpriseCommand):
             rows.sort(key=operator.itemgetter('record_uid'))
             last_ruid = ''
             formatted_rows = []
+            record_lookup = sd.get_records()
             for row in rows:
                 r_uid = row.get('record_uid')
-                rec = sd.get_records().get(r_uid)
-                r_title = rec.data.get('title')
-                r_type = rec.data.get('record_type')
-                r_url = rec.data.get('url')
-                formatted_ruid = r_uid if report_fmt != 'json' and r_uid != last_ruid else ''
+                rec = record_lookup.get(r_uid)
+                r_data = rec.data
+                r_title = r_data.get('title', '')
+                r_type = r_data.get('record_type', '')
+                r_url = r_data.get('url', '')
+                formatted_ruid = r_uid if report_fmt != 'table' or last_ruid != r_uid else ''
                 u_email = row.get('email')
                 permissions = RecordPermissions.to_permissions_str(row.get('permissions'))
-                fmt_row = [formatted_ruid, r_title, r_type, u_email, permissions, r_url]
+                fmt_row = [formatted_ruid, r_title, r_type, u_email, permissions, r_url.rstrip('/')]
                 formatted_rows.append(fmt_row)
                 last_ruid = r_uid
             return formatted_rows

--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -1683,8 +1683,9 @@ class ComplianceReportCommand(EnterpriseCommand):
                       f'Total Users: {num_users} Total shared records: {num_shared}'
                 logging.info(msg)
             help_txt = "\nGet record and sharing information from all vaults in the enterprise\n" \
-                       "Format:\ncompliance-report [-h] [--rebuild] [--node NODE] [--username USERNAME] " \
-                       "[--job-title JOB_TITLE] [--shared] [--output OUTPUT] [--format {table,csv,json}]" \
+                       "Format:\ncompliance-report [-h] [--rebuild] [--no-cache] [--node NODE] [--username USERNAME] " \
+                       "[--job-title JOB_TITLE] [--url DOMAIN] [--shared] [--output OUTPUT] " \
+                       "[--format {table,csv,json}]" \
                        "\n\nExamples:" \
                        "\nSee all records for a user" \
                        "\n\t'compliance-report --username USERNAME'" \

--- a/keepercommander/sox/__init__.py
+++ b/keepercommander/sox/__init__.py
@@ -111,6 +111,7 @@ def get_compliance_data(params, node_id, enterprise_id=0, rebuild=False, min_upd
                 tasks = [sync_chunk(chunk, users_uids, limit) for chunk in ruid_chunks]
                 await asyncio.gather(*tasks, return_exceptions=return_exceptions)
                 sdata.storage.set_compliance_data_updated()
+                print('')
 
             py_version_3_6 = not hasattr(asyncio, 'run')
             if not py_version_3_6:


### PR DESCRIPTION
1) removed trailing slashes in URL values, 
2) all record UIDs now included in csv/json outputs 
3) added newline to end of data-download progress output to stdout,
4) fixed bug with wrong record UIDs being assigned to rows