### PR TITLE
KC-942: Publish Commander container on new builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 ENV PYTHONUNBUFFERED 1
 
@@ -21,11 +21,19 @@ COPY . /commander
 # Install the package as root
 RUN pip install --no-cache-dir -e .
 
+# Copy and set up entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # Change ownership of the application directory to the commander user
 RUN chown -R commander:commander /commander
+# Create .keeper directory with proper permissions for the commander user
+RUN mkdir -p /home/commander/.keeper && \
+    chown -R commander:commander /home/commander/.keeper && \
+    chmod -R 755 /home/commander/.keeper
 
 # Switch to non-root user
 USER commander
 
 # Set up an entrypoint
-ENTRYPOINT ["python3", "keeper.py"]
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -e
+
+# Function to log messages
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Function to parse --user, --password, and --server from arguments
+parse_credentials() {
+    USER=""
+    PASSWORD=""
+    SERVER=""
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --user)
+                USER="$2"
+                shift 2
+                ;;
+            --password)
+                PASSWORD="$2"
+                shift 2
+                ;;
+            --server)
+                SERVER="$2"
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+}
+
+# Function to setup device registration and persistent login
+setup_device() {
+    local user="$1"
+    local password="$2"
+    local server="$3"
+    log "Setting up device registration and persistent login..."
+
+    # Step 1: Register device
+    log "Running: python3 keeper.py this-device register --user $user --password [HIDDEN] --server $server"
+    if ! python3 keeper.py this-device register --user "$user" --password "$password" --server $server; then
+        log "ERROR: Device registration failed"
+        exit 1
+    fi
+    
+    # Step 2: Enable persistent login
+    log "Running: python3 keeper.py this-device persistent-login on --user $user --password [HIDDEN] --server $server"
+    if ! python3 keeper.py this-device persistent-login on --user "$user" --password "$password" --server $server; then
+        log "ERROR: Persistent login setup failed"
+        exit 1
+    fi
+    
+    log "Device setup completed successfully"
+}
+
+# Function to remove --user, --password, and --server from arguments and return the rest
+filter_args() {
+    local filtered_args=()
+    
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --user)
+                shift 2  # Skip --user and its value
+                ;;
+            --password)
+                shift 2  # Skip --password and its value
+                ;;
+            --server)
+                shift 2  # Skip --server and its value
+                ;;
+            *)
+                filtered_args+=("$1")
+                shift
+                ;;
+        esac
+    done
+    
+    echo "${filtered_args[@]}"
+}
+
+parse_credentials "$@"
+
+# Set default server if not specified
+if [[ -z "$SERVER" ]]; then
+    SERVER="keepersecurity.com"
+    log "Using default server: $SERVER"
+else
+    log "Using specified server: $SERVER"
+fi
+
+# Ensure .keeper directory exists (permissions set in Dockerfile)
+log "Ensuring .keeper directory exists..."
+log "Current user: $(whoami), UID: $(id -u), GID: $(id -g)"
+mkdir -p /home/commander/.keeper
+log "Directory permissions: $(ls -ld /home/commander/.keeper)"
+
+# Check if config.json is mounted
+CONFIG_FILE="/home/commander/.keeper/config.json"
+if [[ -f "$CONFIG_FILE" ]]; then
+    log "Config file found at $CONFIG_FILE, using config-based authentication"
+    
+    # Filter out --user and --password from arguments, keep the rest
+    COMMAND_ARGS=$(filter_args "$@")
+    
+    # Run the service command with config file
+    log "Running: python3 keeper.py --config $CONFIG_FILE $COMMAND_ARGS"
+    exec python3 keeper.py --config "$CONFIG_FILE" $COMMAND_ARGS
+elif [[ -n "$USER" && -n "$PASSWORD" ]]; then
+    log "No config file found, using user/password authentication"
+    
+    # Setup device registration first
+    setup_device "$USER" "$PASSWORD" "$SERVER"
+
+    # Filter out --user, --password, and --server from arguments, keep the rest
+    COMMAND_ARGS=$(filter_args "$@")
+
+    # Run the service-create command without credentials (device is now registered)
+    log "Running: python3 keeper.py $COMMAND_ARGS"
+    exec python3 keeper.py $COMMAND_ARGS
+else
+    log "No config file found and no user/password provided, running command directly"
+    log "Note: Command may require authentication parameters to be passed directly"
+    
+    # Filter out --user, --password, and --server from arguments, keep the rest
+    COMMAND_ARGS=$(filter_args "$@")
+
+    # Run the command directly without any authentication setup
+    log "Running: python3 keeper.py $COMMAND_ARGS"
+    exec python3 keeper.py $COMMAND_ARGS
+fi


### PR DESCRIPTION
## Enhanced Docker Support and Documentation [(KC-942)](https://keeper.atlassian.net/browse/KC-942)

- Improved Docker deployment for Keeper Commander with greater usability and clearer documentation.

### Key Changes

- Dockerfile: Updated to python:3.11-slim and added support for an entrypoint script.
- Entrypoint Script: Introduced automatic device registration, persistent login, and support for multiple authentication methods (username/password and mount-config based).
- Documentation: Streamlined examples, added a configuration file setup guide, and expanded coverage of interactive mode.