### PR TITLE
(KC-592) `share-report`/`shared-records-report` fix/improvement: 

### DIFF
--- a/keepercommander/shared_record.py
+++ b/keepercommander/shared_record.py
@@ -41,7 +41,6 @@ def get_shared_records(params, record_uids, cache_only=False):
         return members
 
     def fetch_sf_admins():
-        # todo: check if 'share_admins' data is already in params.shared_folder_cache (don't call KA endpoint if so)
         sf_uids = [uid for uid in params.shared_folder_cache]
         return {sf_uid: api.get_share_admins_for_shared_folder(params, sf_uid) for sf_uid in sf_uids}
 

--- a/keepercommander/shared_record.py
+++ b/keepercommander/shared_record.py
@@ -27,7 +27,7 @@ def get_shared_records(params, record_uids, cache_only=False):
         if not params.enterprise:
             return members
 
-        team_users = params.enterprise.get('team_users')
+        team_users = params.enterprise.get('team_users') or []
         team_users = [tu for tu in team_users if tu.get('user_type') != 2 and tu.get('team_uid') in t_uids]
 
         for tu in team_users:


### PR DESCRIPTION
1) handle NoneType params.enterprise["team_users"] value exception in shared_record.get_shared_records() common function
2) clean up (remove extraneous TODO comment)