### PR TITLE
DR-892 Fix command not stopping on errors and message fix.

### DIFF
--- a/keepercommander/commands/pam_service/list.py
+++ b/keepercommander/commands/pam_service/list.py
@@ -58,10 +58,12 @@ class PAMActionServiceListCommand(PAMGatewayActionDiscoverCommandBase):
                             "machines": []
                         }
                     text = f"{resource_record.title} ({resource_record.record_uid}) :"
+                    comma = ""
                     if acl.is_service is True:
                         text += f" {bcolors.OKGREEN}Services{bcolors.ENDC}"
+                        comma = ","
                     if acl.is_task is True:
-                        text += f" {bcolors.OKBLUE}Scheduled Tasks{bcolors.ENDC}"
+                        text += f"{comma} {bcolors.OKGREEN}Scheduled Tasks{bcolors.ENDC}"
                     service_map[user_record.record_uid]["machines"].append(text)
 
         print("")


### PR DESCRIPTION
The add command was not stopping when the OS is not set in the machine record. Wasn't fatal, but the OS should be set in the machine record.

* Fixed command help to reference UID of record.
* Fixed the poorly written success message.
* Fixed the Service/Scheduled Task indicators. Used color to separate them, but blended together if user is not using colors.