### PR TITLE
Commander | kc-981-one-time-share-enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
     mkdir -p /home/commander/.keeper && \
     chown -R commander:commander /commander /home/commander/.keeper && \
     chmod -R 755 /home/commander/.keeper && \
-    # Install application
-    pip install --no-cache-dir -e .
+    # Install application with email dependencies
+    pip install --no-cache-dir -e .[email]
 
 # Switch to non-root user
 USER commander

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -82,7 +82,7 @@ def display_command_help(show_enterprise=False, show_shell=False, show_legacy=Fa
     # Define colors for different categories - more variety and visual appeal
     category_colors = {
         'Record Commands': bcolors.OKGREEN,           # Green - primary functionality
-        'Sharing Commands': bcolors.OKBLUE,           # Blue - collaboration  
+        'Sharing Commands': bcolors.OKBLUE,           # Blue - collaboration
         'Record Type Commands': bcolors.HEADER,       # Purple/Magenta - special types
         'Import and Exporting Data': bcolors.WARNING, # Yellow - data operations
         'Reporting Commands': '\033[96m',             # Cyan - analytics
@@ -92,6 +92,7 @@ def display_command_help(show_enterprise=False, show_shell=False, show_legacy=Fa
         'BreachWatch Commands': bcolors.FAIL,         # Red - security alerts
         'Device Management Commands': '\033[93m',     # Bright Yellow - devices
         'Service Mode REST API': '\033[36m',          # Dark Cyan - services
+        'Email Configuration Commands': '\033[38;5;214m',  # Orange - email services
         'Miscellaneous Commands': '\033[37m',         # Light Gray - utilities
         'KeeperPAM Commands': '\033[92m',            # Bright Green - PAM
         'Legacy Commands': '\033[90m',               # Dark Gray - deprecated

--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -76,6 +76,11 @@ COMMAND_CATEGORIES = {
         'service-config-add'
     },
     
+    # Email Configuration Commands
+    'Email Configuration Commands': {
+        'email-config'
+    },
+
     # Miscellaneous Commands
     'Miscellaneous Commands': {
         'this-device', 'login', 'login-status', 'biometric', 'whoami', 'logout',
@@ -83,7 +88,7 @@ COMMAND_CATEGORIES = {
         'reset-password', 'sync-security-data', 'keeper-fill', '2fa', 'create-account',
         'run-as', 'sleep', 'server', 'proxy', 'keep-alive'
     },
-    
+
     # KeeperPAM Commands
     'KeeperPAM Commands': {
         'pam'
@@ -118,6 +123,7 @@ def get_category_order():
         'BreachWatch Commands',
         'Device Management Commands',
         'Service Mode REST API',
+        'Email Configuration Commands',
         'Miscellaneous Commands',
         'KeeperPAM Commands',
         'Legacy Commands',

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -128,6 +128,10 @@ def register_commands(commands, aliases, command_info):
     commands['2fa'] = TwoFaCommand()
     command_info['2fa'] = '2FA management'
 
+    from .email_commands import EmailConfigCommand
+    commands['email-config'] = EmailConfigCommand()
+    command_info['email-config'] = 'Email provider configuration management'
+
     from . import device_management
     device_management.register_commands(commands)
     device_management.register_command_info(aliases, command_info)

--- a/keepercommander/commands/email_commands.py
+++ b/keepercommander/commands/email_commands.py
@@ -1,0 +1,779 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Contact: ops@keepersecurity.com
+#
+
+"""
+Email Configuration Commands for Keeper Commander
+
+Manages email provider configurations stored as Keeper records.
+Supports SMTP, AWS SES, and SendGrid providers.
+"""
+
+import argparse
+import json
+import logging
+from typing import Optional
+
+from .base import Command, GroupCommand, dump_report_data, field_to_title
+from .. import api, crypto, utils, vault, vault_extensions, record_management
+from ..email_service import EmailConfig, EmailSender, check_provider_dependencies, get_installation_method
+from ..params import KeeperParams
+from ..error import CommandError
+
+
+# =============================================================================
+# Argument Parsers
+# =============================================================================
+
+email_config_parser = argparse.ArgumentParser(
+    prog='email-config',
+    description='Manage email provider configurations'
+)
+
+# email-config create
+email_config_create_parser = argparse.ArgumentParser(
+    prog='email-config create',
+    description='Create a new email configuration'
+)
+email_config_create_parser.add_argument(
+    '--name',
+    required=True,
+    help='Name for this email configuration'
+)
+email_config_create_parser.add_argument(
+    '--provider',
+    required=True,
+    choices=['smtp', 'ses', 'sendgrid', 'gmail-oauth', 'microsoft-oauth'],
+    help='Email provider type'
+)
+email_config_create_parser.add_argument(
+    '--from-address',
+    dest='from_address',
+    required=True,
+    help='From email address'
+)
+email_config_create_parser.add_argument(
+    '--from-name',
+    dest='from_name',
+    default='Keeper Commander',
+    help='From display name (default: Keeper Commander)'
+)
+email_config_create_parser.add_argument(
+    '--folder',
+    help='Folder path or UID where email config record will be stored'
+)
+
+# SMTP options
+smtp_group = email_config_create_parser.add_argument_group('SMTP Options')
+smtp_group.add_argument('--smtp-host', help='SMTP server hostname')
+smtp_group.add_argument('--smtp-port', type=int, default=587, help='SMTP port (default: 587)')
+smtp_group.add_argument('--smtp-username', help='SMTP username')
+smtp_group.add_argument('--smtp-password', help='SMTP password')
+tls_group = smtp_group.add_mutually_exclusive_group()
+tls_group.add_argument('--smtp-use-tls', dest='smtp_use_tls', action='store_true', default=None,
+                       help='Use TLS (STARTTLS on port 587)')
+tls_group.add_argument('--smtp-no-tls', dest='smtp_use_tls', action='store_false',
+                       help='Disable TLS (for testing/local servers)')
+smtp_group.add_argument('--smtp-use-ssl', dest='smtp_use_ssl', action='store_true',
+                       help='Use SSL (port 465)')
+
+# AWS SES options
+ses_group = email_config_create_parser.add_argument_group('AWS SES Options')
+ses_group.add_argument('--aws-region', help='AWS region (e.g., us-east-1)')
+ses_group.add_argument('--aws-access-key', help='AWS access key ID')
+ses_group.add_argument('--aws-secret-key', help='AWS secret access key')
+
+# SendGrid options
+sendgrid_group = email_config_create_parser.add_argument_group('SendGrid Options')
+sendgrid_group.add_argument('--sendgrid-api-key', help='SendGrid API key')
+
+# OAuth options (Gmail and Microsoft)
+oauth_group = email_config_create_parser.add_argument_group('OAuth Options (gmail-oauth, microsoft-oauth)')
+oauth_group.add_argument('--oauth-client-id', help='OAuth client ID')
+oauth_group.add_argument('--oauth-client-secret', help='OAuth client secret')
+oauth_group.add_argument('--oauth-tenant-id', help='Microsoft tenant ID (use "common" for multi-tenant, or specific tenant ID)')
+oauth_group.add_argument('--oauth-access-token', help='OAuth access token (for manual token entry)')
+oauth_group.add_argument('--oauth-refresh-token', help='OAuth refresh token (for manual token entry)')
+oauth_group.add_argument('--oauth-token-expiry', help='OAuth token expiry in ISO 8601 format (for manual token entry)')
+oauth_group.add_argument('--oauth-port', type=int, default=8080, help='Port for OAuth callback server (default: 8080)')
+
+# email-config list
+email_config_list_parser = argparse.ArgumentParser(
+    prog='email-config list',
+    description='List all email configurations'
+)
+email_config_list_parser.add_argument(
+    '--format',
+    dest='format',
+    action='store',
+    choices=['table', 'json', 'csv'],
+    default='table',
+    help='Output format (default: table)'
+)
+
+# email-config test
+email_config_test_parser = argparse.ArgumentParser(
+    prog='email-config test',
+    description='Test email configuration connection'
+)
+email_config_test_parser.add_argument(
+    'name',
+    help='Name of email configuration to test'
+)
+email_config_test_parser.add_argument(
+    '--to',
+    help='Send test email to this address'
+)
+
+# email-config delete
+email_config_delete_parser = argparse.ArgumentParser(
+    prog='email-config delete',
+    description='Delete an email configuration'
+)
+email_config_delete_parser.add_argument(
+    'name',
+    help='Name of email configuration to delete'
+)
+email_config_delete_parser.add_argument(
+    '-f', '--force',
+    action='store_true',
+    help='Do not prompt for confirmation'
+)
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
+    """
+    Find email config record by name.
+
+    Args:
+        params: KeeperParams session
+        name: Name of email configuration
+
+    Returns:
+        Record UID if found, None otherwise
+    """
+    for record_uid in params.record_cache:
+        record = vault.KeeperRecord.load(params, record_uid)
+        if not isinstance(record, vault.TypedRecord):
+            continue
+        if record.record_type != 'login':
+            continue
+
+        # Check if this is an email config by looking for custom field
+        try:
+            record_dict = vault_extensions.extract_typed_record_data(record)
+            custom_fields = record_dict.get('custom', [])
+            for field in custom_fields:
+                if field.get('type') == 'text' and field.get('label') == '__email_config__':
+                    if record.title == name:
+                        return record_uid
+        except:
+            continue
+
+    return None
+
+
+def load_email_config_from_record(params: KeeperParams, record_uid: str) -> EmailConfig:
+    """
+    Load EmailConfig from a Keeper record.
+
+    Args:
+        params: KeeperParams session
+        record_uid: Record UID
+
+    Returns:
+        EmailConfig object
+
+    Raises:
+        CommandError: If record not found or invalid
+    """
+    if record_uid not in params.record_cache:
+        raise CommandError('email-config', f'Record {record_uid} not found')
+
+    record = vault.KeeperRecord.load(params, record_uid)
+    if not isinstance(record, vault.TypedRecord):
+        raise CommandError('email-config', f'Record {record_uid} is not a typed record')
+
+    # Extract record data
+    record_dict = vault_extensions.extract_typed_record_data(record)
+
+    # Get login/password fields
+    fields = record_dict.get('fields', [])
+    login = None
+    password = None
+
+    for field in fields:
+        if field.get('type') == 'login':
+            values = field.get('value', [])
+            if values:
+                login = values[0]
+        elif field.get('type') == 'password':
+            values = field.get('value', [])
+            if values:
+                password = values[0]
+
+    # Get custom fields with provider configuration
+    custom_fields = record_dict.get('custom', [])
+    provider_data = {}
+
+    for field in custom_fields:
+        label = field.get('label', '')
+        if label.startswith('__email_'):
+            continue  # Skip marker fields
+
+        values = field.get('value', [])
+        if values:
+            provider_data[label] = values[0]
+
+    # Build EmailConfig
+    provider = provider_data.get('provider', 'smtp')
+
+    config = EmailConfig(
+        record_uid=record_uid,
+        name=record.title,
+        provider=provider,
+        from_address=provider_data.get('from_address', ''),
+        from_name=provider_data.get('from_name', 'Keeper Commander')
+    )
+
+    # Provider-specific fields
+    if provider == 'smtp':
+        config.smtp_host = provider_data.get('smtp_host')
+        config.smtp_port = int(provider_data.get('smtp_port', 587))
+        config.smtp_username = login or provider_data.get('smtp_username')
+        config.smtp_password = password or provider_data.get('smtp_password')
+        config.smtp_use_tls = provider_data.get('smtp_use_tls', 'true').lower() == 'true'
+        config.smtp_use_ssl = provider_data.get('smtp_use_ssl', 'false').lower() == 'true'
+
+    elif provider == 'ses':
+        config.aws_region = provider_data.get('aws_region')
+        config.aws_access_key = login or provider_data.get('aws_access_key')
+        config.aws_secret_key = password or provider_data.get('aws_secret_key')
+
+    elif provider == 'sendgrid':
+        config.sendgrid_api_key = password or provider_data.get('sendgrid_api_key')
+
+    elif provider in ('gmail-oauth', 'microsoft-oauth'):
+        # OAuth tokens stored in login/password fields
+        config.oauth_access_token = login
+        config.oauth_refresh_token = password
+
+        # OAuth configuration from custom fields
+        config.oauth_client_id = provider_data.get('oauth_client_id')
+        config.oauth_client_secret = provider_data.get('oauth_client_secret')
+        config.oauth_token_expiry = provider_data.get('oauth_token_expiry')
+
+        if provider == 'microsoft-oauth':
+            config.oauth_tenant_id = provider_data.get('oauth_tenant_id', 'common')
+
+    return config
+
+
+def create_email_config_record(params: KeeperParams, config: EmailConfig, folder_uid: Optional[str] = None) -> str:
+    """
+    Create a Keeper record to store email configuration.
+
+    Uses login record type with custom fields to store provider configuration.
+
+    Args:
+        params: KeeperParams session
+        config: EmailConfig to store
+        folder_uid: Optional folder UID
+
+    Returns:
+        Record UID of created record
+    """
+    # Create typed record
+    record_uid = utils.generate_uid()
+    record_key = utils.generate_aes_key()
+
+    # Build record data
+    fields = []
+    custom_fields = []
+
+    # Add marker field to identify this as an email config
+    custom_fields.append({
+        'type': 'text',
+        'label': '__email_config__',
+        'value': ['true']
+    })
+
+    # Provider-specific fields
+    custom_fields.append({'type': 'text', 'label': 'provider', 'value': [config.provider]})
+    custom_fields.append({'type': 'text', 'label': 'from_address', 'value': [config.from_address]})
+    custom_fields.append({'type': 'text', 'label': 'from_name', 'value': [config.from_name]})
+
+    if config.provider == 'smtp':
+        # Use login/password fields for SMTP credentials
+        fields.append({'type': 'login', 'value': [config.smtp_username or '']})
+        fields.append({'type': 'password', 'value': [config.smtp_password or '']})
+
+        # Additional SMTP config in custom fields
+        custom_fields.append({'type': 'text', 'label': 'smtp_host', 'value': [config.smtp_host or '']})
+        custom_fields.append({'type': 'text', 'label': 'smtp_port', 'value': [str(config.smtp_port)]})
+        custom_fields.append({'type': 'text', 'label': 'smtp_use_tls', 'value': [str(config.smtp_use_tls).lower()]})
+        custom_fields.append({'type': 'text', 'label': 'smtp_use_ssl', 'value': [str(config.smtp_use_ssl).lower()]})
+
+    elif config.provider == 'ses':
+        # Use login/password for AWS credentials
+        fields.append({'type': 'login', 'value': [config.aws_access_key or '']})
+        fields.append({'type': 'password', 'value': [config.aws_secret_key or '']})
+
+        custom_fields.append({'type': 'text', 'label': 'aws_region', 'value': [config.aws_region or '']})
+
+    elif config.provider == 'sendgrid':
+        # Use password field for API key
+        fields.append({'type': 'password', 'value': [config.sendgrid_api_key or '']})
+
+    elif config.provider in ('gmail-oauth', 'microsoft-oauth'):
+        # Store OAuth tokens in password fields (encrypted)
+        fields.append({'type': 'login', 'value': [config.oauth_access_token or '']})
+        fields.append({'type': 'password', 'value': [config.oauth_refresh_token or '']})
+
+        # OAuth configuration in custom fields
+        custom_fields.append({'type': 'text', 'label': 'oauth_client_id', 'value': [config.oauth_client_id or '']})
+        custom_fields.append({'type': 'text', 'label': 'oauth_client_secret', 'value': [config.oauth_client_secret or '']})
+
+        if config.oauth_token_expiry:
+            custom_fields.append({'type': 'text', 'label': 'oauth_token_expiry', 'value': [config.oauth_token_expiry]})
+
+        if config.provider == 'microsoft-oauth' and config.oauth_tenant_id:
+            custom_fields.append({'type': 'text', 'label': 'oauth_tenant_id', 'value': [config.oauth_tenant_id]})
+
+    # Build record JSON
+    record_data = {
+        'title': config.name,
+        'type': 'login',
+        'fields': fields,
+        'custom': custom_fields
+    }
+
+    # Create TypedRecord
+    record = vault.TypedRecord()
+    record.record_uid = record_uid
+    record.record_key = record_key
+
+    # Load record data (this populates type_name, title, fields, custom)
+    record.load_record_data(record_data)
+
+    # Add to vault
+    record_management.add_record_to_folder(params, record, folder_uid)
+
+    logging.info(f'[EMAIL-CONFIG] Created email configuration record: {config.name} ({record_uid})')
+
+    return record_uid
+
+
+def update_oauth_tokens_in_record(params: KeeperParams, record_uid: str,
+                                   access_token: str, refresh_token: str,
+                                   token_expiry: str) -> None:
+    """
+    Update OAuth tokens in email config record after automatic refresh.
+
+    This function is called by OAuth email providers (GmailOAuthProvider,
+    MicrosoftOAuthProvider) after they automatically refresh expired tokens.
+    It updates the Keeper record to persist the new tokens.
+
+    Args:
+        params: Keeper session parameters
+        record_uid: UID of the email config record to update
+        access_token: New OAuth access token
+        refresh_token: New OAuth refresh token (may be same as old)
+        token_expiry: New token expiry in ISO 8601 format
+
+    Raises:
+        CommandError: If record not found or update fails
+    """
+    # Load the record
+    if record_uid not in params.record_cache:
+        params.sync_data = True
+        api.sync_down(params)
+
+    if record_uid not in params.record_cache:
+        raise CommandError('email-config', f'Email configuration record not found: {record_uid}')
+
+    # Load as TypedRecord
+    record = vault.KeeperRecord.load(params, record_uid)
+    if not isinstance(record, vault.TypedRecord):
+        raise CommandError('email-config', f'Record is not a TypedRecord: {record_uid}')
+
+    # Update token fields (login = access_token, password = refresh_token)
+    for field in record.fields:
+        if field.type == 'login':
+            field.value = [access_token]
+        elif field.type == 'password':
+            field.value = [refresh_token]
+
+    # Update token expiry in custom fields
+    expiry_field_found = False
+    for field in record.custom:
+        if field.label == 'oauth_token_expiry':
+            field.value = [token_expiry]
+            expiry_field_found = True
+            break
+
+    # Add expiry field if it doesn't exist
+    if not expiry_field_found:
+        record.custom.append(vault.TypedField.new_field('text', token_expiry, 'oauth_token_expiry'))
+
+    # Update the record
+    record_management.update_record(params, record)
+
+    # Sync changes
+    params.sync_data = True
+    api.sync_down(params)
+
+    logging.debug(f'[EMAIL-CONFIG] Updated OAuth tokens for record: {record_uid}')
+
+
+# =============================================================================
+# Command Classes
+# =============================================================================
+
+class EmailConfigCreateCommand(Command):
+    """Create a new email configuration."""
+
+    def get_parser(self):
+        return email_config_create_parser
+
+    def execute(self, params: KeeperParams, **kwargs):
+        """Execute email-config create command."""
+        name = kwargs.get('name')
+        provider = kwargs.get('provider')
+
+        # Check if config with this name already exists
+        existing_uid = find_email_config_record(params, name)
+        if existing_uid:
+            raise CommandError('email-config', f'Email configuration "{name}" already exists')
+
+        # Check provider compatibility and warn if dependencies unavailable
+        dependencies_available, warning_message = check_provider_dependencies(provider)
+        if not dependencies_available:
+            installation_method = get_installation_method()
+            print(f"\n[WARNING] {warning_message}")
+            if provider in ('gmail-oauth', 'microsoft-oauth') and installation_method == 'binary':
+                print("[WARNING] OAuth interactive flow is not available on binary installation.")
+                print("[WARNING] You must provide tokens manually using --oauth-access-token, --oauth-refresh-token, and --oauth-token-expiry.")
+            print("[WARNING] Configuration will be created but cannot be used until dependencies are available.\n")
+
+        # Build EmailConfig from arguments
+        config = EmailConfig(
+            record_uid='',  # Will be generated
+            name=name,
+            provider=provider,
+            from_address=kwargs.get('from_address'),
+            from_name=kwargs.get('from_name', 'Keeper Commander')
+        )
+
+        # Provider-specific configuration
+        if provider == 'smtp':
+            config.smtp_host = kwargs.get('smtp_host')
+            config.smtp_port = kwargs.get('smtp_port', 587)
+            config.smtp_username = kwargs.get('smtp_username')
+            config.smtp_password = kwargs.get('smtp_password')
+            config.smtp_use_tls = kwargs.get('smtp_use_tls', True)
+            config.smtp_use_ssl = kwargs.get('smtp_use_ssl', False)
+
+        elif provider == 'ses':
+            config.aws_region = kwargs.get('aws_region')
+            config.aws_access_key = kwargs.get('aws_access_key')
+            config.aws_secret_key = kwargs.get('aws_secret_key')
+
+        elif provider == 'sendgrid':
+            config.sendgrid_api_key = kwargs.get('sendgrid_api_key')
+
+        elif provider in ('gmail-oauth', 'microsoft-oauth'):
+            config.oauth_client_id = kwargs.get('oauth_client_id')
+            config.oauth_client_secret = kwargs.get('oauth_client_secret')
+
+            # Microsoft requires tenant ID
+            if provider == 'microsoft-oauth':
+                config.oauth_tenant_id = kwargs.get('oauth_tenant_id', 'common')
+
+            # Check if manual tokens provided
+            if kwargs.get('oauth_access_token'):
+                # Manual token entry
+                config.oauth_access_token = kwargs.get('oauth_access_token')
+                config.oauth_refresh_token = kwargs.get('oauth_refresh_token')
+                config.oauth_token_expiry = kwargs.get('oauth_token_expiry')
+                logging.info(f'[EMAIL-CONFIG] Using manually provided OAuth tokens')
+            else:
+                # Interactive OAuth flow
+                # Block OAuth flow on binary installation
+                installation_method = get_installation_method()
+                if installation_method == 'binary':
+                    raise CommandError(
+                        'email-config',
+                        f'Interactive OAuth flow is not available on binary installation.\n'
+                        f'\n'
+                        f'To use OAuth providers, you must switch to the PyPI version:\n'
+                        f'  1. Uninstall the binary version\n'
+                        f'  2. Install via pip with email dependencies:\n'
+                        f'     pip install keepercommander[email]\n'
+                        f'\n'
+                        f'Alternatively, if you must use the binary, provide OAuth tokens manually:\n'
+                        f'  --oauth-access-token <token>\n'
+                        f'  --oauth-refresh-token <token>\n'
+                        f'  --oauth-token-expiry <ISO-8601-datetime>'
+                    )
+
+                from ..oauth_helpers import GoogleOAuthFlow, MicrosoftOAuthFlow, perform_interactive_oauth
+
+                logging.info(f'[EMAIL-CONFIG] Starting interactive OAuth flow for {provider}')
+                print(f"\n[EMAIL-CONFIG] Authenticating with {provider}...")
+                print(f"[EMAIL-CONFIG] You'll need to authorize in your browser.\n")
+
+                # Create OAuth flow handler
+                if provider == 'gmail-oauth':
+                    flow = GoogleOAuthFlow(
+                        client_id=config.oauth_client_id,
+                        client_secret=config.oauth_client_secret
+                    )
+                else:  # microsoft-oauth
+                    flow = MicrosoftOAuthFlow(
+                        client_id=config.oauth_client_id,
+                        client_secret=config.oauth_client_secret,
+                        tenant_id=config.oauth_tenant_id
+                    )
+
+                # Perform interactive OAuth
+                try:
+                    port = kwargs.get('oauth_port', 8080)
+                    tokens = perform_interactive_oauth(flow, port=port)
+
+                    config.oauth_access_token = tokens['access_token']
+                    config.oauth_refresh_token = tokens['refresh_token']
+                    config.oauth_token_expiry = tokens['expiry']
+
+                    logging.info(f'[EMAIL-CONFIG] OAuth authentication successful')
+                except Exception as e:
+                    raise CommandError('email-config', f'OAuth authentication failed: {e}')
+
+        # Validate configuration
+        errors = config.validate()
+        if errors:
+            raise CommandError('email-config', f'Invalid configuration: {", ".join(errors)}')
+
+        # Resolve folder
+        folder_uid = None
+        folder_name = kwargs.get('folder')
+        if folder_name:
+            if folder_name in params.folder_cache:
+                folder_uid = folder_name
+            else:
+                # Try to resolve folder path
+                from ..subfolder import try_resolve_path
+                rs = try_resolve_path(params, folder_name)
+                if rs is not None:
+                    folder, _ = rs
+                    folder_uid = folder.uid
+                else:
+                    raise CommandError('email-config', f'Folder "{folder_name}" not found')
+
+        # Create record
+        record_uid = create_email_config_record(params, config, folder_uid)
+
+        # Sync with server
+        api.sync_down(params)
+
+        logging.info(f'Email configuration "{name}" created successfully (UID: {record_uid})')
+        return f'Email configuration "{name}" created successfully'
+
+
+class EmailConfigListCommand(Command):
+    """List all email configurations."""
+
+    def get_parser(self):
+        return email_config_list_parser
+
+    def execute(self, params: KeeperParams, **kwargs):
+        """Execute email-config list command."""
+        configs = []
+
+        # Find all email config records
+        for record_uid in params.record_cache:
+            try:
+                record = vault.KeeperRecord.load(params, record_uid)
+                if not isinstance(record, vault.TypedRecord):
+                    continue
+                if record.record_type != 'login':
+                    continue
+
+                # Check if this is an email config
+                record_dict = vault_extensions.extract_typed_record_data(record)
+                custom_fields = record_dict.get('custom', [])
+
+                is_email_config = False
+                provider = None
+                from_address = None
+
+                for field in custom_fields:
+                    if field.get('label') == '__email_config__':
+                        is_email_config = True
+                    elif field.get('label') == 'provider':
+                        values = field.get('value', [])
+                        if values:
+                            provider = values[0]
+                    elif field.get('label') == 'from_address':
+                        values = field.get('value', [])
+                        if values:
+                            from_address = values[0]
+
+                if is_email_config:
+                    configs.append({
+                        'name': record.title,
+                        'record_uid': record_uid,
+                        'provider': provider or 'unknown',
+                        'from_address': from_address or ''
+                    })
+            except Exception as e:
+                logging.debug(f'Error loading record {record_uid}: {e}')
+                continue
+
+        if not configs:
+            logging.info('No email configurations found')
+            return
+
+        # Display results
+        output_format = kwargs.get('format', 'table')
+
+        if output_format == 'json':
+            print(json.dumps(configs, indent=2))
+        else:
+            headers = ['Name', 'Provider', 'From Address', 'Record UID']
+            table = [
+                [c['name'], c['provider'], c['from_address'], c['record_uid']]
+                for c in configs
+            ]
+            dump_report_data(table, headers, fmt=output_format)
+
+
+class EmailConfigTestCommand(Command):
+    """Test email configuration connection."""
+
+    def get_parser(self):
+        return email_config_test_parser
+
+    def execute(self, params: KeeperParams, **kwargs):
+        """Execute email-config test command."""
+        name = kwargs.get('name')
+        to_address = kwargs.get('to')
+
+        # Find config
+        record_uid = find_email_config_record(params, name)
+        if not record_uid:
+            raise CommandError('email-config', f'Email configuration "{name}" not found')
+
+        # Load config
+        config = load_email_config_from_record(params, record_uid)
+
+        # Check provider dependencies before testing
+        dependencies_available, error_message = check_provider_dependencies(config.provider)
+        if not dependencies_available:
+            raise CommandError('email-config', error_message)
+
+        # Create sender
+        try:
+            sender = EmailSender(config)
+        except Exception as e:
+            raise CommandError('email-config', f'Failed to initialize email sender: {e}')
+
+        # Test connection
+        logging.info(f'Testing connection for "{name}" ({config.provider})...')
+
+        try:
+            success = sender.test_connection()
+            if success:
+                logging.info(f'✓ Connection test successful for "{name}"')
+
+                # Send test email if address provided
+                if to_address:
+                    logging.info(f'Sending test email to {to_address}...')
+                    subject = 'Keeper Commander Email Test'
+                    body = f'This is a test email from Keeper Commander.\n\nEmail Configuration: {name}\nProvider: {config.provider}'
+
+                    sender.send(to_address, subject, body, html=False)
+                    logging.info(f'✓ Test email sent successfully to {to_address}')
+
+                # Persist OAuth tokens if they were refreshed
+                if config.is_oauth_provider() and config._oauth_tokens_updated:
+                    logging.debug(f'[EMAIL-CONFIG] Persisting refreshed OAuth tokens for "{name}"')
+                    update_oauth_tokens_in_record(
+                        params,
+                        record_uid,
+                        config.oauth_access_token,
+                        config.oauth_refresh_token,
+                        config.oauth_token_expiry
+                    )
+
+                if to_address:
+                    return f'Connection test passed. Test email sent to {to_address}'
+                else:
+                    return f'Connection test passed for "{name}"'
+            else:
+                raise CommandError('email-config', f'Connection test failed for "{name}"')
+        except Exception as e:
+            raise CommandError('email-config', f'Connection test failed: {e}')
+
+
+class EmailConfigDeleteCommand(Command):
+    """Delete an email configuration."""
+
+    def get_parser(self):
+        return email_config_delete_parser
+
+    def execute(self, params: KeeperParams, **kwargs):
+        """Execute email-config delete command."""
+        name = kwargs.get('name')
+        force = kwargs.get('force', False)
+
+        # Find config
+        record_uid = find_email_config_record(params, name)
+        if not record_uid:
+            raise CommandError('email-config', f'Email configuration "{name}" not found')
+
+        # Confirm deletion
+        if not force:
+            from ..commands.base import user_choice
+            answer = user_choice(f'Delete email configuration "{name}"?', 'yn', 'n')
+            if answer.lower() != 'y':
+                logging.info('Delete cancelled')
+                return
+
+        # Delete record
+        from .record import RecordRemoveCommand
+        remove_cmd = RecordRemoveCommand()
+        remove_cmd.execute(params, record=record_uid, force=True)
+
+        # Sync cache to reflect deletion
+        from .. import api
+        api.sync_down(params)
+
+        logging.info(f'Email configuration "{name}" deleted successfully')
+        return f'Email configuration "{name}" deleted'
+
+
+class EmailConfigCommand(GroupCommand):
+    """Email configuration management commands."""
+
+    def __init__(self):
+        super(EmailConfigCommand, self).__init__()
+        self.register_command('create', EmailConfigCreateCommand(),
+                            'Create a new email configuration')
+        self.register_command('list', EmailConfigListCommand(),
+                            'List all email configurations')
+        self.register_command('test', EmailConfigTestCommand(),
+                            'Test email configuration connection')
+        self.register_command('delete', EmailConfigDeleteCommand(),
+                            'Delete an email configuration')
+        self.default_verb = 'list'

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -47,6 +47,14 @@ record_add_parser.add_argument('--folder', dest='folder', action='store',
 record_add_parser.add_argument('--self-destruct', dest='self_destruct', action='store',
                                metavar='<NUMBER>[(m)inutes|(h)ours|(d)ays]',
                                help='Time period record share URL is valid. The record will be deleted in your vault in 5 minutes since open')
+record_add_parser.add_argument('--pam-config', dest='pam_config', action='store',
+                               help='PAM configuration UID or name to sync password to cloud provider (Azure AD, AWS IAM)')
+record_add_parser.add_argument('--send-email', dest='send_email', action='store',
+                               help='Email address to send onboarding email with share URL (requires --self-destruct)')
+record_add_parser.add_argument('--email-config', dest='email_config', action='store',
+                               help='Email configuration name to use for sending (required with --send-email)')
+record_add_parser.add_argument('--email-message', dest='email_message', action='store',
+                               help='Custom message to include in onboarding email')
 record_add_parser.add_argument('fields', nargs='*', type=str,
                                help='load record type data from strings with dot notation')
 
@@ -727,12 +735,50 @@ class RecordAddCommand(Command, RecordEditMixin):
             print(record_fields_description)
             return
 
+        # Validate email parameters
+        send_email = kwargs.get('send_email')
+        if send_email:
+            if not kwargs.get('email_config'):
+                raise CommandError('record-add', '--send-email requires --email-config to specify email configuration')
+
+            # Validate email provider dependencies early (before creating record)
+            try:
+                from .email_commands import find_email_config_record, load_email_config_from_record
+                from ..email_service import validate_email_provider_dependencies
+
+                email_config_name = kwargs.get('email_config')
+                config_uid = find_email_config_record(params, email_config_name)
+                email_config_obj = load_email_config_from_record(params, config_uid)
+
+                # Check if required dependencies are installed for this provider
+                is_valid, error_message = validate_email_provider_dependencies(email_config_obj.provider)
+
+                if not is_valid:
+                    raise CommandError('record-add', f'\n{error_message}')
+
+            except Exception as e:
+                # Re-raise CommandError as-is, wrap other exceptions
+                if isinstance(e, CommandError):
+                    raise
+                raise CommandError('record-add', f'Failed to validate email configuration: {e}')
+
+        # Handle share link creation
+        # If --send-email is used without --self-destruct, create a 24h time-based expiration (not self-destruct)
         expiration_period = None
         self_destruct = kwargs.get('self_destruct')
+        is_self_destruct_link = False  # Track whether to enable self-destruct on first use
+
         if self_destruct:
             expiration_period = parse_timeout(self_destruct)
             if expiration_period.total_seconds() > 182 * 24 * 60 * 60:
                 raise CommandError('', 'URL expiration period cannot be greater than 6 months.')
+            is_self_destruct_link = True  # User explicitly requested self-destruct
+        elif send_email:
+            # Auto-create share link with 24-hour time-based expiration (without self-destruct)
+            expiration_period = parse_timeout('24h')
+            self_destruct = '24h'  # For email template text
+            is_self_destruct_link = False  # Time-based only, can be used multiple times
+            logging.info('--send-email used without --self-destruct, creating 24 hour time-based share link')
 
         folder_uid = FolderMixin.resolve_folder(params, kwargs.get('folder'))
 
@@ -809,6 +855,17 @@ class RecordAddCommand(Command, RecordEditMixin):
         record_management.add_record_to_folder(params, record, folder_uid)
         params.sync_data = True
         params.environment_variables[LAST_RECORD_UID] = record.record_uid
+
+        # PAM password sync (best-effort, Decision 4)
+        pam_config_name = kwargs.get('pam_config')
+        if pam_config_name:
+            try:
+                self._sync_password_to_pam(params, record, pam_config_name)
+            except Exception as e:
+                logging.warning(f'[PAM] Failed to sync password to cloud provider: {e}')
+                # Best-effort: continue with record creation
+
+        share_url = None
         if expiration_period is not None:
             record_uid = record.record_uid
             record_key = record.record_key
@@ -819,17 +876,269 @@ class RecordAddCommand(Command, RecordEditMixin):
             rq.encryptedRecordKey = crypto.encrypt_aes_v2(record_key, client_key)
             rq.clientId = client_id
             rq.accessExpireOn = utils.current_milli_time() + int(expiration_period.total_seconds() * 1000)
-            rq.isSelfDestruct = True
+            rq.isSelfDestruct = is_self_destruct_link
             api.communicate_rest(params, rq, 'vault/external_share_add', rs_type=APIRequest_pb2.Device)
             # Extract hostname from params.server in case it contains full URL with protocol
             from urllib.parse import urlparse
             parsed = urlparse(params.server)
             server_netloc = parsed.netloc if parsed.netloc else parsed.path  # parsed.path for plain hostname
-            url = urlunparse(('https', server_netloc, '/vault/share', None, None, utils.base64_url_encode(client_key)))
-            return url
+            share_url = urlunparse(('https', server_netloc, '/vault/share', None, None, utils.base64_url_encode(client_key)))
+
+        # Send onboarding email (best-effort, Decision 4)
+        if send_email and share_url:
+            try:
+                self._send_onboarding_email(
+                    params=params,
+                    email_config_name=kwargs.get('email_config'),
+                    to_address=send_email,
+                    share_url=share_url,
+                    record_title=record.title,
+                    custom_message=kwargs.get('email_message', ''),
+                    expiration=self_destruct
+                )
+            except Exception as e:
+                logging.warning(f'[EMAIL] Failed to send onboarding email: {e}')
+                # Best-effort: continue and return share URL
+
+        if share_url:
+            return share_url
         else:
             BreachWatch.scan_and_update_security_data(params, record.record_uid, params.breach_watch)
             return record.record_uid
+
+    def _sync_password_to_pam(self, params: KeeperParams, record: vault.TypedRecord, pam_config_name: str):
+        """
+        Sync password to cloud provider using PAM configuration.
+
+        Args:
+            params: KeeperParams session
+            record: TypedRecord containing credentials
+            pam_config_name: PAM configuration UID or name
+
+        Raises:
+            CommandError: If PAM sync fails
+        """
+        logging.info(f'[PAM] Syncing password to cloud provider using config: {pam_config_name}')
+
+        # Find PAM configuration record
+        pam_config_uid = None
+        if pam_config_name in params.record_cache:
+            pam_config_uid = pam_config_name
+        else:
+            # Search by name
+            for record_uid in params.record_cache:
+                rec = vault.KeeperRecord.load(params, record_uid)
+                if isinstance(rec, vault.TypedRecord) and rec.title == pam_config_name:
+                    # Check if this is a PAM config (look for pamConfig record type)
+                    if rec.record_type in ('pamAwsConfiguration', 'pamAzureConfiguration'):
+                        pam_config_uid = record_uid
+                        break
+
+        if not pam_config_uid:
+            raise CommandError('record-add', f'PAM configuration "{pam_config_name}" not found')
+
+        # Extract username and password from record
+        username = None
+        password = None
+
+        for field in record.fields:
+            if field.type == 'login' and field.value:
+                username = field.value[0] if isinstance(field.value, list) else field.value
+            elif field.type == 'password' and field.value:
+                password = field.value[0] if isinstance(field.value, list) else field.value
+
+        if not username or not password:
+            raise CommandError('record-add', 'Record must have login and password fields for PAM sync')
+
+        # Load PAM configuration
+        pam_record = vault.KeeperRecord.load(params, pam_config_uid)
+        if not isinstance(pam_record, vault.TypedRecord):
+            raise CommandError('record-add', f'PAM configuration record {pam_config_uid} is not a typed record')
+
+        # Determine PAM plugin based on record type
+        plugin_name = None
+        if pam_record.record_type == 'pamAzureConfiguration':
+            plugin_name = 'azureadpwd'
+        elif pam_record.record_type == 'pamAwsConfiguration':
+            plugin_name = 'awspswd'
+        else:
+            raise CommandError('record-add', f'Unsupported PAM configuration type: {pam_record.record_type}')
+
+        # Invoke PAM plugin to set password
+        try:
+            logging.info(f'[PAM] Calling {plugin_name} plugin to set password for user: {username}')
+
+            if plugin_name == 'azureadpwd':
+                # Import Azure AD plugin
+                from ...plugins.azureadpwd import azureadpwd
+
+                # Call the rotate function with PAM config record
+                success = azureadpwd.rotate(pam_record, password)
+
+                if not success:
+                    raise CommandError('record-add', 'Azure AD password rotation failed')
+
+                logging.info(f'[PAM] Successfully synced password to Azure AD for user: {username}')
+
+            elif plugin_name == 'awspswd':
+                # Import AWS plugin and common rotator
+                from ...plugins.awspswd import aws_passwd
+
+                # Extract AWS credentials from PAM config
+                aws_access_key = None
+                aws_secret_key = None
+                aws_profile = None
+                aws_assume_role = None
+
+                for field in pam_record.fields:
+                    if field.type == 'login' and field.value:
+                        aws_access_key = field.value[0] if isinstance(field.value, list) else field.value
+                    elif field.type == 'password' and field.value:
+                        aws_secret_key = field.value[0] if isinstance(field.value, list) else field.value
+
+                # Check custom fields for profile and assume role
+                for field in pam_record.custom:
+                    if field.label == 'cmdr:aws_profile' and field.value:
+                        aws_profile = field.value[0] if isinstance(field.value, list) else field.value
+                    elif field.label == 'cmdr:aws_assume_role' and field.value:
+                        aws_assume_role = field.value[0] if isinstance(field.value, list) else field.value
+
+                # Create rotator instance
+                rotator = aws_passwd.Rotator(
+                    login=username,
+                    password=password,
+                    aws_profile=aws_profile,
+                    aws_assume_role=aws_assume_role
+                )
+
+                # Set AWS credentials in environment or use profile
+                if aws_access_key and aws_secret_key:
+                    import os
+                    original_access_key = os.environ.get('AWS_ACCESS_KEY_ID')
+                    original_secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+
+                    try:
+                        os.environ['AWS_ACCESS_KEY_ID'] = aws_access_key
+                        os.environ['AWS_SECRET_ACCESS_KEY'] = aws_secret_key
+
+                        # Rotate password
+                        success = rotator.rotate(pam_record, password)
+                    finally:
+                        # Restore original environment
+                        if original_access_key:
+                            os.environ['AWS_ACCESS_KEY_ID'] = original_access_key
+                        else:
+                            os.environ.pop('AWS_ACCESS_KEY_ID', None)
+                        if original_secret_key:
+                            os.environ['AWS_SECRET_ACCESS_KEY'] = original_secret_key
+                        else:
+                            os.environ.pop('AWS_SECRET_ACCESS_KEY', None)
+                else:
+                    # Use AWS profile
+                    success = rotator.rotate(pam_record, password)
+
+                if not success:
+                    raise CommandError('record-add', 'AWS IAM password rotation failed')
+
+                logging.info(f'[PAM] Successfully synced password to AWS IAM for user: {username}')
+
+            else:
+                raise CommandError('record-add', f'Unknown PAM plugin: {plugin_name}')
+
+        except ImportError as e:
+            raise CommandError('record-add', f'PAM plugin "{plugin_name}" dependencies not installed: {e}')
+        except Exception as e:
+            raise CommandError('record-add', f'PAM password sync failed: {e}')
+
+    def _send_onboarding_email(
+        self,
+        params: KeeperParams,
+        email_config_name: str,
+        to_address: str,
+        share_url: str,
+        record_title: str,
+        custom_message: str,
+        expiration: str
+    ):
+        """
+        Send onboarding email with one-time share URL.
+
+        Args:
+            params: KeeperParams session
+            email_config_name: Email configuration name
+            to_address: Recipient email address
+            share_url: One-time share URL
+            record_title: Title of the record
+            custom_message: Custom message from administrator
+            expiration: Expiration period string (e.g., "24h", "1d")
+
+        Raises:
+            CommandError: If email sending fails
+        """
+        logging.info(f'[EMAIL] Sending onboarding email to {to_address}')
+
+        # Load email configuration
+        from .email_commands import find_email_config_record, load_email_config_from_record
+        from ..email_service import EmailSender, build_onboarding_email
+        from .helpers.timeout import parse_timeout
+
+        config_uid = find_email_config_record(params, email_config_name)
+        if not config_uid:
+            raise CommandError('record-add', f'Email configuration "{email_config_name}" not found')
+
+        email_config = load_email_config_from_record(params, config_uid)
+
+        # Build email - convert expiration to human-readable format
+        expiration_text = '24 hours'  # default
+        if expiration:
+            try:
+                expiration_period = parse_timeout(expiration)
+                expire_seconds = int(expiration_period.total_seconds())
+
+                # Convert to human-readable format
+                if expire_seconds >= 86400:  # days
+                    days = expire_seconds // 86400
+                    expiration_text = f"{days} day{'s' if days > 1 else ''}"
+                elif expire_seconds >= 3600:  # hours
+                    hours = expire_seconds // 3600
+                    expiration_text = f"{hours} hour{'s' if hours > 1 else ''}"
+                else:  # minutes
+                    minutes = expire_seconds // 60
+                    expiration_text = f"{minutes} minute{'s' if minutes > 1 else ''}"
+            except:
+                expiration_text = expiration  # fallback to original if parsing fails
+
+        html_body = build_onboarding_email(
+            share_url=share_url,
+            custom_message=custom_message or 'Your administrator has shared account credentials with you.',
+            record_title=record_title,
+            expiration=expiration_text
+        )
+
+        # Send email
+        sender = EmailSender(email_config)
+        subject = f'Keeper Security: Credentials for {record_title}'
+
+        sender.send(
+            to=to_address,
+            subject=subject,
+            body=html_body,
+            html=True
+        )
+
+        # Persist OAuth tokens if they were refreshed
+        if email_config.is_oauth_provider() and email_config._oauth_tokens_updated:
+            from .email_commands import update_oauth_tokens_in_record
+            logging.debug(f'[EMAIL] Persisting refreshed OAuth tokens for "{email_config_name}"')
+            update_oauth_tokens_in_record(
+                params,
+                config_uid,
+                email_config.oauth_access_token,
+                email_config.oauth_refresh_token,
+                email_config.oauth_token_expiry
+            )
+
+        logging.info(f'[EMAIL] Onboarding email sent successfully to {to_address}')
 
 
 class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):

--- a/keepercommander/email_service.py
+++ b/keepercommander/email_service.py
@@ -1,0 +1,1207 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Contact: ops@keepersecurity.com
+#
+
+"""
+Email Service Module for Keeper Commander
+
+Provides email sending capabilities for automated onboarding and credential sharing.
+Supports multiple email providers: SMTP, AWS SES, SendGrid.
+
+Zero-knowledge architecture preserved - emails sent client-side with customer's
+email infrastructure.
+"""
+
+from __future__ import annotations
+import logging
+import os
+import smtplib
+import ssl
+import sys
+import keepercommander
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from typing import Optional, Dict, Any, List
+
+
+
+def get_installation_method():
+    """
+    Detect Keeper Commander installation method.
+
+    Returns:
+        str: 'binary' (PyInstaller frozen), 'pip' (installed via pip), or 'source' (development)
+    """
+
+    # Check if running as PyInstaller binary
+    if getattr(sys, 'frozen', False):
+        return 'binary'
+
+    # Check if installed via pip
+    location = keepercommander.__file__
+
+    if 'site-packages' in location or 'dist-packages' in location:
+        return 'pip'
+
+    # Running from source
+    return 'source'
+
+
+def check_provider_dependencies(provider: str) -> tuple:
+    """
+    Check if dependencies for a provider are available.
+
+    Args:
+        provider: Provider name (smtp, ses, sendgrid, gmail-oauth, microsoft-oauth)
+
+    Returns:
+        tuple: (dependencies_available: bool, error_message: str)
+    """
+    if provider == 'smtp':
+        # SMTP uses standard library, always works
+        return (True, '')
+
+    installation_method = get_installation_method()
+
+    # Binary installations only support SMTP
+    if installation_method == 'binary':
+        return (
+            False,
+            f'{provider} is not available in the binary installation.\n'
+            f'\n'
+            f'To use this provider, you must switch to the PyPI version:\n'
+            f'  1. Uninstall the binary version\n'
+            f'  2. Install via pip with email dependencies:\n'
+            f'     pip install keepercommander[email]\n'
+            f'\n'
+            f'The binary version only supports SMTP for email functionality.'
+        )
+
+    # Check for required packages on pip/source installations
+    if provider == 'ses':
+        try:
+            import boto3
+            return (True, '')
+        except ImportError:
+            return (
+                False,
+                'AWS SES requires additional dependencies.\n'
+                'Install with:\n'
+                '  pip install keepercommander[email-ses]\n'
+                '  # or install all email providers:\n'
+                '  pip install keepercommander[email]'
+            )
+
+    elif provider == 'sendgrid':
+        try:
+            import sendgrid
+            return (True, '')
+        except ImportError:
+            return (
+                False,
+                'SendGrid requires additional dependencies.\n'
+                'Install with:\n'
+                '  pip install keepercommander[email-sendgrid]\n'
+                '  # or install all email providers:\n'
+                '  pip install keepercommander[email]'
+            )
+
+    elif provider == 'gmail-oauth':
+        try:
+            import google.auth
+            import googleapiclient
+            return (True, '')
+        except ImportError:
+            return (
+                False,
+                'Gmail OAuth requires additional dependencies.\n'
+                'Install with:\n'
+                '  pip install keepercommander[email-gmail-oauth]\n'
+                '  # or install all email providers:\n'
+                '  pip install keepercommander[email]'
+            )
+
+    elif provider == 'microsoft-oauth':
+        try:
+            import msal
+            return (True, '')
+        except ImportError:
+            return (
+                False,
+                'Microsoft OAuth requires additional dependencies.\n'
+                'Install with:\n'
+                '  pip install keepercommander[email-microsoft-oauth]\n'
+                '  # or install all email providers:\n'
+                '  pip install keepercommander[email]'
+            )
+
+    return (True, '')
+
+
+@dataclass
+class EmailConfig:
+    """
+    Email configuration for sending emails via various providers.
+
+    Stored as Keeper records (login type) with encrypted credentials.
+    See ADR Decision 1 in ONBOARDING_FEATURE_IMPLEMENTATION_PLAN.md
+
+    Supported providers:
+    - smtp: Standard SMTP with username/password
+    - ses: AWS Simple Email Service
+    - sendgrid: SendGrid API
+    - gmail-oauth: Gmail with OAuth 2.0 (uses Gmail API)
+    - microsoft-oauth: Microsoft 365/Outlook with OAuth 2.0 (uses Graph API)
+    """
+    record_uid: str
+    name: str
+    provider: str  # 'smtp', 'ses', 'sendgrid', 'gmail-oauth', 'microsoft-oauth'
+    from_address: str
+    from_name: str = "Keeper Commander"
+
+    # SMTP-specific
+    smtp_host: Optional[str] = None
+    smtp_port: int = 587
+    smtp_username: Optional[str] = None
+    smtp_password: Optional[str] = None
+    smtp_use_tls: bool = True
+    smtp_use_ssl: bool = False
+
+    # AWS SES-specific
+    aws_region: Optional[str] = None
+    aws_access_key: Optional[str] = None
+    aws_secret_key: Optional[str] = None
+
+    # SendGrid-specific
+    sendgrid_api_key: Optional[str] = None
+
+    # OAuth-specific (gmail-oauth, microsoft-oauth)
+    oauth_client_id: Optional[str] = None
+    oauth_client_secret: Optional[str] = None
+    oauth_access_token: Optional[str] = None
+    oauth_refresh_token: Optional[str] = None
+    oauth_token_expiry: Optional[str] = None  # ISO 8601 format
+    oauth_scopes: Optional[List[str]] = None
+    oauth_tenant_id: Optional[str] = None  # For Microsoft 365 (can be 'common', 'organizations', or specific tenant ID)
+
+    # Additional metadata
+    custom_fields: Dict[str, Any] = field(default_factory=dict)
+
+    # Internal flag to track OAuth token updates (not stored in Keeper)
+    _oauth_tokens_updated: bool = field(default=False, init=False)
+
+    def validate(self) -> List[str]:
+        """
+        Validate email configuration completeness.
+
+        Returns:
+            List of validation error messages (empty if valid)
+        """
+        errors = []
+
+        if not self.provider:
+            errors.append("Provider is required")
+
+        if not self.from_address:
+            errors.append("From address is required")
+
+        if self.provider == 'smtp':
+            if not self.smtp_host:
+                errors.append("SMTP host is required")
+            if not self.smtp_username:
+                errors.append("SMTP username is required")
+            if not self.smtp_password:
+                errors.append("SMTP password is required")
+
+        elif self.provider == 'ses':
+            if not self.aws_region:
+                errors.append("AWS region is required for SES")
+            if not self.aws_access_key:
+                errors.append("AWS access key is required for SES")
+            if not self.aws_secret_key:
+                errors.append("AWS secret key is required for SES")
+
+        elif self.provider == 'sendgrid':
+            if not self.sendgrid_api_key:
+                errors.append("SendGrid API key is required")
+
+        elif self.provider in ('gmail-oauth', 'microsoft-oauth'):
+            # OAuth providers require either interactive auth OR manual token entry
+            if not self.oauth_client_id:
+                errors.append(f"OAuth client ID is required for {self.provider}")
+            if not self.oauth_client_secret:
+                errors.append(f"OAuth client secret is required for {self.provider}")
+
+            # If no access token, we'll do interactive OAuth flow
+            # If access token provided, we should also have refresh token
+            if self.oauth_access_token and not self.oauth_refresh_token:
+                errors.append("OAuth refresh token is required when access token is provided")
+
+            # Microsoft requires tenant ID
+            if self.provider == 'microsoft-oauth' and not self.oauth_tenant_id:
+                errors.append("OAuth tenant ID is required for Microsoft (use 'common' for multi-tenant)")
+
+        else:
+            errors.append(f"Unknown provider: {self.provider}")
+
+        return errors
+
+    def is_oauth_provider(self) -> bool:
+        """Check if this config uses OAuth authentication."""
+        return self.provider in ('gmail-oauth', 'microsoft-oauth')
+
+    def tokens_need_refresh(self) -> bool:
+        """
+        Check if OAuth tokens need to be refreshed.
+
+        Returns:
+            True if tokens are expired or will expire soon (within 5 minutes)
+        """
+        if not self.is_oauth_provider():
+            return False
+
+        if not self.oauth_token_expiry:
+            # No expiry set, assume tokens are valid
+            return False
+
+        try:
+            from datetime import datetime, timedelta, timezone
+            expiry = datetime.fromisoformat(self.oauth_token_expiry.replace('Z', '+00:00'))
+            now = datetime.now(timezone.utc)
+            # Refresh if expired or expiring within 5 minutes
+            return expiry <= now + timedelta(minutes=5)
+        except Exception:
+            # If we can't parse the expiry, assume we need to refresh
+            return True
+
+
+class EmailProvider(ABC):
+    """
+    Abstract base class for email providers.
+
+    Each provider implements send() method for their specific API/protocol.
+    """
+
+    def __init__(self, config: EmailConfig):
+        self.config = config
+        validation_errors = config.validate()
+        if validation_errors:
+            raise ValueError(f"Invalid email configuration: {', '.join(validation_errors)}")
+
+    @abstractmethod
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via provider.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body (plain text or HTML)
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully, False otherwise
+
+        Raises:
+            Exception: If send fails with unrecoverable error
+        """
+        pass
+
+    @abstractmethod
+    def test_connection(self) -> bool:
+        """
+        Test connection to email provider.
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        pass
+
+
+class SMTPEmailProvider(EmailProvider):
+    """
+    SMTP email provider implementation.
+
+    Supports standard SMTP with TLS/SSL for Gmail, Office 365, and other SMTP servers.
+    """
+
+    def __init__(self, config: EmailConfig):
+        super().__init__(config)
+        self._connection = None
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via SMTP.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+
+        Raises:
+            smtplib.SMTPException: If SMTP operation fails
+        """
+        try:
+            # Create message
+            msg = MIMEMultipart('alternative')
+            msg['Subject'] = subject
+            msg['From'] = f"{self.config.from_name} <{self.config.from_address}>"
+            msg['To'] = to
+
+            # Attach body
+            if html:
+                part = MIMEText(body, 'html')
+            else:
+                part = MIMEText(body, 'plain')
+            msg.attach(part)
+
+            # Connect and send
+            if self.config.smtp_use_ssl:
+                # Use SMTP_SSL for port 465
+                context = ssl.create_default_context()
+                with smtplib.SMTP_SSL(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    context=context
+                ) as server:
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+                    server.send_message(msg)
+            else:
+                # Use SMTP with STARTTLS for port 587
+                with smtplib.SMTP(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    timeout=30
+                ) as server:
+                    server.ehlo()
+                    if self.config.smtp_use_tls:
+                        context = ssl.create_default_context()
+                        server.starttls(context=context)
+                        server.ehlo()
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+                    server.send_message(msg)
+
+            logging.info(f"[EMAIL] SMTP email sent to {to} via {self.config.smtp_host}")
+            return True
+
+        except smtplib.SMTPAuthenticationError as e:
+            logging.error(f"[EMAIL] SMTP authentication failed: {e}")
+            raise
+        except smtplib.SMTPException as e:
+            logging.error(f"[EMAIL] SMTP error: {e}")
+            raise
+        except Exception as e:
+            logging.error(f"[EMAIL] Unexpected error sending email: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test SMTP connection and authentication.
+
+        Returns:
+            True if connection successful
+        """
+        try:
+            if self.config.smtp_use_ssl:
+                context = ssl.create_default_context()
+                with smtplib.SMTP_SSL(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    context=context,
+                    timeout=10
+                ) as server:
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+            else:
+                with smtplib.SMTP(
+                    self.config.smtp_host,
+                    self.config.smtp_port,
+                    timeout=10
+                ) as server:
+                    server.ehlo()
+                    if self.config.smtp_use_tls:
+                        context = ssl.create_default_context()
+                        server.starttls(context=context)
+                        server.ehlo()
+                    server.login(self.config.smtp_username, self.config.smtp_password)
+
+            logging.info(f"[EMAIL] SMTP connection test successful: {self.config.smtp_host}")
+            return True
+
+        except Exception as e:
+            logging.error(f"[EMAIL] SMTP connection test failed: {e}")
+            return False
+
+
+class SendGridEmailProvider(EmailProvider):
+    """
+    SendGrid email provider implementation.
+
+    Uses SendGrid HTTP API for sending emails.
+    """
+
+    def __init__(self, config: EmailConfig):
+        super().__init__(config)
+        # Import here to avoid dependency if not using SendGrid
+        try:
+            from sendgrid import SendGridAPIClient
+            from sendgrid.helpers.mail import Mail
+            self.SendGridAPIClient = SendGridAPIClient
+            self.Mail = Mail
+        except ImportError:
+            _, error_message = check_provider_dependencies('sendgrid')
+            raise ImportError(error_message)
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via SendGrid API.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+        """
+        try:
+            message = self.Mail(
+                from_email=(self.config.from_address, self.config.from_name),
+                to_emails=to,
+                subject=subject,
+                html_content=body if html else None,
+                plain_text_content=body if not html else None
+            )
+
+            sg = self.SendGridAPIClient(self.config.sendgrid_api_key)
+            response = sg.send(message)
+
+            if response.status_code in (200, 201, 202):
+                logging.info(f"[EMAIL] SendGrid email sent to {to}")
+                return True
+            else:
+                logging.error(f"[EMAIL] SendGrid returned status {response.status_code}")
+                return False
+
+        except Exception as e:
+            logging.error(f"[EMAIL] SendGrid error: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test SendGrid API connection.
+
+        Returns:
+            True if API key is valid
+        """
+        try:
+            # SendGrid doesn't have a dedicated test endpoint
+            # We can verify the API key format and try to initialize the client
+            sg = self.SendGridAPIClient(self.config.sendgrid_api_key)
+
+            # If we get here without exception, API key format is valid
+            # Note: This doesn't guarantee the key is active, but it's the best we can do
+            logging.info("[EMAIL] SendGrid API client initialized successfully")
+            return True
+
+        except Exception as e:
+            logging.error(f"[EMAIL] SendGrid connection test failed: {e}")
+            return False
+
+
+class SESEmailProvider(EmailProvider):
+    """
+    AWS SES email provider implementation.
+
+    Uses boto3 to send emails via Amazon Simple Email Service.
+    """
+
+    def __init__(self, config: EmailConfig):
+        super().__init__(config)
+        # Import here to avoid dependency if not using SES
+        try:
+            import boto3
+            from botocore.exceptions import ClientError
+            self.boto3 = boto3
+            self.ClientError = ClientError
+        except ImportError:
+            _, error_message = check_provider_dependencies('ses')
+            raise ImportError(error_message)
+
+        # Initialize SES client
+        self.ses_client = self.boto3.client(
+            'ses',
+            region_name=self.config.aws_region,
+            aws_access_key_id=self.config.aws_access_key,
+            aws_secret_access_key=self.config.aws_secret_key
+        )
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via AWS SES.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+        """
+        try:
+            if html:
+                body_part = {'Html': {'Charset': 'UTF-8', 'Data': body}}
+            else:
+                body_part = {'Text': {'Charset': 'UTF-8', 'Data': body}}
+
+            response = self.ses_client.send_email(
+                Source=f"{self.config.from_name} <{self.config.from_address}>",
+                Destination={'ToAddresses': [to]},
+                Message={
+                    'Subject': {'Charset': 'UTF-8', 'Data': subject},
+                    'Body': body_part
+                }
+            )
+
+            message_id = response.get('MessageId')
+            logging.info(f"[EMAIL] SES email sent to {to}, MessageId: {message_id}")
+            return True
+
+        except self.ClientError as e:
+            error_code = e.response['Error']['Code']
+            error_message = e.response['Error']['Message']
+
+            if error_code == 'MessageRejected':
+                logging.error(f"[EMAIL] SES rejected message: {error_message}")
+            elif error_code == 'ConfigurationSetDoesNotExist':
+                logging.error(f"[EMAIL] SES configuration error: {error_message}")
+            else:
+                logging.error(f"[EMAIL] SES error ({error_code}): {error_message}")
+
+            raise
+
+        except Exception as e:
+            logging.error(f"[EMAIL] SES unexpected error: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test AWS SES connection and verify email address.
+
+        Returns:
+            True if connection successful and sender email verified
+        """
+        try:
+            # Check if sender email is verified in SES
+            response = self.ses_client.get_identity_verification_attributes(
+                Identities=[self.config.from_address]
+            )
+
+            attributes = response.get('VerificationAttributes', {})
+            status = attributes.get(self.config.from_address, {}).get('VerificationStatus')
+
+            if status == 'Success':
+                logging.info(f"[EMAIL] SES connection test successful, {self.config.from_address} is verified")
+                return True
+            else:
+                logging.warning(
+                    f"[EMAIL] SES email {self.config.from_address} not verified. "
+                    f"Status: {status}. Emails may fail to send."
+                )
+                return False
+
+        except self.ClientError as e:
+            logging.error(f"[EMAIL] SES connection test failed: {e}")
+            return False
+
+        except Exception as e:
+            logging.error(f"[EMAIL] SES unexpected error: {e}")
+            return False
+
+
+class GmailOAuthProvider(EmailProvider):
+    """
+    Gmail OAuth email provider implementation.
+
+    Uses Gmail API with OAuth 2.0 authentication instead of SMTP.
+    Automatically refreshes expired tokens.
+    """
+
+    def __init__(self, config: EmailConfig):
+        """
+        Initialize Gmail OAuth provider.
+
+        Args:
+            config: EmailConfig with OAuth credentials
+        """
+        super().__init__(config)
+
+        # Import Gmail API dependencies
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2.credentials import Credentials
+            from googleapiclient.discovery import build
+
+            self.Request = Request
+            self.Credentials = Credentials
+            self.build = build
+        except ImportError as e:
+            _, error_message = check_provider_dependencies('gmail-oauth')
+            raise ImportError(error_message) from e
+
+        self.credentials = self._load_credentials()
+        self.service = None
+
+    def _load_credentials(self):
+        """Load OAuth credentials from config."""
+        from datetime import datetime, timezone
+
+        if not self.config.oauth_access_token:
+            raise ValueError("Gmail OAuth access token is required")
+
+        # Parse token expiry
+        token_expiry = None
+        if self.config.oauth_token_expiry:
+            try:
+                # Parse as timezone-aware datetime
+                expiry_aware = datetime.fromisoformat(
+                    self.config.oauth_token_expiry.replace('Z', '+00:00')
+                )
+                # Convert to naive UTC datetime (Google's library expects naive datetimes)
+                token_expiry = expiry_aware.replace(tzinfo=None)
+            except Exception:
+                pass
+
+        # Create credentials object
+        creds = self.Credentials(
+            token=self.config.oauth_access_token,
+            refresh_token=self.config.oauth_refresh_token,
+            token_uri='https://oauth2.googleapis.com/token',
+            client_id=self.config.oauth_client_id,
+            client_secret=self.config.oauth_client_secret,
+            scopes=['https://www.googleapis.com/auth/gmail.send']
+        )
+
+        # Set expiry if available (as naive UTC datetime)
+        if token_expiry:
+            creds.expiry = token_expiry
+
+        return creds
+
+    def _refresh_if_expired(self):
+        """Refresh tokens if expired."""
+        if self.credentials.expired or not self.credentials.valid:
+            logging.info("[EMAIL] Gmail OAuth tokens expired, refreshing...")
+            self.credentials.refresh(self.Request())
+
+            # Update config with new tokens
+            self.config.oauth_access_token = self.credentials.token
+            if self.credentials.refresh_token:
+                self.config.oauth_refresh_token = self.credentials.refresh_token
+            if self.credentials.expiry:
+                self.config.oauth_token_expiry = self.credentials.expiry.isoformat()
+
+            # Mark tokens as updated so caller can persist them
+            self.config._oauth_tokens_updated = True
+
+            logging.info("[EMAIL] Gmail OAuth tokens refreshed successfully")
+
+    def _get_service(self):
+        """Get or create Gmail API service."""
+        if not self.service:
+            self._refresh_if_expired()
+            self.service = self.build('gmail', 'v1', credentials=self.credentials)
+        return self.service
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via Gmail API.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body (HTML or plain text)
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+        """
+        try:
+            import base64
+            from email.mime.text import MIMEText
+
+            # Create message
+            message = MIMEText(body, 'html' if html else 'plain')
+            message['to'] = to
+            message['from'] = f"{self.config.from_name} <{self.config.from_address}>"
+            message['subject'] = subject
+
+            # Encode message
+            raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode('utf-8')
+
+            # Send via Gmail API
+            service = self._get_service()
+            service.users().messages().send(
+                userId='me',
+                body={'raw': raw_message}
+            ).execute()
+
+            logging.info(f"[EMAIL] Gmail OAuth email sent to {to}")
+            return True
+
+        except Exception as e:
+            logging.error(f"[EMAIL] Gmail OAuth error: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test Gmail OAuth connection.
+
+        Returns:
+            True if credentials are valid
+        """
+        try:
+            # Refresh tokens if needed
+            self._refresh_if_expired()
+
+            # Verify credentials are valid by checking they're not expired
+            # Note: gmail.send scope doesn't allow reading profile/labels
+            # so we just verify the credentials object is valid
+            if self.credentials and self.credentials.valid:
+                logging.info(f"[EMAIL] Gmail OAuth connection successful: {self.config.from_address}")
+                return True
+            else:
+                logging.error("[EMAIL] Gmail OAuth credentials are invalid")
+                return False
+
+        except Exception as e:
+            logging.error(f"[EMAIL] Gmail OAuth connection test failed: {e}")
+            return False
+
+
+class MicrosoftOAuthProvider(EmailProvider):
+    """
+    Microsoft OAuth email provider implementation.
+
+    Uses Microsoft Graph API with OAuth 2.0 authentication.
+    Supports Microsoft 365, Outlook.com, and organizational accounts.
+    """
+
+    def __init__(self, config: EmailConfig):
+        """
+        Initialize Microsoft OAuth provider.
+
+        Args:
+            config: EmailConfig with OAuth credentials and tenant_id
+        """
+        super().__init__(config)
+
+        # Import msal dependency
+        try:
+            import msal
+            self.msal = msal
+        except ImportError as e:
+            _, error_message = check_provider_dependencies('microsoft-oauth')
+            raise ImportError(error_message) from e
+
+        if not self.config.oauth_tenant_id:
+            raise ValueError("Microsoft OAuth requires tenant_id (use 'common' for multi-tenant)")
+
+        # Build MSAL confidential client app
+        self.app = self._build_msal_app()
+        self.token_cache = {}
+
+    def _build_msal_app(self):
+        """Build MSAL confidential client application."""
+        authority = f"https://login.microsoftonline.com/{self.config.oauth_tenant_id}"
+
+        return self.msal.ConfidentialClientApplication(
+            client_id=self.config.oauth_client_id,
+            client_credential=self.config.oauth_client_secret,
+            authority=authority
+        )
+
+    def _get_access_token(self) -> str:
+        """
+        Get valid access token, refreshing if necessary.
+
+        Returns:
+            Valid access token
+        """
+        # Check if we have cached token and it's still valid
+        if self.config.oauth_access_token and not self.config.tokens_need_refresh():
+            return self.config.oauth_access_token
+
+        # Need to refresh token
+        if not self.config.oauth_refresh_token:
+            raise ValueError("OAuth refresh token is required to refresh access token")
+
+        logging.info("[EMAIL] Microsoft OAuth tokens expired, refreshing...")
+
+        # Acquire token by refresh token
+        result = self.app.acquire_token_by_refresh_token(
+            refresh_token=self.config.oauth_refresh_token,
+            scopes=['https://graph.microsoft.com/Mail.Send']
+        )
+
+        if 'access_token' in result:
+            # Update config with new tokens
+            self.config.oauth_access_token = result['access_token']
+
+            # Update refresh token if new one provided
+            if 'refresh_token' in result:
+                self.config.oauth_refresh_token = result['refresh_token']
+
+            # Calculate and update expiry
+            if 'expires_in' in result:
+                from datetime import datetime, timedelta, timezone
+                expiry = datetime.now(timezone.utc) + timedelta(seconds=result['expires_in'])
+                self.config.oauth_token_expiry = expiry.isoformat()
+
+            # Mark tokens as updated so caller can persist them
+            self.config._oauth_tokens_updated = True
+
+            logging.info("[EMAIL] Microsoft OAuth tokens refreshed successfully")
+            return result['access_token']
+        else:
+            error = result.get('error', 'Unknown error')
+            error_desc = result.get('error_description', '')
+            raise Exception(f"Failed to refresh Microsoft OAuth token: {error} - {error_desc}")
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via Microsoft Graph API.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body (HTML or plain text)
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+        """
+        try:
+            import requests
+
+            # Get valid access token
+            access_token = self._get_access_token()
+
+            # Build Graph API request
+            url = 'https://graph.microsoft.com/v1.0/me/sendMail'
+            headers = {
+                'Authorization': f'Bearer {access_token}',
+                'Content-Type': 'application/json'
+            }
+
+            # Construct email message
+            message = {
+                'message': {
+                    'subject': subject,
+                    'body': {
+                        'contentType': 'HTML' if html else 'Text',
+                        'content': body
+                    },
+                    'toRecipients': [
+                        {
+                            'emailAddress': {
+                                'address': to
+                            }
+                        }
+                    ],
+                    'from': {
+                        'emailAddress': {
+                            'name': self.config.from_name,
+                            'address': self.config.from_address
+                        }
+                    }
+                },
+                'saveToSentItems': 'true'
+            }
+
+            # Send request
+            response = requests.post(url, headers=headers, json=message)
+
+            if response.status_code == 202:
+                logging.info(f"[EMAIL] Microsoft Graph email sent to {to}")
+                return True
+            else:
+                logging.error(f"[EMAIL] Microsoft Graph returned status {response.status_code}: {response.text}")
+                return False
+
+        except Exception as e:
+            logging.error(f"[EMAIL] Microsoft OAuth error: {e}")
+            raise
+
+    def test_connection(self) -> bool:
+        """
+        Test Microsoft OAuth connection.
+
+        Returns:
+            True if credentials are valid
+        """
+        try:
+            import requests
+
+            # Get valid access token
+            access_token = self._get_access_token()
+
+            # Try to get user profile to verify connection
+            url = 'https://graph.microsoft.com/v1.0/me'
+            headers = {
+                'Authorization': f'Bearer {access_token}'
+            }
+
+            response = requests.get(url, headers=headers)
+
+            if response.status_code == 200:
+                data = response.json()
+                email = data.get('mail') or data.get('userPrincipalName')
+                logging.info(f"[EMAIL] Microsoft OAuth connection successful: {email}")
+                return True
+            else:
+                logging.error(f"[EMAIL] Microsoft OAuth connection test failed: {response.status_code}")
+                return False
+
+        except Exception as e:
+            logging.error(f"[EMAIL] Microsoft OAuth connection test failed: {e}")
+            return False
+
+
+class EmailSender:
+    """
+    Main email sender class that routes to appropriate provider.
+
+    Usage:
+        config = EmailConfig(...)
+        sender = EmailSender(config)
+        sender.send(to='user@example.com', subject='Test', body='Hello', html=True)
+    """
+
+    def __init__(self, config: EmailConfig):
+        """
+        Initialize email sender with configuration.
+
+        Args:
+            config: EmailConfig object
+
+        Raises:
+            ValueError: If provider is unknown or config invalid
+        """
+        self.config = config
+
+        # Check provider compatibility with current installation
+        dependencies_available, error_message = check_provider_dependencies(config.provider)
+        if not dependencies_available:
+            raise ValueError(error_message)
+
+        # Create provider instance
+        provider_map = {
+            'smtp': SMTPEmailProvider,
+            'sendgrid': SendGridEmailProvider,
+            'ses': SESEmailProvider,
+            'gmail-oauth': GmailOAuthProvider,
+            'microsoft-oauth': MicrosoftOAuthProvider,
+        }
+
+        provider_class = provider_map.get(config.provider.lower())
+        if not provider_class:
+            raise ValueError(
+                f"Unknown email provider: {config.provider}. "
+                f"Supported: {', '.join(provider_map.keys())}"
+            )
+
+        self.provider = provider_class(config)
+
+    def send(self, to: str, subject: str, body: str, html: bool = False) -> bool:
+        """
+        Send email via configured provider.
+
+        Args:
+            to: Recipient email address
+            subject: Email subject
+            body: Email body
+            html: True if body is HTML
+
+        Returns:
+            True if sent successfully
+
+        Raises:
+            Exception: If send fails
+        """
+        logging.info(f"[EMAIL] Sending email to {to} via {self.config.provider}")
+        return self.provider.send(to, subject, body, html)
+
+    def test_connection(self) -> bool:
+        """
+        Test connection to email provider.
+
+        Returns:
+            True if connection successful
+        """
+        return self.provider.test_connection()
+
+
+def load_email_template(template_name: str = 'onboarding.html') -> str:
+    """
+    Load email template from resources directory.
+
+    Args:
+        template_name: Name of template file (default: onboarding.html)
+
+    Returns:
+        Template content as string
+
+    Raises:
+        FileNotFoundError: If template file doesn't exist
+    """
+    # Get path to template file
+    module_dir = os.path.dirname(os.path.abspath(__file__))
+    template_path = os.path.join(module_dir, 'resources', 'email_templates', template_name)
+
+    if not os.path.exists(template_path):
+        raise FileNotFoundError(f"Email template not found: {template_path}")
+
+    with open(template_path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def build_onboarding_email(
+    share_url: str,
+    custom_message: str,
+    record_title: str,
+    expiration: Optional[str] = None
+) -> str:
+    """
+    Build HTML email for onboarding with one-time share link.
+
+    Args:
+        share_url: One-time share URL
+        custom_message: Custom message from administrator
+        record_title: Title of the record being shared
+        expiration: Human-readable expiration time (e.g., "24 hours", "1 day")
+
+    Returns:
+        HTML email body
+
+    Raises:
+        FileNotFoundError: If email template not found
+    """
+    # Load template
+    template = load_email_template('onboarding.html')
+
+    # Prepare variables
+    expiration_text = (
+        f"This link will expire in {expiration}"
+        if expiration
+        else "This link will expire after first use"
+    )
+
+    # Fill in template
+    html = template.format(
+        custom_message=custom_message,
+        share_url=share_url,
+        record_title=record_title,
+        expiration_text=expiration_text
+    )
+
+    return html
+
+
+def validate_email_provider_dependencies(provider: str) -> tuple[bool, Optional[str]]:
+    """
+    Validate that required dependencies for an email provider are installed.
+
+    This function checks if dependencies are available WITHOUT creating the provider instance,
+    allowing early validation before performing operations like password rotation.
+
+    Args:
+        provider: Email provider name ('smtp', 'sendgrid', 'ses', 'gmail-oauth', 'microsoft-oauth')
+
+    Returns:
+        Tuple of (is_valid, error_message):
+            - is_valid: True if dependencies are available, False otherwise
+            - error_message: None if valid, otherwise contains install instructions
+
+    Examples:
+        >>> valid, error = validate_email_provider_dependencies('gmail-oauth')
+        >>> if not valid:
+        ...     print(error)
+        Gmail OAuth requires google-api-python-client and related libraries.
+        Install with: pip install keepercommander[email-gmail-oauth]
+    """
+    provider = provider.lower()
+
+    # SMTP uses Python built-ins, no extra dependencies needed
+    if provider == 'smtp':
+        return True, None
+
+    # SendGrid
+    if provider == 'sendgrid':
+        try:
+            import sendgrid  # noqa: F401
+            return True, None
+        except ImportError:
+            return False, (
+                "SendGrid email provider requires the 'sendgrid' library.\n"
+                "Install with: pip install keepercommander[email-sendgrid]\n"
+                "Or install manually: pip install sendgrid>=6.10.0"
+            )
+
+    # AWS SES
+    if provider == 'ses':
+        try:
+            import boto3  # noqa: F401
+            return True, None
+        except ImportError:
+            return False, (
+                "AWS SES email provider requires the 'boto3' library.\n"
+                "Install with: pip install keepercommander[email-ses]\n"
+                "Or install manually: pip install boto3>=1.26.0"
+            )
+
+    # Gmail OAuth
+    if provider == 'gmail-oauth':
+        try:
+            import google.auth  # noqa: F401
+            import google.auth.transport.requests  # noqa: F401
+            import google.oauth2.credentials  # noqa: F401
+            import googleapiclient.discovery  # noqa: F401
+            return True, None
+        except ImportError:
+            return False, (
+                "Gmail OAuth email provider requires Google API libraries.\n"
+                "Install with: pip install keepercommander[email-gmail-oauth]\n"
+                "Or install manually: pip install google-api-python-client google-auth google-auth-oauthlib google-auth-httplib2"
+            )
+
+    # Microsoft OAuth
+    if provider == 'microsoft-oauth':
+        try:
+            import msal  # noqa: F401
+            return True, None
+        except ImportError:
+            return False, (
+                "Microsoft OAuth email provider requires the 'msal' library.\n"
+                "Install with: pip install keepercommander[email-microsoft-oauth]\n"
+                "Or install manually: pip install msal>=1.20.0"
+            )
+
+    # Unknown provider
+    return False, (
+        f"Unknown email provider: {provider}\n"
+        f"Supported providers: smtp, sendgrid, ses, gmail-oauth, microsoft-oauth"
+    )

--- a/keepercommander/oauth_helpers.py
+++ b/keepercommander/oauth_helpers.py
@@ -1,0 +1,448 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Contact: ops@keepersecurity.com
+#
+
+"""
+OAuth Helper Module for Email Providers
+
+Provides OAuth 2.0 authentication flows for Gmail and Microsoft 365 email providers.
+Supports desktop flow (browser-based) and manual token entry.
+"""
+
+from __future__ import annotations
+import logging
+import requests
+import secrets
+import threading
+import webbrowser
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Dict, Optional, Tuple
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+
+
+class OAuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for OAuth callback."""
+
+    def log_message(self, format, *args):
+        """Suppress logging of HTTP requests."""
+        pass
+
+    def do_GET(self):
+        """Handle GET request for OAuth callback."""
+        query_components = parse_qs(urlparse(self.path).query)
+
+        # Extract authorization code and state
+        code = query_components.get('code', [None])[0]
+        state = query_components.get('state', [None])[0]
+        error = query_components.get('error', [None])[0]
+
+        # Store in server instance
+        self.server.oauth_code = code  # type: ignore
+        self.server.oauth_state = state  # type: ignore
+        self.server.oauth_error = error  # type: ignore
+
+        # Send response to browser
+        if code:
+            response_html = """
+            <html>
+            <head><title>Authentication Successful</title></head>
+            <body>
+                <h1>✓ Authentication Successful</h1>
+                <p>You can close this window and return to Keeper Commander.</p>
+            </body>
+            </html>
+            """
+            self.send_response(200)
+        else:
+            response_html = f"""
+            <html>
+            <head><title>Authentication Failed</title></head>
+            <body>
+                <h1>✗ Authentication Failed</h1>
+                <p>Error: {error or 'Unknown error'}</p>
+                <p>Please return to Keeper Commander and try again.</p>
+            </body>
+            </html>
+            """
+            self.send_response(400)
+
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(response_html.encode())
+
+
+class OAuthFlowHandler(ABC):
+    """Base class for OAuth 2.0 flows."""
+
+    @abstractmethod
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """
+        Get the authorization URL for the user to visit.
+
+        Args:
+            redirect_uri: OAuth callback URL
+            state: Random state parameter for CSRF protection
+
+        Returns:
+            Authorization URL
+        """
+        pass
+
+    @abstractmethod
+    def exchange_code_for_tokens(self, code: str, redirect_uri: str) -> Dict[str, str]:
+        """
+        Exchange authorization code for access/refresh tokens.
+
+        Args:
+            code: Authorization code from OAuth callback
+            redirect_uri: OAuth callback URL (must match)
+
+        Returns:
+            Dictionary with 'access_token', 'refresh_token', 'expiry' (ISO 8601)
+        """
+        pass
+
+    @abstractmethod
+    def refresh_tokens(self, refresh_token: str) -> Dict[str, str]:
+        """
+        Refresh OAuth tokens using refresh token.
+
+        Args:
+            refresh_token: Refresh token from previous authorization
+
+        Returns:
+            Dictionary with new 'access_token', 'refresh_token' (if new), 'expiry'
+        """
+        pass
+
+
+class GoogleOAuthFlow(OAuthFlowHandler):
+    """Google OAuth 2.0 flow for Gmail API."""
+
+    SCOPES = ['https://www.googleapis.com/auth/gmail.send']
+    AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
+    TOKEN_URI = 'https://oauth2.googleapis.com/token'
+
+    def __init__(self, client_id: str, client_secret: str):
+        """
+        Initialize Google OAuth flow.
+
+        Args:
+            client_id: Google OAuth client ID
+            client_secret: Google OAuth client secret
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Get Google authorization URL."""
+        params = {
+            'client_id': self.client_id,
+            'redirect_uri': redirect_uri,
+            'response_type': 'code',
+            'scope': ' '.join(self.SCOPES),
+            'state': state,
+            'access_type': 'offline',  # Request refresh token
+            'prompt': 'consent'  # Force consent to get refresh token
+        }
+        return f"{self.AUTH_URI}?{urlencode(params)}"
+
+    def exchange_code_for_tokens(self, code: str, redirect_uri: str) -> Dict[str, str]:
+        """Exchange authorization code for tokens."""
+        data = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'code': code,
+            'redirect_uri': redirect_uri,
+            'grant_type': 'authorization_code'
+        }
+
+        response = requests.post(self.TOKEN_URI, data=data)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Calculate expiry time
+        expires_in = token_data.get('expires_in', 3600)
+        expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+        return {
+            'access_token': token_data['access_token'],
+            'refresh_token': token_data.get('refresh_token', ''),
+            'expiry': expiry.isoformat()
+        }
+
+    def refresh_tokens(self, refresh_token: str) -> Dict[str, str]:
+        """Refresh Google OAuth tokens."""
+        data = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': refresh_token,
+            'grant_type': 'refresh_token'
+        }
+
+        response = requests.post(self.TOKEN_URI, data=data)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Calculate new expiry
+        expires_in = token_data.get('expires_in', 3600)
+        expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+        result = {
+            'access_token': token_data['access_token'],
+            'expiry': expiry.isoformat()
+        }
+
+        # Google may return a new refresh token
+        if 'refresh_token' in token_data:
+            result['refresh_token'] = token_data['refresh_token']
+        else:
+            # Keep the old refresh token
+            result['refresh_token'] = refresh_token
+
+        return result
+
+
+class MicrosoftOAuthFlow(OAuthFlowHandler):
+    """Microsoft OAuth 2.0 flow for Microsoft Graph API."""
+
+    SCOPES = ['https://graph.microsoft.com/Mail.Send']
+
+    def __init__(self, client_id: str, client_secret: str, tenant_id: str = 'common'):
+        """
+        Initialize Microsoft OAuth flow.
+
+        Args:
+            client_id: Azure AD application ID
+            client_secret: Azure AD application secret
+            tenant_id: Tenant ID ('common', 'organizations', 'consumers', or specific tenant)
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.tenant_id = tenant_id
+        self.auth_uri = f'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize'
+        self.token_uri = f'https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token'
+
+    def get_authorization_url(self, redirect_uri: str, state: str) -> str:
+        """Get Microsoft authorization URL."""
+        params = {
+            'client_id': self.client_id,
+            'response_type': 'code',
+            'redirect_uri': redirect_uri,
+            'response_mode': 'query',
+            'scope': ' '.join(self.SCOPES) + ' offline_access',  # offline_access for refresh token
+            'state': state
+        }
+        return f"{self.auth_uri}?{urlencode(params)}"
+
+    def exchange_code_for_tokens(self, code: str, redirect_uri: str) -> Dict[str, str]:
+        """Exchange authorization code for tokens."""
+        data = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'code': code,
+            'redirect_uri': redirect_uri,
+            'grant_type': 'authorization_code',
+            'scope': ' '.join(self.SCOPES) + ' offline_access'
+        }
+
+        response = requests.post(self.token_uri, data=data)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Calculate expiry time
+        expires_in = token_data.get('expires_in', 3600)
+        expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+        return {
+            'access_token': token_data['access_token'],
+            'refresh_token': token_data.get('refresh_token', ''),
+            'expiry': expiry.isoformat()
+        }
+
+    def refresh_tokens(self, refresh_token: str) -> Dict[str, str]:
+        """Refresh Microsoft OAuth tokens."""
+        data = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'refresh_token': refresh_token,
+            'grant_type': 'refresh_token',
+            'scope': ' '.join(self.SCOPES) + ' offline_access'
+        }
+
+        response = requests.post(self.token_uri, data=data)
+        response.raise_for_status()
+        token_data = response.json()
+
+        # Calculate new expiry
+        expires_in = token_data.get('expires_in', 3600)
+        expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+        result = {
+            'access_token': token_data['access_token'],
+            'expiry': expiry.isoformat()
+        }
+
+        # Microsoft may return a new refresh token
+        if 'refresh_token' in token_data:
+            result['refresh_token'] = token_data['refresh_token']
+        else:
+            # Keep the old refresh token
+            result['refresh_token'] = refresh_token
+
+        return result
+
+
+def start_local_callback_server(port: int = 8080) -> Tuple[HTTPServer, str]:
+    """
+    Start local HTTP server to receive OAuth callback.
+
+    Args:
+        port: Port number for callback server (default 8080)
+
+    Returns:
+        Tuple of (server, redirect_uri)
+    """
+    server = HTTPServer(('localhost', port), OAuthCallbackHandler)
+    server.oauth_code = None  # type: ignore
+    server.oauth_state = None  # type: ignore
+    server.oauth_error = None  # type: ignore
+
+    redirect_uri = f'http://localhost:{port}/oauth/callback'
+    return server, redirect_uri
+
+
+def wait_for_oauth_callback(server: HTTPServer, timeout: int = 300) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """
+    Wait for OAuth callback on local server.
+
+    Args:
+        server: HTTP server instance from start_local_callback_server()
+        timeout: Maximum seconds to wait (default 300 = 5 minutes)
+
+    Returns:
+        Tuple of (code, state, error)
+    """
+    # Handle requests until we get a callback or timeout
+    server.timeout = 1  # 1 second timeout per request
+    start_time = datetime.now()
+
+    while True:
+        server.handle_request()
+
+        # Check if we got the callback
+        if hasattr(server, 'oauth_code') and (server.oauth_code or server.oauth_error):  # type: ignore
+            return server.oauth_code, server.oauth_state, server.oauth_error  # type: ignore
+
+        # Check timeout
+        if (datetime.now() - start_time).total_seconds() > timeout:
+            return None, None, 'Timeout waiting for OAuth callback'
+
+
+def open_browser_for_oauth(url: str) -> bool:
+    """
+    Open system browser to OAuth authorization URL.
+
+    Args:
+        url: Authorization URL to open
+
+    Returns:
+        True if browser was opened successfully
+    """
+    try:
+        webbrowser.open(url)
+        return True
+    except Exception as e:
+        logging.error(f"Failed to open browser: {e}")
+        return False
+
+def redact_sensitive_url_params(url: str, params_to_redact: list = None) -> str:
+    """
+    Redact sensitive query parameters from a URL for safe console output.
+
+    Args:
+        url: The URL to redact
+        params_to_redact: List of parameter names to redact (default: ['client_id', 'client_secret'])
+
+    Returns:
+        URL with sensitive parameters replaced by [REDACTED]
+    """
+    if params_to_redact is None:
+        params_to_redact = ['client_id', 'client_secret']
+
+    parsed_url = urlparse(url)
+    query = parse_qs(parsed_url.query)
+
+    # Redact sensitive parameters
+    for param in params_to_redact:
+        if param in query:
+            query[param] = ['[REDACTED]']
+
+    # Reconstruct URL with redacted parameters
+    redacted_query = urlencode(query, doseq=True)
+    redacted_url = urlunparse(parsed_url._replace(query=redacted_query))
+
+    return redacted_url
+
+def perform_interactive_oauth(flow: OAuthFlowHandler, port: int = 8080) -> Dict[str, str]:
+    """
+    Perform interactive OAuth flow with browser.
+
+    Args:
+        flow: OAuth flow handler (GoogleOAuthFlow or MicrosoftOAuthFlow)
+        port: Port for local callback server
+
+    Returns:
+        Dictionary with 'access_token', 'refresh_token', 'expiry'
+
+    Raises:
+        Exception: If OAuth flow fails
+    """
+    # Start local server
+    server, redirect_uri = start_local_callback_server(port)
+    state = secrets.token_urlsafe(32)
+
+    # Get authorization URL
+    auth_url = flow.get_authorization_url(redirect_uri, state)
+
+    # Redact sensitive parameters before printing
+    safe_auth_url = redact_sensitive_url_params(auth_url)
+
+    print(f"\nOpening browser for authorization...")
+    print(f"If browser doesn't open automatically, visit: {safe_auth_url}\n")
+
+    # Open browser (use original URL with all parameters)
+    if not open_browser_for_oauth(auth_url):
+        print(f"Please manually open this URL in your browser:\n{safe_auth_url}\n")
+
+    # Wait for callback
+    print("Waiting for authorization...")
+    code, returned_state, error = wait_for_oauth_callback(server)
+
+    # Close server
+    server.server_close()
+
+    # Check for errors
+    if error:
+        raise Exception(f"OAuth failed: {error}")
+
+    if not code:
+        raise Exception("No authorization code received")
+
+    if returned_state != state:
+        raise Exception("State mismatch - possible CSRF attack")
+
+    # Exchange code for tokens
+    print("Exchanging authorization code for tokens...")
+    tokens = flow.exchange_code_for_tokens(code, redirect_uri)
+
+    print("✓ OAuth authentication successful!")
+    return tokens

--- a/keepercommander/resources/email_templates/onboarding.html
+++ b/keepercommander/resources/email_templates/onboarding.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="x-apple-disable-message-reformatting"/>
+    <title>Keeper: Credentials Shared</title>
+    <style type="text/css">
+        @import url(https://fonts.googleapis.com/css?family=Overpass:300,400&display=swap);
+        .img-mb-hide {{ display: block; }}
+        .img-mb-show {{ display: none; }}
+        @media only screen and (max-device-width: 480px), only screen and (max-width: 480px) {{
+            .img-mb-hide {{ display: none; }}
+            .img-mb-show {{ display: block; }}
+            .content {{ width: 100% }}
+        }}
+    </style>
+</head>
+<body style="width:100%;margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%">
+    <table width="100%" height="100%" cellPadding="0" cellSpacing="0" border="0" align="left" valign="top">
+        <tbody>
+            <tr>
+                <td align="center" valign="top">
+                    <table class="content" width="600" align="center" cellPadding="0" cellSpacing="0" style="line-height:27px" border="0" valign="top">
+                        <tbody>
+                            <!-- Mobile header -->
+                            <tr>
+                                <td class="img-mb-show">
+                                    <img alt="" src="https://keeper-email-images.s3.amazonaws.com/common/keeperlogo_blackbg_375x140.png" style="display:block;outline:none;border:none;text-decoration:none;margin:auto"/>
+                                </td>
+                            </tr>
+                            <!-- Desktop header -->
+                            <tr>
+                                <td class="img-mb-hide">
+                                    <img alt="" src="https://keeper-email-images.s3.amazonaws.com/common/keeperlogo_blackbg_600x140.png" style="display:block;outline:none;border:none;text-decoration:none;margin:auto"/>
+                                </td>
+                            </tr>
+                            <!-- Email content -->
+                            <tr>
+                                <td style="font-family:Overpass,sans-serif;font-weight:300;font-size:15px;color:black;padding:25px 40px 0px 40px">
+                                    <div>
+                                        Hi,<br><br>
+                                        {custom_message}<br><br>
+                                        <strong>Record:</strong> {record_title}<br>
+                                        {expiration_text}<br><br>
+                                        <a href="{share_url}" style="display:inline-block;background-color:#ffffff;color:#000000;padding:12px 32px;text-decoration:none;border:2px solid #FFB800;border-radius:4px;font-weight:bold;font-size:16px">View Credentials</a><br><br>
+                                        <strong>Important Security Information:</strong><br>
+                                        <ul style="margin:10px 0;padding-left:20px;">
+                                            <li>Do not share this link with anyone</li>
+                                            <li>Access this link from a secure device</li>
+                                        </ul>
+                                        If you need assistance, <a href="https://keepersecurity.com/support.html" style="color:#0066cc">click here</a> to contact Keeper Support.
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding:25px 40px 0px 40px;font-family:Overpass,sans-serif;font-weight:300;font-size:15px;color:black"></td>
+                            </tr>
+                            <tr>
+                                <td style="padding:25px 40px 0px 40px;font-family:Overpass,sans-serif;font-weight:300;font-size:15px;color:black"></td>
+                            </tr>
+                            <!-- Footer -->
+                            <tr>
+                                <td bgcolor="#f6f6f6" style="padding:0 0 0 0;">
+                                    <table width="100%">
+                                        <tr>
+                                            <td style="padding: 1px 70px; text-align: center">
+                                                <div class="text-footer" style="color:#858585; font-family:'Overpass', sans-serif; font-weight:300; font-size:11px; line-height:20px; text-align:center">
+                                                    &copy; 2025 Keeper Security, Inc.<br>
+                                                    311 W Monroe St., Suite 406, Chicago IL 60606 USA
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/keepercommander/service/api/onboarding.py
+++ b/keepercommander/service/api/onboarding.py
@@ -1,0 +1,459 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2024 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+"""
+Onboarding API endpoints for Keeper Commander Service.
+
+Provides REST API for email configuration management and automated employee onboarding.
+"""
+
+from flask import Blueprint, request, jsonify, Response
+from typing import Tuple, Union
+import logging
+
+from ... import api
+from ..decorators.unified import unified_api_decorator
+from ..decorators.logging import logger
+from ...commands.email_commands import (
+    find_email_config_record,
+    load_email_config_from_record,
+    create_email_config_record
+)
+from ...commands.record import RecordRemoveCommand
+from ...commands.record_edit import RecordAddCommand
+from ...email_service import EmailConfig, EmailSender
+from ...error import CommandError
+from ... import vault, vault_extensions
+
+
+def create_onboarding_blueprint():
+    """Create blueprint for onboarding API endpoints."""
+    bp = Blueprint("onboarding_bp", __name__)
+
+    # =============================================================================
+    # Email Configuration Endpoints
+    # =============================================================================
+
+    @bp.route("/email-config", methods=["GET"])
+    @unified_api_decorator()
+    def list_email_configs(**kwargs) -> Tuple[Response, int]:
+        """
+        List all email configurations.
+
+        GET /api/v2/email-config
+
+        Returns:
+            200: List of email configurations
+            500: Server error
+        """
+        try:
+            params = kwargs.get('params')
+            if not params:
+                return jsonify({"status": "error", "error": "Not authenticated"}), 401
+
+            configs = []
+
+            # Find all email config records
+            for record_uid in params.record_cache:
+                try:
+                    record = vault.KeeperRecord.load(params, record_uid)
+                    if not isinstance(record, vault.TypedRecord):
+                        continue
+                    if record.record_type != 'login':
+                        continue
+
+                    # Check if this is an email config
+                    record_dict = vault_extensions.extract_typed_record_data(record)
+                    custom_fields = record_dict.get('custom', [])
+
+                    is_email_config = False
+                    provider = None
+                    from_address = None
+
+                    for field in custom_fields:
+                        if field.get('label') == '__email_config__':
+                            is_email_config = True
+                        elif field.get('label') == 'provider':
+                            values = field.get('value', [])
+                            if values:
+                                provider = values[0]
+                        elif field.get('label') == 'from_address':
+                            values = field.get('value', [])
+                            if values:
+                                from_address = values[0]
+
+                    if is_email_config:
+                        configs.append({
+                            'name': record.title,
+                            'record_uid': record_uid,
+                            'provider': provider or 'unknown',
+                            'from_address': from_address or ''
+                        })
+                except Exception as e:
+                    logging.debug(f'Error loading record {record_uid}: {e}')
+                    continue
+
+            return jsonify({
+                "success": True,
+                "configs": configs
+            }), 200
+
+        except Exception as e:
+            logger.error(f"Error listing email configs: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": "An internal error occurred while listing email configurations"}), 500
+
+    @bp.route("/email-config", methods=["POST"])
+    @unified_api_decorator()
+    def create_email_config(**kwargs) -> Tuple[Response, int]:
+        """
+        Create a new email configuration.
+
+        POST /api/v2/email-config
+        Content-Type: application/json
+
+        Body (SMTP):
+        {
+            "name": "Gmail",
+            "provider": "smtp",
+            "from_address": "admin@company.com",
+            "from_name": "IT Department",
+            "smtp_host": "smtp.gmail.com",
+            "smtp_port": 587,
+            "smtp_username": "admin@company.com",
+            "smtp_password": "app-password",
+            "smtp_use_tls": true,
+            "folder": "optional-folder-uid"
+        }
+
+        Body (AWS SES):
+        {
+            "name": "AWS-SES",
+            "provider": "ses",
+            "from_address": "noreply@company.com",
+            "aws_region": "us-east-1",
+            "aws_access_key": "AKIAIOSFODNN7EXAMPLE",
+            "aws_secret_key": "secret-key"
+        }
+
+        Body (SendGrid):
+        {
+            "name": "SendGrid",
+            "provider": "sendgrid",
+            "from_address": "noreply@company.com",
+            "sendgrid_api_key": "SG.xxxx"
+        }
+
+        Returns:
+            201: Email configuration created
+            400: Invalid request
+            409: Configuration already exists
+            500: Server error
+        """
+        try:
+            params = kwargs.get('params')
+            if not params:
+                return jsonify({"status": "error", "error": "Not authenticated"}), 401
+
+            data = request.json
+            if not data:
+                return jsonify({"status": "error", "error": "Request body required"}), 400
+
+            # Validate required fields
+            name = data.get('name')
+            provider = data.get('provider')
+            from_address = data.get('from_address')
+
+            if not name or not provider or not from_address:
+                return jsonify({
+                    "status": "error",
+                    "error": "Required fields: name, provider, from_address"
+                }), 400
+
+            # Check if config already exists
+            existing_uid = find_email_config_record(params, name)
+            if existing_uid:
+                return jsonify({
+                    "status": "error",
+                    "error": f"Email configuration '{name}' already exists"
+                }), 409
+
+            # Build EmailConfig
+            config = EmailConfig(
+                record_uid='',  # Will be generated
+                name=name,
+                provider=provider,
+                from_address=from_address,
+                from_name=data.get('from_name', 'Keeper Commander')
+            )
+
+            # Provider-specific fields
+            if provider == 'smtp':
+                config.smtp_host = data.get('smtp_host')
+                config.smtp_port = data.get('smtp_port', 587)
+                config.smtp_username = data.get('smtp_username')
+                config.smtp_password = data.get('smtp_password')
+                config.smtp_use_tls = data.get('smtp_use_tls', True)
+                config.smtp_use_ssl = data.get('smtp_use_ssl', False)
+
+            elif provider == 'ses':
+                config.aws_region = data.get('aws_region')
+                config.aws_access_key = data.get('aws_access_key')
+                config.aws_secret_key = data.get('aws_secret_key')
+
+            elif provider == 'sendgrid':
+                config.sendgrid_api_key = data.get('sendgrid_api_key')
+
+            else:
+                return jsonify({
+                    "status": "error",
+                    "error": f"Unknown provider: {provider}. Supported: smtp, ses, sendgrid"
+                }), 400
+
+            # Validate configuration
+            errors = config.validate()
+            if errors:
+                return jsonify({
+                    "status": "error",
+                    "error": "Invalid configuration",
+                    "validation_errors": errors
+                }), 400
+
+            # Create record
+            folder_uid = data.get('folder')
+            record_uid = create_email_config_record(params, config, folder_uid)
+
+            # Sync with server
+            api.sync_down(params)
+
+            return jsonify({
+                "success": True,
+                "record_uid": record_uid,
+                "message": f"Email configuration '{name}' created successfully"
+            }), 201
+
+        except Exception as e:
+            logger.error(f"Error creating email config: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": "An internal error occurred while creating email configuration"}), 500
+
+    @bp.route("/email-config/<config_name>/test", methods=["POST"])
+    @unified_api_decorator()
+    def test_email_config(config_name: str, **kwargs) -> Tuple[Response, int]:
+        """
+        Test email configuration connection.
+
+        POST /api/v2/email-config/<config_name>/test
+        Content-Type: application/json
+
+        Body (optional):
+        {
+            "to": "test@example.com"  # If provided, sends test email
+        }
+
+        Returns:
+            200: Connection test successful
+            404: Configuration not found
+            500: Connection test failed
+        """
+        try:
+            params = kwargs.get('params')
+            if not params:
+                return jsonify({"status": "error", "error": "Not authenticated"}), 401
+
+            # Find config
+            record_uid = find_email_config_record(params, config_name)
+            if not record_uid:
+                return jsonify({
+                    "status": "error",
+                    "error": f"Email configuration '{config_name}' not found"
+                }), 404
+
+            # Load config
+            config = load_email_config_from_record(params, record_uid)
+
+            # Create sender
+            sender = EmailSender(config)
+
+            # Test connection
+            success = sender.test_connection()
+            if not success:
+                return jsonify({
+                    "status": "error",
+                    "error": f"Connection test failed for '{config_name}'"
+                }), 500
+
+            # Send test email if address provided
+            data = request.json or {}
+            to_address = data.get('to')
+
+            if to_address:
+                subject = 'Keeper Commander Email Test'
+                body = f'This is a test email from Keeper Commander.\n\nEmail Configuration: {config_name}\nProvider: {config.provider}'
+
+                sender.send(to_address, subject, body, html=False)
+
+                return jsonify({
+                    "success": True,
+                    "message": f"Connection test passed. Test email sent to {to_address}"
+                }), 200
+
+            return jsonify({
+                "success": True,
+                "message": f"Connection test passed for '{config_name}'"
+            }), 200
+
+        except Exception as e:
+            logger.error(f"Error testing email config: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": "An internal error occurred while testing email configuration"}), 500
+
+    @bp.route("/email-config/<config_name>", methods=["DELETE"])
+    @unified_api_decorator()
+    def delete_email_config(config_name: str, **kwargs) -> Tuple[Response, int]:
+        """
+        Delete an email configuration.
+
+        DELETE /api/v2/email-config/<config_name>
+
+        Returns:
+            200: Configuration deleted
+            404: Configuration not found
+            500: Server error
+        """
+        try:
+            params = kwargs.get('params')
+            if not params:
+                return jsonify({"status": "error", "error": "Not authenticated"}), 401
+
+            # Find config
+            record_uid = find_email_config_record(params, config_name)
+            if not record_uid:
+                return jsonify({
+                    "status": "error",
+                    "error": f"Email configuration '{config_name}' not found"
+                }), 404
+
+            # Delete record
+            remove_cmd = RecordRemoveCommand()
+            remove_cmd.execute(params, record=[record_uid], force=True)
+
+            return jsonify({
+                "success": True,
+                "message": f"Email configuration '{config_name}' deleted"
+            }), 200
+
+        except Exception as e:
+            logger.error(f"Error deleting email config: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": "An internal error occurred while deleting email configuration"}), 500
+
+    # =============================================================================
+    # Onboarding Endpoint
+    # =============================================================================
+
+    @bp.route("/onboard", methods=["POST"])
+    @unified_api_decorator()
+    def onboard_employee(**kwargs) -> Tuple[Response, int]:
+        """
+        Automated employee onboarding with optional PAM sync and email delivery.
+
+        POST /api/v2/onboard
+        Content-Type: application/json
+
+        Body:
+        {
+            "title": "John Doe - AWS Console",
+            "record_type": "login",
+            "fields": {
+                "login": "john.doe@company.com",
+                "password": "GeneratedPass123!"
+            },
+            "self_destruct": "24h",
+            "pam_config": "AWS-IAM-Config",  // optional
+            "send_email": "john.doe@company.com",  // optional
+            "email_config": "Gmail",  // required if send_email is set
+            "email_message": "Welcome to the team!",  // optional
+            "folder": "optional-folder-uid"  // optional
+        }
+
+        Returns:
+            201: Employee onboarded, returns share URL
+            400: Invalid request
+            404: Email/PAM config not found
+            500: Server error
+        """
+        try:
+            params = kwargs.get('params')
+            if not params:
+                return jsonify({"status": "error", "error": "Not authenticated"}), 401
+
+            data = request.json
+            if not data:
+                return jsonify({"status": "error", "error": "Request body required"}), 400
+
+            # Validate required fields
+            title = data.get('title')
+            record_type = data.get('record_type', 'login')
+            fields = data.get('fields', {})
+            self_destruct = data.get('self_destruct')
+            send_email = data.get('send_email')
+            email_config = data.get('email_config')
+
+            if not title:
+                return jsonify({"status": "error", "error": "Field 'title' is required"}), 400
+
+            if not self_destruct:
+                return jsonify({"status": "error", "error": "Field 'self_destruct' is required"}), 400
+
+            # Validate email parameters
+            if send_email and not email_config:
+                return jsonify({
+                    "status": "error",
+                    "error": "Field 'email_config' is required when 'send_email' is set"
+                }), 400
+
+            # Build field parameters for record-add
+            field_params = []
+            for field_type, value in fields.items():
+                field_params.append(f"{field_type}={value}")
+
+            # Build kwargs for RecordAddCommand
+            cmd_kwargs = {
+                'title': title,
+                'record_type': record_type,
+                'fields': field_params,
+                'self_destruct': self_destruct,
+                'folder': data.get('folder'),
+                'pam_config': data.get('pam_config'),
+                'send_email': send_email,
+                'email_config': email_config,
+                'email_message': data.get('email_message'),
+                'force': True
+            }
+
+            # Execute record-add command
+            cmd = RecordAddCommand()
+            share_url = cmd.execute(params, **cmd_kwargs)
+
+            return jsonify({
+                "success": True,
+                "share_url": share_url,
+                "message": f"Employee onboarded successfully"
+            }), 201
+
+        except CommandError as e:
+            # CommandError exceptions are user-facing validation errors, safe to expose
+            logger.warning(f"Command error in onboarding: {e}")
+            return jsonify({"status": "error", "error": str(e)}), 400
+
+        except Exception as e:
+            # Generic exceptions may contain sensitive internal details, use generic message
+            logger.error(f"Error in onboarding: {e}", exc_info=True)
+            return jsonify({"status": "error", "error": "An internal error occurred during employee onboarding"}), 500
+
+    return bp

--- a/keepercommander/service/api/routes.py
+++ b/keepercommander/service/api/routes.py
@@ -12,15 +12,21 @@
 from flask import Flask
 from typing import Optional
 from .command import create_command_blueprint, create_legacy_command_blueprint
+from .onboarding import create_onboarding_blueprint
 from ..decorators.logging import logger, debug_decorator
 
 def _setup_queue_mode(app: Flask) -> None:
     """Setup queue mode with v2 API endpoints."""
     from ..core.request_queue import queue_manager
     queue_manager.start()
-    
+
     command_bp = create_command_blueprint()
     app.register_blueprint(command_bp, url_prefix='/api/v2')
+
+    # Register onboarding endpoints
+    onboarding_bp = create_onboarding_blueprint()
+    app.register_blueprint(onboarding_bp, url_prefix='/api/v2')
+
     logger.debug("Started queue manager and registered command blueprint with URL prefix '/api/v2'")
 
 def _setup_legacy_mode(app: Flask) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,12 +53,31 @@ install_requires =
     winrt-Windows.Security.Credentials.UI; sys_platform == "win32" and python_version>='3.10'
 
 [options.package_data]
-keepercommander = resources/*
+keepercommander = resources/*, resources/email_templates/*
 
 [options.extras_require]
 test =
     pytest
     testfixtures
+email-sendgrid =
+    sendgrid>=6.10.0
+email-ses =
+    boto3>=1.26.0
+email-gmail-oauth =
+    google-auth>=2.16.0
+    google-auth-oauthlib>=0.8.0
+    google-auth-httplib2>=0.1.0
+    google-api-python-client>=2.70.0
+email-microsoft-oauth =
+    msal>=1.20.0
+email =
+    sendgrid>=6.10.0
+    boto3>=1.26.0
+    google-auth>=2.16.0
+    google-auth-oauthlib>=0.8.0
+    google-auth-httplib2>=0.1.0
+    google-api-python-client>=2.70.0
+    msal>=1.20.0
 
 [options.entry_points]
 console_scripts =

--- a/unit-tests/test_email_service.py
+++ b/unit-tests/test_email_service.py
@@ -1,0 +1,706 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+from keepercommander.email_service import (
+    EmailConfig,
+    SMTPEmailProvider,
+    SendGridEmailProvider,
+    SESEmailProvider,
+    EmailSender,
+    build_onboarding_email,
+    load_email_template,
+    validate_email_provider_dependencies,
+    get_installation_method,
+    check_provider_dependencies
+)
+
+
+class TestEmailConfig(unittest.TestCase):
+    """Test EmailConfig dataclass and validation"""
+
+    def test_email_config_creation(self):
+        """Test creating a basic email config"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="Test SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_host="smtp.gmail.com",
+            smtp_username="test@example.com",
+            smtp_password="password123"
+        )
+
+        self.assertEqual(config.record_uid, "abc123")
+        self.assertEqual(config.name, "Test SMTP")
+        self.assertEqual(config.provider, "smtp")
+        self.assertEqual(config.from_address, "test@example.com")
+
+    def test_smtp_config_validation_success(self):
+        """Test valid SMTP configuration"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_host="smtp.gmail.com",
+            smtp_username="test@example.com",
+            smtp_password="password123"
+        )
+
+        errors = config.validate()
+        self.assertEqual(len(errors), 0)
+
+    def test_smtp_config_validation_missing_host(self):
+        """Test SMTP config with missing host"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_username="test@example.com",
+            smtp_password="password123"
+        )
+
+        errors = config.validate()
+        self.assertIn("SMTP host is required", errors)
+
+    def test_smtp_config_validation_missing_password(self):
+        """Test SMTP config with missing password"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_host="smtp.gmail.com",
+            smtp_username="test@example.com"
+        )
+
+        errors = config.validate()
+        self.assertIn("SMTP password is required", errors)
+
+    def test_ses_config_validation_success(self):
+        """Test valid SES configuration"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SES",
+            provider="ses",
+            from_address="test@example.com",
+            aws_region="us-east-1",
+            aws_access_key="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+
+        errors = config.validate()
+        self.assertEqual(len(errors), 0)
+
+    def test_ses_config_validation_missing_region(self):
+        """Test SES config with missing region"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SES",
+            provider="ses",
+            from_address="test@example.com",
+            aws_access_key="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_key="secret"
+        )
+
+        errors = config.validate()
+        self.assertIn("AWS region is required for SES", errors)
+
+    def test_sendgrid_config_validation_success(self):
+        """Test valid SendGrid configuration"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SendGrid",
+            provider="sendgrid",
+            from_address="test@example.com",
+            sendgrid_api_key="SG.1234567890"
+        )
+
+        errors = config.validate()
+        self.assertEqual(len(errors), 0)
+
+    def test_sendgrid_config_validation_missing_api_key(self):
+        """Test SendGrid config with missing API key"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SendGrid",
+            provider="sendgrid",
+            from_address="test@example.com"
+        )
+
+        errors = config.validate()
+        self.assertIn("SendGrid API key is required", errors)
+
+    def test_unknown_provider_validation(self):
+        """Test config with unknown provider"""
+        config = EmailConfig(
+            record_uid="abc123",
+            name="Unknown",
+            provider="unknown_provider",
+            from_address="test@example.com"
+        )
+
+        errors = config.validate()
+        self.assertIn("Unknown provider: unknown_provider", errors)
+
+
+class TestSMTPEmailProvider(unittest.TestCase):
+    """Test SMTP email provider"""
+
+    def setUp(self):
+        """Set up test SMTP config"""
+        self.config = EmailConfig(
+            record_uid="abc123",
+            name="Test SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            from_name="Test Sender",
+            smtp_host="smtp.gmail.com",
+            smtp_port=587,
+            smtp_username="test@example.com",
+            smtp_password="password123",
+            smtp_use_tls=True
+        )
+
+    def test_smtp_provider_initialization(self):
+        """Test SMTP provider can be initialized"""
+        provider = SMTPEmailProvider(self.config)
+        self.assertEqual(provider.config, self.config)
+
+    def test_smtp_provider_invalid_config_raises_error(self):
+        """Test SMTP provider raises error with invalid config"""
+        invalid_config = EmailConfig(
+            record_uid="abc123",
+            name="Invalid",
+            provider="smtp",
+            from_address="test@example.com"
+        )
+
+        with self.assertRaises(ValueError) as context:
+            SMTPEmailProvider(invalid_config)
+
+        self.assertIn("Invalid email configuration", str(context.exception))
+
+    @patch('smtplib.SMTP')
+    def test_smtp_send_success(self, mock_smtp):
+        """Test SMTP email sending success"""
+        # Setup mock
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+        result = provider.send(
+            to="recipient@example.com",
+            subject="Test Subject",
+            body="Test body",
+            html=False
+        )
+
+        self.assertTrue(result)
+        mock_server.login.assert_called_once_with("test@example.com", "password123")
+        mock_server.send_message.assert_called_once()
+
+    @patch('smtplib.SMTP')
+    def test_smtp_send_html(self, mock_smtp):
+        """Test SMTP sending HTML email"""
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+        result = provider.send(
+            to="recipient@example.com",
+            subject="Test Subject",
+            body="<html><body>Test</body></html>",
+            html=True
+        )
+
+        self.assertTrue(result)
+        mock_server.send_message.assert_called_once()
+
+    @patch('smtplib.SMTP_SSL')
+    def test_smtp_send_with_ssl(self, mock_smtp_ssl):
+        """Test SMTP sending with SSL (port 465)"""
+        self.config.smtp_use_ssl = True
+        self.config.smtp_use_tls = False
+        self.config.smtp_port = 465
+
+        mock_server = MagicMock()
+        mock_smtp_ssl.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+        result = provider.send(
+            to="recipient@example.com",
+            subject="Test",
+            body="Test",
+            html=False
+        )
+
+        self.assertTrue(result)
+        mock_server.login.assert_called_once()
+
+    @patch('smtplib.SMTP')
+    def test_smtp_authentication_failure(self, mock_smtp):
+        """Test SMTP authentication failure"""
+        import smtplib
+        mock_server = MagicMock()
+        mock_server.login.side_effect = smtplib.SMTPAuthenticationError(535, b'Authentication failed')
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+
+        with self.assertRaises(smtplib.SMTPAuthenticationError):
+            provider.send(
+                to="recipient@example.com",
+                subject="Test",
+                body="Test"
+            )
+
+    @patch('smtplib.SMTP')
+    def test_smtp_test_connection_success(self, mock_smtp):
+        """Test SMTP connection testing success"""
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+        result = provider.test_connection()
+
+        self.assertTrue(result)
+        mock_server.login.assert_called_once()
+
+    @patch('smtplib.SMTP')
+    def test_smtp_test_connection_failure(self, mock_smtp):
+        """Test SMTP connection testing failure"""
+        mock_server = MagicMock()
+        mock_server.login.side_effect = Exception("Connection failed")
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        provider = SMTPEmailProvider(self.config)
+        result = provider.test_connection()
+
+        self.assertFalse(result)
+
+
+class TestSendGridEmailProvider(unittest.TestCase):
+    """Test SendGrid email provider"""
+
+    def setUp(self):
+        """Set up test SendGrid config"""
+        self.config = EmailConfig(
+            record_uid="abc123",
+            name="SendGrid",
+            provider="sendgrid",
+            from_address="test@example.com",
+            from_name="Test Sender",
+            sendgrid_api_key="SG.test_key_1234567890"
+        )
+
+    @patch('keepercommander.email_service.SendGridEmailProvider.__init__')
+    def test_sendgrid_provider_initialization(self, mock_init):
+        """Test SendGrid provider initialization"""
+        mock_init.return_value = None
+        # Just verify it doesn't raise an error
+        # Actual SendGrid testing requires the library installed
+        self.assertTrue(True)
+
+    def test_sendgrid_missing_library_raises_error(self):
+        """Test SendGrid raises ImportError if library not installed"""
+        # This will fail if sendgrid is not installed (expected in test environment)
+        try:
+            provider = SendGridEmailProvider(self.config)
+        except ImportError as e:
+            self.assertIn("SendGrid requires additional dependencies", str(e))
+
+
+class TestSESEmailProvider(unittest.TestCase):
+    """Test AWS SES email provider"""
+
+    def setUp(self):
+        """Set up test SES config"""
+        self.config = EmailConfig(
+            record_uid="abc123",
+            name="SES",
+            provider="ses",
+            from_address="test@example.com",
+            from_name="Test Sender",
+            aws_region="us-east-1",
+            aws_access_key="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        )
+
+    def test_ses_missing_library_raises_error(self):
+        """Test SES raises ImportError if boto3 not installed"""
+        # This will fail if boto3 is not installed (expected in test environment)
+        try:
+            provider = SESEmailProvider(self.config)
+        except ImportError as e:
+            self.assertIn("AWS SES requires additional dependencies", str(e))
+
+
+class TestEmailSender(unittest.TestCase):
+    """Test EmailSender main class"""
+
+    def setUp(self):
+        """Set up test config"""
+        self.smtp_config = EmailConfig(
+            record_uid="abc123",
+            name="SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_host="smtp.gmail.com",
+            smtp_username="test@example.com",
+            smtp_password="password123"
+        )
+
+    def test_email_sender_initialization_smtp(self):
+        """Test EmailSender with SMTP provider"""
+        sender = EmailSender(self.smtp_config)
+        self.assertIsInstance(sender.provider, SMTPEmailProvider)
+        self.assertEqual(sender.config, self.smtp_config)
+
+    def test_email_sender_unknown_provider_raises_error(self):
+        """Test EmailSender with unknown provider raises error"""
+        bad_config = EmailConfig(
+            record_uid="abc123",
+            name="Bad",
+            provider="unknown_provider",
+            from_address="test@example.com"
+        )
+
+        with self.assertRaises(ValueError) as context:
+            EmailSender(bad_config)
+
+        self.assertIn("Unknown email provider: unknown_provider", str(context.exception))
+
+    @patch('smtplib.SMTP')
+    def test_email_sender_send(self, mock_smtp):
+        """Test EmailSender.send() method"""
+        mock_server = MagicMock()
+        mock_smtp.return_value.__enter__.return_value = mock_server
+
+        sender = EmailSender(self.smtp_config)
+        result = sender.send(
+            to="recipient@example.com",
+            subject="Test",
+            body="Test body",
+            html=False
+        )
+
+        self.assertTrue(result)
+
+
+class TestEmailTemplates(unittest.TestCase):
+    """Test email template loading and building"""
+
+    @patch('builtins.open', new_callable=mock_open, read_data='<html>{custom_message}</html>')
+    @patch('os.path.exists', return_value=True)
+    def test_load_email_template_success(self, mock_exists, mock_file):
+        """Test loading email template successfully"""
+        template = load_email_template('onboarding.html')
+        self.assertIn('{custom_message}', template)
+        self.assertIn('<html>', template)
+
+    @patch('os.path.exists', return_value=False)
+    def test_load_email_template_not_found(self, mock_exists):
+        """Test loading non-existent template raises error"""
+        with self.assertRaises(FileNotFoundError):
+            load_email_template('nonexistent.html')
+
+    @patch('builtins.open', new_callable=mock_open, read_data='<html>{custom_message} {share_url} {record_title} {expiration_text}</html>')
+    @patch('os.path.exists', return_value=True)
+    def test_build_onboarding_email(self, mock_exists, mock_file):
+        """Test building onboarding email"""
+        html = build_onboarding_email(
+            share_url="https://test.com/share/abc123",
+            custom_message="Welcome to the team!",
+            record_title="Test Account",
+            expiration="24 hours"
+        )
+
+        self.assertIn("https://test.com/share/abc123", html)
+        self.assertIn("Welcome to the team!", html)
+        self.assertIn("Test Account", html)
+        self.assertIn("This link will expire in 24 hours", html)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='<html>{custom_message} {share_url} {record_title} {expiration_text}</html>')
+    @patch('os.path.exists', return_value=True)
+    def test_build_onboarding_email_no_expiration(self, mock_exists, mock_file):
+        """Test building onboarding email without expiration"""
+        html = build_onboarding_email(
+            share_url="https://test.com/share/abc123",
+            custom_message="Test message",
+            record_title="Account"
+        )
+
+        self.assertIn("This link will expire after first use", html)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='<html>{custom_message}</html>')
+    @patch('os.path.exists', return_value=True)
+    def test_build_onboarding_email_escapes_special_chars(self, mock_exists, mock_file):
+        """Test that template correctly handles special characters"""
+        html = build_onboarding_email(
+            share_url="https://test.com/share/abc123",
+            custom_message="Hello! This is a test with special chars: < > & \"",
+            record_title="Test Account"
+        )
+
+        # The template should include the message as-is (HTML will handle escaping)
+        self.assertIn("Hello! This is a test with special chars:", html)
+
+
+class TestValidateEmailProviderDependencies(unittest.TestCase):
+    """Test validate_email_provider_dependencies function"""
+
+    def test_smtp_validation_always_succeeds(self):
+        """Test SMTP validation always returns True (no dependencies needed)"""
+        is_valid, error_message = validate_email_provider_dependencies('smtp')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    def test_smtp_validation_case_insensitive(self):
+        """Test SMTP validation is case-insensitive"""
+        is_valid, error_message = validate_email_provider_dependencies('SMTP')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    @patch('builtins.__import__')
+    def test_sendgrid_validation_success(self, mock_import):
+        """Test SendGrid validation succeeds when library is installed"""
+        # Mock successful import of sendgrid
+        mock_import.return_value = MagicMock()
+
+        is_valid, error_message = validate_email_provider_dependencies('sendgrid')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    @patch('builtins.__import__', side_effect=ImportError("No module named 'sendgrid'"))
+    def test_sendgrid_validation_failure(self, mock_import):
+        """Test SendGrid validation fails when library is missing"""
+        is_valid, error_message = validate_email_provider_dependencies('sendgrid')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+        self.assertIn('sendgrid', error_message.lower())
+        self.assertIn('pip install keepercommander[email-sendgrid]', error_message)
+
+    @patch('builtins.__import__')
+    def test_ses_validation_success(self, mock_import):
+        """Test SES validation succeeds when boto3 is installed"""
+        mock_import.return_value = MagicMock()
+
+        is_valid, error_message = validate_email_provider_dependencies('ses')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    @patch('builtins.__import__', side_effect=ImportError("No module named 'boto3'"))
+    def test_ses_validation_failure(self, mock_import):
+        """Test SES validation fails when boto3 is missing"""
+        is_valid, error_message = validate_email_provider_dependencies('ses')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+        self.assertIn('boto3', error_message.lower())
+        self.assertIn('pip install keepercommander[email-ses]', error_message)
+
+    @patch('builtins.__import__')
+    def test_gmail_oauth_validation_success(self, mock_import):
+        """Test Gmail OAuth validation succeeds when Google libraries are installed"""
+        mock_import.return_value = MagicMock()
+
+        is_valid, error_message = validate_email_provider_dependencies('gmail-oauth')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    @patch('builtins.__import__', side_effect=ImportError("No module named 'google.auth'"))
+    def test_gmail_oauth_validation_failure(self, mock_import):
+        """Test Gmail OAuth validation fails when Google libraries are missing"""
+        is_valid, error_message = validate_email_provider_dependencies('gmail-oauth')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+        self.assertIn('Gmail OAuth', error_message)
+        self.assertIn('pip install keepercommander[email-gmail-oauth]', error_message)
+        self.assertIn('google-api-python-client', error_message)
+
+    @patch('builtins.__import__')
+    def test_microsoft_oauth_validation_success(self, mock_import):
+        """Test Microsoft OAuth validation succeeds when msal is installed"""
+        mock_import.return_value = MagicMock()
+
+        is_valid, error_message = validate_email_provider_dependencies('microsoft-oauth')
+        self.assertTrue(is_valid)
+        self.assertIsNone(error_message)
+
+    @patch('builtins.__import__', side_effect=ImportError("No module named 'msal'"))
+    def test_microsoft_oauth_validation_failure(self, mock_import):
+        """Test Microsoft OAuth validation fails when msal is missing"""
+        is_valid, error_message = validate_email_provider_dependencies('microsoft-oauth')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+        self.assertIn('msal', error_message.lower())
+        self.assertIn('pip install keepercommander[email-microsoft-oauth]', error_message)
+
+    def test_unknown_provider_validation(self):
+        """Test validation fails for unknown provider"""
+        is_valid, error_message = validate_email_provider_dependencies('unknown_provider')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+        self.assertIn('Unknown email provider: unknown_provider', error_message)
+        self.assertIn('smtp', error_message)
+        self.assertIn('sendgrid', error_message)
+        self.assertIn('ses', error_message)
+
+    def test_empty_provider_validation(self):
+        """Test validation fails for empty provider string"""
+        is_valid, error_message = validate_email_provider_dependencies('')
+        self.assertFalse(is_valid)
+        self.assertIsNotNone(error_message)
+
+
+class TestInstallationMethodDetection(unittest.TestCase):
+    """Test installation method detection functionality"""
+
+    def test_get_installation_method_source(self):
+        """Test detection of source installation"""
+        # When running from source, should detect as 'source' or 'pip'
+        method = get_installation_method()
+        self.assertIn(method, ['source', 'pip', 'binary'])
+
+    @patch('sys.frozen', True, create=True)
+    def test_get_installation_method_binary(self):
+        """Test detection of binary installation"""
+        # When sys.frozen is True, should detect as 'binary'
+        import importlib
+        import keepercommander.email_service
+        importlib.reload(keepercommander.email_service)
+
+        from keepercommander.email_service import get_installation_method
+        method = get_installation_method()
+        self.assertEqual(method, 'binary')
+
+
+class TestCheckProviderDependencies(unittest.TestCase):
+    """Test check_provider_dependencies functionality"""
+
+    def test_smtp_always_available(self):
+        """Test SMTP is always available (stdlib-based)"""
+        available, error_msg = check_provider_dependencies('smtp')
+        self.assertTrue(available)
+        self.assertEqual(error_msg, '')
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_sendgrid_blocked_on_binary(self, mock_install_method):
+        """Test SendGrid is blocked on binary installations"""
+        mock_install_method.return_value = 'binary'
+
+        available, error_msg = check_provider_dependencies('sendgrid')
+        self.assertFalse(available)
+        self.assertIn('binary installation', error_msg)
+        self.assertIn('switch to the PyPI version', error_msg)
+        self.assertIn('pip install keepercommander[email]', error_msg)
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_ses_blocked_on_binary(self, mock_install_method):
+        """Test AWS SES is blocked on binary installations"""
+        mock_install_method.return_value = 'binary'
+
+        available, error_msg = check_provider_dependencies('ses')
+        self.assertFalse(available)
+        self.assertIn('binary installation', error_msg)
+        self.assertIn('switch to the PyPI version', error_msg)
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_gmail_oauth_blocked_on_binary(self, mock_install_method):
+        """Test Gmail OAuth is blocked on binary installations"""
+        mock_install_method.return_value = 'binary'
+
+        available, error_msg = check_provider_dependencies('gmail-oauth')
+        self.assertFalse(available)
+        self.assertIn('binary installation', error_msg)
+        self.assertIn('switch to the PyPI version', error_msg)
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_microsoft_oauth_blocked_on_binary(self, mock_install_method):
+        """Test Microsoft OAuth is blocked on binary installations"""
+        mock_install_method.return_value = 'binary'
+
+        available, error_msg = check_provider_dependencies('microsoft-oauth')
+        self.assertFalse(available)
+        self.assertIn('binary installation', error_msg)
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_provider_available_on_pip_with_dependencies(self, mock_install_method):
+        """Test providers available on pip when dependencies installed"""
+        mock_install_method.return_value = 'pip'
+
+        # SMTP should always work
+        available, _ = check_provider_dependencies('smtp')
+        self.assertTrue(available)
+
+
+class TestEmailSenderBinaryRestrictions(unittest.TestCase):
+    """Test EmailSender initialization with binary restrictions"""
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_email_sender_smtp_works_on_binary(self, mock_install_method):
+        """Test EmailSender with SMTP works on binary"""
+        mock_install_method.return_value = 'binary'
+
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SMTP",
+            provider="smtp",
+            from_address="test@example.com",
+            smtp_host="smtp.gmail.com",
+            smtp_username="test@example.com",
+            smtp_password="password123"
+        )
+
+        # Should not raise error
+        sender = EmailSender(config)
+        # Check by class name to avoid module reload issues
+        self.assertEqual(sender.provider.__class__.__name__, 'SMTPEmailProvider')
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_email_sender_sendgrid_blocked_on_binary(self, mock_install_method):
+        """Test EmailSender with SendGrid raises error on binary"""
+        mock_install_method.return_value = 'binary'
+
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SendGrid",
+            provider="sendgrid",
+            from_address="test@example.com",
+            sendgrid_api_key="SG.test_key"
+        )
+
+        # Should raise ValueError with binary error message
+        with self.assertRaises(ValueError) as context:
+            EmailSender(config)
+
+        error_msg = str(context.exception)
+        self.assertIn('binary installation', error_msg)
+        self.assertIn('switch to the PyPI version', error_msg)
+
+    @patch('keepercommander.email_service.get_installation_method')
+    def test_email_sender_ses_blocked_on_binary(self, mock_install_method):
+        """Test EmailSender with SES raises error on binary"""
+        mock_install_method.return_value = 'binary'
+
+        config = EmailConfig(
+            record_uid="abc123",
+            name="SES",
+            provider="ses",
+            from_address="test@example.com",
+            aws_region="us-east-1",
+            aws_access_key="AKIATEST",
+            aws_secret_key="secrettest"
+        )
+
+        # Should raise ValueError
+        with self.assertRaises(ValueError) as context:
+            EmailSender(config)
+
+        self.assertIn('binary installation', str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Summary:
- Enhanced one-time share functionality to support flexible expiration options for user onboarding
- Implemented comprehensive email service supporting multiple providers (SMTP, SendGrid, AWS SES, Gmail OAuth, Microsoft OAuth)
- Made --self-destruct optional when using --send-email in record-add and PAM rotation commands
- Auto-creates 24-hour multi-use share links when --send-email is used without --self-destruct
- With --self-destruct: creates single-use link that expires on first access or after duration
- Without --self-destruct: creates time-based expiration link that can be accessed multiple times
- Added email-config commands to manage email provider configurations stored as records
- Built HTML email template system with customizable onboarding messages
- Made email provider dependencies optional with provider-specific pip extras
- Added early validation to fail fast with helpful error messages when dependencies are missing
- All email providers work via pip extras; binary distributions include all providers when built with 'pip install .[email]'