### PR TITLE
DR-886 Change API call from language to languages

### DIFF
--- a/keepercommander/commands/discover/job_start.py
+++ b/keepercommander/commands/discover/job_start.py
@@ -25,7 +25,7 @@ class PAMGatewayActionDiscoverJobStartCommand(PAMGatewayActionDiscoverCommandBas
                         help='Gateway name of UID.')
     parser.add_argument('--resource', '-r', required=False, dest='resource_uid', action='store',
                         help='UID of the resource record. Set to discover specific resource.')
-    parser.add_argument('--lang', required=False, dest='language', action='store', default="en",
+    parser.add_argument('--lang', required=False, dest='language', action='store', default="en_US",
                         help='Language')
     parser.add_argument('--include-machine-dir-users', required=False, dest='include_machine_dir_users',
                         action='store_false', default=True, help='Include directory users found on the machine.')
@@ -194,7 +194,7 @@ class PAMGatewayActionDiscoverJobStartCommand(PAMGatewayActionDiscoverCommandBas
             ),
 
             shared_folder_uid=gateway_context.default_shared_folder_uid,
-            language=kwargs.get('language'),
+            languages=[kwargs.get('language')],
 
             # Settings
             include_machine_dir_users=kwargs.get('include_machine_dir_users', True),

--- a/keepercommander/commands/pam/pam_dto.py
+++ b/keepercommander/commands/pam/pam_dto.py
@@ -21,7 +21,7 @@ class RouterRequest:
 
 class GatewayActionDiscoverJobStartInputs:
 
-    def __init__(self, configuration_uid, user_map, shared_folder_uid, resource_uid=None, language="en",
+    def __init__(self, configuration_uid, user_map, shared_folder_uid, resource_uid=None, languages=None,
                  # Settings
                  include_machine_dir_users=False,
                  include_azure_aadds=False,
@@ -31,11 +31,13 @@ class GatewayActionDiscoverJobStartInputs:
                  skip_directories=False,
                  skip_cloud_users=False,
                  credentials=None):
+        if languages is None:
+            languages = ["en_US"]
         self.configurationUid = configuration_uid
         self.resourceUid = resource_uid
         self.userMap = user_map
         self.sharedFolderUid = shared_folder_uid
-        self.language = language
+        self.languages = languages
         self.includeMachineDirUsers = include_machine_dir_users
         self.includeAzureAadds = include_azure_aadds
         self.skipRules = skip_rules


### PR DESCRIPTION
Gateway now accepts the languages. It can handle multiple, so it changed to an list.

Default changed to en_US which matches the language code returned by the translation team.

Also fix code that is not supported in Python >= 3.8.