### PR TITLE
KC-762: Respect "MASTER_PASSWORD_REENTRY" enforcement.

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -387,6 +387,9 @@ class FolderRenameCommand(Command):
         folder_name = kwargs.get('folder')
         if not folder_name:
             raise CommandError('', 'Enter the path or UID of existing folder.')
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('rndir', 'Operation cancelled: Re-authentication failed')
 
         folder_uid = None
         if folder_name in params.folder_cache:
@@ -597,6 +600,10 @@ class FolderRemoveCommand(Command):
         return rmdir_parser
 
     def execute(self, params, **kwargs):
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('rmdir', 'Operation cancelled: Re-authentication failed')
+
         folder = params.folder_cache.get(params.current_folder, params.root_folder)
         folders = []
         pattern_list = kwargs.get('pattern', [])

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -2112,6 +2112,10 @@ class RecordRemoveCommand(Command):
         return rm_parser
 
     def execute(self, params, **kwargs):
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('rm', 'Operation cancelled: Re-authentication failed')
+
         records_to_delete = []     # type: List[Tuple[BaseFolderNode, str]]
         record_names = kwargs.get('records')
         rq_obj_limit = 999

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -849,6 +849,11 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
         record_name = kwargs.get('record')
         if not record_name:
             raise CommandError('record-update', 'Record parameter is required.')
+        
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('record-update', 'Operation cancelled: Re-authentication failed')
+
         record = RecordMixin.resolve_single_record(params, record_name)
         if not record:
             raise CommandError('record-update', f'Record \"{record_name}\" not found.')

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -244,6 +244,10 @@ class ShareFolderCommand(Command):
         return share_folder_parser
 
     def execute(self, params, **kwargs):
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('share-folder', 'Operation cancelled: Re-authentication failed')
+
         def get_share_admin_obj_uids(obj_names, obj_type):
             # type: (List[Optional[str], int], int) -> Optional[Set[str]]
             if not obj_names:
@@ -907,6 +911,10 @@ class ShareRecordCommand(Command):
         emails = kwargs.get('email') or []
         if not emails:
             raise CommandError('share-record', '\'email\' parameter is missing')
