### PR TITLE
(KC-661) `share-record`/`security-audit-report` improvements: 

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -815,11 +815,6 @@ class ShareRecordCommand(Command):
             dump_report_data(table, headers, row_number=True, group_by=0)
             return
 
-        if transfer_ruids and params.enterprise_ec_key:
-            from .utils import SyncSecurityDataCommand
-            ssd_cmd = SyncSecurityDataCommand()
-            ssd_cmd.execute(params, record=transfer_ruids, quiet=True)
-
         while len(rq.addSharedRecord) > 0 or len(rq.updateSharedRecord) > 0 or len(rq.removeSharedRecord) > 0:
             rq1 = record_pb2.RecordShareUpdateRequest()
             left = 990

--- a/keepercommander/commands/security_audit.py
+++ b/keepercommander/commands/security_audit.py
@@ -307,16 +307,6 @@ class SecurityAuditReportCommand(EnterpriseCommand):
                 # type: (List[APIRequest_pb2.SecurityReportIncrementalData]) -> List[Dict[str, Dict[str, int] or None]]
                 return [decrypt_incremental_data(x) for x in inc_dataset]
 
-            def is_reset_needed(inc_datas):
-                inc_datas = [x for x in inc_datas if x and isinstance(x, dict)]
-                curr_inc_datas = [x.get('curr', dict()) for x in inc_datas]
-                has_reset_inc_data = any([x for x in curr_inc_datas if x and x.get('reset')])
-                return has_reset_inc_data
-
-            def clear_scores(sec_data):
-                new_scores = {k: 0 for k in self.score_data_keys}
-                return {**sec_data, **new_scores}
-
             def get_security_score_deltas(rec_sec_data, delta):
                 bw_result = rec_sec_data.get('bw_result')
                 pw_strength = rec_sec_data.get('strength')

--- a/keepercommander/commands/security_audit.py
+++ b/keepercommander/commands/security_audit.py
@@ -335,10 +335,6 @@ class SecurityAuditReportCommand(EnterpriseCommand):
                 return sec_data
 
             def update_scores(user_sec_data, inc_dataset):
-                reset = is_reset_needed(inc_dataset)
-                if reset:
-                    user_sec_data = clear_scores(user_sec_data)
-
                 def update(u_sec_data, old_sec_d, diff):
                     if not old_sec_d:
                         return u_sec_data
@@ -346,14 +342,9 @@ class SecurityAuditReportCommand(EnterpriseCommand):
                     return apply_score_deltas(u_sec_data, deltas)
 
                 for inc_data in inc_dataset:
-                    curr_sec_data = inc_data.get('curr')
                     existing_data_keys = [k for k, d in inc_data.items() if d]
-                    if reset:
-                        if curr_sec_data:
-                            user_sec_data = update(user_sec_data, curr_sec_data, 1)
-                    else:
-                        for k in existing_data_keys:
-                            user_sec_data = update(user_sec_data, inc_data.get(k), -1 if k == 'old' else 1)
+                    for k in existing_data_keys:
+                        user_sec_data = update(user_sec_data, inc_data.get(k), -1 if k == 'old' else 1)
 
                 return user_sec_data
 


### PR DESCRIPTION
1) remove security-data update prior to record transfer in `share-record` 
2) remove logic for clearing summary security scores via vault-initiated security-data "hard" sync (via `ssd --hard`, to be deprecated)