### PR TITLE
KC-971: Support to ensure and update config file permissions

### DIFF
--- a/keepercommander/config_storage/loader.py
+++ b/keepercommander/config_storage/loader.py
@@ -119,6 +119,8 @@ def store_config_properties(params):
         try:
             with open(params.config_filename, 'w') as fd:
                 json.dump(config_json, fd, ensure_ascii=False, indent=2)
+            # Set secure file permissions (600) for configuration files containing sensitive data
+            utils.set_file_permissions(params.config_filename)
         except Exception as error:
             logging.debug(error, exc_info=True)
             logging.error(f'Failed to write configuration to {params.config_filename}. '
@@ -131,6 +133,10 @@ def load_config_properties(params):
 
     if not isinstance(params.config, dict):
         return
+
+    # Check and fix permissions for existing config files
+    if hasattr(params, 'config_filename') and params.config_filename:
+        utils.ensure_config_permissions(params.config_filename)
 
     if CONFIG_STORAGE_URL in params.config:
         url = params.config[CONFIG_STORAGE_URL]

--- a/keepercommander/service/config/file_handler.py
+++ b/keepercommander/service/config/file_handler.py
@@ -93,6 +93,8 @@ class ConfigFormatHandler:
     def _save_json(self, config_data: Dict[str, Any], config_path) -> Path:
         """Save configuration as JSON."""
         config_path.write_text(json.dumps(config_data, indent=4))
+        from ... import utils
+        utils.set_file_permissions(str(config_path))
         logger.debug(f"Configuration saved to {config_path}")
         # self.encrypt_config_file(config_path, self.config_dir)
         return config_path
@@ -101,6 +103,8 @@ class ConfigFormatHandler:
         """Save configuration as YAML."""
         with open(config_path, 'w') as yaml_file:
             yaml.dump(config_data, yaml_file, default_flow_style=False)
+        from ... import utils
+        utils.set_file_permissions(str(config_path))
         logger.debug(f"Configuration saved to {config_path}")
         # self.encrypt_config_file(config_path, self.config_dir)
         return config_path
@@ -110,6 +114,9 @@ class ConfigFormatHandler:
         config_path = self.config_path
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
+        
+        from ... import utils
+        utils.ensure_config_permissions(str(config_path))
         
         format_type = self.get_config_format()
         try:

--- a/keepercommander/service/config/service_config.py
+++ b/keepercommander/service/config/service_config.py
@@ -164,12 +164,14 @@ class ServiceConfig:
         """ Read plain text config file and update configuration """
         with open(config_path, "r") as f:
                      config_data = json.load(f) if file_format == "json" else yaml.safe_load(f) or {}
+        config_data.update(updates)
         # Save updated configuration
         with open(config_path, "w") as f:
             if file_format == "json":
                     json.dump(config_data, f, indent=4)
             else:
                 yaml.safe_dump(config_data, f, default_flow_style=False)
+        utils.set_file_permissions(config_path)
  
         logging.info(f"Updated keys in {config_path.name}: {', '.join(updates.keys())}")
 
@@ -191,6 +193,7 @@ class ServiceConfig:
                 dest_path = keeper_dir / src_path.name
                 if src_path.exists():
                     shutil.copy(src_path, dest_path)
+                    utils.set_file_permissions(str(dest_path))
                     saved_files.append(dest_path)
                     updated_names[key] = src_path.name  # Store only the filename, not the full path
                 else:

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -55,6 +55,7 @@ class GlobalLogger:
             # Write the default config
             with open(config_path, "w") as f:
                 yaml.dump(default_config, f, sort_keys=False)
+            utils.set_file_permissions(str(config_path))
         return default_config["logging"]
     
     def _load_config(self):
@@ -62,6 +63,7 @@ class GlobalLogger:
         
         # config_path = os.getenv("LOGGING_CONFIG_PATH", "logging_config.yaml")
         if os.path.exists(config_path):
+            utils.ensure_config_permissions(str(config_path))
             with open(config_path, "r") as f:
                 return yaml.safe_load(f).get("logging", {})
         return {"enabled": True, "level": "INFO"}

--- a/keepercommander/utils.py
+++ b/keepercommander/utils.py
@@ -13,8 +13,13 @@ import base64
 import json
 import logging
 import math
+import os
+import platform
 import re
+import stat
+import subprocess
 import time
+from typing import Dict, Union
 from urllib.parse import urlparse, parse_qs, unquote
 from pathlib import Path
 import sys
@@ -43,6 +48,70 @@ def generate_uid():             # type: () -> str
 
 def generate_aes_key():         # type: () -> bytes
     return crypto.get_random_bytes(32)
+
+
+def set_file_permissions(file_path):     # type: (str) -> None
+    """
+    Set secure file permissions (600) for configuration files containing sensitive data.
+    This ensures only the owner can read and write the file.
+    """
+    file_path = os.path.abspath(file_path)
+    
+    try:
+        if os.path.islink(file_path):
+            logging.warning(f'Skipping permission setting on symbolic link: {file_path}')
+            return
+        
+        if platform.system() != 'Windows':
+            file_stat = os.stat(file_path)
+            if file_stat.st_uid != os.getuid():
+                logging.warning(f'Skipping permission setting on file not owned by current user: {file_path}')
+                return
+            
+            os.chmod(file_path, stat.S_IRUSR | stat.S_IWUSR)
+            logging.debug(f'Set secure permissions (600) for file: {file_path}')
+        else:
+            username = os.getlogin()
+            subprocess.run(["icacls", file_path, "/inheritance:r"], check=True, capture_output=True)
+            subprocess.run(["icacls", file_path, "/remove", "NT AUTHORITY\\SYSTEM", "BUILTIN\\Administrators"], check=False, capture_output=True)
+            subprocess.run(["icacls", file_path, "/grant", f"{username}:RW"], check=True, capture_output=True)
+            logging.debug(f'Set secure permissions (owner RW only) for Windows file: {file_path}')
+    except Exception:
+        logging.warning(f'Failed to set file permissions for {file_path}')
+
+
+def ensure_config_permissions(file_path):     # type: (str) -> None
+    """
+    Check and fix file permissions for existing configuration files.
+    If the file has overly permissive permissions, log a warning and fix them.
+    """
+    file_path = os.path.abspath(file_path)
+    
+    if not os.path.exists(file_path):
+        return
+    
+    try:
+        if os.path.islink(file_path):
+            logging.warning(f'Skipping permission check on symbolic link: {file_path}')
+            return
+        
+        if platform.system() != 'Windows':
+            file_stat = os.stat(file_path)
+            if file_stat.st_uid != os.getuid():
+                logging.warning(f'Skipping permission check on file not owned by current user: {file_path} (owner: {file_stat.st_uid}, current: {os.getuid()})')
+                return
+            
+            current_permissions = file_stat.st_mode & 0o777
+            if current_permissions != 0o600:
+                logging.warning(f'Configuration file {file_path} has insecure permissions '
+                              f'{oct(current_permissions)}. Setting to secure permissions (600).')
+                set_file_permissions(file_path)
+        else:
+            logging.debug(f'Checking Windows file permissions for: {file_path}')
+            set_file_permissions(file_path)
+            
+    except OSError:
+        logging.warning(f'Failed to check file permissions for {file_path}')
 
 
 def current_milli_time():       # type: () -> int


### PR DESCRIPTION
## Resolves [KC-971](https://keeper.atlassian.net/browse/KC-971): Fix world-readable permissions on ~/.keeper/config.json file

- **Security Fix**: Set secure 600 permissions on configuration files containing sensitive credentials (device_token, private_key) to prevent local users from reading other users' Keeper vaults
- **Cross-Platform Support**: Added Windows compatibility and Unix permission handling with proper symlink attack prevention and file ownership validation 

[KC-971]: https://keeper.atlassian.net/browse/KC-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