### PR TITLE
(KC-581/587) `find-duplicate --merge` fix/improvements:

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -1348,7 +1348,7 @@ class SharedRecordsReport(Command):
             for p in permissions:
                 sources = [t.value for t in p.types]
                 share_from = '\n'.join([shared_from_mapping.get(min(s, max(shared_from_mapping.keys())), 'Other Share') for s in sources])
-                row = [sr.uid, sr.name, share_from, p.get_target(show_team_users), p.get_permissions_text(), folder_paths]
+                row = [sr.uid, sr.name, share_from, p.get_target(show_team_users), p.permissions_text, folder_paths]
                 rows.append(row)
         rows.sort(key=lambda x: x[5], reverse=True)
         fields = ['record_uid', 'title', 'share_to', 'shared_from', 'permissions', 'folder_path']

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -18,6 +18,7 @@ import json
 import logging
 import re
 import time
+import urllib.parse
 from typing import Optional, Dict, Iterable, Any, Set, List
 from urllib.parse import urlunparse
 
@@ -1757,6 +1758,8 @@ class FindDuplicateCommand(Command):
                     title = (not j or not by_title) and record.title or ''
                     login = (not j or not by_login) and record.login or ''
                     url = record.login_url or ''
+                    url = urllib.parse.urlparse(url.encode()).hostname
+                    url = url.decode()[:30] if url else ''
                     url = [url] if by_url else []
                     owner = shared_record.owner or params.meta_data_cache.get(record_uid).get('owner') and params.user
                     team_user_type = SharePermissions.SharePermissionsType.TEAM_USER


### PR DESCRIPTION
1) add support for matching on shares, 
2) fix inadvertent removal of shares upon duplicate record deletion, 
3) add support for "dry-run" mode, 
4) add support for "quiet" mode
5) limit displayed URL string length (for clarity of output)