### PR TITLE
Update 'warning' color for better readability

### DIFF
--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -26,7 +26,7 @@ class bcolors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
+    WARNING = '\033[33m'
     FAIL = '\033[91m'
     ENDC = '\033[0m'
     BOLD = '\033[1m'


### PR DESCRIPTION
**Resolves:** [Issue 1253](https://github.com/Keeper-Security/Commander/issues/1253)

Changed WARNING color for better visibility on light-themed terminals while preserving clarity on dark themes. 

![screenshot_2025-06-18_at_4 55 17___pm_360](https://github.com/user-attachments/assets/12110c86-7efe-4c45-ac4d-99ba9bb93471)