### PR TITLE
KC-642: Support for setting default working directory

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -31,7 +31,7 @@ from .params import KeeperParams
 from .config_storage import loader
 
 
-def get_params_from_config(config_filename=None, launched_with_shortcut=False):    # type: (Optional[str], bool) -> KeeperParams
+def get_params_from_config(config_filename=None, launched_with_shortcut=False, data_dir=None):    # type: (Optional[str], bool, Optional[str]) -> KeeperParams
     if os.getenv("KEEPER_COMMANDER_DEBUG"):
         logging.getLogger().setLevel(logging.DEBUG)
         logging.info('Debug ON')
@@ -46,7 +46,7 @@ def get_params_from_config(config_filename=None, launched_with_shortcut=False): 
     if not config_filename:
         config_filename = 'config.json'
         if launched_with_shortcut or not os.path.isfile(config_filename):
-            config_filename = os.path.join(utils.get_default_path(), config_filename)
+            config_filename = os.path.join(utils.get_default_path(data_dir), config_filename)
         else:
             config_filename = os.path.join(os.getcwd(), config_filename)
     else:
@@ -119,6 +119,7 @@ parser.add_argument('--unmask-all', action='store_true', help=unmask_help)
 fail_on_throttle_help = 'Disable default client-side pausing of command execution and re-sending of requests upon ' \
                         'server-side throttling'
 parser.add_argument('--fail-on-throttle', action='store_true', help=fail_on_throttle_help)
+parser.add_argument('--data-dir', dest='data_dir', action='store', help='Directory to use for Commander data (config, cache, etc.). Overrides environment variables.')
 parser.add_argument('command', nargs='?', type=str, action='store', help='Command')
 parser.add_argument('options', nargs='*', action='store', help='Options')
 parser.error = usage
@@ -242,7 +243,7 @@ def main(from_package=False):
                 # Skip arguments that were handled by main parser
                 main_parser_args = ['--config', '--server', '--user', '--password', '--version', '--debug', 
                                   '--batch-mode', '--launched-with-shortcut', '--proxy', '--unmask-all', '--fail-on-throttle',
-                                  '-ks', '-ku', '-kp', '-lwsc']
+                                  '--data-dir', '-ks', '-ku', '-kp', '-lwsc']
                 
                 is_main_parser_arg = False
                 for main_arg in main_parser_args:
@@ -265,7 +266,7 @@ def main(from_package=False):
     if opts.launched_with_shortcut:
         os.chdir(Path.home())
 
-    params = get_params_from_config(opts.config, opts.launched_with_shortcut)
+    params = get_params_from_config(opts.config, opts.launched_with_shortcut, opts.data_dir)
 
     if opts.batch_mode:
         params.batch_mode = True

--- a/keepercommander/service/core/globals.py
+++ b/keepercommander/service/core/globals.py
@@ -28,6 +28,6 @@ def ensure_params_loaded() -> KeeperParams:
     if not params: 
         from ...__main__ import get_params_from_config
         config_path = utils.get_default_path() / "config.json"
-        params = get_params_from_config(config_path)
+        params = get_params_from_config(str(config_path))
         init_globals(params)
     return params

--- a/keepercommander/utils.py
+++ b/keepercommander/utils.py
@@ -28,8 +28,45 @@ VALID_URL_SCHEME_CHARS = '+-.:'
 def get_logger():
     return logging.getLogger('keeper')
 
-def get_default_path():
-    default_path = Path.home().joinpath('.keeper')
+def get_default_path(override_path=None):
+    """
+    Get the default path for Commander's data directory.
+    
+    Precedence order (highest to lowest):
+    1. override_path parameter (e.g., from CLI --data-dir) - auto-appends .keeper if needed
+    2. KEEPER_DATA_HOME environment variable - auto-appends .keeper if needed
+    3. XDG_DATA_HOME/.keeper (XDG Base Directory Specification)
+    4. HOME/.keeper (legacy default)
+    
+    Args:
+        override_path (str, optional): Override path, typically from CLI argument
+        
+    Returns:
+        Path: The path to use for Commander's data directory
+    """
+    import os
+    
+    def ensure_keeper_suffix(path_str):
+        """Helper to ensure path ends with .keeper suffix"""
+        expanded_path = Path(os.path.expanduser(path_str))
+        if expanded_path.name == '.keeper':
+            return expanded_path
+        else:
+            return expanded_path.joinpath('.keeper')
+    
+    if override_path:
+        default_path = ensure_keeper_suffix(override_path)
+    else:
+        keeper_data_home = os.getenv('KEEPER_DATA_HOME')
+        if keeper_data_home:
+            default_path = ensure_keeper_suffix(keeper_data_home)
+        else:
+            xdg_data_home = os.getenv('XDG_DATA_HOME')
+            if xdg_data_home:
+                default_path = Path(xdg_data_home).joinpath('.keeper')
+            else:
+                default_path = Path.home().joinpath('.keeper')
+    
     default_path.mkdir(parents=True, exist_ok=True)
     return default_path
 


### PR DESCRIPTION
# Working Directory Resolution (`get_default_path()`)

The `get_default_path()` function determines Commander's working directory.  
It now supports both **environment variables** and **CLI parameters**, following a clear precedence order.

---

## Precedence Order (highest → lowest)

1. **CLI `--data-dir` parameter**  
2. **`KEEPER_DATA_HOME` environment variable**  
3. **`XDG_DATA_HOME/.keeper`** — follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)  
4. **`$HOME/.keeper`** — legacy default (for backward compatibility)

---

## Path Handling Rules

| Input Path           | Resulting Working Directory |
|----------------------|-----------------------------|
| `/Users/xyz`         | `/Users/xyz/.keeper`        |
| `/Users/xyz/.keeper` | `/Users/xyz/.keeper` (no change) |

These rules apply to both **CLI parameters** and **`KEEPER_DATA_HOME`**.

---

## Usage Examples

### Environment Variables

```bash
# Use custom directory via KEEPER_DATA_HOME
export KEEPER_DATA_HOME="/Users/xyz"        # resolves to /Users/xyz/.keeper

# Use XDG-compliant data directory
export XDG_DATA_HOME="/opt/data"             # resolves to /opt/data/.keeper
```

### CLI Parameter
```bash
# Explicitly specify a data directory (highest precedence)
keeper shell --data-dir /custom/path         # resolves to /custom/path/.keeper
```

### Default Behavior
```bash
# No environment variables or CLI options provided
keeper                                       # resolves to ~/.keeper
```

