### PR TITLE
security audit scores reset/security data update improvements: 

### DIFF
--- a/keepercommander/commands/breachwatch.py
+++ b/keepercommander/commands/breachwatch.py
@@ -131,8 +131,6 @@ class BreachWatchPasswordCommand(Command):
 
 
 class BreachWatchResetCommand(Command):
-    URL_SUFFIX = '/reset_keeper_sec'
-
     def get_parser(self):  # type: () -> Optional[argparse.ArgumentParser]
         return breachwatch_reset_parser
 


### PR DESCRIPTION
1) de-couple sec. score resetting from "domain" value in incremental security data 
2) remove extraneous properties from updated security data 
3) limit domain string length (to prevent issues w/ RSA encryption data size limit)