### PR TITLE
record/folder path resolution and related fixes/improvements (KC-561, KC-558):

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -312,14 +312,13 @@ class FolderTreeCommand(Command):
             display.formatted_tree(params, folder, verbose=verbose, show_records=records, shares=shares,
                                    hide_shares_key=hide_key, title=title)
         else:
-            rs = try_resolve_path(params, folder_name)
-            if rs is not None:
-                folder, pattern = rs
-                if len(pattern) == 0:
+            folders, pattern = try_resolve_path(params, folder_name, find_all_matches=True)
+            if not pattern:
+                for idx, folder in enumerate(folders):
                     display.formatted_tree(params, folder, verbose=verbose, show_records=records, shares=shares,
-                                           hide_shares_key=hide_key, title=title)
-                else:
-                    raise CommandError('tree', f'Folder {folder_name} not found')
+                                           hide_shares_key=hide_key or idx > 0, title=title)
+            else:
+                raise CommandError('tree', f'Folder {folder_name} not found')
 
 
 class FolderRenameCommand(Command):

--- a/keepercommander/commands/helpers/record.py
+++ b/keepercommander/commands/helpers/record.py
@@ -1,23 +1,25 @@
+from typing import Set, Optional
+
 from keepercommander import api
 from keepercommander.params import KeeperParams
 from keepercommander.subfolder import try_resolve_path
 
 
-# Get record UID given one of its identifiers: name (if current folder contains the record), path, or UID
-def get_record_uid(params, name):   # type: (KeeperParams, str) -> str or None
-    uid = None
+# Get record UID(s) given one of its identifiers: name (if current folder contains the record), path, or UID
+def get_record_uids(params, name):  # type: (KeeperParams, str) -> Set[Optional[str]]
+    uids = set()
     if name in params.record_cache:
-        uid = name
+        uids = [name]
     else:
-        rs = try_resolve_path(params, name)
-        if rs is not None:
-            folder, name = rs
-            if folder is not None and name is not None:
+        rs = try_resolve_path(params, name, find_all_matches=True)
+        # if rs is not None:
+        folders, name = rs
+        if folders and name is not None:
+            for folder in folders:
                 folder_uid = folder.uid or ''
                 if folder_uid in params.subfolder_record_cache:
                     for r_uid in params.subfolder_record_cache[folder_uid]:
                         r = api.get_record(params, r_uid)
                         if r.title.lower() == name.lower():
-                            uid = r_uid
-                            break
-    return uid
+                            uids.add(r_uid)
+    return uids

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -31,7 +31,7 @@ from keeper_secrets_manager_core.utils import url_safe_str_to_bytes, bytes_to_ba
 
 from . import aliases, commands, enterprise_commands, msp_commands, record
 from .base import raise_parse_exception, suppress_exit, user_choice, Command, dump_report_data, as_boolean
-from .helpers.record import get_record_uid
+from .helpers.record import get_record_uids as get_ruids
 from .helpers.timeout import (
     enforce_timeout_range, format_timeout, get_delta_from_timeout_setting, get_timeout_setting_from_delta, parse_timeout
 )
@@ -2204,11 +2204,11 @@ class SyncSecurityDataCommand(Command):
                 names = [names]
             if names:
                 for name in names:
-                    uid = get_record_uid(params, name)
-                    if uid is None:
-                        raise CommandError('sync-security-data', f'Record {name} could not be found.')
+                    record_uids = get_ruids(params, name)
+                    if not record_uids:
+                        logging.warning(f'Record {name} could not be found (skipping security data update).')
                     else:
-                        uids.add(uid)
+                        uids.update(get_ruids(params, name))
             return uids
 
         if not params.enterprise_ec_key:

--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -8,6 +8,7 @@
 # Contact: ops@keepersecurity.com
 #
 import json
+import re
 import shutil
 from collections import OrderedDict as OD
 from typing import Tuple, List, Union
@@ -16,8 +17,9 @@ from asciitree import LeftAligned
 from colorama import init, Fore, Back, Style
 from tabulate import tabulate
 
-from keepercommander import __version__
-from .subfolder import BaseFolderNode, SharedFolderNode, get_contained_records
+from keepercommander import __version__, api
+from .record import Record
+from .subfolder import BaseFolderNode, SharedFolderNode, get_contained_record_uids
 
 init()
 
@@ -188,9 +190,6 @@ def formatted_folders(folders):
 
 
 def formatted_tree(params, folder, verbose=False, show_records=False, shares=False, hide_shares_key=False, title=None):
-    if show_records:
-        from .recordv3 import RecordV3
-
     def print_share_permissions_key():
         perms_key = 'Share Permissions Key:\n' \
                '======================\n' \
@@ -229,6 +228,7 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                 info.append(f'[{name}:{",".join(privs)}]')
             return 'teams:' + ','.join(info) if info else ''
 
+        result = ''
         if isinstance(node, SharedFolderNode):
             sf = params.shared_folder_cache.get(node.uid)
             teams_info = get_teams_info(sf.get('teams', []))
