### PR TITLE
(KC-769)`share-record` / `get` / `trash get` bug-fixes: 

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -1446,7 +1446,7 @@ def load_records_in_shared_folder(params, shared_folder_uid, record_uids=None):
                         'username': up.username,
                         'owner': up.owner,
                         'share_admin': up.shareAdmin,
-                        'sharable': up.sharable,
+                        'shareable': up.sharable,
                         'editable': up.editable,
                         'awaiting_approval': up.awaitingApproval,
                         'expiration': up.expiration,

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -528,7 +528,7 @@ class RecordGetUidCommand(Command):
                             perm = rec['shares']['user_permissions'].copy()
                             perm.sort(key=lambda r: (' 1' if r.get('owner') else
                                                      ' 2' if r.get('editable') else
-                                                     ' 3' if r.get('sharable') else
+                                                     ' 3' if r.get('shareable') else
                                                      '') + r.get('username'))
                             for no, uo in enumerate(perm):
                                 username = uo['username']
@@ -542,7 +542,7 @@ class RecordGetUidCommand(Command):
                                 else:
                                     if uo.get('editable'):
                                         flags = 'Can Edit'
-                                    if uo.get('sharable'):
+                                    if uo.get('shareable'):
                                         if flags:
                                             flags = flags + ' & '
                                         else:
@@ -980,7 +980,7 @@ class TrashGetCommand(Command, TrashMixin):
                     perm = rec['shares']['user_permissions'].copy()
                     perm.sort(key=lambda r: (' 1' if r.get('owner') else
                                              ' 2' if r.get('editable') else
-                                             ' 3' if r.get('sharable') else
+                                             ' 3' if r.get('shareable') else
                                              '') + r.get('username'))
                     no = 0
                     for uo in perm:
@@ -989,7 +989,7 @@ class TrashGetCommand(Command, TrashMixin):
                             continue
                         if uo.get('editable'):
                             flags = 'Can Edit'
-                        if uo.get('sharable'):
+                        if uo.get('shareable'):
                             if flags:
                                 flags = flags + ' & '
                             else:

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -715,12 +715,11 @@ class ShareRecordCommand(Command):
                 if rs is not None:
                     folder, name = rs
                     if name:
-                        if folder.uid in params.subfolder_record_cache:
-                            for uid in params.subfolder_record_cache[folder.uid]:
-                                r = api.get_record(params, uid)
-                                if r.title.lower() == name.lower():
-                                    record_uid = uid
-                                    break
+                        for uid in params.subfolder_record_cache.get(folder.uid or ''):
+                            r = api.get_record(params, uid)
+                            if r.title.lower() == name.lower():
+                                record_uid = uid
+                                break
                     else:
                         if isinstance(folder, (SharedFolderNode, SharedFolderFolderNode)):
                             folder_uid = folder.uid
@@ -880,14 +879,14 @@ class ShareRecordCommand(Command):
                             ro.transfer = True
                             transfer_ruids.add(record_uid)
                         else:
-                            ro.editable = True if can_edit else current['editable']
-                            ro.shareable = True if can_share else current['sharable']
+                            ro.editable = True if can_edit else current.get('editable')
+                            ro.shareable = True if can_share else current.get('shareable')
                         rq.updateSharedRecord.append(ro)
                 else:
                     if can_share or can_edit:
                         current = existing_shares[email]
-                        ro.editable = False if can_edit else current['editable']
-                        ro.shareable = False if can_share else current['sharable']
+                        ro.editable = False if can_edit else current.get('editable')
+                        ro.shareable = False if can_share else current.get('shareable')
                         rq.updateSharedRecord.append(ro)
                     else:
                         rq.removeSharedRecord.append(ro)


### PR DESCRIPTION
`share-record`
1) root-folder records can now be referenced by title 
2) fixed bug preventing updating of shares for records previously shared w/ same user

`get` / `trash get`
1) correct record-(re)sharing permissions now shown