### PR TITLE
KC-875: Add `license-consumption-report` command

### DIFF
--- a/keepercommander/commands/LICENSE_CONSUMPTION_REPORT.md
+++ b/keepercommander/commands/LICENSE_CONSUMPTION_REPORT.md
@@ -1,0 +1,183 @@
+# License Consumption Report
+
+## Overview
+
+The `license-consumption-report` command helps enterprise administrators identify which users are consuming feature licenses based on role enforcement policies. This addresses the common need to understand license utilization for compliance, budgeting, and license management purposes.
+
+## How It Works
+
+### Enforcement Policy Detection
+
+The report works by:
+
+1. **Analyzing Role Enforcements**: Examines all enterprise roles and their enforcement policies
+2. **Categorizing by Feature**: Groups enforcement policies by feature type (PAM, Secrets Manager, etc.)
+3. **Finding Feature Users**: Identifies users assigned to roles that have feature-specific enforcements enabled
+4. **Team Resolution**: Optionally includes users assigned to roles through team membership
+
+## Usage Examples
+
+### Basic PAM License Report
+```bash
+keeper license-consumption-report --feature pam
+```
+Shows all users with PAM enforcement policies enabled. By default, shows feature counts only.
+
+### Show Detailed Feature Names
+```bash
+keeper license-consumption-report --feature pam --details
+```
+Shows the specific feature names instead of just counts (useful for detailed analysis).
+
+### All Features Consolidated Report
+```bash
+keeper license-consumption-report --feature all
+```
+Shows license consumption across all feature types in a single report with separate columns for each feature.
+
+### Include Team Assignments
+```bash
+keeper license-consumption-report --feature pam --include-teams
+```
+Also includes users who get PAM access through team membership in roles with PAM policies.
+
+### Filter by Organization Node
+```bash
+keeper license-consumption-report --feature pam --node "Engineering"
+```
+Limits results to users in the "Engineering" node and its descendants.
+
+### Export Results
+```bash
+keeper license-consumption-report --feature pam --format csv --output pam_licenses.csv
+```
+Exports results in CSV format for further analysis in spreadsheet applications.
+
+### Comprehensive Analysis Examples
+```bash
+# All features with detailed breakdown
+keeper license-consumption-report --feature all --details --include-teams
+
+# PAM users with details, including teams, export to CSV
+keeper license-consumption-report --feature pam --details --include-teams --format csv --output pam_detailed.csv
+
+# Quick overview of all license consumption
+keeper license-consumption-report --feature all
+```
+
+### Individual Feature Types
+```bash
+keeper license-consumption-report --feature secrets-manager
+keeper license-consumption-report --feature connection-manager
+keeper license-consumption-report --feature breachwatch
+```
+
+## Report Output
+
+### Columns Included
+
+#### Single Feature Reports
+| Column | Description |
+|--------|-------------|
+| Username | User's email address |
+| Display Name | User's full name |
+| Node | Organization node path |
+| Status | User account status |
+| Direct Roles | Roles directly assigned to user |
+| Team Roles | Roles assigned through team membership |
+| [FEATURE] Features | Feature count by default, detailed names with `--details` |
+| Feature Count* | Number of feature enforcement policies |
+
+*Feature Count column only appears when NOT using `--details` (to avoid redundancy)
+
+#### All Features Report
+| Column | Description |
+|--------|-------------|
+| Username | User's email address |
+| Display Name | User's full name |
+| Node | Organization node path |
+| Status | User account status |
+| Direct Roles | Roles directly assigned to user |
+| Team Roles | Roles assigned through team membership |
+| Pam Features* | PAM feature details (if `--details` flag used) |
+| Pam Count** | Number of PAM features |
+| Secrets Manager Count** | Number of Secrets Manager features |
+| Connection Manager Count** | Number of Connection Manager features |
+| Breachwatch Count** | Number of BreachWatch features |
+| Total Features | Sum of all feature counts (always shown) |
+
+*Feature detail columns only appear when using `--details` flag  
+**Individual count columns only appear when NOT using `--details` (to avoid redundancy)
+
+### Sample Output
+
+#### Default Output (Feature Counts Only)
+```
+PAM License Consumption Report - 15 Users Found
+
+Username              Display Name    Node         Status  Direct Roles    Team Roles           PAM Features    Feature Count
+john.doe@company.com  John Doe       Engineering  Active  PAM Admin       IT Team -> PAM User  2 feature(s)    2
+jane.smith@company.com Jane Smith     IT           Active                  DevOps -> PAM Role   1 feature(s)    1
+```
+
+#### With --details Flag (No Redundant Count Column)
+```
+PAM License Consumption Report - 15 Users Found
+
+Username              Display Name    Node         Status  Direct Roles    Team Roles           PAM Features
+john.doe@company.com  John Doe       Engineering  Active  PAM Admin       IT Team -> PAM User  PAM Gateway, Configure RBI
+jane.smith@company.com Jane Smith     IT           Active                  DevOps -> PAM Role   Launch PAM Tunnels
+```
+
+#### All Features Report (Default - Counts Only)
+```
+All Features License Consumption Report - 15 Users Found
+
+Username              Display Name    Node         Status  Direct Roles    Pam Count  Secrets Manager Count  Connection Manager Count  Breachwatch Count  Total Features
+john.doe@company.com  John Doe       Engineering  Active  PAM Admin       10         1                      1                         0                  12
+jane.smith@company.com Jane Smith     IT           Active  DevOps          0          1                      0                         1                  2
+```
+
+#### All Features Report (With --details - No Redundant Count Columns)
+```
+All Features License Consumption Report - 15 Users Found
+
+Username              Display Name    Node         Status  Direct Roles    Pam Features                         Secrets Manager Features    Total Features
+john.doe@company.com  John Doe       Engineering  Active  PAM Admin       PAM Gateway, Configure RBI, ...      Secrets Manager              12
+jane.smith@company.com Jane Smith     IT           Active  DevOps                                               Secrets Manager              2
+```
+
+## This Report Addresses the Following Questions:
+
+### ✅ **"Which users are consuming PAM licenses?"**
+The report identifies all users with any of the 13 PAM enforcement checkboxes enabled in their roles.
+
+### ✅ **"No simple command in commander"** 
+Now available as `license-consumption-report` with alias `lcr`.
+
+### ✅ **"Users from teams assigned to roles"**
+The `--include-teams` flag captures users who get PAM access through team membership.
+
+### ✅ **"Unique users from all roles"**
+Automatically deduplicates users who appear in multiple roles or teams.
+
+### ✅ **"Format option for enterprise-team"**
+Provides CSV, JSON, and other output formats for analysis.
+
+## Command Alias
+
+The command is available as both:
+- `license-consumption-report` (full name)
+- `lcr` (alias for quick access)
+
+### Quick Examples with Alias
+```bash
+# Quick PAM report with counts only
+lcr --feature pam
+
+# All features overview  
+lcr --feature all
+
+# Detailed PAM report including teams
+lcr --feature pam --details --include-teams
+```

