### PR TITLE
Feat/search by name

### DIFF
--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -84,7 +84,14 @@ def find_records(params,                   # type: KeeperParams
         if type_filter and record.record_type not in type_filter:
             continue
 
-        is_match = matches_record(record, pattern) if pattern else True
+        if pattern:
+            if search_field == 'name':
+                is_match = bool(pattern(record.title))
+            else:
+                is_match = matches_record(record, pattern)
+        else:
+            is_match = True
+
         if is_match:
             yield record
 

--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -40,7 +40,7 @@ def matches_record(record, pattern, search_fields=None):    # type: (vault.Keepe
         search_fields = {f.lower() for f in search_fields}
 
     for key, value in record.enumerate_fields():
-        m = re.search(r'^\(\w+\)\.?', key)
+        m = re.match(r'^\((\w+)\)\.?', key)
         if m:
             key = m.group(1)
         if search_fields is not None and key.lower() not in search_fields:

--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -48,11 +48,12 @@ def matches_record(record, pattern):    # type: (vault.KeeperRecord, Union[str, 
     return False
 
 
-def find_records(params,                  # type: KeeperParams
-                 search_str=None,         # type: Optional[str]
-                 record_type=None,        # type: Union[str, Iterable[str], None]
-                 record_version=None      # type: Union[int, Iterable[int], None]
-                 ):                       # type: (...) -> Iterator[vault.KeeperRecord]
+def find_records(params,                   # type: KeeperParams
+                 search_str=None,          # type: Optional[str]
+                 record_type=None,         # type: Union[str, Iterable[str], None]
+                 record_version=None,      # type: Union[int, Iterable[int], None]
+                 search_field=None         # type: Optional[str],
+                 ):                        # type: (...) -> Iterator[vault.KeeperRecord]
     pattern = re.compile(search_str, re.IGNORECASE).search if search_str else None
 
     type_filter = None       # type: Optional[Set[str]]

--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -40,7 +40,7 @@ def matches_record(record, pattern, search_fields=None):    # type: (vault.Keepe
         search_fields = {f.lower() for f in search_fields}
 
     for key, value in record.enumerate_fields():
-        m = re.match(r'^\((\w+)\)\.?', key)
+        m = re.search(r'^\(\w+\)\.?', key)
         if m:
             key = m.group(1)
         if search_fields is not None and key.lower() not in search_fields:
@@ -88,10 +88,7 @@ def find_records(params,                   # type: KeeperParams
         if type_filter and record.record_type not in type_filter:
             continue
 
-        if pattern:
-            is_match = matches_record(record, pattern, search_fields)
-        else:
-            is_match = True
+        is_match = matches_record(record, pattern) if pattern else True
 
         if is_match:
             yield record

--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -32,15 +32,19 @@ def _match_value(pattern, value):  # type: (Callable[[str], Any], Any) -> bool
     return False
 
 
-def matches_record(record, pattern):    # type: (vault.KeeperRecord, Union[str, Callable[[str], Any]]) -> bool
+def matches_record(record, pattern, search_fields=None):    # type: (vault.KeeperRecord, Union[str, Callable[[str], Any]], Optional[Iterable[str]]) -> bool
     if isinstance(pattern, str):
         pattern = re.compile(pattern, re.IGNORECASE).search
 
+    if search_fields is not None:
+        search_fields = {f.lower() for f in search_fields}
+
     for key, value in record.enumerate_fields():
-        m = re.search(r'^\(\w+\)\.?', key)
+        m = re.match(r'^\((\w+)\)\.?', key)
         if m:
-            span = m.span(0)
-            key = key[span[1]:]
+            key = m.group(1)
+        if search_fields is not None and key.lower() not in search_fields:
+            continue
         if key and _match_value(pattern, key):
             return True
         if value and _match_value(pattern, value):
@@ -52,8 +56,8 @@ def find_records(params,                   # type: KeeperParams
                  search_str=None,          # type: Optional[str]
                  record_type=None,         # type: Union[str, Iterable[str], None]
                  record_version=None,      # type: Union[int, Iterable[int], None]
-                 search_field=None         # type: Optional[str],
-                 ):                        # type: (...) -> Iterator[vault.KeeperRecord]
+                 search_fields=None        # type: Optional[Iterable[str]]
+                 ):                       # type: (...) -> Iterator[vault.KeeperRecord]
     pattern = re.compile(search_str, re.IGNORECASE).search if search_str else None
 
     type_filter = None       # type: Optional[Set[str]]
@@ -85,10 +89,7 @@ def find_records(params,                   # type: KeeperParams
             continue
 
         if pattern:
-            if search_field == 'name':
-                is_match = bool(pattern(record.title))
-            else:
-                is_match = matches_record(record, pattern)
+            is_match = matches_record(record, pattern, search_fields)
         else:
             is_match = True
 

--- a/unit-tests/test_command_record.py
+++ b/unit-tests/test_command_record.py
@@ -196,17 +196,17 @@ class TestRecord(TestCase):
             cmd.execute(params, uid=record_uid)
             cmd.execute(params, format='json', uid=record_uid)
 
-    def test_record_list_command_with_name(self):
+    def test_record_list_command_with_fields(self):
         params = get_synced_params()
         cmd = record.RecordListCommand()
 
         with mock.patch('builtins.print') as mock_print:
-            cmd.execute(params, name='Record 3')
+            cmd.execute(params, field=['title'], pattern='Record 3')
             printed_args = mock_print.call_args[0][0] if mock_print.call_args else ''
             self.assertIn('Record 3', printed_args)
 
         with mock.patch('builtins.print') as mock_print:
-            cmd.execute(params, name='NonExistentRecordName')
+            cmd.execute(params, field=['title'], pattern='NonExistentRecordName')
             mock_print.assert_not_called()
 
     def test_get_shared_folder_uid(self):

--- a/unit-tests/test_command_record.py
+++ b/unit-tests/test_command_record.py
@@ -140,14 +140,6 @@ class TestRecord(TestCase):
                 cmd.execute(params, records=[rec.title])
                 self.assertTrue(KeeperApiHelper.is_expect_empty())
 
-    def test_search_command(self):
-        params = get_synced_params()
-        cmd = record.SearchCommand()
-
-        with mock.patch('builtins.print'):
-            cmd.execute(params, pattern='.*')
-            cmd.execute(params, pattern='Non-existing-name')
-
     def test_record_list_command(self):
         params = get_synced_params()
         cmd = record.RecordListCommand()
@@ -203,6 +195,19 @@ class TestRecord(TestCase):
         with mock.patch('builtins.print'), mock.patch('keepercommander.api.get_record_shares'):
             cmd.execute(params, uid=record_uid)
             cmd.execute(params, format='json', uid=record_uid)
+
+    def test_record_list_command_with_name(self):
+        params = get_synced_params()
+        cmd = record.RecordListCommand()
+
+        with mock.patch('builtins.print') as mock_print:
+            cmd.execute(params, name='Record 3')
+            printed_args = mock_print.call_args[0][0] if mock_print.call_args else ''
+            self.assertIn('Record 3', printed_args)
+
+        with mock.patch('builtins.print') as mock_print:
+            cmd.execute(params, name='NonExistentRecordName')
+            mock_print.assert_not_called()
 
     def test_get_shared_folder_uid(self):
         params = get_synced_params()

--- a/unit-tests/test_command_record.py
+++ b/unit-tests/test_command_record.py
@@ -140,6 +140,14 @@ class TestRecord(TestCase):
                 cmd.execute(params, records=[rec.title])
                 self.assertTrue(KeeperApiHelper.is_expect_empty())
 
+    def test_search_command(self):
+        params = get_synced_params()
+        cmd = record.SearchCommand()
+
+        with mock.patch('builtins.print'):
+            cmd.execute(params, pattern='.*')
+            cmd.execute(params, pattern='Non-existing-name')
+
     def test_record_list_command(self):
         params = get_synced_params()
         cmd = record.RecordListCommand()


### PR DESCRIPTION
Feature Description
We introduced a new --field parameter that lets users restrict searches to specific record fields. For example, specifying --field title searches only in the record’s title, while --field notes focuses on notes. This flexibility makes searches more precise when you know exactly which field(s) to filter on.

Benefit
By allowing users to target fields rather than searching across all of them, the new feature avoids returning matches from irrelevant fields. This results in fewer, more relevant records in the output and creates a more efficient user experience.

How It Works

General Pattern Search:
By default, the CLI searches across multiple fields for any provided pattern. This can sometimes return broad or cluttered results if the pattern appears in notes, descriptions, or other fields.
Field-Based Search:
When the user specifies one or more --field parameters (e.g., --field title, --field notes), the search logic applies the pattern only to those named fields. This filters out records where the pattern only appears in other fields, delivering a more focused set of results.
Overall Impact

Reduced Noise: Users see fewer extraneous matches, as only the specified fields are searched.
Improved Flexibility: Users can pass multiple --field flags for more nuanced searches (e.g., --field title --field notes).
Quicker Targeting: When searching by title only, it’s easier to locate a known record by name without sifting through other field matches.
Example

**General Search: Running list AWS might show multiple records if they have “AWS” in any field.
Field-Based Search: Running  list --field title AWS finds only records whose titles contain “AWS,” ignoring notes and other fields.**

![Screenshot 2025-02-03 at 8 22 13 PM](https://github.com/user-attachments/assets/7844c079-cdfd-4a52-b54d-2ad89c5de6c0)



