### PR TITLE
(KC-761) `compliance stats` + `ssh-agent` fixes / improvements

### DIFF
--- a/keepercommander/commands/compliance.py
+++ b/keepercommander/commands/compliance.py
@@ -604,7 +604,8 @@ class ComplianceSummaryReportCommand(BaseComplianceReportCommand):
             num_owned = len(u.records)
             vault_recs = sox_data.get_vault_records(u.user_uid)
             num_total = len(vault_recs)
-            return u.email, num_total, num_owned, num_active, num_deleted
+            email = managed_user_email_lookup.get(u.user_uid) or u.email
+            return email, num_total, num_owned, num_active, num_deleted
 
         filter_by_node = node != root_node
         from keepercommander.commands.enterprise import EnterpriseInfoCommand
@@ -618,7 +619,8 @@ class ComplianceSummaryReportCommand(BaseComplianceReportCommand):
         }
         cmd_rs = partial(cmd.execute, params, **cmd_kwargs)()
         managed_users = json.loads(cmd_rs)
-        managed_user_ids = {mu.get('user_id') for mu in managed_users}
+        managed_user_email_lookup = {mu.get('user_id'): mu.get('email') for mu in managed_users}
+        managed_user_ids = set(managed_user_email_lookup.keys())
         empty_vault_user_ids = {user_id for user_id in managed_user_ids if user_id not in sox_data.get_users()}
         empty_vault_users = [mu for mu in managed_users if mu.get('user_id') in empty_vault_user_ids]
         sox_users = sox_data.get_users().values()

--- a/keepercommander/commands/ssh_agent.py
+++ b/keepercommander/commands/ssh_agent.py
@@ -207,7 +207,7 @@ def try_extract_private_key(params, record_or_uid):
     # check notes field
     if not private_key:
         if isinstance(record, (vault.PasswordRecord, vault.TypedRecord)):
-            if 444 < len(record.notes) < 4000:
+            if 444 <= len(record.notes) < 4000:
                 header, _, _ = record.notes.partition('\n')
                 if is_private_key(header):
                     private_key = record.notes
@@ -217,14 +217,14 @@ def try_extract_private_key(params, record_or_uid):
         if isinstance(record, vault.TypedRecord):
             try_values = (x.get_default_value() for x in itertools.chain(record.fields, record.custom) if x.type in ('text', 'multiline', 'secret', 'note'))
             for value in (x for x in try_values if x):
-                if isinstance(value, str) and 444 < len(value) < 4000:
+                if isinstance(value, str) and 444 <= len(value) < 4000:
                     header, _, _ = value.partition('\n')
                     if is_private_key(header):
                         private_key = value
                         break
         elif isinstance(record, vault.PasswordRecord):
             for value in (x.value for x in record.custom if x.value):
-                if isinstance(value, str) and 444 < len(value) < 4000:
+                if isinstance(value, str) and 444 <= len(value) < 4000:
                     header, _, _ = value.partition('\n')
                     if is_private_key(header):
                         private_key = value
@@ -244,7 +244,7 @@ def try_extract_private_key(params, record_or_uid):
                         if file_record.name and file_record.name != file_record.title:
                             names.append(file_record.name)
                         if any(True for x in names if is_private_key_name(x)):
-                            if 444 < file_record.size < 4000:
+                            if 444 <= file_record.size < 4000:
                                 key_file_uids.append(file_uid)
                 if len(key_file_uids) == 1:
                     download_rq = next(attachment.prepare_attachment_download(params, key_file_uids[0]), None)
@@ -258,7 +258,7 @@ def try_extract_private_key(params, record_or_uid):
                     if atta.name and atta.title != atta.name:
                         names.append(atta.name)
                     if any(True for x in names if is_private_key_name(x)):
-                        if 444 < atta.size < 4000:
+                        if 444 <= atta.size < 4000:
                             key_attachment_ids.append(atta.id)
             if len(key_attachment_ids) == 1:
                 download_rq = next(attachment.prepare_attachment_download(params, record.record_uid, key_attachment_ids[0]), None)
@@ -504,7 +504,7 @@ class SshAgentContext(logging.Handler):
                             hash_algorithm = hashes.SHA512()
                             signature_method = 'rsa-sha2-512'
                         elif flags & SSH_AGENT_RSA_SHA2_256:
-                            hash_algorithm = hashes.SHA512()
+                            hash_algorithm = hashes.SHA256()
                             signature_method = 'rsa-sha2-256'
                         else:
                             hash_algorithm = hashes.SHA1()


### PR DESCRIPTION
`compliance stats`: 
- show account primary email instead of alias; 
 `ssh-agent`:
- allow loading private keys w/ 444 byte-length (valid range minimum now inclusive) 
- fix signing w/ "rsa-sha2-256" key+hash