### PR TITLE
(KC-696) BreachWatch / security-data update improvements / fixes: 

### DIFF
--- a/keepercommander/commands/breachwatch.py
+++ b/keepercommander/commands/breachwatch.py
@@ -189,7 +189,10 @@ class BreachWatchScanCommand(Command):
                 params.sync_data = True
             if euid_to_delete:
                 params.breach_watch.delete_euids(params, euid_to_delete)
-        logging.info(f'Scanned {len(record_passwords)} passwords.')
+        if not kwargs.get('suppress_no_op') or record_passwords:
+            logging.info(f'Scanned {len(record_passwords)} passwords.')
+            if record_passwords:
+                api.sync_down(params)
 
 
 class BreachWatchIgnoreCommand(Command):

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -1047,10 +1047,8 @@ class TrashRestoreCommand(Command, TrashMixin):
         api.sync_down(params)
         TrashMixin.last_revision = 0
         for record_uid in to_restore:
-            if params.breach_watch:
-                params.breach_watch.scan_and_store_record_status(params, record_uid, True, False, False)
-                api.sync_down(params)
-
+            BreachWatch.scan_and_update_security_data(params, record_uid, params.breach_watch,
+                                                      force_update=False, set_reused_pws=False)
             params.queue_audit_event('record_restored', record_uid=record_uid)
 
         params.sync_data = True

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Any, Dict, Union, Sequence
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
+from keepercommander.breachwatch import BreachWatch
 
 from .base import Command, RecordMixin, FolderMixin
 from .. import api, vault, record_types, generator, crypto, attachment, record_facades, record_management
@@ -764,11 +765,8 @@ class RecordAddCommand(Command, RecordEditMixin):
         record_management.add_record_to_folder(params, record, folder_uid)
 
         params.environment_variables[LAST_RECORD_UID] = record.record_uid
-        if params.breach_watch:
-            api.sync_down(params)
-            params.breach_watch.scan_and_store_record_status(params, record.record_uid)
-        else:
-            params.sync_data = True
+        BreachWatch.scan_and_update_security_data(params, record.record_uid, params.breach_watch)
+        params.sync_data = True
 
         return record.record_uid
 

--- a/keepercommander/commands/recordv2.py
+++ b/keepercommander/commands/recordv2.py
@@ -15,6 +15,8 @@ import logging
 import os
 import re
 
+from keepercommander.breachwatch import BreachWatch
+
 from .base import suppress_exit, raise_parse_exception, Command
 from .. import api, generator, utils, crypto
 from ..error import CommandError
@@ -208,8 +210,7 @@ class RecordAddCommand(Command, RecordUtils):
         api.sync_down(params)
         if params.enterprise_ec_key:
             api.add_record_audit_data(params, [record_uid])
-        if params.breach_watch:
-            params.breach_watch.scan_and_store_record_status(params, record_uid)
+        BreachWatch.scan_and_update_security_data(params, record_uid, params.breach_watch)
 
         params.sync_data = True
         params.environment_variables[LAST_RECORD_UID] = record_uid
@@ -325,7 +326,5 @@ class RecordEditCommand(Command, RecordUtils):
 
         if changed:
             api.update_record(params, record)
-            if params.breach_watch:
-                api.sync_down(params)
-                params.breach_watch.scan_and_store_record_status(params, record_uid)
+            BreachWatch.scan_and_update_security_data(params, record_uid, params.breach_watch)
             params.sync_data = True

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import requests
 from Cryptodome.Cipher import AES
+from keepercommander.breachwatch import BreachWatch
 
 from . import recordv2 as recordv2
 from .base import suppress_exit, raise_parse_exception, dump_report_data, Command
@@ -441,9 +442,7 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
         res = api.add_record_v3(params, record, **{'record_links': record_links, 'rq': rq})
         if res:
             params.environment_variables[LAST_RECORD_UID] = record_uid
-            if params.breach_watch:
-                api.sync_down(params)
-                params.breach_watch.scan_and_store_record_status(params, record_uid)
+            BreachWatch.scan_and_update_security_data(params, record_uid, params.breach_watch)
             params.sync_data = True
 
             return record_uid
@@ -658,9 +657,7 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
             if 'return_result' in kwargs:
                 kwargs['return_result']['update_record_v3'] = result
 
-            if params.breach_watch:
-                api.sync_down(params)
-                params.breach_watch.scan_and_store_record_status(params, record_uid)
+            BreachWatch.scan_and_update_security_data(params, record_uid, params.breach_watch)
 
             newpass = recordv3.RecordV3.get_record_password(data) or ''
             oldpass = recordv3.RecordV3.get_record_password(record_data) or ''

--- a/keepercommander/params.py
+++ b/keepercommander/params.py
@@ -155,7 +155,8 @@ class KeeperParams:
         self.session_token_bytes = None
         self.record_type_cache = {}  # RT definitions only
         self.breach_watch = None
-        self.breach_watch_records = None
+        self.breach_watch_records = {}
+        self.breach_watch_security_data = {}
         self.sso_login_info = None
         self.__proxy = None
         self.ssh_agent = None
@@ -214,7 +215,8 @@ class KeeperParams:
         self.session_token_bytes = None
         self.record_type_cache = {}
         self.breach_watch = None
-        self.breach_watch_records = None
+        self.breach_watch_records = {}
+        self.breach_watch_security_data = {}
         self.sso_login_info = None
         self.ws = None
         if self.ssh_agent:

--- a/keepercommander/record_management.py
+++ b/keepercommander/record_management.py
@@ -14,6 +14,8 @@ import json
 import logging
 from typing import Optional, Union
 
+from keepercommander.breachwatch import BreachWatch
+
 from . import api, subfolder, utils, crypto, vault, vault_extensions
 from .error import KeeperApiError
 from .params import KeeperParams
@@ -328,6 +330,7 @@ def update_record(params, record, skip_extra=False):
 
     if bool(record_change_status & RecordChangeStatus.Password):
         params.queue_audit_event('record_password_change', record_uid=record.record_uid)
+        BreachWatch.scan_and_update_security_data(params, record.record_uid, params.breach_watch)
 
 
 def add_record_audit_data(params, record):   # type: (KeeperParams, vault.KeeperRecord) -> None


### PR DESCRIPTION
1) `sync-security-data` fixes / improvements 
2) add BreachWatch scan of vault (detect outdated security-data and update) on full sync-down
3) enable security-data updates for users w/ no BreachWatch add-on
4) option to force-update record security-data (security-data now only updated if older than record-modified date or non-existent, by default)
