### PR TITLE
Yubikey login method bug fix for Commander

### DIFF
--- a/keepercommander/yubikey/yubikey.py
+++ b/keepercommander/yubikey/yubikey.py
@@ -141,6 +141,10 @@ def yubikey_authenticate(request):  # type: (dict) -> Optional[AuthenticationRes
 
     options = request['publicKeyCredentialRequestOptions'].copy()
     origin = ''
+    if 'extensions' not in options:
+        options['extensions'] = {}
+    if 'largeBlob' not in options['extensions']:
+        options['extensions']['largeBlob'] = {'read': False}
     if 'extensions' in options:
         extensions = options['extensions']
         origin = extensions.get('appid') or ''


### PR DESCRIPTION
Resolves: [KC-902](https://keeper.atlassian.net/browse/KC-902)

Ensures required options are set to prevent crashes when using the YubiKey login method on WindowsClient.

[KC-902]: https://keeper.atlassian.net/browse/KC-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