--- a/keepercommander/commands/enterprise_reports.py
+++ b/keepercommander/commands/enterprise_reports.py
@@ -7,17 +7,59 @@ from ..sox.sox_types import RecordPermissions
 from ..error import Error
 from ..display import bcolors
 from . import base
+from .. import constants
+from ..commands.helpers.enterprise import is_addon_enabled
 
 
 def register_commands(commands):
     commands['external-shares-report'] = ExternalSharesReportCommand()
+    commands['license-consumption-report'] = LicenseConsumptionReportCommand()
 
 
 def register_command_info(aliases, command_info):
     aliases['esr'] = 'external-shares-report'
+    aliases['lcr'] = 'license-consumption-report'
 
-    for p in [external_share_report_parser]:
+    for p in [external_share_report_parser, license_consumption_report_parser]:
         command_info[p.prog] = p.description
+
+
+def get_feature_enforcements_from_constants():
+    """Get feature enforcement mappings from constants, categorizing them by feature type"""
+    # Get all PAM-related enforcements from constants
+    pam_enforcements = set()
+    breachwatch_enforcements = set()
+    secrets_manager_enforcements = set()
+    
+    for enforcement_tuple in constants._ENFORCEMENTS:
+        enforcement_name = enforcement_tuple[0]  # First element is always the name
+        enforcement_lower = enforcement_name.lower()
+        
+        if any(pam_keyword in enforcement_lower for pam_keyword in ['pam', 'rbi', 'kcm']):
+            pam_enforcements.add(enforcement_lower)
+        elif 'breach_watch' in enforcement_lower:
+            breachwatch_enforcements.add(enforcement_lower)
+        elif 'secrets_manager' in enforcement_lower:
+            secrets_manager_enforcements.add(enforcement_lower)
+    
+    return {
+        'pam': {
+            'addon_name': 'privileged_access_manager',
+            'enforcements': pam_enforcements
+        },
+        'secrets-manager': {
+            'addon_name': 'secrets_manager',
+            'enforcements': secrets_manager_enforcements
+        },
+        'connection-manager': {
+            'addon_name': 'connection_manager',
+            'enforcements': {'allow_view_kcm_recordings'}
+        },
+        'breachwatch': {
+            'addon_name': 'enterprise_breach_watch',
+            'enforcements': breachwatch_enforcements
+        }
+    }
 
 
 ext_shares_report_desc = 'Run an external shares report.'
