### PR TITLE
`shared-records-report` & `tree` fixes/improvement (KC-535):  

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -800,7 +800,7 @@ class ShareRecordCommand(Command):
             dump_report_data(table, headers, row_number=True, group_by=0)
             return
 
-        if transfer_ruids:
+        if transfer_ruids and params.enterprise_ec_key:
             from .utils import SyncSecurityDataCommand
             ssd_cmd = SyncSecurityDataCommand()
             ssd_cmd.execute(params, record=transfer_ruids, quiet=True)

--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -17,7 +17,7 @@ from colorama import init, Fore, Back, Style
 from tabulate import tabulate
 
 from keepercommander import __version__
-from .subfolder import BaseFolderNode, SharedFolderNode
+from .subfolder import BaseFolderNode, SharedFolderNode, get_contained_records
 
 init()
 
@@ -260,16 +260,17 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                 name += ' ' + get_share_info(node)
 
         sfs = [params.folder_cache[sfuid] for sfuid in node.subfolders]
-        rns = []
+        rns = set()
         if show_records:
             node_uid = '' if node.type == '/' else node.uid
-            recs = [params.record_cache.get(ruid) for ruid in params.subfolder_record_cache.get(node_uid, [])]
-            rns.extend(recs)
+            recs = get_contained_records(params, node_uid).get(node_uid)
+            rns.update(recs)
 
         if len(sfs) + len(rns) == 0:
             return name, {}
 
         sfs.sort(key=lambda f: f.name.lower(), reverse=False)
+        rns = [params.record_cache.get(r) for r in rns]
         rns.sort(key=lambda r: RecordV3.get_title(r).lower(), reverse=False)
         nodes = sfs + rns
 


### PR DESCRIPTION
`shared-records-report`: 
1) added filter by containing folder, 
2) fixed bug in share-team getter, 
3) fixed shared-folder path not resolved to UID 

`tree`:
1) fixed bug w/ record-display