### PR TITLE
(KC-701) `share-report` bug-fix: 

### DIFF
--- a/keepercommander/shared_record.py
+++ b/keepercommander/shared_record.py
@@ -150,7 +150,9 @@ class SharedRecord:
     """Defines a Keeper Shared Record (shared either via Direct-Share or as a child of a Shared-Folder node)"""
 
     def __init__(self, params, record, sf_sharing_admins, team_members, role_restricted_members):
-        self.owner = params.user
+        has_owner = record.record_uid in params.record_owner_cache
+        user_owned = has_owner and params.record_owner_cache.get(record.record_uid).owner
+        self.owner = params.user if user_owned else ''
         self.uid = record.record_uid
         self.name = record.title
         self.shared_folders = None


### PR DESCRIPTION
display no owner for owner-less records instead of current user