### PR TITLE
Fix Yubikey 'largeBlob' login issue

### DIFF
--- a/keepercommander/yubikey/yubikey.py
+++ b/keepercommander/yubikey/yubikey.py
@@ -144,6 +144,8 @@ def yubikey_authenticate(request):  # type: (dict) -> Optional[AuthenticationRes
     if 'extensions' in options:
         extensions = options['extensions']
         origin = extensions.get('appid') or ''
+        if 'largeBlob' not in options['extensions']:
+            options['extensions']['largeBlob'] = {'read': None}
 
     credentials = options.get('allowCredentials') or []
     for c in credentials:


### PR DESCRIPTION
Resolves: [KC-902](https://keeper.atlassian.net/browse/KC-902)

Prevents crashes during YubiKey login on Windows by ensuring required options are set. Also handles cases where the _largeBlob_ extension is missing.

[KC-902]: https://keeper.atlassian.net/browse/KC-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