### PR TITLE
Fix KC-922: To check login status without initiating authentication flows

### DIFF
--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -617,7 +617,9 @@ class WhoamiCommand(Command):
                         print('{0:>20s}: {1}'.format('Secure Add Ons' if i == 0 else '', addon))
         else:
             print('{0:>20s}:'.format('Not logged in'))
-
+    
+    def is_authorised(self):
+        return False
 
 class VersionCommand(Command):
     def get_parser(self):
@@ -691,6 +693,9 @@ class KeepAliveCommand(Command):
     def execute(self, params, **kwargs):  # type: (KeeperParams, **any) -> any
         """Just send the keepalive."""
         api.send_keepalive(params)
+    
+    def is_authorised(self):
+        return False
 
 
 class ProxyCommand(Command):


### PR DESCRIPTION
Resolves: [KC-922](https://keeper.atlassian.net/browse/KC-922)
Added `is_authorised()` methods returning False to `WhoamiCommand` and `KeepAliveCommand` to prevent triggering login or 2FA prompts. This allows users to check login status without initiating authentication flows.

[KC-922]: https://keeper.atlassian.net/browse/KC-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