### PR TITLE
Biometric changes: Update display name and time formats

### DIFF
--- a/keepercommander/biometric/README.md
+++ b/keepercommander/biometric/README.md
@@ -72,7 +72,7 @@ You'll be prompted to:
 Example with custom settings:
 
 ```bash
-biometric register --name "My MacBook Touch ID"
+biometric register --name "My MacBook"
 ```
 
 #### 2. Device Registration (Mandatory)
@@ -121,17 +121,17 @@ biometric register [options]
 biometric register
 
 # Registration with custom name
-biometric register --name "Work Laptop Touch ID"
+biometric register --name "Work Laptop"
 ```
 
 **Sample Output:**
 
 ```
-Adding biometric authentication method: My MacBook Touch ID
+Adding biometric authentication method: My MacBook
 Please complete biometric authentication...
 Biometric authentication completed successfully!
 
-Success! Biometric authentication "Touch ID - MacBook" has been registered.
+Success! Biometric authentication "Commander CLI (MacBook)" has been registered.
 
 Please register your device using the "this-device register" command to set biometric authentication as your default login method.
 ```
@@ -149,15 +149,20 @@ biometric list
 ```
 Registered Biometric Authentication Methods:
 ----------------------------------------------------------------------
-Name: Touch ID - MacBook
+Name: Commander CLI (MacBook)
 ID: 12345
-Created: 1703123456789
-Last Used: 1703234567890
+Created: December 20, 2023
+Last Used: Today
 ----------------------------------------------------------------------
-Name: Windows Hello - Desktop
+Name: iCloud Keychain
 ID: 67890
-Created: 1703123456789
-Last Used: 1703234567890
+Created: December 18, 2023
+Last Used: July 10, 2025
+----------------------------------------------------------------------
+Name: Chrome on Mac
+ID: 54321
+Created: November 15, 2023
+Last Used: Never
 ----------------------------------------------------------------------
 ```
 
@@ -230,30 +235,32 @@ This command provides an interactive interface to:
 **Sample Interaction:**
 
 ```
-Found 2 biometric credential(s)
+Found 2 biometric credential(s) with friendly names
 
 Available Biometric Credentials:
 --------------------------------------------------
- 1. Touch ID - MacBook
+ 1. Commander CLI (MacBook)
     ID: 12345
-    Created: 2024-01-15 | Last Used: 2024-01-20
+    Created: January 15, 2024
+    Last Used: Today
 
- 2. Windows Hello - Desktop  
+ 2. Commander CLI (Desktop)  
     ID: 67890
-    Created: 2024-01-10 | Last Used: 2024-01-18
+    Created: January 10, 2024
+    Last Used: January 18, 2024
 
 Select credential number (1-2): 1
-Selected: Touch ID - MacBook
+Selected: Commander CLI (MacBook)
 
-Current Name: Touch ID - MacBook
+Current Name: Commander CLI (MacBook)
 Enter a new friendly name (max 32 characters):
-New name: Personal MacBook Touch ID
+New name: Personal MacBook
 
 Update Summary:
 --------------------
 ID: 12345
-Current Name:  Touch ID - MacBook
-New Name:      Personal MacBook Touch ID
+Current Name:  Commander CLI (MacBook)
+New Name:      Personal MacBook
 
 Proceed with update? (y/n): y
 
@@ -261,8 +268,8 @@ Passkey Update Results:
 ==============================
 Status: Success
 ID: 12345
