### PR TITLE
`transform-folder` bug-fixes/improvements (KC-756): 

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -1426,7 +1426,7 @@ class FolderTransformCommand(Command):
         def get_copy_name(folder, dest):
             def get_path_tokens(folder_node:BaseFolderNode):
                 result = []
-                while folder_node:
+                while folder_node and folder_node is not params.root_folder:
                     result = [folder_node.name, *result]
                     folder_node = params.folder_cache.get(folder_node.parent_uid) or params.root_folder \
                         if folder_node is not params.root_folder \


### PR DESCRIPTION
1) allow non-share-admins w/ full share-permissions to do folder transform, 
2) allow transformation (and rebasing) of shared-folder subfolders, 
3) add `--clear-shares` flag to allow transforming a shared-folder or shared-folder subfolder and all its sub-folders to user-folders
4) removed record-permissions checking