### PR TITLE
Fix ls -l command to exclude ANSI color codes from JSON output

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -270,10 +270,12 @@ class FolderListCommand(Command, RecordMixin):
                         row = [f.uid, f.name, folder_flags(f), f.parent_uid or '/']
                         table.append(row)
                     table.sort(key=lambda x: (x[1] or '').lower())
-                    for i in range(len(table)):
-                        name = table[i][1]
-                        if name in colors:
-                            table[i][1] = display.keeper_colorize(name, colors[name])
+                    # Only apply colorization if not JSON format
+                    if fmt not in ('json', 'csv'):
+                        for i in range(len(table)):
+                            name = table[i][1]
+                            if name in colors:
+                                table[i][1] = display.keeper_colorize(name, colors[name])
                     if fmt != 'json':
                         headers = base.fields_to_titles(headers)
                     if fmt in ('json', 'csv'):

--- a/unit-tests/test_command_folder.py
+++ b/unit-tests/test_command_folder.py
@@ -22,6 +22,24 @@ class TestFolder(TestCase):
         with mock.patch('builtins.print'), mock.patch('keepercommander.api.get_record_shares'):
             cmd.execute(params)
             cmd.execute(params, detail=True)
+            
+    def test_list_json_no_ansi_colors(self):
+        """Test that ls command with JSON format doesn't include ANSI color codes."""
+        params = get_synced_params()
+        cmd = folder.FolderListCommand()
+        
+        # Execute with JSON format - this should not include ANSI color codes
+        with mock.patch('keepercommander.api.get_record_shares'):
+            result = cmd.execute(params, detail=True, format='json')
+            
+            # If result is returned (JSON/CSV format), check it doesn't contain ANSI codes
+            if result:
+                import json
+                # Convert to JSON string to check for ANSI escape sequences
+                json_str = json.dumps(result)
+                # Check that no ANSI escape sequences are present
+                self.assertNotIn('\u001b[', json_str, "JSON output should not contain ANSI escape sequences")
+                self.assertNotIn('\\u001b[', json_str, "JSON output should not contain ANSI escape sequences")
 
     def test_change_directory(self):
         params = get_synced_params()


### PR DESCRIPTION
- Modified FolderListCommand.execute() to only apply color formatting for non-JSON/CSV formats
- Added unit test to verify JSON output contains no ANSI escape sequences
- Preserves colored terminal output while ensuring clean JSON for programmatic parsing

Fixes issue where ls -l command was including escape sequences like \u001b[35m in JSON output