-Old Name: Touch ID - MacBook
-New Name: Personal MacBook Touch ID
+Old Name: Commander CLI (MacBook)
+New Name: Personal MacBook
 Message: Passkey friendly name was successfully updated
 ==============================
 ```

--- a/keepercommander/biometric/client.py
+++ b/keepercommander/biometric/client.py
@@ -207,7 +207,8 @@ class BiometricClient:
                 'name': passkey.friendlyName,
                 'created': passkey.createdAtMillis,
                 'last_used': passkey.lastUsedMillis,
-                'credential_id': passkey.credentialId
+                'credential_id': passkey.credentialId,
+                'aaguid': getattr(passkey, 'AAGUID', None)
             } for passkey in rs.passkeyInfo]
 
         except Exception as e:

--- a/keepercommander/biometric/commands/list.py
+++ b/keepercommander/biometric/commands/list.py
@@ -12,6 +12,7 @@
 import argparse
 
 from .base import BiometricCommand
+from ..utils.aaguid import get_provider_name_from_aaguid
 
 
 class BiometricListCommand(BiometricCommand):
@@ -38,8 +39,18 @@ class BiometricListCommand(BiometricCommand):
             print("\nRegistered Biometric Authentication Methods:")
             print("-" * 70)
             for passkey in passkeys:
-                print(f"Name: {passkey['name']}")
+                created_date = self._format_timestamp(passkey.get('created'))
+                last_used_date = self._format_timestamp(passkey.get('last_used'))
+                
+                display_name = passkey['name']
+                # If name is empty, use provider name from AAGUID
+                if not display_name:
+                    aaguid = passkey.get('aaguid')
+                    provider_name = get_provider_name_from_aaguid(aaguid)
+                    display_name = provider_name
+                
+                print(f"Name: {display_name}")
                 print(f"ID: {passkey['id']}")
-                print(f"Created: {passkey['created']}")
-                print(f"Last Used: {passkey['last_used']}")
+                print(f"Created: {created_date}")
+                print(f"Last Used: {last_used_date}")
                 print("-" * 70) 

--- a/keepercommander/biometric/commands/update_name.py
+++ b/keepercommander/biometric/commands/update_name.py
@@ -10,7 +10,6 @@
 #
 
 import argparse
-import time
 
 from .base import BiometricCommand
 from ...commands.base import user_choice
@@ -28,8 +27,15 @@ class BiometricUpdateNameCommand(BiometricCommand):
     def execute(self, params, **kwargs):
         """Execute biometric update-name command"""
         def _update_name():
-            available_credentials = self._get_available_credentials_or_error(params)
-            print(f"Found {len(available_credentials)} biometric credential(s)")
+            all_credentials = self._get_available_credentials_or_error(params)
+            available_credentials = [cred for cred in all_credentials if cred.get('name') and cred['name'].strip()]
+            
+            if not available_credentials:
+                print("No biometric credentials with friendly names found.")
+                print("Use 'biometric register' to create a new credential with a friendly name.")
+                return
+                
+            print(f"Found {len(available_credentials)} biometric credential(s) with friendly names")
 
             selected_index = self._interactive_credential_selection(available_credentials)
 
@@ -65,12 +71,13 @@ class BiometricUpdateNameCommand(BiometricCommand):
         print("-" * 50)
         
         for i, credential in enumerate(available_credentials, 1):
-            created_date = time.strftime('%Y-%m-%d', time.localtime(credential['created'] / 1000))
-            last_used = time.strftime('%Y-%m-%d', time.localtime(credential['last_used'] / 1000)) if credential['last_used'] else 'Never'
+            created_date = self._format_timestamp(credential.get('created'))
+            last_used = self._format_timestamp(credential.get('last_used'))
             
             print(f"{i:2}. {credential['name']}")
             print(f"    ID: {credential['id']}")
-            print(f"    Created: {created_date} | Last Used: {last_used}")
+            print(f"    Created: {created_date}")
+            print(f"    Last Used: {last_used}")
             print()
         
         while True:

--- a/keepercommander/biometric/utils/aaguid.py
+++ b/keepercommander/biometric/utils/aaguid.py
@@ -1,0 +1,41 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2025 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+"""
+AAGUID (Authenticator Attestation GUID) related constants and utilities.
+These constants help identify the specific authenticator/provider used for WebAuthn credentials.
+"""
+
+# AAGUID to provider name mapping
+# Based on community-sourced data from https://github.com/passkeydeveloper/passkey-authenticator-aaguids
+AAGUID_PROVIDER_MAPPING = {
+    'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4': 'Google Password Manager',
+    'adce0002-35bc-c60a-648b-0b25f1f05503': 'Chrome on Mac',
+    'fbfc3007-154e-4ecc-8c0b-6e020557d7bd': 'iCloud Keychain',
+    'dd4ec289-e01d-41c9-bb89-70fa845d4bf2': 'iCloud Keychain (Managed)',
+    '08987058-cadc-4b81-b6e1-30de50dcbe96': 'Windows Hello',
+    '9ddd1817-af5a-4672-a2b9-3e3dd95000a9': 'Windows Hello',
+    '6028b017-b1d4-4c02-b4b3-afcdafc96bb2': 'Windows Hello',
+    '00000000-0000-0000-0000-000000000000': 'Platform Authenticator'
+}
+
+
+def get_provider_name_from_aaguid(aaguid: str) -> str:
+    """Get friendly provider name from AAGUID"""
+    if not aaguid:
+        return None
+    
+    # Normalize AAGUID format (ensure lowercase, with dashes)
+    normalized_aaguid = aaguid.lower()
+    if len(normalized_aaguid) == 32:  # No dashes
+        normalized_aaguid = f"{normalized_aaguid[:8]}-{normalized_aaguid[8:12]}-{normalized_aaguid[12:16]}-{normalized_aaguid[16:20]}-{normalized_aaguid[20:]}"
+    
+    return AAGUID_PROVIDER_MAPPING.get(normalized_aaguid)

--- a/keepercommander/biometric/utils/constants.py
+++ b/keepercommander/biometric/utils/constants.py
@@ -110,12 +110,8 @@ SUCCESS_MESSAGES = {
     'credential_disabled': 'Passkey was successfully disabled and no longer available for login'
 }
 
-# Default credential name templates
-CREDENTIAL_NAME_TEMPLATES = {
-    PLATFORM_WINDOWS: "Windows Hello - {hostname}",
-    PLATFORM_DARWIN: "Touch ID - {hostname}",
-    'default': "Biometric - {hostname}"
-}
+# Default credential name template
+CREDENTIAL_NAME_TEMPLATE = "Commander CLI ({hostname})"
 
 # Common authentication reasons
 AUTH_REASONS = {


### PR DESCRIPTION
# PR Description

### Summary

This PR improves biometric credential handling and display in Keeper Commander.

### Changes

- **Credential Listing Enhancements**
  - Now shows credentials registered via browser (e.g., iCloud Keychain, Chrome on Mac).
  - Uses AAGUID mapping to assign provider names if no friendly name is set.

- **Improved Timestamp Formatting**
  - Timestamps (`created`, `last_used`) are now shown in local time format.
  - Displays "Today" or "Never" where applicable.

- **Default Credential Name Update**
  - Replaces platform-based names with `Commander CLI (<hostname>)`.

### Docs
- Updated `README.md` and sample outputs to match these changes.
