### PR TITLE
lambda_handler.py overhaul

### DIFF
--- a/examples/aws_lambda/lambda_handler.py
+++ b/examples/aws_lambda/lambda_handler.py
@@ -7,127 +7,92 @@
 # Keeper Commander
 # Copyright 2024 Keeper Security Inc.
 # Contact: ops@keepersecurity.com
-#
-#
-# Sample AWS Lambda handler script
-# In this example, we generate a report that combines the outputs
-# of the `security-audit-report` and `user-report` commands,
-# and then send those results to a specified email address ("KEEPER_SENDTO")
 
-
-import json
 import os
-import datetime
-from typing import Optional
 
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
-
-import boto3
+# Without mounted volumes, Lambda can only write to /tmp. 
+# The following environment variables are needed to make sure the Python import cache 
+# is written to /tmp and not the user folder.
+os.environ['HOME'] = '/tmp'
+os.environ['TMPDIR'] = '/tmp'
+os.environ['TEMP'] = '/tmp'
 
 from keepercommander import api
-from keepercommander.commands.enterprise import UserReportCommand
-from keepercommander.commands.security_audit import SecurityAuditReportCommand
-from keepercommander.params import KeeperParams
+from keepercommander.__main__ import get_params_from_config
 
+# By default, Keeper Commander will attempt to create a .keeper directory 
+# in the user folder to store the JSON configuration.
+# In this case we will create a .keeper directory in /tmp 
+# to store the JSON configuration (using get_params_from_config()).
+keeper_tmp = '/tmp/.keeper'
+os.makedirs(keeper_tmp, exist_ok=True)
 
-# This Lambda's entry point
-def lambda_handler(event, context):
-    params = get_params()
-    api.login(params)
-    api.query_enterprise(params, True)
-
-    # Log Commander-related issues (e.g., incorrect credentials)
-    # using AWS's built-in logging module and abort
-    if not params.session_token:
-        print('Not connected')
-        return 'Error: See Lambda log for details'
-    if not params.enterprise:
-        print('Not enterprise administrator')
-        return 'Error: See Lambda log for details'
-
-    # Generate and send report
-    report = create_user_report(params)
-    response = email_result(report)
-    return response
-
-
-# Create report (format: JSON) combining data from 2 existing Commander reports
-def create_user_report(params):  # type: (KeeperParams) -> Optional[str]
-    user_report_cmd = UserReportCommand()
-    user_report_data = user_report_cmd.execute(params, format='json')
-    data = json.loads(user_report_data)
-    users = {x['email']: x for x in data}
-    security_audit_report = SecurityAuditReportCommand()
-    security_audit_report_data = security_audit_report.execute(params, format='json')
-    if security_audit_report_data:
-        data = json.loads(security_audit_report_data)
-        for x in data:
-            if 'email' in x:
-                email = x['email']
-                if email in users:
-                    user = users[email]
-                    for key in x:
-                        if key not in user:
-                            if key not in ('node_path', 'username'):
-                                user[key] = x[key]
-                else:
-                    users[email] = x
-
-    return json.dumps(list(users.values()), indent=2)
-
-
-# Email report data (as JSON attachment) to recipient specified in this Lambda
-# function's environment variables
-def email_result(report):
-    sender = os.environ.get('KEEPER_SENDER')
-    sendto = os.environ.get('KEEPER_SENDTO')
-    region = 'us-east-1'
-    ses_client = boto3.client('ses', region_name=region)
-
-    message = MIMEMultipart('mixed')
-    message['Subject'] = 'Keeper Commander User Security Report With  CSV (attached)'
-    message['To'] = sendto
-    message['From'] = sender
-    now = datetime.datetime.now()
-
-    body = MIMEText(f'User Report Output created and sent at {now}', 'plain')
-    message.attach(body)
-
-    attachment = MIMEApplication(report)
-    attachment.add_header(
-        'Content-Disposition',
-        'attachment',
-        filename='user-report.json'
-    )
-    message.attach(attachment)
-
-    response = ses_client.send_raw_email(
-        Source=message['From'],
-        Destinations=[sendto],
-        RawMessage={'Data': message.as_string()}
-    )
-
-    return response
-
-
-# Get required Commander parameters from Lambda's environment variables (in "Configuration")
+# ------------------------------------------------------
+# Keeper initialization function
+# ------------------------------------------------------
 def get_params():
