### PR TITLE
Fix SyntaxWarning in python3.14+

### DIFF
--- a/keepercommander/security_audit.py
+++ b/keepercommander/security_audit.py
@@ -164,8 +164,7 @@ def attach_security_data(params, record, rq_param):
             rq_param.securityScoreData.data = prep_score_data(record)
     except:
         pass
-    finally:
-        return rq_param
+    return rq_param
 
 def get_security_data_key_type(params):
     return record_pb2.ENCRYPTED_BY_PUBLIC_KEY_ECC if params.forbid_rsa \


### PR DESCRIPTION
## Fix SyntaxWarning in Python 3.14+

Resolves: Github Issue #1646 

Removed `return` from `finally` block in `security_audit.py::attach_security_data()`.