### PR TITLE
Fix user-statuses logic in Commander reports to align with Admin Console statuses

### DIFF
--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -138,7 +138,7 @@ aging_report_parser.error = raise_parse_exception
 aging_report_parser.exit = suppress_exit
 
 action_report_parser = argparse.ArgumentParser(prog='action-report', description='Run a user action report.', parents=[report_output_parser])
-action_report_target_statuses = ['no-logon', 'no-update', 'locked', 'invited', 'no-security-question-update', 'blocked']
+action_report_target_statuses = ['no-logon', 'no-update', 'locked', 'invited', 'no-security-question-update']
 action_report_parser.add_argument('--target', '-t', dest='target_user_status', action='store',
                                   choices=action_report_target_statuses, default='no-logon',
                                   help='user status to report on')
@@ -2114,8 +2114,6 @@ class ActionReportCommand(EnterpriseCommand):
         locked = [u for u in users if u.get('username') in emails_locked]
         emails_invited = {c.get('email') for c in candidates if c.get('status', '').lower() == 'invited'}
         invited = [u for u in users if u.get('username') in emails_invited]
-        emails_blocked = {c.get('email') for c in candidates if c.get('transfer_status', '').lower() == 'blocked'}
-        blocked = [u for u in users if u.get('username') in emails_blocked]
 
         target_status = kwargs.get('target_user_status', 'no-logon')
         days = kwargs.get('days_since')
@@ -2127,8 +2125,7 @@ class ActionReportCommand(EnterpriseCommand):
             'no-update': [active, days, ['record_add', 'record_update']],
             'locked': [locked, days, ['lock_user'], 'to_username'],
             'invited': [invited, days, ['send_invitation', 'auto_invite_user'], 'email'],
-            'no-security-question-update': [active, days, ['change_security_question']],
-            'blocked': [blocked, days, ['accept_transfer']]
+            'no-security-question-update': [active, days, ['change_security_question']]
         }
         args = args_by_status.get(target_status)
 

--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -306,7 +306,7 @@ _DEFAULT_PASSWORD_COMPLEXITY = """[
 def get_user_status_dict(user):
 
     def lock_text(lock):
-        return 'Locked' if lock == 1 else 'Disabled' if lock == 2 else ''
+        return 'Locked' if lock == 1 else 'Locked by IdP' if lock == 2 else ''
 
     account_status = 'Invited' if user['status'] == 'invited' else 'Active'
 
@@ -3470,13 +3470,7 @@ class UserReportCommand(EnterpriseCommand):
         if lock == 1:
             status = 'Locked'
         elif lock == 2:
-            status = 'Disabled'
-        if 'account_share_expiration' in user:
-            expire_at = datetime.datetime.fromtimestamp(user['account_share_expiration']/1000.0)
-            if expire_at < datetime.datetime.now():
-                status = 'Blocked'
-            else:
-                status = 'Pending Transfer'
+            status = 'Locked by IdP'
         return status
 
 


### PR DESCRIPTION
### Fix: Match Admin Console user status logic in Commander reports

Updates Commander's user status reporting to align with streamlined Admin Console statuses:

- `Disabled` → `Locked by IdP`
- Removed `Blocked` and `Pending Transfer` status 
- Removed `blocked` from action-report targets