### PR TITLE
Added `--node` flag in `action-report` command

### DIFF
--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -2115,10 +2115,14 @@ class ActionReportCommand(EnterpriseCommand):
         invited = [u for u in users if u.get('username') in emails_invited]
 
         node_name = kwargs.get('node')
-        if node_name:
+        if node_name is not None:
             # Validate input type
             if not isinstance(node_name, str):
                 logging.warning(f'Invalid node parameter type: expected string, got {type(node_name).__name__}')
+                return
+            
+            if not node_name.strip():
+                logging.warning('Please provide node name or node ID. The --node parameter cannot be empty.')
                 return
             
             nodes = list(self.resolve_nodes(params, node_name))


### PR DESCRIPTION
## Add `--node` Flag to `action-report` Command to Filter Users in Specific Node

##  Summary
This update introduces a flag `--node` to the `action-report` command.  
It allows administrators to filter user actions based on a specific **node name or ID**.  

---

##  Example Usage
```bash
action-report --target <target> --node "<Node name/ID>"
