### PR TITLE
(KC-589) `share-folder` improvement/ fix:

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -254,7 +254,7 @@ class ShareFolderCommand(Command):
             for u in (kwargs.get('user') or []):
                 if u == '*':
                     default_account = True
-                elif u == '@current':
+                elif u in ('@existing', '@current'):
                     all_users = True
                 else:
                     em = re.match(constants.EMAIL_PATTERN, u)
@@ -280,7 +280,7 @@ class ShareFolderCommand(Command):
             for r in records:
                 if r == '*':
                     default_record = True
-                elif r == '@current':
+                elif r in ('@existing', '@current'):
                     all_records = True
                 else:
                     r_uids = get_record_uids(params, r)

--- a/keepercommander/shared_record.py
+++ b/keepercommander/shared_record.py
@@ -60,7 +60,7 @@ def get_shared_records(params, record_uids, cache_only=False):
         no_share_users = {uname_lookup.get(u.get('enterprise_user_id')) for u in r_users}
         no_share_teams = {t.get('team_uid') for t in r_teams}
         cached_team_members = get_cached_team_members(no_share_teams, uname_lookup)
-        no_share_team_members = {t for team_uid in no_share_teams for t in cached_team_members.get(team_uid)}
+        no_share_team_members = {t for team_uid in no_share_teams for t in cached_team_members.get(team_uid) or []}
         members = no_share_users.union(no_share_teams).union(no_share_team_members)
         return members
 


### PR DESCRIPTION
1) add support for "@existing" pseudo-username/record value in `share-folder` (to allow setting of specified permissions for existing users and/or records
2) fix NoneType cached_team_members issue in get_shared_records() (due to deleted team member accounts)