### PR TITLE
`security-audit-report` improvements (KC-569): 

### DIFF
--- a/keepercommander/utils.py
+++ b/keepercommander/utils.py
@@ -276,7 +276,7 @@ def password_score(password):  # type: (str) -> int
 
 
 def is_pw_weak(pw_score):           # type: (int) -> bool
-    return pw_score <= 40
+    return pw_score < 40
 
 
 def is_pw_strong(pw_score):         # type: (int) -> bool


### PR DESCRIPTION
1) add option for specifying score type ("strong_passwords" type results in score calculation and format identical to vault's),
2) match vault's definition of "weak" (strength < 40)