@@ -239,54 +239,50 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
             user_perms = 'user:' + ','.join(user_perms)
             perms = [default_perms, user_perms, teams_info, users_info]
             perms = [p for p in perms if p]
-            return f'({"; ".join(perms)})'
+            result = f' ({"; ".join(perms)})' if shares else ''
+
+        return result
 
     def tree_node(node):
-        if isinstance(node, dict):
-            name = Style.DIM + RecordV3.get_title(node)
-            if verbose:
-                name += f' ({node.get("record_uid")})'
-            name += ' [Record]' + Style.NORMAL
-            return name, {}
+        node_uid = node.record_uid if isinstance(node, Record) else node.uid or ''
+        node_name = node.title if isinstance(node, Record) else node.name
+        node_name = f'{node_name} ({node_uid})'
+        share_info = get_share_info(node) if isinstance(node, SharedFolderNode) and shares else ''
+        node_name = f'{Style.DIM}{node_name} [Record]{Style.NORMAL}' if isinstance(node, Record) \
+            else f'{node_name}{Style.BRIGHT} [SHARED]{Style.NORMAL}{share_info}' if isinstance(node, SharedFolderNode)\
+            else node_name
 
-        if verbose and node.uid:
-            name = f'{node.name} ({node.uid})'
-        else:
-            name = node.name
-
-        if isinstance(node, SharedFolderNode):
-            name += ' ' + Style.BRIGHT + '[Shared]' + Style.NORMAL
-            if shares:
-                name += ' ' + get_share_info(node)
-
-        sfs = [params.folder_cache[sfuid] for sfuid in node.subfolders]
-        rns = set()
-        if show_records:
+        dir_nodes = [] if isinstance(node, Record) \
+            else [params.folder_cache.get(fuid) for fuid in node.subfolders]
+        rec_nodes = []
+        if show_records and isinstance(node, BaseFolderNode):
             node_uid = '' if node.type == '/' else node.uid
-            recs = get_contained_records(params, node_uid).get(node_uid)
-            rns.update(recs)
+            rec_uids = get_contained_record_uids(params, node_uid).get(node_uid)
+            rec_nodes.extend([api.get_record(params, rec_uid) for rec_uid in rec_uids])
 
-        if len(sfs) + len(rns) == 0:
-            return name, {}
+        dir_nodes.sort(key=lambda f: f.name.lower(), reverse=False)
+        rec_nodes.sort(key=lambda r: r.title.lower(), reverse=False)
+        child_nodes = dir_nodes + rec_nodes
 
-        sfs.sort(key=lambda f: f.name.lower(), reverse=False)
-        rns = [params.record_cache.get(r) for r in rns]
-        rns.sort(key=lambda r: RecordV3.get_title(r).lower(), reverse=False)
-        nodes = sfs + rns
+        tns = [tree_node(n) for n in child_nodes]
+        return node_name, OD(tns)
 
-        tns = [tree_node(n) for n in nodes]
-        return name, OD(tns)
-
-    t = tree_node(folder)
-    tree = {
-        t[0]: t[1]
-    }
+    root, branches = tree_node(folder)
+    tree = {root: branches}
     tr = LeftAligned()
     if shares and not hide_shares_key:
         print_share_permissions_key()
     if title:
         print(title)
-    print(tr(tree))
+    tree_txt = str(tr(tree))
+    tree_txt = re.sub(r'\s+\(\)', '', tree_txt)
+    if not verbose:
+        lines = tree_txt.splitlines()
+        for idx, line in enumerate(lines):
+            line = re.sub(r'\s+\(.+?\)', '', line, count=1)
+            lines[idx] = line
+        tree_txt = '\n'.join(lines)
+    print(tree_txt)
     print('')
 
 

--- a/keepercommander/subfolder.py
+++ b/keepercommander/subfolder.py
@@ -9,7 +9,7 @@
 # Contact: ops@keepersecurity.com
 #
 import logging
-from typing import Optional, Tuple, Dict, Iterable
+from typing import Optional, Tuple, Dict, Iterable, List, Set
 
 from .params import KeeperParams
 
@@ -74,38 +74,35 @@ def find_parent_top_folder(params, record_uid):
     return shared_folders_containing_record
 
 
-def contained_folder(params, folder, component):
-    """Return the folder of component within parent folder 'folder' - or None if not present."""
-    if component == '.':
-        return folder
-    if component == '..':
-        if folder.parent_uid is None:
-            return params.root_folder
-        return params.folder_cache[folder.parent_uid]
-    if component in params.folder_cache:
-        return params.folder_cache[component]
-    for subfolder_uid in folder.subfolders:
-        subfolder = params.folder_cache[subfolder_uid]
-        if subfolder.name == component:
-            return subfolder
-    return None
+def contained_folders(params, folders, component):
+    # type: (KeeperParams, List[Optional[BaseFolderNode]], str) -> List[Optional[BaseFolderNode]]
+    """Return list of folders (empty if component not present) containing component within parent folder 'folder'"""
+    get_folder_by_id = lambda uid: params.folder_cache.get(uid)
+    get_folder_ids = lambda: params.folder_cache.keys()
+    result = folders if component in ('.', '') \
+        else [(f if f.parent_uid else params.root_folder) for f in folders] if component == '..' \
+        else [get_folder_by_id(component)] if component in get_folder_ids() \
+        else [get_folder_by_id(uid) for f in folders for uid in f.subfolders if get_folder_by_id(uid).name == component]
+    return result
 
 
 def lookup_path(params, folder, components):