-    user = os.environ.get('KEEPER_USER')
-    pw = os.environ.get('KEEPER_PASSWORD')
-    server = os.environ.get('KEEPER_SERVER')
-    private_key = os.environ.get('KEEPER_PRIVATE_KEY')
-    token = os.environ.get('KEEPER_DEVICE_TOKEN')
-    my_params = KeeperParams()
+    # Change the default JSON configuration location to /tmp
+    params = get_params_from_config(keeper_tmp + '/config.json') 
 
-    # Force password-login (needed for SSO + Master Password accounts)
-    my_params.config = {'sso_master_password': True}
+    # Set username and password for Keeper Commander login
+    #params.config = {'sso_master_password': True} # Force Master-Password login for SSO users
+    #params.server = os.environ.get('KEEPER_SERVER') # https://keepersecurity.com
+    params.user = os.environ.get('KEEPER_USER')
+    params.password = os.environ.get('KEEPER_PASSWORD')
+    
 
-    my_params.user = user
-    my_params.password = pw
-    my_params.server = server
-    my_params.device_private_key = private_key
-    my_params.device_token = token
-    return my_params
+    return params
 
+# ------------------------------------------------------
+# Keeper JSON report function
+# ------------------------------------------------------
+def get_keeper_report(params, kwargs):
+    from keepercommander.commands.aram import AuditReportCommand
+    from json import loads
+    
+    report_class = AuditReportCommand()
+    report = report_class.execute(params, **kwargs)
+    return loads(report)
+    
+# ------------------------------------------------------
+# Keeper CLI function
+# ------------------------------------------------------
+def run_keeper_cli(params, command):
+    from keepercommander import cli
+    
+    cli.do_command(params, command)
+    # No return statement as this function runs the CLI command 
+    # without returning anything in Python
+    
+# ------------------------------------------------------
+# Lambda handler
+# ------------------------------------------------------
+def lambda_handler(event, context):
+    # Initialize Keeper Commander params
+    params = get_params()
+
+    # Keeper login and sync
+    api.login(params)
+    api.sync_down(params)
+    # Enterprise sync (for enterprise commands)
+    api.query_enterprise(params)
+
+    run_keeper_cli(
+        params, 
+        'device-approve -a'
+    )
+    
+    run_keeper_cli(
+        params, 
+        'action-report --target locked --apply-action delete --dry-run'
+    )
+
+    return get_keeper_report(
+        params,
+        {
+            'report_type':'raw', 
+            'format':'json',
+            'limit':100,
+            'event_type':['login']
+        }
+    )


### PR DESCRIPTION
Our Lambda handler script returns an error in production, mainly due to Lambda's file system not allowing writing to other directories than /tmp. See more details below:
 → We import keepercommander without setting `HOME`, `TMPDIR `and `TEMP `environment variables, which would cause an issue as it would create pycache in user directory.
 → We call `api.login()`, which will attempt to create a .keeper/config.json file in user directory - which Lambda isn't allowed to do.
This change request introduces the following:
1. Complete overhaul of the lambda handler script
-Added `HOME`, `TMPDIR `and `TEMP `environment variables before import
-Added code that creates custom /tmp/.keeper/ dir to store the config file.
-Added code that leverages the `get_params_from_config()` function to store the config file in custom /tmp/.keeper/ dir.
-Removed email handler function as it was useful but not on topic for Keeper SDK. Replaced it with more basic functions specific to Keeper SDK.
2. Reworked the step by step explanation of the program to fit the overhaul.
The Layer Content script is also outdated by hoping to get some help from Commander contributors for this.