### PR TITLE
Fix share-record with force flag for cancel action

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -943,9 +943,12 @@ class ShareRecordCommand(Command):
                     emails = [*good_emails, *replacements]
 
         if action == 'cancel':
-            answer = base.user_choice(
-                bcolors.FAIL + bcolors.BOLD + '\nALERT!\n' + bcolors.ENDC + 'This action cannot be undone.\n\n' +
-                'Do you want to cancel all shares with user(s): ' + ', '.join(emails) + ' ?', 'yn', 'n')
+            if not force:
+                answer = base.user_choice(
+                    bcolors.FAIL + bcolors.BOLD + '\nALERT!\n' + bcolors.ENDC + 'This action cannot be undone.\n\n' +
+                    'Do you want to cancel all shares with user(s): ' + ', '.join(emails) + ' ?', 'yn', 'n')
+            else:
+                answer = 'y'
             if answer.lower() in {'y', 'yes'}:
                 for email in emails:
                     rq = {


### PR DESCRIPTION
## Problem
The `share-record` command with `-a cancel -f` was still showing a confirmation prompt, which breaks automation workflows.

## Solution
Fix a check for the `-f/--force` flag to skip the confirmation prompt when `-f/--force` is provided.
