### PR TITLE
`tree` and `transform-folder` improvements/fixes (Jira KC-526)

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -1414,17 +1414,13 @@ class FolderTransformCommand(Command):
             # Create copy folder of appropriate type
             mkdir_cmd = FolderMakeCommand()
             copy_name = get_copy_name(folder, dest)
-            cmd_args = []
-            if transform and dest.type in (BaseFolderNode.UserFolderType, BaseFolderNode.RootFolderType):
-                if folder.type in (BaseFolderNode.SharedFolderFolderType, BaseFolderNode.UserFolderType):
-                    cmd_args.append('-sf')
-                else:
-                    cmd_args.append('-uf')
-            else:
-                cmd_args.append('-uf')
-            cmd_args.append(copy_name)
-            cmd_args = ' '.join(cmd_args)
-            mkdir_cmd.execute_args(params, cmd_args)
+            cmd_kwargs = {'folder': copy_name}
+            is_folder_sf = folder.type == BaseFolderNode.SharedFolderType
+            is_dest_uf = dest.type in (BaseFolderNode.UserFolderType, BaseFolderNode.RootFolderType)
+            is_copy_sf = transform and is_dest_uf and not is_folder_sf
+            copy_folder_type = 'shared_folder' if is_copy_sf else 'user_folder'
+            cmd_kwargs[copy_folder_type] = True
+            mkdir_cmd.execute(params, **cmd_kwargs)
             api.sync_down(params)
             copy_uid = get_folder_uid(copy_name)
             folder_copies[folder.uid] = copy_uid

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -1543,11 +1543,11 @@ class FolderTransformCommand(Command):
             return root_copy
 
         def preview_transform(xform_pairs):
+            logging.info('\nORIGINAL vs. TRANSFORMED folder structures:')
+            logging.info('===========================================\n')
             hide_key = False
             for root, xformed in xform_pairs:
                 params.current_folder = root.parent_uid or ''
-                logging.info('\nORIGINAL vs. TRANSFORMED folder structures:')
-                logging.info('===========================================\n')
                 tree_cmd = FolderTreeCommand()
                 tree_cmd.execute(params, folder=root.name, records=True, shares=True, hide_shares_key=hide_key,
                                  title='ORIGINAL:\n=========')

--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -242,11 +242,11 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
             return f'({"; ".join(perms)})'
 
     def tree_node(node):
-        if isinstance(node, dict) and show_records:
-            name = RecordV3.get_title(node)
+        if isinstance(node, dict):
+            name = Style.DIM + RecordV3.get_title(node)
             if verbose:
                 name += f' ({node.get("record_uid")})'
-            name += Style.BRIGHT + ' [Record]' + Style.NORMAL
+            name += ' [Record]' + Style.NORMAL
             return name, {}
 
         if verbose and node.uid:
@@ -260,16 +260,20 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                 name += ' ' + get_share_info(node)
 
         sfs = [params.folder_cache[sfuid] for sfuid in node.subfolders]
+        rns = []
         if show_records:
-            recs = [params.record_cache.get(ruid) for ruid in params.subfolder_record_cache.get(node.uid, [])]
-            sfs.extend(recs)
+            node_uid = '' if node.type == '/' else node.uid
+            recs = [params.record_cache.get(ruid) for ruid in params.subfolder_record_cache.get(node_uid, [])]
+            rns.extend(recs)
 
-        if len(sfs) == 0:
+        if len(sfs) + len(rns) == 0:
             return name, {}
 
-        sort_fn = lambda f: f.name.lower() if isinstance(f, BaseFolderNode) else RecordV3.get_title(f).lower()
-        sfs.sort(key=sort_fn, reverse=False)
-        tns = [tree_node(sf) for sf in sfs]
+        sfs.sort(key=lambda f: f.name.lower(), reverse=False)
+        rns.sort(key=lambda r: RecordV3.get_title(r).lower(), reverse=False)
+        nodes = sfs + rns
+
+        tns = [tree_node(n) for n in nodes]
         return name, OD(tns)
 
     t = tree_node(folder)


### PR DESCRIPTION
`transform-folder` cmd:
1) added support for transforming folders w/ space(s) in name

`tree` cmd w/ --records option:
1) root-folder records now shown 
2) record text formatted for clarity
3) nodes sorting identical to vault GUI (folders precede records for each folder node)