### PR TITLE
Add --file flag for save debug logs to file

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -12,12 +12,14 @@
 import datetime
 import logging
 import os
+import re
 import shlex
 import subprocess
 import sys
 import threading
 import time
 from collections import OrderedDict
+from pathlib import Path
 from typing import Union
 
 from prompt_toolkit import PromptSession
@@ -299,6 +301,7 @@ def do_command(params, command_line):
             print("\nToggle debug mode")
             print("\noptional arguments:")
             print("  -h, --help            show this help message and exit")
+            print("  --file=PATH           write DEBUG logs to PATH (does not enable terminal DEBUG)")
             return
         elif command_line.lower().startswith('q ') or command_line.lower().startswith('quit '):
             print("usage: quit|q [-h]")
@@ -314,10 +317,13 @@ def do_command(params, command_line):
     if command_line.lower() == 'c' or command_line.lower() == 'cls' or command_line.lower() == 'clear':
         print(chr(27) + "[2J")
 
-    elif command_line == 'debug':
-        is_debug = logging.getLogger().level <= logging.DEBUG
-        logging.getLogger().setLevel((logging.WARNING if params.batch_mode else logging.INFO) if is_debug else logging.DEBUG)
-        logging.info('Debug %s', 'OFF' if is_debug else 'ON')
+    elif command_line.startswith('debug'):
+        try:
+            tokens = shlex.split(command_line)
+            debug_manager.process_command(tokens, params.batch_mode)
+        except Exception as e:
+            logging.error(f"Error processing debug command: {e}")
+
 
     else:
         cmd, args = command_and_args_from_cmd(command_line)
@@ -432,6 +438,182 @@ def force_quit():
 
 
 prompt_session = None
+
+class DebugManager:
+    """Debug manager for console and file logging."""
+    
+    def __init__(self):
+        self.logger = logging.getLogger()
+    
+    def has_file_logging(self):
+        """Check if file logging is active."""
+        return any(getattr(h, '_debug_file', False) for h in self.logger.handlers)
+    
+    def is_console_debug_on(self, batch_mode):
+        """Check if console debug is enabled."""
+        for h in self.logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not getattr(h, '_debug_file', False):
+                return h.level == logging.DEBUG
+        return self.logger.level == logging.DEBUG and not self.has_file_logging()
+    
+    def set_console_debug(self, enabled, batch_mode):
+        """Set console debug level."""
+        level = logging.DEBUG if enabled else (logging.WARNING if batch_mode else logging.INFO)
+        for h in self.logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not getattr(h, '_debug_file', False):
+                h.setLevel(level)
+    
+    def setup_file_logging(self, file_path):
+        """Setup debug file logging."""
+        try:
+            validated_path = self._validate_log_file_path(file_path)
+            
+            log_dir = os.path.dirname(validated_path)
+            os.makedirs(log_dir, mode=0o750, exist_ok=True)
+            
+            for h in list(self.logger.handlers):
+                if getattr(h, '_debug_file', False):
+                    self.logger.removeHandler(h)
+                    try:
+                        h.close()
+                    except (OSError, IOError) as close_error:
+                        logging.warning(f'Failed to close log handler: {close_error}')
+                    except Exception as unexpected_error:
+                        logging.error(f'Unexpected error closing log handler: {unexpected_error}')
+            
+            # Add new file handler
+            fh = logging.FileHandler(validated_path, mode='a', encoding='utf-8')
+            fh.setLevel(logging.DEBUG)
+            fh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(name)s - %(message)s'))
+            fh.addFilter(lambda record: record.levelno != logging.INFO)  # Filter out INFO
+            fh._debug_file = True
+            self.logger.addHandler(fh)
+            self.logger.setLevel(logging.DEBUG)
+            
+            logging.info(f'Debug file logging enabled: {validated_path}')
+            return True
+        except (ValueError, OSError, IOError) as e:
+            logging.error(f'Failed to setup file logging: {e}')
+            return False
+        except Exception as e:
+            logging.error(f'Unexpected error setting up file logging: {e}')
+            return False
+
+    def _validate_log_file_path(self, file_path):
+        """Validate and sanitize log file path to prevent security issues."""
+        if not file_path or not isinstance(file_path, str):
+            raise ValueError("File path must be a non-empty string")
+        
+        sanitized_path = ''.join(char for char in file_path if ord(char) >= 32 and char != '\x7f')
+        
+        if not sanitized_path:
+            raise ValueError("File path contains only invalid characters")
+        
+        try:
+            path_obj = Path(sanitized_path)
+            
+            resolved_path = path_obj.resolve()
+                        
+            resolved_str = str(resolved_path).lower()
+            forbidden_paths = ['/etc/', '/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/', 
+                             '/boot/', '/dev/', '/proc/', '/sys/', '/root/']
+            
+            for forbidden in forbidden_paths:
+                if resolved_str.startswith(forbidden):
+                    raise ValueError(f"Access to system directory '{forbidden}' is not allowed")
+            
+            filename = path_obj.name
+            if not filename or filename in ('.', '..'):
+                raise ValueError("Invalid filename")
+            
+            suspicious_patterns = ['..', '~/', '$', '`', ';', '|', '&', '<', '>', '*', '?']
+            for pattern in suspicious_patterns:
+                if pattern in filename:
+                    raise ValueError(f"Filename contains suspicious pattern: '{pattern}'")
+            
+            valid_extensions = ['.log', '.txt', '.out']
+            if not any(filename.lower().endswith(ext) for ext in valid_extensions):
+                logging.warning(f"Log file '{filename}' does not have a standard log extension")
+            
+            return str(resolved_path)
+            
+        except (OSError, RuntimeError) as e:
+            raise ValueError(f"Invalid file path: {e}")
+        except Exception as e:
+            raise ValueError(f"Path validation failed: {e}")
+    
+    def _looks_like_filename(self, token):
+        """Check if a token looks like a filename with proper validation."""
+        if not token or not isinstance(token, str):
+            return False
+        
+        token = token.strip()
+        
+        if len(token) < 1:
+            return False
+        
+        has_extension = re.search(r'\.[a-zA-Z0-9]{1,10}$', token)
+        
+        has_path_separator = '/' in token or '\\' in token
+        
+        looks_like_name = len(token) > 2 and re.match(r'^[a-zA-Z0-9._-]+$', token)
+        
+        return bool(has_extension or has_path_separator or looks_like_name)
+    
+    def toggle_console_debug(self, batch_mode):
+        """Toggle console debug on/off."""
+        current = self.is_console_debug_on(batch_mode)
+        new_state = not current
+        
+        self.set_console_debug(new_state, batch_mode)
+        
+        if not self.has_file_logging():
+            level = logging.DEBUG if new_state else (logging.WARNING if batch_mode else logging.INFO)
+            self.logger.setLevel(level)
+        
+        logging.info(f'Debug {"ON" if new_state else "OFF"}')
+        return new_state
+    
+    def process_command(self, tokens, batch_mode):
+        """Process debug command."""
+        # Look for --file argument
+        file_path = None
+        file_flag_present = False
+        
+        for i, token in enumerate(tokens[1:], 1):
+            if token == '--file':
+                file_flag_present = True
+                if i + 1 < len(tokens):
+                    next_token = tokens[i + 1]
+                    if not next_token.startswith('-'):
+                        file_path = next_token
+                break
+            elif token.startswith('--file='):
+                file_flag_present = True
+                file_path = token.split('=', 1)[1]
+                # Handle empty value after equals sign
+                if not file_path.strip():
+                    file_path = None
+                break
+        
+        if file_flag_present and not file_path:
+            print("Please specify the file path for logging to file: debug --file <file_path>")
+            return False
+        elif file_path:
+            return self.setup_file_logging(file_path)
+        else:
+            # No --file flag present, check for potential filename arguments
+            if len(tokens) > 1:
+                for token in tokens[1:]:
+                    # Check if token looks like a filename
+                    if not token.startswith('-') and self._looks_like_filename(token):
+                        print(f"Please specify the --file flag for logging to file: debug --file {token}")
+                        return False
+            
+            self.toggle_console_debug(batch_mode)
+            return True
+
+debug_manager = DebugManager()
 
 
 def read_command_with_continuation(prompt_session, params):

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -498,6 +498,8 @@ class ThisDeviceCommand(Command):
 
         print('{:>32}: {}'.format('Is SSO User', params.settings['sso_user'] if 'sso_user' in params.settings else False))
 
