### PR TITLE
refactor: Extracted common Cache class for KeeperParams and made it pickable

### DIFF
--- a/keepercommander/subfolder.py
+++ b/keepercommander/subfolder.py
@@ -227,6 +227,22 @@ class BaseFolderNode:
             return 'Subfolder in Shared Folder'
         return ''
 
+    def __eq__(self, other):
+        if not isinstance(other, BaseFolderNode):
+            return False
+
+        return (
+                self.type == other.type and
+                self.uid == other.uid and
+                self.parent_uid == other.parent_uid and
+                self.name == other.name and
+                self.color == other.color and
+                self.subfolders == other.subfolders
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __repr__(self):
         return 'BaseFolderNode(type={}, uid={}, parent_uid={}, name={}, subfolders={})'.format(
             self.type,

--- a/unit-tests/test_params_pickling.py
+++ b/unit-tests/test_params_pickling.py
@@ -1,0 +1,75 @@
+import pickle
+from unittest import TestCase
+
+from data_vault import VaultEnvironment, get_synced_params
+from keepercommander.params import KeeperParams
+
+vault_env = VaultEnvironment()
+
+
+class TestParamsPickling(TestCase):
+    def test_pickling(self):
+        params = get_synced_params()
+        pickled_params = pickle.dumps(get_synced_params())
+
+        self.assertIsInstance(pickled_params, bytes)
+
+        actual = pickle.loads(pickled_params)
+
+        self.assertIsInstance(actual, KeeperParams)
+        self.assertEqual(len(actual.record_cache), 3)
+        self.assertIsNone(actual.account_uid_bytes)
+        self.assertIsNone(actual.auth_verifier)
+        self.assertIsNone(actual.automators)
+        self.assertIsNone(actual.available_team_cache)
+        self.assertEqual(actual.batch_mode, params.batch_mode)
+        self.assertIsNone(actual.client_key)
+        self.assertIsNone(actual.clone_code)
+        self.assertEqual(actual.config_filename, params.config_filename)
+        self.assertIsNone(actual.current_folder)
+        self.assertIsNone(actual.data_key)
+        self.assertEqual(actual.debug, params.debug)
+        self.assertIsNone(actual.device_private_key)
+        self.assertIsNone(actual.device_token)
+        self.assertIsNone(actual.ecc_key)
+        self.assertIsNone(actual.enforcements)
+        self.assertIsNone(actual.enterprise)
+        self.assertIsNone(actual.enterprise_ec_key)
+        self.assertEqual(actual.enterprise_id, params.enterprise_id)
+        self.assertIsNone(actual.enterprise_loader)
+        self.assertIsNone(actual.enterprise_rsa_key)
+        self.assertEqual(actual.iterations, params.iterations)
+        self.assertIsNone(actual.license)
+        self.assertEqual(actual.logout_timer, 0)
+        self.assertIsNone(actual.msp_tree_key)
+        self.assertEqual(actual.password, "")
+        self.assertFalse(actual.pending_share_requests)
+        self.assertIsNone(actual.proxy)
+        self.assertEqual(actual.rest_context, params.rest_context)
+        self.assertEqual(actual.revision, params.revision)
+        self.assertIsNone(actual.rsa_key)
+        self.assertIsNone(actual.rsa_key2)
+        self.assertIsNone(actual.salt)
+        self.assertEqual(actual.server, params.server)
+        self.assertIsNone(actual.session_token)
+        self.assertIsNone(actual.session_token_bytes)
+        self.assertIsNone(actual.settings)
+        self.assertIsNone(actual.ssh_agent)
+        self.assertIsNone(actual.sso_login_info)
+        self.assertEqual(actual.sync_data, params.sync_data)
+        self.assertIsNone(actual.sync_down_token)
+        self.assertEqual(actual.root_folder, params.root_folder)
+        self.assertEqual(actual.cache, params.cache)
+        self.assertEqual(len(actual.shared_folder_cache), 1)
+        self.assertEqual(len(actual.team_cache), 1)
+        self.assertEqual(len(actual.cache.folder_cache), 2)
+        self.assertEqual(len(params.cache.folder_cache), 2)
+        self.assert_key_unencrypted(actual)
+
+    def assert_key_unencrypted(self, params):
+        for r in params.record_cache.values():
+            self.assertTrue('record_key_unencrypted' in r)
+        for sf in params.shared_folder_cache.values():
+            self.assertTrue('shared_folder_key_unencrypted' in sf)
+        for t in params.team_cache.values():
+            self.assertTrue('team_key_unencrypted' in t)


### PR DESCRIPTION
Hello,

We are using the keepercommander library as a secrets backend in Airflow, so for that we implemented a custom SecretsBackend which allows us to use Keeper as a backend for all our Airflow connections.  To do so we directly use the KeeperParams class in python, not through CLI, which works great.

The issue we discovered is that when we have a lot of simultanious tasks, the Keeper API get's called to much and we are being throttled meaning tasks are stuch until Keeper allows us to call the API again, which is logical.  Still we didn't understand why the API got called so much as the results are being cached in the KeeperParams class.

So after investigation we discovered that even though the results are being cached, it doesn't help in our case because we are running in a multi-processing environment using Kubernetes which not only means threads don't share state but also that the process running the task could be running on another pod.

So our solution would be to pickle (and of course encrypt the pickled result) the cached records of the KeeperParams and store it on the shared filesystem, that way each time we have to instantiated a new KeeperParams, we first check if there is a pickled file available and if so load it.  That way we have the cached records instantly available without the need to reconnect to the Keeper API.

The first thing I did is move al cache related dictionnaries in the KeeperParams to a dedicated class named Cache which is pickable but also comparable which makes assertions in the tests easier.  I also made the BaseFolderNode comparable.  The I implemented the reduce method for KeeperParams which only pickles non sensitive data and the cache.

At the moment we have a custom solution which pickles the required caches from the KeeperParams class, but I thought it would be better if this was directly available in the keepercommander code base, so that in the future refactorings would occur, the pickling would still work and we just have to pickle the KeeperParams without being worried it could break in the future.

Of course I added a unit test which tests the pickling and makes assertations on the fields that should be pickled and those that should not.