### PR TITLE
Fixed scim push, multiple group and get user list from google

### DIFF
--- a/keepercommander/commands/scim.py
+++ b/keepercommander/commands/scim.py
@@ -970,7 +970,7 @@ class ScimPushCommand(EnterpriseCommand):
         group_lookup = {x['id']: x['name'] for x in groups['groups']}
 
         if scim_group:
-            group_id = next((g_id for g_id, g_name in group_lookup.items()), None)
+            group_id = next((g_id for g_id, g_name in group_lookup.items() if g_id == scim_group or g_name == scim_group), None)
             if not group_id:
                 raise CommandError('', f'Google Workspace: group "{scim_group}" not found')
             del group_lookup[group_id]


### PR DESCRIPTION
I encountered unexpected users deactivation when I run 'scim push' to sync groups from google workspace to keeper enterprise.

I created a keeper vault record to sync groups described in https://docs.keeper.io/secrets-manager/commander-cli/command-reference/enterprise-management-commands/scim-push-configuration.
And I set group name which include users we expect to use keeper.(`Google #6`)

If scim_group is set in the record for scim-push config to get member list from specified group. The function `scim_group` use member list from incorrect group. The function does not search/lookup group id by group name, it use the first group of group list from google workspace.

As a result user list in keeper become not desired.

BTW, now users are provisioned by SCIM procedure. I think the `scim push` command does not require to provision users, it can focus on provision group/team.