### PR TITLE
Add missing commands to help and update logger name

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -202,6 +202,9 @@ def main(from_package=False):
         except:
             pass
     logging.basicConfig(format='%(message)s', force=True)
+    logger = logging.getLogger()
+    if logger:
+        logger.name = 'keepercommander'
 
     # Use system CA certificates when available (supports Zscaler), fallback to certifi
     ssl_cert_file = get_ssl_cert_file()

--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -34,7 +34,7 @@ COMMAND_CATEGORIES = {
     
     # Reporting Commands
     'Reporting Commands': {
-        'audit-log', 'audit-report', 'user-report', 'security-audit-report',
+        'audit-log', 'audit-report', 'audit-alert', 'user-report', 'security-audit-report',
         'share-report', 'shared-records-report', 'aging-report', 'action-report',
         'compliance-report', 'compliance', 'external-shares-report', 'risk-management',
         'security-audit'
@@ -52,7 +52,7 @@ COMMAND_CATEGORIES = {
         'enterprise-info', 'enterprise-user', 'enterprise-role', 'enterprise-team',
         'enterprise-node', 'enterprise-push', 'team-approve', 'device-approve',
         'create-user', 'transfer-user', 'automator', 'scim', 'enterprise-down',
-        'public-api-key', 'audit-alert'
+        'public-api-key'
     },
     
     # Secrets Manager Commands

--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -18,7 +18,7 @@ COMMAND_CATEGORIES = {
     # Sharing Commands
     'Sharing Commands': {
         'share-record', 'share-folder', 'record-permissions', 'record-permission', 'one-time-share',
-        'external-shares-report', 'share'
+        'external-shares-report'
     },
     
     # Record Type Commands
@@ -34,7 +34,7 @@ COMMAND_CATEGORIES = {
     
     # Reporting Commands
     'Reporting Commands': {
-        'audit-log', 'audit-report', 'audit-alert', 'user-report', 'security-audit-report',
+        'audit-log', 'audit-report', 'user-report', 'security-audit-report',
         'share-report', 'shared-records-report', 'aging-report', 'action-report',
         'compliance-report', 'compliance', 'external-shares-report', 'risk-management',
         'security-audit'
@@ -52,7 +52,7 @@ COMMAND_CATEGORIES = {
         'enterprise-info', 'enterprise-user', 'enterprise-role', 'enterprise-team',
         'enterprise-node', 'enterprise-push', 'team-approve', 'device-approve',
         'create-user', 'transfer-user', 'automator', 'scim', 'enterprise-down',
-        'public-api-key'
+        'public-api-key', 'audit-alert'
     },
     
     # Secrets Manager Commands

--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -91,6 +91,8 @@ def register_command_info(aliases, command_info):
               user_report_parser]:
         command_info[p.prog] = p.description
 
+    command_info['audit-alert'] = 'Manage audit alerts and notifications'
+
     compliance.register_command_info(aliases, command_info)
     security_audit.register_command_info(aliases, command_info)
 

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -76,9 +76,11 @@ def register_command_info(aliases, command_info):
     for p in [get_info_parser, search_parser, list_parser, list_sf_parser, list_team_parser,
               record_history_parser, shared_records_report_parser, record_edit.record_add_parser,
               record_edit.record_update_parser, record_edit.append_parser, record_edit.download_parser,
-              record_edit.upload_parser, record_edit.delete_attachment_parser, clipboard_copy_parser, record_totp.totp_parser]:
+              record_edit.upload_parser, record_edit.delete_attachment_parser, clipboard_copy_parser, record_totp.totp_parser,
+              rm_parser, record_file_report.file_report_parser]:
         command_info[p.prog] = p.description
     command_info['trash'] = 'Manage records in the deleted items'
+    command_info['find-password'] = 'Find and display password for a record'
 
 
 get_info_parser = argparse.ArgumentParser(prog='get', description='Get the details of a record/folder/team by UID or title')

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -68,7 +68,6 @@ def register_command_info(aliases, command_info):
         command_info[p.prog] = p.description
 
     command_info['one-time-share'] = 'Manage and create One-Time Shares'
-    command_info['share'] = 'Manage and create One-Time Shares'
 
 
 share_record_parser = argparse.ArgumentParser(prog='share-record', description='Change the sharing permissions of an individual record')

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -40,7 +40,7 @@ def register_enterprise_commands(commands):
 
 
 def register_command_info(aliases, command_info):
-    for p in [import_parser, export_parser, download_membership_parser, apply_membership_parser, download_record_type_parser]:
+    for p in [import_parser, export_parser, download_membership_parser, apply_membership_parser, download_record_type_parser, load_record_type_parser]:
         command_info[p.prog] = p.description
 
 
@@ -137,7 +137,7 @@ download_record_type_parser.add_argument(
 
 
 load_record_type_parser = argparse.ArgumentParser(
-    prog='load_record_types', description='Loads custom record types from JSON file into Keeper.')
+    prog='load-record-types', description='Loads custom record types from JSON file into Keeper.')
 load_record_type_parser.add_argument(
     'name', type=str, nargs='?', help='Input file name. "record_types.json" if omitted.')
 


### PR DESCRIPTION
## Fix Missing Commands in Help System

### Changes
- **Added missing commands to help system:**
  - `find-password` - Find and display password for a record
  - `file-report` - File reporting functionality  
  - `rm` - Remove/delete records
  - `load-record-types` - Load custom record types from JSON file
  - `audit-alert` - Manage audit alerts and notifications

- **Updated logger configuration:**
  - Set logger name to `keepercommander` for consistent logging across the application and to enable external log level configuration for keepercommander-specific logs