### PR TITLE
(KC-663) `action-report` fix: 

### DIFF
--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -1898,8 +1898,8 @@ class ActionReportCommand(EnterpriseCommand):
             emails = [u.get('username') for u in users]
             action_handlers = {
                 'none': partial(run_cmd, users, None, None, dryrun),
-                'lock': partial(run_cmd, users, lambda: exec_fn(params, email=emails, lock=True, force=True), 'lock', dry_run),
-                'delete': partial(run_cmd, users, lambda: exec_fn(params, email=emails, delete=True, force=True), 'delete', dry_run),
+                'lock': partial(run_cmd, users, lambda: exec_fn(params, email=emails, lock=True, force=True, return_results=True), 'lock', dry_run),
+                'delete': partial(run_cmd, users, lambda: exec_fn(params, email=emails, delete=True, force=True, return_results=True), 'delete', dry_run),
                 'transfer': partial(transfer_accounts, users, kwargs.get('target_user'), dryrun)
             }
 

--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -1735,6 +1735,9 @@ class EnterpriseUserCommand(EnterpriseCommand):
                 self.display_user(params, user, is_verbose)
                 print('\n')
 
+        if request_batch and kwargs.get('return_results'):
+            return results
+
     def display_user(self, params, user, is_verbose=False):
         enterprise_user_id = user['enterprise_user_id']
         username = user['username'] if 'username' in user else '[empty]'


### PR DESCRIPTION
output wrongly indicates failed operation when action is applied successfully