### PR TITLE
`find-duplicate` improvements:

### DIFF
--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -196,6 +196,11 @@ def is_json_value_field(obj):
 WORDS_TO_CAPITALIZE = {'Id', 'Uid', 'Ip', 'Url', 'Scim'}
 
 
+def fields_to_titles(fields): # type: (List[str]) -> Optional[List[str]]
+    titles = [field_to_title(f) for f in fields]
+    return titles
+
+
 def field_to_title(field):   # type: (str) -> str
     words = field.split('_')
     words = [x.capitalize() for x in words if x]

--- a/keepercommander/sox/sox_data.py
+++ b/keepercommander/sox/sox_data.py
@@ -65,6 +65,10 @@ class SoxData:
     def get_shared_folders(self, sf_uids=None):
         return self._shared_folders if sf_uids is None else {uid: self._shared_folders.get(uid) for uid in sf_uids}
 
+    def get_record_sfs(self, record_uid):
+        get_ruids = lambda sf: [rp.record_uid for rp in sf.record_permissions]
+        return [sf.folder_uid for sf in self._shared_folders.values() if record_uid in get_ruids(sf)]
+
     def get_record_owner(self, rec_uid):
         owner = None
         if rec_uid in self._records:


### PR DESCRIPTION
1) added options for exporting and formatting resulting relevant data
2) added `--scope` option (w/ additional ability to expand duplicate-record search to  all enterprise vaults)