### PR TITLE
Remove ID from biometric list and update-name

### DIFF
--- a/keepercommander/biometric/README.md
+++ b/keepercommander/biometric/README.md
@@ -150,17 +150,14 @@ biometric list
 Registered Biometric Authentication Methods:
 ----------------------------------------------------------------------
 Name: Commander CLI (MacBook)
-ID: 12345
 Created: December 20, 2023
 Last Used: Today
 ----------------------------------------------------------------------
 Name: iCloud Keychain
-ID: 67890
 Created: December 18, 2023
 Last Used: July 10, 2025
 ----------------------------------------------------------------------
 Name: Chrome on Mac
-ID: 54321
 Created: November 15, 2023
 Last Used: Never
 ----------------------------------------------------------------------
@@ -240,12 +237,10 @@ Found 2 biometric credential(s) with friendly names
 Available Biometric Credentials:
 --------------------------------------------------
  1. Commander CLI (MacBook)
-    ID: 12345
     Created: January 15, 2024
     Last Used: Today
 
  2. Commander CLI (Desktop)  
-    ID: 67890
     Created: January 10, 2024
     Last Used: January 18, 2024
 
@@ -258,7 +253,6 @@ New name: Personal MacBook
 
 Update Summary:
 --------------------
-ID: 12345
 Current Name:  Commander CLI (MacBook)
 New Name:      Personal MacBook
 
@@ -267,7 +261,6 @@ Proceed with update? (y/n): y
 Passkey Update Results:
 ==============================
 Status: Success
-ID: 12345
 Old Name: Commander CLI (MacBook)
 New Name: Personal MacBook
 Message: Passkey friendly name was successfully updated

--- a/keepercommander/biometric/commands/list.py
+++ b/keepercommander/biometric/commands/list.py
@@ -50,7 +50,6 @@ class BiometricListCommand(BiometricCommand):
                     display_name = provider_name
                 
                 print(f"Name: {display_name}")
-                print(f"ID: {passkey['id']}")
                 print(f"Created: {created_date}")
                 print(f"Last Used: {last_used_date}")
                 print("-" * 70) 

--- a/keepercommander/biometric/commands/update_name.py
+++ b/keepercommander/biometric/commands/update_name.py
@@ -75,7 +75,6 @@ class BiometricUpdateNameCommand(BiometricCommand):
             last_used = self._format_timestamp(credential.get('last_used'))
             
             print(f"{i:2}. {credential['name']}")
-            print(f"    ID: {credential['id']}")
             print(f"    Created: {created_date}")
             print(f"    Last Used: {last_used}")
             print()
@@ -128,7 +127,6 @@ class BiometricUpdateNameCommand(BiometricCommand):
         """Confirm the update operation"""
         print("\nUpdate Summary:")
         print("-" * 20)
-        print(f"ID: {credential['id']}")
         print(f"Current Name:  {credential['name']}")
         print(f"New Name:      {new_name}")
         print()
@@ -143,7 +141,6 @@ class BiometricUpdateNameCommand(BiometricCommand):
         status_code = result['status']
         status_text = get_status_message(status_code)
         print(f"Status: {status_text}")
-        print(f"ID: {credential['id']}")
         print(f"Old Name: {credential['name']}")
         print(f"New Name: {new_name}")
         print(f"Message: {result['message']}")


### PR DESCRIPTION
### PR Description

### **Changes**: 

- Removes internal ID display from `biometric list` and `biometric update-name` commands. 
- Updates README sample outputs accordingly.