### PR TITLE
`compliance` improvements/additions:

### DIFF
--- a/keepercommander/sox/__init__.py
+++ b/keepercommander/sox/__init__.py
@@ -262,6 +262,8 @@ def get_compliance_data(params, node_id, enterprise_id=0, rebuild=False, min_upd
                 entity = sdata.storage.teams.get_entity(team_uid) or StorageTeam()
                 entity.team_uid = team_uid
                 entity.team_name = team.teamName
+                entity.restrict_edit = team.restrictEdit
+                entity.restrict_share = team.restrictShare
                 entities.append(entity)
             sdata.storage.teams.put_entities(entities)
 


### PR DESCRIPTION
1) add `shared-folder-report` subcommand 
2) add `--show-team-users` option to `team-report` subcommand 
3) fix shown team->shared-folder permissions in `team-report` 
4) display number of records contained by each shared folder in `team-report` output 
5) add `stats` alias for `summary-report` subcommand
6) SOX data retrieval fix: set team share restrictions indicated in response