+
+        from ..enforcement import MasterPasswordReentryEnforcer
+        if not MasterPasswordReentryEnforcer.check_and_enforce(params, "record_level"):
+            raise CommandError('share-record', 'Operation cancelled: Re-authentication failed')
 
         force = kwargs.get('force') is True
         action = kwargs.get('action') or 'grant'

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -1,0 +1,356 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2025 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+import json
+import logging
+import getpass
+import threading
+from datetime import datetime, timedelta
+from typing import Tuple
+
+from . import api, utils, crypto
+from .proto import APIRequest_pb2
+from .display import bcolors
+from .params import KeeperParams
+from .error import KeeperApiError
+
+
+class MasterPasswordReentryEnforcer:
+    """Handler for MASTER_PASSWORD_REENTRY enforcement with multi-factor authentication support."""
+    
+    # Class variable to store the last successful validation time per user (thread-safe)
+    _last_validation_time = {}
+    _validation_lock = threading.RLock()
+    
+    @classmethod
+    def requires_master_password_reentry(cls, params: KeeperParams, operation: str = "record_level") -> bool:
+        """
+        Check if master password reentry is required for the given operation.
+        
+        Args:
+            params: KeeperParams instance
+            operation: The operation being performed (default: "record_level")
+            
+        Returns:
+            bool: True if master password reentry is required
+        """
+        # Input validation for operation parameter
+        if not operation or not isinstance(operation, str) or len(operation.strip()) == 0:
+            logging.error("Invalid operation parameter provided")
+            return False
+            
+        # Sanitize operation string to prevent injection attacks
+        operation = operation.strip()[:100]  # Limit length and strip whitespace
+        # Bypass enforcement when running in service mode
+        if params and hasattr(params, 'service_mode') and params.service_mode:
+            logging.info(f"Bypassing master password enforcement for operation '{operation}' - running in service mode")
+            return False
+
+        if not params or not params.enforcements:
+            return False
+            
+        # Look for MASTER_PASSWORD_REENTRY enforcement
+        json_enforcements = params.enforcements.get('jsons', [])
+        
+        for enforcement in json_enforcements:
+            if enforcement.get('key') == 'master_password_reentry':
+                try:
+                    enforcement_value = json.loads(enforcement.get('value', '{}'))
+                    operations = enforcement_value.get('operations', [])
+                    timeout_minutes = enforcement_value.get('timeout', 5)
+                    
+                    # Validate timeout to prevent integer overflow and ensure reasonable bounds
+                    if not isinstance(timeout_minutes, (int, float)) or timeout_minutes < 0 or timeout_minutes > 999:  # Max 999 minutes
+                        logging.error("Invalid timeout value in enforcement policy, timeout value must be more than or equal to 0 and less than or equal to 999 minutes, timeout value will be set to 5 minutes")
+                        timeout_minutes = 5  # Default fallback
+                    
+                    # Check if the current operation requires master password reentry
+                    if operation in operations:
+                        # Check if we're still within the timeout period (thread-safe)
+                        user_key = params.user if params.user else None
+                        if not user_key:
+                            logging.error("User key not available")
+                            return True  # Enforcement required if user key is missing
+                            
+                        with cls._validation_lock:
+                            if user_key in cls._last_validation_time:
+                                last_validation = cls._last_validation_time[user_key]
+                                if datetime.now() - last_validation < timedelta(minutes=timeout_minutes):
+                                    return False  # Still within timeout, no need to reenter
+                        
+                        return True  # Enforcement required
+                        
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    logging.error("Failed to parse MASTER_PASSWORD_REENTRY enforcement")
+                    
+        return False
+
+    @classmethod
+    def _is_biometric_available(cls, params: KeeperParams) -> bool:
+        """
+        Check if biometric authentication is available for the user.
+        
+        Args:
+            params: KeeperParams instance
+            
+        Returns:
+            bool: True if biometric authentication is available
+        """
+        try:
+            from .biometric import check_biometric_previously_used, BiometricClient
+            from .biometric.platforms.detector import BiometricDetector
+            
+            # Check if biometric was previously used
+            if not check_biometric_previously_used(params.user):
+                return False
+                
+            # Check if platform supports biometric
+            detector = BiometricDetector()
+            supported, _ = detector.detect_platform_capabilities()
+            if not supported:
+                return False
+                
+            # Check if user has registered biometric credentials
+            client = BiometricClient()
+            credentials = client.get_available_credentials(params)
+            return len(credentials) > 0
+            
+        except (ImportError, Exception):
+            logging.debug("Biometric not available")
+            return False
+    
+    @classmethod 
+    def _validate_biometric(cls, params: KeeperParams) -> bool:
+        """
+        Perform biometric authentication for vault re-authentication.
+        
+        Args:
+            params: KeeperParams instance
+            
+        Returns:
+            bool: True if biometric validation successful, False otherwise
+        """
+        try:
+            from .biometric import BiometricClient
+            
+            print(f'{bcolors.WARNING}Biometric authentication required for this operation.{bcolors.ENDC}')
+            print('Please complete biometric authentication...')
+            
+            client = BiometricClient()
+            
+            # Generate authentication options for vault re-authentication
+            auth_options = client.generate_authentication_options(params, purpose='vault')
+            
+            # Perform biometric authentication
+            auth_response = client.perform_authentication(auth_options)
+            
+            if auth_response:
+                # Store successful validation time (thread-safe)
+                user_key = params.user if params and params.user else None
+                if user_key:
+                    with cls._validation_lock:
+                        cls._last_validation_time[user_key] = datetime.now()
+                print(f'{bcolors.OKGREEN}Biometric authentication successful.{bcolors.ENDC}')
+                return True
+            else:
+                logging.warning("Biometric authentication failed")
+                return False
+                
+        except KeyboardInterrupt:
+            logging.info("Biometric authentication cancelled by user")
+            return False
+        except Exception:
+            logging.debug("Biometric authentication failed")
+            return False
+    
+    @classmethod
+    def _has_master_password_or_alternate(cls, params: KeeperParams) -> Tuple[bool, bool]:
+        """
+        Check if user has master password or alternate SSO master password.
+        
+        Args:
+            params: KeeperParams instance
+            
+        Returns:
+            Tuple[bool, bool]: (has_regular_master_password, has_alternate_sso_password)
+        """
+        is_sso_user = params.settings.get('sso_user', False) if params.settings else False
+        logging.debug(f"Checking authentication methods - is_sso_user: {is_sso_user}")
+        
+        # For regular users, check if they can use master password authentication
+        has_salt = hasattr(params, 'salt') and params.salt
+        has_iterations = hasattr(params, 'iterations') and params.iterations
+        
+        # If user is logged in (has session token) but doesn't have salt/iterations in params,
+        # assume they can still do master password auth (persistent login scenario)
+        # We'll fetch salt/iterations when needed during validation
+        if not is_sso_user:
+            if has_salt and has_iterations:
+                has_regular = True
+                logging.debug(f"Regular user - salt/iterations available in params")
+            elif params.session_token and params.user:
+                has_regular = True
+                logging.debug(f"Regular user - persistent login detected, will fetch salt/iterations when needed")
+            else:
+                has_regular = False
+                logging.debug(f"Regular user - no session or authentication data available")
+        else:
+            has_regular = False
+        
+        # Check if SSO user has alternate password
+        has_alternate = False
+        if is_sso_user:
+            try:
+                current_salt = api.communicate_rest(params, None, 'authentication/get_salt_and_iterations',
+                                                  rs_type=APIRequest_pb2.Salt)
+                has_alternate = current_salt is not None
+                logging.debug(f"SSO user - API call successful")
+            except KeeperApiError as kae:
+                has_alternate = kae.result_code != 'doesnt_exist'
+                logging.debug(f"SSO user - API error: {kae.result_code}")
+            except Exception:
+                logging.debug("SSO user - Exception checking alternate password")
+                pass
+                
+        return has_regular, has_alternate
+    
+    @classmethod
+    def _validate_master_or_alternate_password(cls, params: KeeperParams) -> bool:
+        """
+        Validate master password or alternate SSO master password.
+        
+        Args:
+            params: KeeperParams instance
+            
+        Returns:
+            bool: True if validation successful, False otherwise
+        """
+        is_sso_user = params.settings.get('sso_user', False)
+        has_regular, has_alternate = cls._has_master_password_or_alternate(params)
+        
+        if not has_regular and not has_alternate:
+            return False
+            
+        try:
+            if is_sso_user and has_alternate:
+                # Get salt and iterations for alternate password
+                try:
+                    current_salt = api.communicate_rest(params, None, 'authentication/get_salt_and_iterations',
+                                                      rs_type=APIRequest_pb2.Salt)
+                    salt = current_salt.salt
+                    iterations = current_salt.iterations
+                except Exception:
+                    logging.error("Cannot validate alternate SSO master password: no salt information available")
+                    return False
+                    
+                prompt_text = f'{bcolors.WARNING}Alternate SSO master password reentry required for this operation.{bcolors.ENDC}\nEnter alternate SSO master password: '
+            else:
+                # Use regular master password
+                # Check if salt/iterations are in params, if not fetch them (persistent login scenario)
+                if hasattr(params, 'salt') and params.salt and hasattr(params, 'iterations') and params.iterations:
+                    salt = params.salt
+                    iterations = params.iterations
+                    logging.debug("Using salt/iterations from params")
+                else:
+                    # Fetch salt/iterations from server (persistent login case)
+                    try:
+                        logging.debug("Fetching salt/iterations from server for persistent login user")
+                        current_salt = api.communicate_rest(params, None, 'authentication/get_salt_and_iterations',
+                                                          rs_type=APIRequest_pb2.Salt)
+                        salt = current_salt.salt
+                        iterations = current_salt.iterations
+                        logging.debug("Successfully fetched salt/iterations from server")
+                    except Exception:
+                        logging.error("Cannot validate master password: failed to get salt information from server")
+                        return False
+                    
+                prompt_text = f'{bcolors.WARNING}Master password reentry required for this operation.{bcolors.ENDC}\nEnter master password: '
+            
+            # Prompt for password
+            master_password = getpass.getpass(prompt=prompt_text).strip()
+            
+            if not master_password:
+                logging.error("Password is required")
+                return False
+            
+            try:
+                # Create authentication hash
+                auth_hash = crypto.derive_keyhash_v1(master_password, salt, iterations)
+                
+                # Create master password reentry request
+                rq = APIRequest_pb2.MasterPasswordReentryRequest()
+                rq.pbkdf2Password = utils.base64_url_encode(auth_hash)
+                rq.action = APIRequest_pb2.UNMASK
+                
+                # Validate with server
+                rs = api.communicate_rest(params, rq, 'authentication/validate_master_password',
+                                        rs_type=APIRequest_pb2.MasterPasswordReentryResponse, payload_version=1)
+                
+                if rs.status == APIRequest_pb2.MP_SUCCESS:
+                    # Store successful validation time (thread-safe)
+                    user_key = params.user if params and params.user else None
+                    if user_key:
+                        with cls._validation_lock:
+                            cls._last_validation_time[user_key] = datetime.now()
+                    return True
+                else:
+                    logging.error("Password validation failed")
+                    return False
+                    
+            finally:
+                # Clear sensitive data from memory
+                master_password = 'x' * len(master_password)
+                del master_password
+                if 'auth_hash' in locals():
+                    auth_hash = b'x' * len(auth_hash)
+                    del auth_hash
+                
+        except Exception:
+            logging.error("Password validation failed")
+            return False
+    
+    @classmethod
+    def check_and_enforce(cls, params: KeeperParams, operation: str = "record_level") -> bool:
+        """
+        Check if enforcement is required and handle multi-factor authentication if needed.
+        
+        Uses priority-based authentication:
+        1. First check biometric (if enabled)
+        2. Then check master password/alternate SSO master password (if available)
+        3. If none available, policy does not apply
+        
+        Args:
+            params: KeeperParams instance
+            operation: The operation being performed
+            
+        Returns:
+            bool: True if operation can proceed, False if validation failed
+        """
+        if not cls.requires_master_password_reentry(params, operation):
+            return True
+            
+        # Priority 1: Biometric authentication
+        if cls._is_biometric_available(params):
+            logging.info("Using biometric authentication for re-authentication")
+            return cls._validate_biometric(params)
+        
+        # Priority 2: Master password or alternate SSO master password
+        has_regular, has_alternate = cls._has_master_password_or_alternate(params)
+        if has_regular or has_alternate:
+            if has_alternate:
+                logging.info("Using alternate SSO master password for re-authentication")
+            else:
+                logging.info("Using master password for re-authentication")
+            return cls._validate_master_or_alternate_password(params)
+        
+        # If no authentication methods are available, policy does not apply
+        logging.info("Master Password Re-authentication skipped: Master Password or alternate SSO Master Password not available - policy does not apply")
+        return True

