### PR TITLE
`sync-security-data` improvements and related additions:

### DIFF
--- a/keepercommander/commands/helpers/record.py
+++ b/keepercommander/commands/helpers/record.py
@@ -1,0 +1,23 @@
+from keepercommander import api
+from keepercommander.params import KeeperParams
+from keepercommander.subfolder import try_resolve_path
+
+
+# Get record UID given one of its identifiers: name (if current folder contains the record), path, or UID
+def get_record_uid(params, name):   # type: (KeeperParams, str) -> str or None
+    uid = None
+    if name in params.record_cache:
+        uid = name
+    else:
+        rs = try_resolve_path(params, name)
+        if rs is not None:
+            folder, name = rs
+            if folder is not None and name is not None:
+                folder_uid = folder.uid or ''
+                if folder_uid in params.subfolder_record_cache:
+                    for r_uid in params.subfolder_record_cache[folder_uid]:
+                        r = api.get_record(params, r_uid)
+                        if r.title.lower() == name.lower():
+                            uid = r_uid
+                            break
+    return uid


### PR DESCRIPTION
`sync-security-data`: added support for 
1) pagination (for vaults w/ more than 1000 password records)
2) filter by records
3) "--quiet" option

additional improvements:
1) added helper module (includes record UID getter) for record-related tasks