### PR TITLE
Pin fido2 to 1.x.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pyperclip
 PySocks
 tabulate
 websockets
-fido2
+fido2~=1.0
 requests; python_version<'3.7'
 requests>=2.30.0; python_version>='3.7'
 cryptography>=39.0.1


### PR DESCRIPTION
Fixes #1470 at least until more work is done to update to support python-fido2 2.0.0