+        print('{:>32}: {}'.format('Config file', params.config_filename))
+
         print("\nAvailable sub-commands: ", bcolors.OKBLUE + (", ".join(this_device_available_command_verbs)) + bcolors.ENDC)
 
 

--- a/keepercommander/service/commands/security_config_handler.py
+++ b/keepercommander/service/commands/security_config_handler.py
@@ -32,7 +32,7 @@ class SecurityConfigHandler(Command):
         config_data["is_advanced_security_enabled"] = (
             self.service_config._get_yes_no_input(self.messages['advanced_security_prompt'])
         )
-        config_data["ip_allowed_list"] = '0.0.0.0/0'
+        config_data["ip_allowed_list"] = '0.0.0.0/0,::/0'
         if config_data["is_advanced_security_enabled"] == "y":
             self._configure_advanced_security(config_data)
 

--- a/keepercommander/service/commands/service_config_handlers.py
+++ b/keepercommander/service/commands/service_config_handlers.py
@@ -47,7 +47,7 @@ class ServiceConfigHandler:
     @debug_decorator
     def handle_streamlined_config(self, config_data: Dict[str, Any], args, params: KeeperParams) -> None:
         if args.allowedip is None:
-            args.allowedip = '0.0.0.0/0'
+            args.allowedip = '0.0.0.0/0,::/0'
         
         run_mode = args.run_mode if args.run_mode is not None else "foreground"
         if args.run_mode is not None and run_mode not in ['foreground', 'background']:


### PR DESCRIPTION
## Support debug file logging

This PR introduces support for a new `--file` flag to the `debug` command and `this-device` will show where is config.json file in Keeper Commander.  
The flag allows users to send all DEBUG-level logs to a specified file.

---

## Changes

- **New flag:** `debug --file=/path/to/log`
  - Creates (or switches to) a file handler that captures **all DEBUG logs**.
  - Console output level is preserved (INFO/WARNING), so enabling file logging does not spam the terminal with debug lines.
  
 - **config.json file**: `this-device`
   - Now `this-device` command will show config.json file location.

---

## Usage Examples

```bash
debug --file=/tmp/debug.log
# => enables debug logging to /tmp/debug.log