+    # type: (KeeperParams, BaseFolderNode, List[Optional[str]]) -> Tuple[int, List[Optional[BaseFolderNode]]]
     """
-    Lookup a path of components within the folder cache.
+    Lookup path of components within the folder cache.
 
-    Get all the folders starting from the left end of component, plus the index of the first component that isn't present in the
-    folder cache.
+    Get all the folders starting from the left end of component, plus the index of the first component that isn't
+    present in the folder cache.
     """
     remainder = 0
+    folders = [folder]
     for index, component in enumerate(components):
-        temp_folder = contained_folder(params, folder, component)
-        if temp_folder is None:
+        child_folders = contained_folders(params, folders, component)
+        if not child_folders:
             break
-        folder = temp_folder
+        folders = child_folders
         remainder = index + 1
-    return remainder, folder
+    return remainder, folders
 
 
 def is_abs_path(path_string):
@@ -123,13 +120,14 @@ def path_split(params, folder, path_string):
     return folder, components
 
 
-def try_resolve_path(params, path):
-    # type: (KeeperParams, str) -> Optional[Tuple[BaseFolderNode, Optional[str]]]
+def try_resolve_path(params, path, find_all_matches=False):
+    # type: (KeeperParams, str, bool) -> Optional[Tuple[List[BaseFolderNode] or BaseFolderNode, Optional[str]]]
     """
     Look up the final keepercommander.subfolder.UserFolderNode and name of the final component(s).
+    Set find_all_matches = True to get a list of folders and component path
 
     If a record, the final component is the record.
-    If an existent folder, the final component is ''.
+    If existent folder(s), the final component is ''.
     If a non-existent folder, the final component is the folders, joined with /, that do not (yet) exist..
     """
     if type(path) is not str:
@@ -143,36 +141,36 @@ def try_resolve_path(params, path):
 
     folder, components = path_split(params, folder, path)
 
-    remainder, folder = lookup_path(params, folder, components)
+    remainder, folders = lookup_path(params, folder, components)
 
     tail = components[remainder:]
 
     path = '/'.join(component.replace('/', '//') for component in tail)
 
-    # Return a 2-tuple of keepercommander.subfolder.UserFolderNode, str
-    # The first is the folder containing the second, or the folder of the last component if the second is ''.
+    # Return a 2-tuple of BaseFolderNode (or List[BaseFolderNode] if find_all_matches set to True), str
+    # The first is the folder/s containing the second, or the folder of the last component if the second is ''.
     # The second is the final component of the path we're passed as an argument to this function. It could be a record, or
     # a not-yet-existent directory.
-    return (folder, path)
+    return (folders, path) if find_all_matches \
+        else (next(iter(folders)) if folders else None, path)
 
 
-def get_folder_uid(params, name):   # type: (KeeperParams, str) -> str
-    uid = None
+def get_folder_uids(params, name):  # type: (KeeperParams, str) -> Set[Optional[str]]
+    uids = set()
     if name in params.folder_cache or name == '':
-        uid = name
+        uids.add(name)
     else:
-        rs = try_resolve_path(params, name)
+        rs = try_resolve_path(params, name, find_all_matches=True)
         if rs is not None:
-            folder, pattern = rs
+            folders, pattern = rs
             if len(pattern) == 0:
-                uid = folder.uid
-    return uid
+                uids.update([folder.uid for folder in folders])
+    return uids
 
 
-def get_contained_records(params, name, children_only=True):
+def get_contained_record_uids(params, name, children_only=True):
     # type: (KeeperParams, str, bool) -> Dict[str, Iterable[str]]
-    uid = get_folder_uid(params, name)
-
+    from keepercommander.commands.base import FolderMixin
     recs_by_folder = dict()
 
     def add_child_recs(f_uid):
@@ -183,11 +181,11 @@ def get_contained_records(params, name, children_only=True):
         if f.uid in params. subfolder_record_cache:
             add_child_recs(f.uid)
 
-    if children_only:
-        add_child_recs(uid)
-    else:
-        from keepercommander.commands import base
-        base.FolderMixin.traverse_folder_tree(params, uid, on_folder)
+    for uid in get_folder_uids(params, name):
+        if children_only:
+            add_child_recs(uid)
+        else:
+            FolderMixin.traverse_folder_tree(params, uid, on_folder)
     return recs_by_folder
 
 


### PR DESCRIPTION
1. modify / add helper functions that enable resolution of folder/record paths to all associated UIDs
2. `tree` CMD improvement/fix: 
- bug fix for records/folders w/ duplicate paths not displayed in tree-structure 
- resolve folder path command args (used to filter command output) to all associated UIDs
3. `shared-records-report` improvement: filter results using all UIDs mapped to specified folder paths
4.  `sync-security-data` improvement