--- a/keepercommander/params.py
+++ b/keepercommander/params.py
@@ -167,6 +167,7 @@ class KeeperParams:
         self.salt = None
         self.iterations = 0
         self.biometric = None
+        self.service_mode = False  # Flag to indicate if running in service mode
 
 
     def clear_session(self):

--- a/keepercommander/service/config/cli_handler.py
+++ b/keepercommander/service/config/cli_handler.py
@@ -24,6 +24,10 @@ class CommandHandler:
         output = io.StringIO()
         sys.stdout = output
         try:
+            # Set service mode flag to bypass master password enforcement
+            original_service_mode = getattr(params, 'service_mode', False)
+            params.service_mode = True
+            
             from ... import cli
             cli.do_command(params, command)
             return output.getvalue()
@@ -32,6 +36,8 @@ class CommandHandler:
             return ''
         finally:
             sys.stdout = sys.__stdout__
+            # Restore original service mode flag
+            params.service_mode = original_service_mode
 
     @debug_decorator
     def find_config_record(self, params: KeeperParams, title: str) -> Optional[str]:
@@ -50,10 +56,18 @@ class CommandHandler:
         """Get help output from CLI."""
         output = io.StringIO()
         sys.stdout = output
-        from ... import cli
-        cli.do_command(params, 'help')
-        sys.stdout = sys.__stdout__
-        return output.getvalue()
+        try:
+            # Set service mode flag to bypass master password enforcement
+            original_service_mode = getattr(params, 'service_mode', False)
+            params.service_mode = True
+            
+            from ... import cli
+            cli.do_command(params, 'help')
+            return output.getvalue()
+        finally:
+            sys.stdout = sys.__stdout__
+            # Restore original service mode flag
+            params.service_mode = original_service_mode
     
     @debug_decorator
     def download_config_from_vault(self, params: KeeperParams, title: str, config_dir: Path) -> bool:

