### PR TITLE
DR-853 Recude Controller API calls

### DIFF
--- a/keepercommander/commands/discover/__init__.py
+++ b/keepercommander/commands/discover/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 from ..base import Command
 from ..pam.config_facades import PamConfigurationRecordFacade
-from ..pam import gateway_helper
 from ..pam.router_helper import get_response_payload
 from ..pam.gateway_helper import get_all_gateways
 from ..ksm import KSMCommand
@@ -33,7 +32,14 @@ class GatewayContext:
         self._shared_folders = None
 
     @staticmethod
-    def from_configuration_uid(params: KeeperParams, configuration_uid: str):
+    def all_gateways(params: KeeperParams):
+        return get_all_gateways(params)
+
+    @staticmethod
+    def from_configuration_uid(params: KeeperParams, configuration_uid: str, gateways: Optional[List] = None):
+
+        if gateways is None:
+            gateways = GatewayContext.all_gateways(KeeperParams)
 
         configuration_record = vault.KeeperRecord.load(params, configuration_uid)
         if not isinstance(configuration_record, vault.TypedRecord):
@@ -44,7 +50,7 @@ class GatewayContext:
         configuration_facade.record = configuration_record
 
         gateway_uid = configuration_facade.controller_uid
-        gateway = next((x for x in gateway_helper.get_all_gateways(params)
+        gateway = next((x for x in gateways
                         if utils.base64_url_encode(x.controllerUid) == gateway_uid),
                        None)
 

--- a/keepercommander/commands/discover/job_remove.py
+++ b/keepercommander/commands/discover/job_remove.py
@@ -27,10 +27,13 @@ class PAMGatewayActionDiscoverJobRemoveCommand(PAMGatewayActionDiscoverCommandBa
 
         # Get all the PAM configuration records
         configuration_records = list(vault_extensions.find_records(params, "pam.*Configuration"))
+        all_gateways = GatewayContext.all_gateways(params)
 
         for configuration_record in configuration_records:
 
-            gateway_context = GatewayContext.from_configuration_uid(params, configuration_record.record_uid)
+            gateway_context = GatewayContext.from_configuration_uid(params=params,
+                                                                    configuration_uid=configuration_record.record_uid,
+                                                                    gateways=all_gateways)
             if gateway_context is None:
                 continue
 

--- a/keepercommander/commands/discover/job_status.py
+++ b/keepercommander/commands/discover/job_status.py
@@ -240,13 +240,16 @@ class PAMGatewayActionDiscoverJobStatusCommand(PAMGatewayActionDiscoverCommandBa
         max_gateway_name = 12
 
         all_jobs = []
+        all_gateways = GatewayContext.all_gateways(params)
 
         # For each configuration/ gateway, we are going to get all jobs.
         # We are going to query the gateway for any updated status.
         gateway_context = None
         for configuration_record in configuration_records:
 
-            gateway_context = GatewayContext.from_configuration_uid(params, configuration_record.record_uid)
+            gateway_context = GatewayContext.from_configuration_uid(params=params,
+                                                                    configuration_uid=configuration_record.record_uid,
+                                                                    gateways=all_gateways)
             if gateway_context is None:
                 continue
 

--- a/keepercommander/commands/discover/result_process.py
+++ b/keepercommander/commands/discover/result_process.py
@@ -1221,10 +1221,14 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
         dry_run = kwargs.get("dry_run", False)
         debug_level = kwargs.get("debug_level", 0)
 
+        all_gateways = GatewayContext.all_gateways(params)
+
         configuration_records = list(vault_extensions.find_records(params, "pam.*Configuration"))
         for configuration_record in configuration_records:
 
-            gateway_context = GatewayContext.from_configuration_uid(params, configuration_record.record_uid)
+            gateway_context = GatewayContext.from_configuration_uid(params=params,
+                                                                    configuration_uid=configuration_record.record_uid,
+                                                                    gateways=all_gateways)
             if gateway_context is None:
                 continue
 


### PR DESCRIPTION
Commands like ...

    * `pam action discover job remove`
    * `pam action discover job status`
    * `pam action discover process`

were calling `gateway_helper.get_all_gateways` in a loop. Change the code to call the it outside of the loop and passed the list of gateways to the `from_configuration_uid`