### PR TITLE
Typo "Sharable" instead of "Shareable"

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -881,13 +881,13 @@ class ShareRecordCommand(Command):
                             transfer_ruids.add(record_uid)
                         else:
                             ro.editable = True if can_edit else current['editable']
-                            ro.shareable = True if can_share else current['sharable']
+                            ro.shareable = True if can_share else current['shareable']
                         rq.updateSharedRecord.append(ro)
                 else:
                     if can_share or can_edit:
                         current = existing_shares[email]
                         ro.editable = False if can_edit else current['editable']
-                        ro.shareable = False if can_share else current['sharable']
+                        ro.shareable = False if can_share else current['shareable']
                         rq.updateSharedRecord.append(ro)
                     else:
                         rq.removeSharedRecord.append(ro)


### PR DESCRIPTION
![Error Shareable](https://github.com/Keeper-Security/Commander/assets/76915551/6ba795c0-f5eb-4bfa-bbe7-6bc276cd0727)
When running the command ShareRecordCommand.execute on a record that is already shared to the user that it should be shared with again, an error occurs.

The error states that there is no such key as "sharable" because the correct key name is "shareable".

Error: 

keepercommander\commands\register.py", line 884, in execute
    ro.shareable = True if can_share else current['sharable']
                                          ~~~~~~~^^^^^^^^^^^^
KeyError: 'sharable'

When I searched through the whole project I found more than two results (the ones addressed in this pr). 
I didn't want to touch them because I only worked with ShareRecordCommand out of the ones that contain "sharable"