--- a/keepercommander/service/util/command_util.py
+++ b/keepercommander/service/util/command_util.py
@@ -128,6 +128,10 @@ class CommandExecutor:
         from ..core.globals import ensure_params_loaded
         try:
             params = ensure_params_loaded()
+            # Set service mode flag to bypass master password enforcement
+            if params:
+                params.service_mode = True
+
             command = html.unescape(command)
             return_value, printed_output, log_output = CommandExecutor.capture_output_and_logs(params, command)
             response = return_value if return_value else printed_output


### PR DESCRIPTION
### Resolves [KC-762](https://keeper.atlassian.net/browse/KC-762): Respect **MASTER_PASSWORD_REENTRY** Enforcement

#### **Key Changes**

* **Created `enforcement.py`**
  * Implements master password re-entry enforcement policy for Commander with following behavior:
    * Prompt for master password re-entry on record-level commands.
    * If biometric authentication is available and configured → prompt for biometric.
    * If 2FA is configured → bypass policy enforcement.
    * If SSO login is configured → bypass policy enforcement.
    * If SSO user also has master password or biometric setup → enforce those mechanisms.

* **Added Service Mode Support**
  * Bypasses master password enforcement when running in service mode.
  * Handles persistent login scenarios by dynamically fetching salt/iterations.

[KC-762]: https://keeper.atlassian.net/browse/KC-762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