@@ -30,6 +72,20 @@ external_share_report_parser.add_argument('-t', '--share-type', action='store', 
 # external_share_report_parser.add_argument('-e', '--email', action='store', help='filter report by share-recipient email')
 external_share_report_parser.add_argument('-f', '--force', action='store_true', help='apply action w/o confirmation')
 external_share_report_parser.add_argument('-r', '--refresh-data', action='store_true', help='retrieve fresh data')
+
+license_consumption_report_desc = 'Generate a report of users consuming feature licenses based on role enforcement policies.'
+license_consumption_report_parser = argparse.ArgumentParser(prog='license-consumption-report', description=license_consumption_report_desc,
+                                                           parents=[base.report_output_parser])
+license_consumption_report_parser.add_argument('--feature', dest='feature', action='store', 
+                                               choices=['pam', 'secrets-manager', 'connection-manager', 'breachwatch', 'all'],
+                                               default='pam',
+                                               help='feature type to report on, or "all" for consolidated report (default: pam)')
+license_consumption_report_parser.add_argument('--node', dest='node', action='store',
+                                               help='filter users by node (node name or ID)')
+license_consumption_report_parser.add_argument('--include-teams', dest='include_teams', action='store_true',
+                                               help='include users from teams assigned to feature roles')
+license_consumption_report_parser.add_argument('--details', dest='details', action='store_true',
+                                               help='show detailed feature names instead of just counts')
 
 
 class ExternalSharesReportCommand(enterprise_common.EnterpriseCommand):
@@ -143,3 +199,343 @@ class ExternalSharesReportCommand(enterprise_common.EnterpriseCommand):
             apply_action()
         else:
             return generate_report()
+
+
+class LicenseConsumptionReportCommand(enterprise_common.EnterpriseCommand):
+    """Generate a report of users consuming feature licenses based on role enforcement policies."""
+
+    def get_parser(self):
+        return license_consumption_report_parser
+
+    def execute(self, params, **kwargs):
+        output = kwargs.get('output')
+        output_fmt = kwargs.get('format', 'table')
+        feature = kwargs.get('feature', 'pam')
+        node_filter = kwargs.get('node')
+        include_teams = kwargs.get('include_teams', False)
+        show_details = kwargs.get('details', False)
+
+        if not params.enterprise:
+            raise Error('License consumption report requires enterprise data')
+
+        # Get feature enforcements dynamically from constants
+        feature_enforcements_map = get_feature_enforcements_from_constants()
+        
+        if feature == 'all':
+            return self._generate_all_features_report(params, feature_enforcements_map, node_filter, include_teams, show_details, output_fmt, output)
+        
+        if feature not in feature_enforcements_map:
+            raise Error(f'Unknown feature: {feature}. Available: {", ".join(list(feature_enforcements_map.keys()) + ["all"])}')
+
+        feature_config = feature_enforcements_map[feature]
+        feature_enforcements = feature_config['enforcements']
+        addon_name = feature_config.get('addon_name')
+
+        # Check if addon is enabled for this enterprise
+        if addon_name and not is_addon_enabled(params, addon_name):
+            logging.warning(f'{feature.upper()} addon is not enabled for this enterprise')
+
+        # Get feature users using the refactored helper method
+        feature_user_details = self._get_feature_users(params, feature_config, node_filter, include_teams)
+
+        # Generate report data
+        table = []
+        headers = ['Username', 'Display Name', 'Node', 'Status', 'Direct Roles', 'Team Roles', f'{feature.upper()} Features']
+        
+        # Only add Feature Count column when not showing details (since it would be redundant)
+        if not show_details:
+            headers.append('Feature Count')
+        
+        if output_fmt == 'json':
+            headers = ['username', 'display_name', 'node', 'status', 'direct_roles', 'team_roles', f'{feature}_features']
+            if not show_details:
+                headers.append('feature_count')
+
+        for user_detail in sorted(feature_user_details.values(), key=lambda x: x['username'].lower()):
+            node_path = self.get_node_path(params, user_detail['node_id']) if user_detail['node_id'] > 0 else ''
+            
+            direct_roles = ', '.join(user_detail['roles']) if user_detail['roles'] else ''
+            team_roles = ', '.join(user_detail['teams']) if user_detail['teams'] else ''
+            
+            # Format feature enforcements based on details flag
+            feature_count = len(user_detail['feature_enforcements'])
+            if show_details:
+                # Show detailed feature names (current behavior)
+                feature_names = []
+                for enforcement in sorted(user_detail['feature_enforcements']):
+                    # Convert enforcement name to human readable
+                    readable_name = enforcement.replace('allow_', '').replace('_', ' ').title()
+                    # Special handling for some names
+                    readable_name = readable_name.replace('Pam', 'PAM').replace('Rbi', 'RBI').replace('Kcm', 'KCM')
+                    feature_names.append(readable_name)
+                features_str = ', '.join(feature_names)
+            else:
+                # Show just the count (new default behavior)
+                features_str = f'{feature_count} feature(s)'
+            
+            row = [
+                user_detail['username'],
+                user_detail['name'],
+                node_path,
+                user_detail['status'],
+                direct_roles,
+                team_roles, 
+                features_str
+            ]
+            
+            # Only add feature count when not showing details (to avoid redundancy)
+            if not show_details:
+                row.append(feature_count)
+            table.append(row)
+
+        # Add summary information
+        total_feature_users = len(feature_user_details)
+        title = f'{feature.upper()} License Consumption Report - {total_feature_users} Users Found'
+        
+        if node_filter:
+            title += f' (Node: {node_filter})'
+        
+        if include_teams:
+            title += ' (Including Team Assignments)'
+
+        return base.dump_report_data(table, headers, title=title, fmt=output_fmt, filename=output)
+
+    def _generate_all_features_report(self, params, feature_enforcements_map, node_filter, include_teams, show_details, output_fmt, output):
+        """Generate a consolidated report showing license consumption across all features"""
+        
+        # Collect user data for all features
+        all_users = {}  # user_id -> {user_info, feature_data}
+        feature_types = [f for f in feature_enforcements_map.keys()]
+        
+        for feature_type in feature_types:
+            feature_config = feature_enforcements_map[feature_type]
+            addon_name = feature_config.get('addon_name')
+            
+            # Check if addon is enabled
+            if addon_name and not is_addon_enabled(params, addon_name):
+                logging.info(f'{feature_type.upper()} addon is not enabled - skipping')
+                continue
+                
+            # Get users for this feature (reuse existing logic)
+            feature_users = self._get_feature_users(params, feature_config, node_filter, include_teams)
+            
+            for user_id, user_detail in feature_users.items():
+                if user_id not in all_users:
+                    all_users[user_id] = {
+                        'user_info': {
+                            'user_id': user_detail['user_id'],
+                            'username': user_detail['username'],
+                            'name': user_detail['name'],
+                            'node_id': user_detail['node_id'],
+                            'status': user_detail['status'],
+                            'roles': user_detail['roles'],
+                            'teams': user_detail['teams']
+                        },
+                        'features': {}
+                    }
+                
+                # Store feature-specific data
+                all_users[user_id]['features'][feature_type] = {
+                    'count': len(user_detail['feature_enforcements']),
+                    'enforcements': user_detail['feature_enforcements'] if show_details else None
+                }
+
+        # Generate consolidated report
+        headers = ['Username', 'Display Name', 'Node', 'Status', 'Direct Roles', 'Team Roles']
+        
+        # Add feature columns
+        for feature_type in sorted(feature_types):
+            feature_name = feature_type.replace('-', ' ').title()
+            if show_details:
+                headers.append(f'{feature_name} Features')
+            # Only add count columns when not showing details (to avoid redundancy)
+            if not show_details:
+                headers.append(f'{feature_name} Count')
+        
+        # Add total column (always useful in consolidated view)
+        headers.append('Total Features')
+        
+        if output_fmt == 'json':
+            headers = [h.lower().replace(' ', '_') for h in headers]
+
+        table = []
+        for user_data in sorted(all_users.values(), key=lambda x: x['user_info']['username'].lower()):
+            user_info = user_data['user_info']
+            node_path = self.get_node_path(params, user_info['node_id']) if user_info['node_id'] > 0 else ''
+            
+            direct_roles = ', '.join(user_info['roles']) if user_info['roles'] else ''
+            team_roles = ', '.join(user_info['teams']) if user_info['teams'] else ''
+            
+            row = [
+                user_info['username'],
+                user_info['name'],
+                node_path,
+                user_info['status'],
+                direct_roles,
+                team_roles
+            ]
+            
+            total_features = 0
+            for feature_type in sorted(feature_types):
+                feature_data = user_data['features'].get(feature_type, {'count': 0, 'enforcements': set()})
+                feature_count = feature_data['count']
+                total_features += feature_count
+                
+                if show_details and feature_data['enforcements']:
+                    # Show detailed feature names
+                    feature_names = []
+                    for enforcement in sorted(feature_data['enforcements']):
+                        readable_name = enforcement.replace('allow_', '').replace('_', ' ').title()
+                        readable_name = readable_name.replace('Pam', 'PAM').replace('Rbi', 'RBI').replace('Kcm', 'KCM')
+                        feature_names.append(readable_name)
+                    features_str = ', '.join(feature_names) if feature_names else ''
+                    row.append(features_str)
+                
+                # Only add count columns when not showing details (to avoid redundancy) 
+                if not show_details:
+                    row.append(feature_count)
+            
+            row.append(total_features)
+            
+            # Only include users who have at least one feature
+            if total_features > 0:
+                table.append(row)
+
+        # Generate title
+        total_users = len(table)
+        title = f'All Features License Consumption Report - {total_users} Users Found'
+        
+        if node_filter:
+            title += f' (Node: {node_filter})'
+        
+        if include_teams:
+            title += ' (Including Team Assignments)'
+
+        return base.dump_report_data(table, headers, title=title, fmt=output_fmt, filename=output)
+    
+    def _get_feature_users(self, params, feature_config, node_filter, include_teams):
+        """Extract the user collection logic for reuse in all-features report"""
+        feature_enforcements = feature_config['enforcements']
+        
+        # Build lookup dictionaries
+        users_by_id = {user['enterprise_user_id']: user for user in params.enterprise.get('users', [])}
+        roles_by_id = {role['role_id']: role for role in params.enterprise.get('roles', [])}
+        role_enforcements = {re['role_id']: re['enforcements'] for re in params.enterprise.get('role_enforcements', [])}
+        
+        # Filter by node if specified
+        filtered_user_ids = set()
+        if node_filter:
+            target_node_id = None
+            if node_filter.isdigit():
+                target_node_id = int(node_filter)
+            else:
+                # Look up node by name
+                for node in params.enterprise.get('nodes', []):
+                    if node['data'].get('displayname', '').lower() == node_filter.lower():
+                        target_node_id = node['node_id']
+                        break
+            
+            if target_node_id is not None:
+                # Get all users in this node and its descendants
+                def get_descendant_nodes(node_id):
+                    descendants = {node_id}
+                    for node in params.enterprise.get('nodes', []):
+                        if node.get('parent_id') == node_id:
+                            descendants.update(get_descendant_nodes(node['node_id']))
+                    return descendants
+                
+                target_nodes = get_descendant_nodes(target_node_id)
+                filtered_user_ids = {user['enterprise_user_id'] for user in params.enterprise.get('users', [])
+                                   if user.get('node_id') in target_nodes}
+            else:
+                logging.warning(f'Node "{node_filter}" not found')
+                filtered_user_ids = set()
+
+        # Find feature roles (roles with any feature enforcement enabled)
+        feature_roles = set()
+        for role_id, enforcements in role_enforcements.items():
+            if any(enforcement.lower() in feature_enforcements for enforcement in enforcements.keys()):
+                feature_roles.add(role_id)
+
+        # Collect feature users
+        feature_user_details = {}
+
+        # Users directly assigned to feature roles
+        for role_user in params.enterprise.get('role_users', []):
+            role_id = role_user['role_id']
+            user_id = role_user['enterprise_user_id']
+            
+            if role_id in feature_roles:
+                if filtered_user_ids and user_id not in filtered_user_ids:
+                    continue
+                    
+                if user_id not in feature_user_details:
+                    user = users_by_id.get(user_id, {})
+                    feature_user_details[user_id] = {
+                        'user_id': user_id,
+                        'username': user.get('username', ''),
+                        'name': user.get('data', {}).get('displayname', ''),
+                        'node_id': user.get('node_id', 0),
+                        'status': user.get('status', ''),
+                        'roles': [],
+                        'teams': [],
+                        'feature_enforcements': set()
+                    }
+                
+                role = roles_by_id.get(role_id, {})
+                role_name = role.get('data', {}).get('displayname', f'Role {role_id}')
+                feature_user_details[user_id]['roles'].append(role_name)
+                
+                # Add enforcements from this role
+                role_enf = role_enforcements.get(role_id, {})
+                for enforcement in role_enf.keys():
+                    if enforcement.lower() in feature_enforcements:
+                        feature_user_details[user_id]['feature_enforcements'].add(enforcement.lower())
+
+        # Users assigned to feature roles through teams
+        if include_teams:
+            teams_by_uid = {team['team_uid']: team for team in params.enterprise.get('teams', [])}
+            
+            # Get roles assigned to teams
+            for role_team in params.enterprise.get('role_teams', []):
+                role_id = role_team['role_id'] 
+                team_uid = role_team['team_uid']
+                
+                if role_id in feature_roles:
+                    # Get users in this team
+                    for team_user in params.enterprise.get('team_users', []):
+                        if team_user['team_uid'] == team_uid:
+                            user_id = team_user['enterprise_user_id']
+                            
+                            if filtered_user_ids and user_id not in filtered_user_ids:
+                                continue
+                                
+                            if user_id not in feature_user_details:
+                                user = users_by_id.get(user_id, {})
+                                feature_user_details[user_id] = {
+                                    'user_id': user_id,
+                                    'username': user.get('username', ''),
+                                    'name': user.get('data', {}).get('displayname', ''),
+                                    'node_id': user.get('node_id', 0),
+                                    'status': user.get('status', ''),
+                                    'roles': [],
+                                    'teams': [],
+                                    'feature_enforcements': set()
+                                }
+                            
+                            team = teams_by_uid.get(team_uid, {})
+                            team_name = team.get('name', f'Team {team_uid}')
+                            role = roles_by_id.get(role_id, {})
+                            role_name = role.get('data', {}).get('displayname', f'Role {role_id}')
+                            
+                            team_role_name = f'{team_name} -> {role_name}'
+                            if team_role_name not in feature_user_details[user_id]['teams']:
+                                feature_user_details[user_id]['teams'].append(team_role_name)
+                            
+                            # Add enforcements from this role
+                            role_enf = role_enforcements.get(role_id, {})
+                            for enforcement in role_enf.keys():
+                                if enforcement.lower() in feature_enforcements:
+                                    feature_user_details[user_id]['feature_enforcements'].add(enforcement.lower())
+
+        return feature_user_details


### PR DESCRIPTION
Added `license-consumption-report` command to analyze feature license usage. Introduced support for PAM and other features with options for detailed views, node filtering, team inclusion, and multiple output formats.