### PR TITLE
Enterprise API Keys Management - Integration-Based Architecture Refactoring

### DIFF
--- a/keepercommander/commands/enterprise_api_keys.py
+++ b/keepercommander/commands/enterprise_api_keys.py
@@ -12,17 +12,14 @@
 import argparse
 import json
 import logging
-import base64
 import os
 import datetime
-from typing import Optional, List, Dict, Any
 
 from .base import GroupCommand, dump_report_data, report_output_parser, field_to_title, user_choice
 from .enterprise_common import EnterpriseCommand
-from .. import api, utils
+from .. import api
 from ..display import bcolors
 from ..error import CommandError
-from ..params import KeeperParams
 from ..proto import publicapi_pb2
 
 api_key_list_parser = argparse.ArgumentParser(
@@ -49,31 +46,28 @@ api_key_generate_parser = argparse.ArgumentParser(
     epilog='''
 Examples:
   # Generate API key with SIEM role and 30-day expiration
-  public-api-key generate --name "SIEM Integration" --roles "SIEM:2" --expires 30d
+  public-api-key generate --name "SIEM Integration" --integrations "SIEM:2" --expires 30d
   
-  # Generate API key with multiple roles and 24-hour expiration
-  public-api-key generate --name "Temp Access" --roles "Admin:1,SIEM:2" --expires 24h
+  # Generate API key with 24-hour expiration
+  public-api-key generate --name "Temp Access" --integrations "SIEM:2" --expires 24h
   
   # Generate permanent API key with read-only access
-  public-api-key generate --name "Monitoring Tool" --roles "ReadOnly:1" --expires never
+  public-api-key generate --name "Monitoring Tool" --integrations "SIEM:1" --expires never
   
   # Generate API key and save details to JSON file
-  public-api-key generate --name "Backup Tool" --roles "Backup:2" --expires 1y --format json --output backup_key.json
+  public-api-key generate --name "Backup Tool" --integrations "SIEM:2" --expires 1y --format json --output backup_key.json
     ''',
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
 api_key_generate_parser.add_argument('--name', dest='name', required=True, 
                                      help='API key name. Examples: "SIEM Integration", "Backup Tool", "Monitoring Service"')
-api_key_generate_parser.add_argument('--roles', dest='roles', required=True, action='store', 
-                                     help='''Comma-separated list of role IDs with action types. 
-Format: "RoleID:ActionType" or "RoleName:ActionType"
-Action types: 0=NONE (no permissions), 1=READ (read-only), 2=READ_WRITE (full access)
+api_key_generate_parser.add_argument('--integrations', dest='integrations', required=True, action='store', 
+                                     help='''Integration with action type. 
+Format: "RoleName:ActionType"
+Action types: 1=READ (read-only), 2=READ_WRITE (full access)
 Examples: 
-  --roles "SIEM:2"                    # SIEM role with read-write access
-  --roles "Admin:1,SIEM:2"            # Multiple roles with different permissions
-  --roles "123:1,456:2"               # Using role IDs instead of names
-  --roles "ReadOnly:1"                # Read-only access
-  --roles "Backup:2,Monitor:1"        # Backup with full access, Monitor with read-only''')
+  --integrations "SIEM:2"                    # SIEM role with read-write access
+  --integrations "SIEM:1"                    # SIEM role with read-only access''')
 api_key_generate_parser.add_argument('--expires', dest='expires', action='store',
                                      choices=['24h', '7d', '30d', '1y', 'never'],
                                      default='never',
@@ -101,23 +95,23 @@ api_key_revoke_parser = argparse.ArgumentParser(
     epilog='''
 Examples:
   # Revoke API key with confirmation prompt
-  public-api-key revoke 12345
+  public-api-key revoke "SIEM Integration"
   
   # Revoke API key without confirmation (force)
-  public-api-key revoke 12345 --force
+  public-api-key revoke "SIEM Integration" --force
   
   # Short form with force flag
-  public-api-key revoke 12345 -f
+  public-api-key revoke "SIEM Integration" -f
 
 Tips:
-  - Use 'public-api-key list' to find the Token you want to revoke
+  - Use 'public-api-key list' to find the Name you want to revoke
   - Revoked keys cannot be restored, only new keys can be generated
   - Use --force to skip the confirmation prompt (useful for scripts)
     ''',
     formatter_class=argparse.RawDescriptionHelpFormatter
 )
-api_key_revoke_parser.add_argument('token', 
-                                   help='API key Token (get this from "api-key list" command). Example: 12345')
+api_key_revoke_parser.add_argument('name', 
+                                   help='API key Name (get this from "api-key list" command). Example: "SIEM Integration"')
 api_key_revoke_parser.add_argument('--force', '-f', dest='force', action='store_true', 
                                    help='Revoke without confirmation prompt (useful for automated scripts)')
 
@@ -129,6 +123,8 @@ def register_commands(commands):
 def register_command_info(aliases, command_info):
     command_info['public-api-key'] = 'Manage Admin REST API keys for 3rd party integrations'
 
+def get_enterprise_id(enterprise_user_id):
+    return enterprise_user_id >> 32
 
 class ApiKeyCommand(GroupCommand):
     def __init__(self):
@@ -144,7 +140,7 @@ class ApiKeyCommand(GroupCommand):
         print()
         print('Commands:')
         print('  list      - Display all enterprise API keys')
-        print('  generate  - Create a new API key with specified roles and expiration')
+        print('  generate  - Create a new API key with specified integrations and expiration')
         print('  revoke    - Revoke an existing API key')
         print()
         print('Quick Start Examples:')
@@ -152,10 +148,10 @@ class ApiKeyCommand(GroupCommand):
         print('  public-api-key list')
         print()
         print('  # Generate a new API key for SIEM integration (30-day expiration)')
-        print('  public-api-key generate --name "SIEM Tool" --roles "SIEM:2" --expires 30d')
+        print('  public-api-key generate --name "SIEM Tool" --integrations "SIEM:2" --expires 30d')
         print()
         print('  # Revoke an API key')
-        print('  public-api-key revoke 12345')
+        print('  public-api-key revoke "SIEM Integration"')
         print()
         print('Role Action Types:')
         print('  1 = READ       (read-only access)')
@@ -177,7 +173,7 @@ class ApiKeyListCommand(EnterpriseCommand):
 
     def execute(self, params, **kwargs):
         fmt = kwargs.get('format') or ''
-        headers = ['token', 'enterprise_id', 'name', 'status', 'issued_date', 'expiration_date', 'roles']
+        headers = ['enterprise_id', 'name', 'status', 'issued_date', 'expiration_date', 'integration']
         if fmt != 'json':
             headers = [field_to_title(x) for x in headers]
 
@@ -193,7 +189,7 @@ class ApiKeyListCommand(EnterpriseCommand):
                 'public_api/list_token',
                 rs_type=publicapi_pb2.PublicApiTokenResponseList
             )
-            
+
             for token in rs.tokens:
                 issued_date = ''
                 if token.issuedDate:
@@ -205,7 +201,7 @@ class ApiKeyListCommand(EnterpriseCommand):
                     dt = datetime.datetime.fromtimestamp(token.expirationDate / 1000)
                     expiration_date = dt.strftime('%Y-%m-%d %H:%M:%S')
                 
-                roles_str = ', '.join([f"{integration.roleName}:{integration.actionType}" 
+                api_integrations_str = ', '.join([f"{integration.apiIntegrationTypeName}:{integration.actionType}" 
                                      for integration in token.integrations])
                 
                 if token.expirationDate and token.expirationDate < int(datetime.datetime.now().timestamp() * 1000):
@@ -215,19 +211,18 @@ class ApiKeyListCommand(EnterpriseCommand):
                 
                 
                 row = [
-                    token.token,
                     token.enterprise_id,
                     token.name,
                     status,
                     issued_date,
                     expiration_date,
-                    roles_str
+                    api_integrations_str
                 ]
                 table.append(row)
                 
         except Exception as e:
             logging.error(f"Failed to list API keys: {e}")
-            raise CommandError("Failed to retrieve API keys")
+            raise CommandError("public-api-key list", "Failed to retrieve API keys")
         
         return dump_report_data(table, headers=headers, fmt=fmt, filename=kwargs.get('output'))
 
@@ -246,7 +241,7 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
             # Create the generate token request
             rq = publicapi_pb2.GenerateTokenRequest()
             rq.tokenName = name
-            rq.issuedDate = int(datetime.datetime.now().timestamp() * 1000)
+            rq.issuedDate = int(datetime.datetime.now().timestamp() * 1000) + 300
             
             # Set expiration based on the selected option
             expires = kwargs.get('expires', 'never')
@@ -267,31 +262,31 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
                 rq.expirationDate = int(expiration_date.timestamp() * 1000)
             # If expires == 'never', don't set expirationDate (it remains unset/blank)
             
-            # Parse roles - now required
-            roles_str = kwargs.get('roles')
-            if not roles_str:
-                print("At least one role is required. Example: --roles 'SIEM:2,CSPM:1'")
+            # Parse integrations - now required
+            integrations_str = kwargs.get('integrations')
+            if not integrations_str:
+                print("At least one integration is required. Example: --integrations 'SIEM:2'")
                 return
             
-            for role_spec in roles_str.split(','):
-                role_spec = role_spec.strip()
+            for integration_spec in integrations_str.split(','):
+                integration_spec = integration_spec.strip()
                 
                 # Require format: "RoleName:ActionType" or "RoleID:ActionType"
 
-                if ':' in role_spec:
-                    role_id_str, action_type_str = role_spec.split(':', 1)
-                    allowed_roles = [("SIEM", 1), ("CSPM", 2), ("BILLING", 3)]
-                    allowed_role_names = [role[0].upper() for role in allowed_roles]
-                    if role_id_str.strip().upper() not in allowed_role_names:
-                        print(f"Role '{role_id_str.strip()}' does not match allowed roles: {', '.join(allowed_role_names)}. Skipping.")
+                if ':' in integration_spec:
+                    integration_id_str, action_type_str = integration_spec.split(':', 1)
+                    allowed_integrations = [("SIEM", 1)]
+                    allowed_integration_names = [integration[0].upper() for integration in allowed_integrations]
+                    if integration_id_str.strip().upper() not in allowed_integration_names:
+                        print(f"Integration '{integration_id_str.strip()}' does not match allowed integrations: {', '.join(allowed_integration_names)}. Skipping.")
                         return
-                    role_id_str = role_id_str.strip()
-                    role_id = next(role[1] for role in allowed_roles if role[0].upper() == role_id_str.upper())
+                    integration_id_str = integration_id_str.strip()
+                    integration_id = next(integration[1] for integration in allowed_integrations if integration[0].upper() == integration_id_str.upper())
                     action_type_str = action_type_str.strip()
                 else:
                     # If no action type specified, default to READ-write (2)
-                    print(f"Error: Role specification must include action type. Got: '{role_spec}'")
-                    print("Required format: 'RoleName:ActionType' (e.g., 'SIEM:1,CSPM:2,Billing:1')")
+                    print(f"Error: Integration specification must include action type. Got: '{integration_spec}'")
+                    print("Required format: 'IntegrationName:ActionType' (e.g., 'SIEM:1')")
                     return
                 
                 # Map action type number to enum
@@ -303,15 +298,15 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
                         action_type = publicapi_pb2.ActionType.READ_WRITE
                     else:
                         print(f"Invalid action type: '{action_type_str}'. Valid values are: 1=READ, 2=READ_WRITE. Defaulting to READ-write (2)")
-                        action_type = publicapi_pb2.ActionType.READ_WRITE
+                        return
                 except ValueError:
                     print(f"Invalid action type: '{action_type_str}'. Action type must be a number: 1=READ, 2=READ_WRITE. Defaulting to read-write (2)")
-                    action_type = publicapi_pb2.ActionType.READ_WRITE
+                    return
                 
-                role = publicapi_pb2.Role()
-                role.roleId = role_id
-                role.actionType = action_type
-                rq.roles.append(role)
+                integration = publicapi_pb2.IntegrationRequest()
+                integration.apiIntegrationTypeId = integration_id
+                integration.actionType = action_type
+                rq.integrationRequests.append(integration)
             
             # Send the request
             rs = api.communicate_rest(
@@ -330,7 +325,7 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
                     'expiration_date': rs.expirationDate if rs.expirationDate else 'never',
                     'integrations': [
                         {
-                            'role_name': integration.roleName,
+                            'api_integration_type_name': integration.apiIntegrationTypeName,
                             'action_type': integration.actionType,
                             'action_type_name': publicapi_pb2.ActionType.Name(integration.actionType)
                         } for integration in rs.integrations
@@ -346,10 +341,9 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
                     return json.dumps(output, indent=2)
             else:
                 print(f"{bcolors.OKGREEN}API Key generated successfully{bcolors.ENDC}")
-                print(f"Token: {rs.token}")
                 print(f"Name: {rs.name}")
                 print(f"Token: {rs.token}")
-                print(f"Enterprise ID: {rs.enterprise_id}")
+                print(f"Enterprise ID: {get_enterprise_id(self.get_enterprise_id(params))}")
                 if rs.expirationDate:
                     exp_date = datetime.datetime.fromtimestamp(rs.expirationDate / 1000)
                     print(f"Expires: {exp_date.strftime('%Y-%m-%d %H:%M:%S')}")
@@ -357,14 +351,19 @@ class ApiKeyGenerateCommand(EnterpriseCommand):
                     print("Expires: Never")
                 
                 if rs.integrations:
-                    print("Roles:")
+                    print("Integrations:")
                     for integration in rs.integrations:
                         action_name = publicapi_pb2.ActionType.Name(integration.actionType)
                         print(f"  - {integration.roleName}: {action_name} ({integration.actionType})")
                         
         except Exception as e:
-            logging.error(f"Failed to generate API key: {e}")
-            raise CommandError("Failed to generate API key")
+            err = str(e)
+            if "(" in err and ")" in err and err.find("(") < err.find(")"):
+                idx1 = err.find("(") + 1
+                idx2 = err.find(")", idx1)
+                err = err[idx1:idx2]
+            logging.error(f"Failed to generate API key: {err}")
+            raise CommandError("public-api-key generate", "Failed to generate API key")
 
 
 class ApiKeyRevokeCommand(EnterpriseCommand):
@@ -372,16 +371,16 @@ class ApiKeyRevokeCommand(EnterpriseCommand):
         return api_key_revoke_parser
 
     def execute(self, params, **kwargs):
-        token = kwargs.get('token')
-        if not token:
-            print("Token is required")
+        name = kwargs.get('name')
+        if not name:
+            print("Name is required")
             return
         
         # Confirm revocation unless force flag is set
         if not kwargs.get('force'):
             answer = user_choice(
                 bcolors.FAIL + bcolors.BOLD + '\nALERT!\n' + bcolors.ENDC +
-                f'You are about to revoke API key with Token {token}' +
+                f'You are about to revoke API key with Name {name}' +
                 '\n\nDo you want to proceed with revocation?', 'yn', 'n'
             )
             if answer.lower() != 'y':
@@ -390,7 +389,7 @@ class ApiKeyRevokeCommand(EnterpriseCommand):
         try:
             # Create the revoke token request
             rq = publicapi_pb2.RevokeTokenRequest()
-            rq.token = token
+            rq.name = name
             
             # Send the request
             rs = api.communicate_rest(
@@ -399,10 +398,16 @@ class ApiKeyRevokeCommand(EnterpriseCommand):
                 rs_type=publicapi_pb2.RevokeTokenResponse
             )
             
-            print(f"{bcolors.OKGREEN}API Key with Token {token} revoked successfully{bcolors.ENDC}")
+            print(f"{bcolors.OKGREEN}API Key with Name {name} revoked successfully{bcolors.ENDC}")
+            
             if rs.message:
                 print(f"Message: {rs.message}")
                 
         except Exception as e:
-            logging.error(f"Failed to revoke API key: {e}")
-            raise CommandError("Failed to revoke API key") 
+            err = str(e)
+            if "(" in err and ")" in err and err.find("(") < err.find(")"):
+                idx1 = err.find("(") + 1
+                idx2 = err.find(")", idx1)
+                err = err[idx1:idx2]
+            logging.error(f"Failed to revoke API key: {err}")
+            raise CommandError("public-api-key revoke", "Failed to revoke API key") 

--- a/keepercommander/proto/publicapi_pb2.py
+++ b/keepercommander/proto/publicapi_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0fpublicapi.proto\x12\tPublicApi\"A\n\x04Role\x12\x0e\n\x06roleId\x18\x01 \x01(\x05\x12)\n\nactionType\x18\x02 \x01(\x0e\x32\x15.PublicApi.ActionType\"u\n\x14GenerateTokenRequest\x12\x1e\n\x05roles\x18\x01 \x03(\x0b\x32\x0f.PublicApi.Role\x12\x11\n\ttokenName\x18\x02 \x01(\t\x12\x12\n\nissuedDate\x18\x03 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x04 \x01(\x03\"i\n\x0cIntegrations\x12\x10\n\x08roleName\x18\x01 \x01(\t\x12\x1c\n\x14\x61piIntegrationTypeId\x18\x02 \x01(\x05\x12)\n\nactionType\x18\x03 \x01(\x0e\x32\x15.PublicApi.ActionType\"\xe3\x01\n\x0ePublicApiToken\x12\"\n\x1a\x65nterprisePublicApiTokenId\x18\x01 \x01(\x05\x12\x15\n\renterprise_id\x18\x02 \x01(\x05\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05token\x18\x04 \x01(\t\x12\x13\n\x06\x61\x63tive\x18\x05 \x01(\x08H\x00\x88\x01\x01\x12\x12\n\nissuedDate\x18\x06 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x07 \x01(\x03\x12-\n\x0cintegrations\x18\x08 \x03(\x0b\x32\x17.PublicApi.IntegrationsB\t\n\x07_active\"\xc7\x01\n\x16PublicApiTokenResponse\x12\x15\n\renterprise_id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05token\x18\x03 \x01(\t\x12\x13\n\x06\x61\x63tive\x18\x04 \x01(\x08H\x00\x88\x01\x01\x12\x12\n\nissuedDate\x18\x05 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x06 \x01(\x03\x12-\n\x0cintegrations\x18\x07 \x03(\x0b\x32\x17.PublicApi.IntegrationsB\t\n\x07_active\"O\n\x1aPublicApiTokenResponseList\x12\x31\n\x06tokens\x18\x01 \x03(\x0b\x32!.PublicApi.PublicApiTokenResponse\"<\n\x0fPublicApiTokens\x12)\n\x06tokens\x18\x01 \x03(\x0b\x32\x19.PublicApi.PublicApiToken\"#\n\x12RevokeTokenRequest\x12\r\n\x05token\x18\x01 \x01(\t\"&\n\x13RevokeTokenResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"D\n\x12\x41piIntegrationType\x12\x1c\n\x14\x61piIntegrationTypeId\x18\x01 \x01(\x05\x12\x10\n\x08roleName\x18\x02 \x01(\t\"Q\n\x13\x41piIntegrationTypes\x12:\n\x13\x61piIntegrationTypes\x18\x01 \x03(\x0b\x32\x1d.PublicApi.ApiIntegrationType\"+\n\x05Token\x12\"\n\x1a\x65nterprisePublicApiTokenId\x18\x01 \x01(\x05\"\xb0\x01\n\x19ListPublicApiTokenRequest\x12\x32\n\x0cstatusFilter\x18\x01 \x01(\x0e\x32\x17.PublicApi.StatusFilterH\x00\x88\x01\x01\x12\x17\n\nsortByName\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x17\n\nnameFilter\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x0f\n\r_statusFilterB\r\n\x0b_sortByNameB\r\n\x0b_nameFilter*0\n\nActionType\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04READ\x10\x01\x12\x0e\n\nREAD_WRITE\x10\x02*1\n\x0cStatusFilter\x12\n\n\x06\x41\x43TIVE\x10\x00\x12\x0c\n\x08INACTIVE\x10\x01\x12\x07\n\x03\x41LL\x10\x02\x42%\n\x18\x63om.keepersecurity.protoB\tPublicApib\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0fpublicapi.proto\x12\tPublicApi\"A\n\x04Role\x12\x0e\n\x06roleId\x18\x01 \x01(\x05\x12)\n\nactionType\x18\x02 \x01(\x0e\x32\x15.PublicApi.ActionType\"]\n\x12IntegrationRequest\x12\x1c\n\x14\x61piIntegrationTypeId\x18\x01 \x01(\x05\x12)\n\nactionType\x18\x02 \x01(\x0e\x32\x15.PublicApi.ActionType\"\xb1\x01\n\x14GenerateTokenRequest\x12\x1e\n\x05roles\x18\x01 \x03(\x0b\x32\x0f.PublicApi.Role\x12\x11\n\ttokenName\x18\x02 \x01(\t\x12\x12\n\nissuedDate\x18\x03 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x04 \x01(\x03\x12:\n\x13integrationRequests\x18\x05 \x03(\x0b\x32\x1d.PublicApi.IntegrationRequest\"\x89\x01\n\x0cIntegrations\x12\x10\n\x08roleName\x18\x01 \x01(\t\x12\x1c\n\x14\x61piIntegrationTypeId\x18\x02 \x01(\x05\x12)\n\nactionType\x18\x03 \x01(\x0e\x32\x15.PublicApi.ActionType\x12\x1e\n\x16\x61piIntegrationTypeName\x18\x04 \x01(\t\"\xe3\x01\n\x0ePublicApiToken\x12\"\n\x1a\x65nterprisePublicApiTokenId\x18\x01 \x01(\x05\x12\x15\n\renterprise_id\x18\x02 \x01(\x05\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\r\n\x05token\x18\x04 \x01(\t\x12\x13\n\x06\x61\x63tive\x18\x05 \x01(\x08H\x00\x88\x01\x01\x12\x12\n\nissuedDate\x18\x06 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x07 \x01(\x03\x12-\n\x0cintegrations\x18\x08 \x03(\x0b\x32\x17.PublicApi.IntegrationsB\t\n\x07_active\"\xc7\x01\n\x16PublicApiTokenResponse\x12\x15\n\renterprise_id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\r\n\x05token\x18\x03 \x01(\t\x12\x13\n\x06\x61\x63tive\x18\x04 \x01(\x08H\x00\x88\x01\x01\x12\x12\n\nissuedDate\x18\x05 \x01(\x03\x12\x16\n\x0e\x65xpirationDate\x18\x06 \x01(\x03\x12-\n\x0cintegrations\x18\x07 \x03(\x0b\x32\x17.PublicApi.IntegrationsB\t\n\x07_active\"O\n\x1aPublicApiTokenResponseList\x12\x31\n\x06tokens\x18\x01 \x03(\x0b\x32!.PublicApi.PublicApiTokenResponse\"<\n\x0fPublicApiTokens\x12)\n\x06tokens\x18\x01 \x03(\x0b\x32\x19.PublicApi.PublicApiToken\"1\n\x12RevokeTokenRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05token\x18\x02 \x01(\t\"&\n\x13RevokeTokenResponse\x12\x0f\n\x07message\x18\x01 \x01(\t\"D\n\x12\x41piIntegrationType\x12\x1c\n\x14\x61piIntegrationTypeId\x18\x01 \x01(\x05\x12\x10\n\x08roleName\x18\x02 \x01(\t\"Q\n\x13\x41piIntegrationTypes\x12:\n\x13\x61piIntegrationTypes\x18\x01 \x03(\x0b\x32\x1d.PublicApi.ApiIntegrationType\"+\n\x05Token\x12\"\n\x1a\x65nterprisePublicApiTokenId\x18\x01 \x01(\x05\"\xb0\x01\n\x19ListPublicApiTokenRequest\x12\x32\n\x0cstatusFilter\x18\x01 \x01(\x0e\x32\x17.PublicApi.StatusFilterH\x00\x88\x01\x01\x12\x17\n\nsortByName\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x17\n\nnameFilter\x18\x03 \x01(\tH\x02\x88\x01\x01\x42\x0f\n\r_statusFilterB\r\n\x0b_sortByNameB\r\n\x0b_nameFilter*0\n\nActionType\x12\x08\n\x04NONE\x10\x00\x12\x08\n\x04READ\x10\x01\x12\x0e\n\nREAD_WRITE\x10\x02*1\n\x0cStatusFilter\x12\n\n\x06\x41\x43TIVE\x10\x00\x12\x0c\n\x08INACTIVE\x10\x01\x12\x07\n\x03\x41LL\x10\x02\x42%\n\x18\x63om.keepersecurity.protoB\tPublicApib\x06proto3')
 
 _ACTIONTYPE = DESCRIPTOR.enum_types_by_name['ActionType']
 ActionType = enum_type_wrapper.EnumTypeWrapper(_ACTIONTYPE)
@@ -30,6 +30,7 @@ ALL = 2
 
 
 _ROLE = DESCRIPTOR.message_types_by_name['Role']
+_INTEGRATIONREQUEST = DESCRIPTOR.message_types_by_name['IntegrationRequest']
 _GENERATETOKENREQUEST = DESCRIPTOR.message_types_by_name['GenerateTokenRequest']
 _INTEGRATIONS = DESCRIPTOR.message_types_by_name['Integrations']
 _PUBLICAPITOKEN = DESCRIPTOR.message_types_by_name['PublicApiToken']
@@ -48,6 +49,13 @@ Role = _reflection.GeneratedProtocolMessageType('Role', (_message.Message,), {
   # @@protoc_insertion_point(class_scope:PublicApi.Role)
   })
 _sym_db.RegisterMessage(Role)
+
+IntegrationRequest = _reflection.GeneratedProtocolMessageType('IntegrationRequest', (_message.Message,), {
+  'DESCRIPTOR' : _INTEGRATIONREQUEST,
+  '__module__' : 'publicapi_pb2'
+  # @@protoc_insertion_point(class_scope:PublicApi.IntegrationRequest)
+  })
+_sym_db.RegisterMessage(IntegrationRequest)
 
 GenerateTokenRequest = _reflection.GeneratedProtocolMessageType('GenerateTokenRequest', (_message.Message,), {
   'DESCRIPTOR' : _GENERATETOKENREQUEST,
@@ -137,34 +145,36 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\030com.keepersecurity.protoB\tPublicApi'
-  _ACTIONTYPE._serialized_start=1352
-  _ACTIONTYPE._serialized_end=1400
-  _STATUSFILTER._serialized_start=1402
-  _STATUSFILTER._serialized_end=1451
+  _ACTIONTYPE._serialized_start=1555
+  _ACTIONTYPE._serialized_end=1603
+  _STATUSFILTER._serialized_start=1605
+  _STATUSFILTER._serialized_end=1654
   _ROLE._serialized_start=30
   _ROLE._serialized_end=95
-  _GENERATETOKENREQUEST._serialized_start=97
-  _GENERATETOKENREQUEST._serialized_end=214
-  _INTEGRATIONS._serialized_start=216
-  _INTEGRATIONS._serialized_end=321
-  _PUBLICAPITOKEN._serialized_start=324
-  _PUBLICAPITOKEN._serialized_end=551
-  _PUBLICAPITOKENRESPONSE._serialized_start=554
-  _PUBLICAPITOKENRESPONSE._serialized_end=753
-  _PUBLICAPITOKENRESPONSELIST._serialized_start=755
-  _PUBLICAPITOKENRESPONSELIST._serialized_end=834
-  _PUBLICAPITOKENS._serialized_start=836
-  _PUBLICAPITOKENS._serialized_end=896
-  _REVOKETOKENREQUEST._serialized_start=898
-  _REVOKETOKENREQUEST._serialized_end=933
-  _REVOKETOKENRESPONSE._serialized_start=935
-  _REVOKETOKENRESPONSE._serialized_end=973
-  _APIINTEGRATIONTYPE._serialized_start=975
-  _APIINTEGRATIONTYPE._serialized_end=1043
-  _APIINTEGRATIONTYPES._serialized_start=1045
-  _APIINTEGRATIONTYPES._serialized_end=1126
-  _TOKEN._serialized_start=1128
-  _TOKEN._serialized_end=1171
-  _LISTPUBLICAPITOKENREQUEST._serialized_start=1174
-  _LISTPUBLICAPITOKENREQUEST._serialized_end=1350
+  _INTEGRATIONREQUEST._serialized_start=97
+  _INTEGRATIONREQUEST._serialized_end=190
+  _GENERATETOKENREQUEST._serialized_start=193
+  _GENERATETOKENREQUEST._serialized_end=370
+  _INTEGRATIONS._serialized_start=373
+  _INTEGRATIONS._serialized_end=510
+  _PUBLICAPITOKEN._serialized_start=513
+  _PUBLICAPITOKEN._serialized_end=740
+  _PUBLICAPITOKENRESPONSE._serialized_start=743
+  _PUBLICAPITOKENRESPONSE._serialized_end=942
+  _PUBLICAPITOKENRESPONSELIST._serialized_start=944
+  _PUBLICAPITOKENRESPONSELIST._serialized_end=1023
+  _PUBLICAPITOKENS._serialized_start=1025
+  _PUBLICAPITOKENS._serialized_end=1085
+  _REVOKETOKENREQUEST._serialized_start=1087
+  _REVOKETOKENREQUEST._serialized_end=1136
+  _REVOKETOKENRESPONSE._serialized_start=1138
+  _REVOKETOKENRESPONSE._serialized_end=1176
+  _APIINTEGRATIONTYPE._serialized_start=1178
+  _APIINTEGRATIONTYPE._serialized_end=1246
+  _APIINTEGRATIONTYPES._serialized_start=1248
+  _APIINTEGRATIONTYPES._serialized_end=1329
+  _TOKEN._serialized_start=1331
+  _TOKEN._serialized_end=1374
+  _LISTPUBLICAPITOKENREQUEST._serialized_start=1377
+  _LISTPUBLICAPITOKENREQUEST._serialized_end=1553
 # @@protoc_insertion_point(module_scope)

--- a/unit-tests/test_command_enterprise_api_keys.py
+++ b/unit-tests/test_command_enterprise_api_keys.py
@@ -44,20 +44,18 @@ class TestEnterpriseApiKeys(TestCase):
         
         # Verify the table output contains expected headers and data
         output = captured_output.getvalue()
-        self.assertIn('Token', output)
         self.assertIn('Enterprise ID', output)
         self.assertIn('Name', output)
         self.assertIn('Status', output)
         self.assertIn('Issued Date', output)
         self.assertIn('Expiration Date', output)
-        self.assertIn('Roles', output)
+        self.assertIn('Integration', output)
         
         # Verify sample data appears in output
-        self.assertIn('expired_token_43', output)  # Token
         self.assertIn('8560', output)  # Enterprise ID
         self.assertIn('Token Test', output)  # Name
         self.assertIn('Expired', output)  # Status
-        self.assertIn('SIEM:2', output)  # Role
+        self.assertIn('SIEM', output)  # Integration
 
     def test_api_key_list_json_format(self):
         """Test listing API keys in JSON format"""
@@ -73,49 +71,44 @@ class TestEnterpriseApiKeys(TestCase):
         # Assert that the JSON result matches the expected values for all entries
         expected_json = [
             {
-                "token": "expired_token_43",
                 "enterprise_id": 8560,
                 "name": "Token Test",
                 "status": "Expired",
                 "issued_date": "2025-04-14 12:48:26",
                 "expiration_date": "2025-04-15 12:48:26",
-                "roles": "SIEM:2, CSPM:2"
+                "integration": "SIEM:2"
             },
             {
-                "token": "expired_token_44",
                 "enterprise_id": 8560,
                 "name": "Token Test",
                 "status": "Expired",
                 "issued_date": "2025-04-14 12:48:26",
                 "expiration_date": "2025-04-15 12:48:26",
-                "roles": "SIEM:2, CSPM:2"
+                "integration": "SIEM:2"
             },
             {
-                "token": "expired_token_45",
                 "enterprise_id": 8560,
                 "name": "Token Test 2",
                 "status": "Expired",
                 "issued_date": "2025-04-14 12:48:26",
                 "expiration_date": "2025-04-15 12:48:26",
-                "roles": "SIEM:2, CSPM:2"
+                "integration": "SIEM:2"
             },
             {
-                "token": "active_token_53",
                 "enterprise_id": 8560,
-                "name": "CSPM Tool",
+                "name": "SIEM Tool",
                 "status": "Active",
                 "issued_date": "2025-07-08 14:16:07",
                 "expiration_date": "2026-07-08 14:16:07",
-                "roles": "SIEM:2, CSPM:1"
+                "integration": "SIEM:2"
             },
             {
-                "token": "permanent_token_54",
                 "enterprise_id": 8560,
                 "name": "Token For My Tests 111",
                 "status": "Active",
                 "issued_date": "2025-07-09 14:33:26",
                 "expiration_date": "Never",
-                "roles": "SIEM:2, CSPM:2, Billing:2"
+                "integration": "SIEM:2"
             }
         ]
         self.assertEqual(json.loads(result), expected_json)
@@ -129,8 +122,10 @@ class TestEnterpriseApiKeys(TestCase):
         
         # Capture print output to verify exact format from terminal example
         captured_output = io.StringIO()
-        with mock.patch('sys.stdout', captured_output):
-            cmd.execute(params, name='SIEM Tool', roles='SIEM:2', expires='30d')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('sys.stdout', captured_output):
+                cmd.execute(params, name='SIEM Tool', integrations='SIEM:2', expires='30d')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         
@@ -141,7 +136,7 @@ class TestEnterpriseApiKeys(TestCase):
         self.assertIn('Name: SIEM Tool', output)
         self.assertIn('Enterprise ID: 8560', output)
         self.assertIn('Expires: 2025-08-09', output)  # Date format
-        self.assertIn('Roles:', output)
+        self.assertIn('Integrations:', output)
         self.assertIn('- SIEM: READ_WRITE (2)', output)
 
     def test_api_key_generate_success_7d_expiration(self):
@@ -151,8 +146,10 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        with mock.patch('builtins.print'):
-            cmd.execute(params, name='Weekly API Key', roles='CSPM:2', expires='7d')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('builtins.print'):
+                cmd.execute(params, name='Weekly API Key', integrations='SIEM:2', expires='7d')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
@@ -163,8 +160,10 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        with mock.patch('builtins.print'):
-            cmd.execute(params, name='Monthly API Key', roles='BILLING:1', expires='30d')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('builtins.print'):
+                cmd.execute(params, name='Monthly API Key', integrations='SIEM:1', expires='30d')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
@@ -175,8 +174,10 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        with mock.patch('builtins.print'):
-            cmd.execute(params, name='Annual API Key', roles='SIEM:1', expires='1y')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('builtins.print'):
+                cmd.execute(params, name='Annual API Key', integrations='SIEM:1', expires='1y')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
@@ -187,20 +188,24 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        with mock.patch('builtins.print'):
-            cmd.execute(params, name='Permanent API Key', roles='CSPM:2', expires='never')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('builtins.print'):
+                cmd.execute(params, name='Permanent API Key', integrations='SIEM:2', expires='never')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
     def test_api_key_generate_multiple_roles(self):
-        """Test API key generation with multiple roles"""
+        """Test API key generation with multiple integrations"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        with mock.patch('builtins.print'):
-            cmd.execute(params, name='Multi-Role Key', roles='SIEM:2,CSPM:1,BILLING:1', expires='30d')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('builtins.print'):
+                cmd.execute(params, name='Multi-Role Key', integrations='SIEM:2', expires='30d')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
@@ -211,7 +216,7 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        result = cmd.execute(params, name='JSON API Key', roles='SIEM:2', expires='7d', format='json')
+        result = cmd.execute(params, name='JSON API Key', integrations='SIEM:2', expires='7d', format='json')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         self.assertIsNotNone(result)
@@ -228,7 +233,7 @@ class TestEnterpriseApiKeys(TestCase):
         
         try:
             with mock.patch('builtins.print'):
-                cmd.execute(params, name='File Output Key', roles='CSPM:2', expires='1y', 
+                cmd.execute(params, name='File Output Key', integrations='SIEM:2', expires='1y', 
                           format='json', output=temp_filename)
             
             self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
@@ -244,12 +249,12 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         
         with mock.patch('builtins.print') as mock_print:
-            cmd.execute(params, roles='SIEM:2')
+            cmd.execute(params, integrations='SIEM:2')
         
         mock_print.assert_called_with("API key name is required")
 
     def test_api_key_generate_missing_roles(self):
-        """Test API key generation fails when roles are missing"""
+        """Test API key generation fails when integrations are missing"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
@@ -257,30 +262,30 @@ class TestEnterpriseApiKeys(TestCase):
         with mock.patch('builtins.print') as mock_print:
             cmd.execute(params, name='Test Key')
         
-        mock_print.assert_called_with("At least one role is required. Example: --roles 'SIEM:2,CSPM:1'")
+        mock_print.assert_called_with("At least one integration is required. Example: --integrations 'SIEM:2'")
 
     def test_api_key_generate_invalid_role_format(self):
-        """Test API key generation fails with invalid role format"""
+        """Test API key generation fails with invalid integration format"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         
         with mock.patch('builtins.print') as mock_print:
-            cmd.execute(params, name='Test Key', roles='INVALID_ROLE')
+            cmd.execute(params, name='Test Key', integrations='INVALID_ROLE')
         
-        # Should print error about role format
+        # Should print error about integration format
         mock_print.assert_called()
 
     def test_api_key_generate_invalid_role_name(self):
-        """Test API key generation fails with invalid role name"""
+        """Test API key generation fails with invalid integration name"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         
         with mock.patch('builtins.print') as mock_print:
-            cmd.execute(params, name='Test Key', roles='INVALID:2')
+            cmd.execute(params, name='Test Key', integrations='INVALID:2')
         
-        # Should print error about invalid role
+        # Should print error about invalid integration
         mock_print.assert_called()
 
     def test_api_key_revoke_success(self):
@@ -291,7 +296,7 @@ class TestEnterpriseApiKeys(TestCase):
         TestEnterpriseApiKeys.expected_commands = ['revoke_token']
         
         with mock.patch('builtins.print'):
-            cmd.execute(params, token='12345', force=True)
+            cmd.execute(params, name='Test Key', force=True)
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
 
@@ -306,14 +311,14 @@ class TestEnterpriseApiKeys(TestCase):
         captured_output = io.StringIO()
         with mock.patch('keepercommander.commands.enterprise_api_keys.user_choice', return_value='y') as mock_input:
             with mock.patch('sys.stdout', captured_output):
-                cmd.execute(params, token='55')
+                cmd.execute(params, name='SIEM Integration')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         mock_input.assert_called_once()
         
         # Verify output matches Commander terminal example
         output = captured_output.getvalue()
-        self.assertIn('API Key with Token 55 revoked successfully', output)
+        self.assertIn('API Key with Name SIEM Integration revoked successfully', output)
 
     def test_api_key_revoke_cancelled_by_user(self):
         """Test API key revocation cancelled by user"""
@@ -322,14 +327,14 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyRevokeCommand()
         
         with mock.patch('keepercommander.commands.enterprise_api_keys.user_choice', return_value='n') as mock_input:
-            cmd.execute(params, token='12345')
+            cmd.execute(params, name='Test Key')
         
         # Should not have made any API calls
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         mock_input.assert_called_once()
 
     def test_api_key_revoke_missing_token_id(self):
-        """Test API key revocation fails when token_id is missing"""
+        """Test API key revocation fails when name is missing"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyRevokeCommand()
@@ -337,7 +342,7 @@ class TestEnterpriseApiKeys(TestCase):
         with mock.patch('builtins.print') as mock_print:
             cmd.execute(params)
         
-        mock_print.assert_called_with("Token is required")
+        mock_print.assert_called_with("Name is required")
 
 
     def test_api_key_main_command_default_list_behavior(self):
@@ -358,13 +363,11 @@ class TestEnterpriseApiKeys(TestCase):
         
         # Verify output contains list data like terminal example
         output = captured_output.getvalue()
-        # Should show the table with all tokens
-        self.assertIn('Token', output)
+        # Should show the table with all data
         self.assertIn('Enterprise ID', output)
-        self.assertIn('expired_token_43', output)  # First token
         self.assertIn('8560', output)  # Enterprise ID
         self.assertIn('Token Test', output)  # Token name
-        self.assertIn('CSPM Tool', output)  # Another token name
+        self.assertIn('SIEM Tool', output)  # Another token name
         self.assertIn('Expired', output)  # Status
         self.assertIn('Active', output)  # Status
         self.assertIn('Never', output)  # Never expires
@@ -382,7 +385,7 @@ class TestEnterpriseApiKeys(TestCase):
         self.assertIn('Enterprise API Key Management', output)
         self.assertIn('Commands:', output)
         self.assertIn('list      - Display all enterprise API keys', output)
-        self.assertIn('generate  - Create a new API key', output)
+        self.assertIn('generate  - Create a new API key with specified integrations', output)
         self.assertIn('revoke    - Revoke an existing API key', output)
         self.assertIn('Role Action Types:', output)
         self.assertIn('1 = READ       (read-only access)', output)
@@ -429,15 +432,13 @@ class TestEnterpriseApiKeys(TestCase):
         
         # Validate first token
         token = data[0]
-        self.assertEqual(token['token'], 'expired_token_43')
         self.assertEqual(token['enterprise_id'], 8560)
         self.assertEqual(token['name'], 'Token Test')
         self.assertEqual(token['status'], 'Expired')
         self.assertIn('issued_date', token)
         self.assertIn('expiration_date', token)
-        self.assertIn('roles', token)
-        self.assertIn('SIEM:2', token['roles'])
-        self.assertIn('CSPM:2', token['roles'])
+        self.assertIn('integration', token)
+        self.assertIn('SIEM:2', token['integration'])
 
     def test_api_key_generate_json_comprehensive_fields(self):
         """Test API key generation in JSON format with all field validation"""
@@ -446,7 +447,7 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
-        result = cmd.execute(params, name='SIEM Tool', roles='SIEM:2', expires='30d', format='json')
+        result = cmd.execute(params, name='SIEM Tool', integrations='SIEM:2', expires='30d', format='json')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         self.assertIsNotNone(result)
@@ -467,28 +468,28 @@ class TestEnterpriseApiKeys(TestCase):
         integrations = data['integrations']
         self.assertIsInstance(integrations, list)
         self.assertEqual(len(integrations), 1)
-        self.assertEqual(integrations[0]['role_name'], 'SIEM')
+        self.assertEqual(integrations[0]['api_integration_type_name'], 'SIEM')
         self.assertEqual(integrations[0]['action_type'], 2)
         self.assertEqual(integrations[0]['action_type_name'], 'READ_WRITE')
 
     def test_api_key_generate_multiple_roles_comprehensive(self):
-        """Test API key generation with multiple roles like terminal example"""
+        """Test API key generation with multiple integrations like terminal example"""
         params = get_connected_params()
         
         cmd = enterprise_api_keys.ApiKeyGenerateCommand()
         TestEnterpriseApiKeys.expected_commands = ['generate_token']
         
         captured_output = io.StringIO()
-        with mock.patch('sys.stdout', captured_output):
-            cmd.execute(params, name='Multi Role Key', roles='SIEM:2,CSPM:1,BILLING:2', expires='never')
+        # Mock get_enterprise_id to avoid API call - enterprise_id 8560 in 32-bit shifted format
+        with mock.patch.object(cmd, 'get_enterprise_id', return_value=8560 << 32):
+            with mock.patch('sys.stdout', captured_output):
+                cmd.execute(params, name='Multi Role Key', integrations='SIEM:2', expires='never')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         
-        # Verify output shows all roles
+        # Verify output shows all integrations
         output = captured_output.getvalue()
         self.assertIn('SIEM: READ_WRITE (2)', output)
-        self.assertIn('CSPM: READ (1)', output)
-        self.assertIn('BILLING: READ_WRITE (2)', output)  # Role names are uppercase in output
         self.assertIn('Expires: Never', output)  # Never expires
 
     def test_api_key_status_detection_expired_vs_active(self):
@@ -504,17 +505,12 @@ class TestEnterpriseApiKeys(TestCase):
         
         output = captured_output.getvalue()
         
-        # Verify expired tokens show as Expired
-        self.assertIn('expired_token_43', output)
-        self.assertIn('expired_token_44', output) 
-        self.assertIn('expired_token_45', output)
+        # Verify expired tokens show as Expired (token column removed, checking names and status)
         self.assertIn('Token Test              Expired', output)
         self.assertIn('Token Test 2            Expired', output)
         
         # Verify active tokens show as Active
-        self.assertIn('active_token_53', output)
-        self.assertIn('permanent_token_54', output)
-        self.assertIn('CSPM Tool               Active', output)
+        self.assertIn('SIEM Tool               Active', output)
         self.assertIn('Token For My Tests 111  Active', output)
         
         # Verify never expires shows "Never"
@@ -530,13 +526,13 @@ class TestEnterpriseApiKeys(TestCase):
         captured_output = io.StringIO()
         with mock.patch('sys.stdout', captured_output):
             # Force flag should bypass confirmation
-            cmd.execute(params, token='55', force=True)
+            cmd.execute(params, name='SIEM Integration', force=True)
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         
         # Verify output shows successful revocation
         output = captured_output.getvalue()
-        self.assertIn('API Key with Token 55 revoked successfully', output)
+        self.assertIn('API Key with Name SIEM Integration revoked successfully', output)
 
     @staticmethod
     def communicate_rest_success(params, request, path, rs_type=None):
@@ -557,10 +553,8 @@ class TestEnterpriseApiKeys(TestCase):
             token1.expirationDate = int(datetime.datetime(2025, 4, 15, 12, 48, 26).timestamp() * 1000)
             integration1 = token1.integrations.add()
             integration1.roleName = "SIEM"
+            integration1.apiIntegrationTypeName = "SIEM"
             integration1.actionType = 2
-            integration2 = token1.integrations.add()
-            integration2.roleName = "CSPM"
-            integration2.actionType = 2
             
             # Token 44 - Expired
             token2 = rs.tokens.add()
@@ -571,10 +565,8 @@ class TestEnterpriseApiKeys(TestCase):
             token2.expirationDate = int(datetime.datetime(2025, 4, 15, 12, 48, 26).timestamp() * 1000)
             integration3 = token2.integrations.add()
             integration3.roleName = "SIEM"
+            integration3.apiIntegrationTypeName = "SIEM"
             integration3.actionType = 2
-            integration4 = token2.integrations.add()
-            integration4.roleName = "CSPM"
-            integration4.actionType = 2
             
             # Token 45 - Expired
             token3 = rs.tokens.add()
@@ -585,24 +577,20 @@ class TestEnterpriseApiKeys(TestCase):
             token3.expirationDate = int(datetime.datetime(2025, 4, 15, 12, 48, 26).timestamp() * 1000)
             integration5 = token3.integrations.add()
             integration5.roleName = "SIEM"
+            integration5.apiIntegrationTypeName = "SIEM"
             integration5.actionType = 2
-            integration6 = token3.integrations.add()
-            integration6.roleName = "CSPM"
-            integration6.actionType = 2
             
             # Token 53 - Active
             token4 = rs.tokens.add()
             token4.token = "active_token_53"
-            token4.name = "CSPM Tool"
+            token4.name = "SIEM Tool"
             token4.enterprise_id = 8560
             token4.issuedDate = int(datetime.datetime(2025, 7, 8, 14, 16, 7).timestamp() * 1000)
             token4.expirationDate = int(datetime.datetime(2026, 7, 8, 14, 16, 7).timestamp() * 1000)
             integration7 = token4.integrations.add()
             integration7.roleName = "SIEM"
+            integration7.apiIntegrationTypeName = "SIEM"
             integration7.actionType = 2
-            integration8 = token4.integrations.add()
-            integration8.roleName = "CSPM"
-            integration8.actionType = 1
             
             # Token 54 - Active, Never expires
             token5 = rs.tokens.add()
@@ -613,13 +601,8 @@ class TestEnterpriseApiKeys(TestCase):
             # No expiration date for never expires
             integration9 = token5.integrations.add()
             integration9.roleName = "SIEM"
+            integration9.apiIntegrationTypeName = "SIEM"
             integration9.actionType = 2
-            integration10 = token5.integrations.add()
-            integration10.roleName = "CSPM"
-            integration10.actionType = 2
-            integration11 = token5.integrations.add()
-            integration11.roleName = "Billing"
-            integration11.actionType = 2
             
             return rs
             
@@ -634,11 +617,13 @@ class TestEnterpriseApiKeys(TestCase):
                 # Set expiration to match terminal example: 2025-08-09 16:24:35
                 rs.expirationDate = int(datetime.datetime(2025, 8, 9, 16, 24, 35).timestamp() * 1000)
             
-            # Add integration/role from request
-            for role in request.roles:
+            # Add integration from request (using integrationRequests)
+            for integration_req in request.integrationRequests:
                 integration = rs.integrations.add()
-                integration.roleName = TestEnterpriseApiKeys._get_role_name_by_id(role.roleId)
-                integration.actionType = role.actionType
+                integration_name = TestEnterpriseApiKeys._get_role_name_by_id(integration_req.apiIntegrationTypeId)
+                integration.roleName = integration_name
+                integration.apiIntegrationTypeName = integration_name
+                integration.actionType = integration_req.actionType
             
             return rs
             
@@ -654,8 +639,6 @@ class TestEnterpriseApiKeys(TestCase):
     def _get_role_name_by_id(role_id):
         """Helper method to map role IDs to names"""
         role_map = {
-            1: "SIEM",
-            2: "CSPM", 
-            3: "BILLING"
+            1: "SIEM"
         }
         return role_map.get(role_id, f"Role_{role_id}") 


### PR DESCRIPTION
# Enterprise API Keys Management - Integration-Based Architecture Refactoring

## 📋 **Overview**

This PR implements a **major architectural refactoring** of the enterprise API keys management system, transitioning from a **role-based** to an **integration-based** model. The changes align the Commander CLI with the backend API's updated data model, improving clarity and consistency across the entire Public API key management workflow.

## 🔄 **Key Changes in This Commit**

### **Terminology Shift: Roles → Integrations**

The core refactoring replaces the concept of "roles" with "integrations" throughout the API key management system:

- **Command Arguments**: `--roles` parameter renamed to `--integrations`
- **Protobuf Messages**: New `IntegrationRequest` message type for API key generation
- **Field Names**: Updated response fields from `roleName` to `apiIntegrationTypeName`
- **User-Facing Documentation**: All help text, examples, and error messages updated to reflect integration terminology

### **Revocation Model Update**

The revoke operation has been updated to use **name-based identification** instead of token-based:

- **Parameter Change**: `token` parameter replaced with `name` parameter
- **User Experience**: More intuitive revocation using human-readable API key names
- **Protobuf Update**: `RevokeTokenRequest` now includes both `name` and `token` fields

## 🛠 **Implementation Details**

### **Modified Files**

```
keepercommander/commands/enterprise_api_keys.py  # 128 lines changed (±64 insertions/deletions)
keepercommander/proto/publicapi_pb2.py          # 68 lines changed (±34 insertions/deletions)
```

### **Command Structure Changes**

#### **1. API Key List Command**
- **Table Headers**: Removed `token` column from primary display
- **Field Order**: Updated to prioritize `enterprise_id`, `name`, `status`, dates, and `integration`
- **Integration Display**: Shows integration type names with action types (e.g., "SIEM:2")

#### **2. API Key Generate Command**

**Argument Updates:**
```bash
# Old syntax (roles-based)
--roles "SIEM:2,Admin:1"

# New syntax (integration-based, SIEM-only)
--integrations "SIEM:2"
```

**Protobuf Changes:**
- Uses new `IntegrationRequest` message with `apiIntegrationTypeId` and `actionType` fields
- Populates `rq.integrationRequests` array instead of `rq.roles`
- Added `issuedDate` offset (+300ms) for timestamp synchronization (reduced from +3000ms in commit `52dcffd`)

**Response Handling:**
- Processes `apiIntegrationTypeName` field from response
- Displays integration names in formatted output
- JSON export uses `api_integration_type_name` key

**Validation Enhancements:**
- Validates against allowed integration: **SIEM (1)** only
- Strict format enforcement: requires `IntegrationName:ActionType` format
- Enhanced error messages with integration terminology
- Fails fast with early returns on invalid input

#### **3. API Key Revoke Command**

**Parameter Updates:**
```bash
# Old usage (token-based)
public-api-key revoke "expired_token_43"

# New usage (name-based)
public-api-key revoke "SIEM Integration"
```

**Implementation Changes:**
- `rq.name` field used instead of `rq.token`
- Confirmation prompts display API key name
- Success messages reference name for clarity

### **Protobuf Schema Updates**

#### **New Message Types**

**`IntegrationRequest`** (for generation requests):
```protobuf
message IntegrationRequest {
    int32 apiIntegrationTypeId = 1;
    ActionType actionType = 2;
}
```

#### **Updated Message Types**

**`GenerateTokenRequest`** (field addition):
```protobuf
message GenerateTokenRequest {
    repeated Role roles = 1;                           # Legacy field (maintained)
    string tokenName = 2;
    int64 issuedDate = 3;
    int64 expirationDate = 4;
    repeated IntegrationRequest integrationRequests = 5;  # NEW field
}
```

**`Integrations`** (field addition):
```protobuf
message Integrations {
    string roleName = 1;
    int32 apiIntegrationTypeId = 2;
    ActionType actionType = 3;
    string apiIntegrationTypeName = 4;  # NEW field
}
```

**`RevokeTokenRequest`** (field addition):
```protobuf
message RevokeTokenRequest {
    string name = 1;   # NEW field
    string token = 2;  # Existing field
}
```

### **Integration Types and IDs**

The system now uses standardized integration type identifiers:

| Integration Name | ID | Description |
|-----------------|-----|-------------|
| **SIEM** | 1 | Security Information and Event Management |

> **Note**: Earlier versions supported CSPM (2) and BILLING (3) integrations, but these have been removed in commit `52dcffd` to align with current backend capabilities.

**Action Types** (unchanged):
- **1 = READ** - Read-only access
- **2 = READ_WRITE** - Full read/write access

## 📊 **Updated Command Examples**

### **List Operations**
```bash
# Basic table view (updated column headers)
public-api-key list

# JSON output now includes apiIntegrationTypeName
public-api-key list --format json --output api_keys.json
```

**Expected Output Fields:**
- `enterprise_id` - Enterprise identifier  
- `name` - API key name
- `status` - Active/Expired
- `issued_date` - Creation timestamp
- `expiration_date` - Expiration timestamp
- `integration` - Integration assignments (e.g., "SIEM:2")

### **Generate Operations**

```bash
# Basic API key with SIEM integration (30-day expiration)
public-api-key generate --name "SIEM Integration" --integrations "SIEM:2" --expires 30d

# SIEM integration with read-only access (1-year expiration)
public-api-key generate --name "Read-Only SIEM" \
  --integrations "SIEM:1" \
  --expires 1y

# Permanent API key (never expires)
public-api-key generate --name "Permanent Tool" \
  --integrations "SIEM:2" \
  --expires never

# JSON output to file
public-api-key generate --name "Backup Tool" \
  --integrations "SIEM:2" \
  --format json \
  --output backup_key.json
```

**Output Changes:**
- Displays "Integrations:" section instead of "Roles:"
- Shows integration type names from backend response
- Includes enterprise ID via `get_enterprise_id()` helper function

### **Revoke Operations**

```bash
# Interactive revocation with name (new approach)
public-api-key revoke "SIEM Integration"

# Force revocation without confirmation
public-api-key revoke "SIEM Integration" --force

# Short form
public-api-key revoke "My API Key" -f
```

**User Experience Updates:**
- Confirmation prompt shows API key **name** instead of token value
- Success message references the **name** for clarity
- Help text updated to use name-based examples

## 🎨 **Code Quality Improvements**

### **Error Handling Enhancements**

1. **Validation with Early Returns**
   - Invalid integration names return immediately with helpful error messages
   - Invalid action types provide specific guidance on valid values
   - Missing required parameters show example usage

2. **Enhanced Error Messages**
```python
# Before
print("At least one role is required. Example: --roles 'SIEM:2,Admin:1'")

# After
print("At least one integration is required. Example: --integrations 'SIEM:2'")
```

3. **CommandError Consistency**
```python
# Updated error format with command context
raise CommandError("public-api-key generate", "Failed to generate API key")
raise CommandError("public-api-key list", "Failed to retrieve API keys")
raise CommandError("public-api-key revoke", "Failed to revoke API key")
```

### **Helper Functions**

Added `get_enterprise_id()` utility function:
```python
def get_enterprise_id(enterprise_user_id):
    return enterprise_user_id >> 32
```

This extracts the enterprise ID from the enterprise user ID using bitwise operations, aligning with the backend data model.

## 🔍 **Technical Details**

### **Protobuf Serialization Updates**

The binary protobuf descriptor was updated to reflect the new message structure:

**Serialization Range Changes:**
- `_INTEGRATIONREQUEST`: Lines 97-190 (new)
- `_GENERATETOKENREQUEST`: Lines 193-370 (expanded)
- `_INTEGRATIONS`: Lines 373-510 (updated)
- `_REVOKETOKENREQUEST`: Lines 1087-1136 (modified)

### **Field Processing Logic**

**List Command:**
```python
# Updated field processing (displays SIEM integrations)
api_integrations_str = ', '.join([
    f"{integration.apiIntegrationTypeName}:{integration.actionType}"
    for integration in token.integrations
])
```

**Generate Command:**
```python
# New integration request creation (SIEM-only)
integration = publicapi_pb2.IntegrationRequest()
integration.apiIntegrationTypeId = integration_id  # Must be 1 (SIEM)
integration.actionType = action_type  # 1=READ or 2=READ_WRITE
rq.integrationRequests.append(integration)
```

**JSON Response Processing:**
```python
'integrations': [
    {
        'api_integration_type_name': integration.apiIntegrationTypeName,
        'action_type': integration.actionType,
        'action_type_name': publicapi_pb2.ActionType.Name(integration.actionType)
    } for integration in rs.integrations
]
```

## ✅ **Backward Compatibility Notes**

### **Breaking Changes**

1. **CLI Arguments**: `--roles` parameter removed, must use `--integrations`
2. **Revoke Parameter**: Now requires API key `name` instead of `token`
3. **Integration Support**: Only SIEM integration is supported; CSPM and BILLING have been removed

### **Migration Guide**

**For Automated Scripts:**
```bash
# Update all script references from:
--roles "SIEM:2,Admin:1"

# To:
--integrations "SIEM:2"

# Note: Only SIEM integration is now supported
```

**For Revocation Operations:**
```bash
# Old approach (by token):
public-api-key revoke "abc123xyz..."

# New approach (by name):
public-api-key revoke "My API Key Name"
```

## 🧪 **Testing Considerations**

### **Areas Requiring Test Updates**

1. **Argument Parsing Tests**: Update to use `--integrations` instead of `--roles`
2. **Mock Responses**: Include `apiIntegrationTypeName` field in mock data
3. **Revocation Tests**: Use `name` parameter instead of `token`
4. **Validation Tests**: Test new integration name validation logic
5. **Error Message Tests**: Verify updated error messages and examples

### **Example Test Data Updates**

```python
# Old mock structure
integration.roleName = "SIEM"

# New mock structure
integration.apiIntegrationTypeName = "SIEM"
integration.roleName = "SIEM"  # Still included for backward compatibility
```

## 📈 **Impact Summary**

### **User Experience**
- ✅ **Clearer Terminology**: "Integrations" more accurately reflects the purpose of API keys
- ✅ **Name-Based Revocation**: More intuitive than using token strings
- ✅ **Better Error Messages**: Specific guidance with correct examples
- ✅ **Consistent Naming**: Aligned with backend API terminology

### **Developer Experience**
- ✅ **Type Safety**: New `IntegrationRequest` message type provides clear structure
- ✅ **Field Clarity**: Distinct field names prevent confusion
- ✅ **Validation**: Strict integration name checking prevents errors early
- ✅ **Maintainability**: Consistent terminology across codebase

### **System Architecture**
- ✅ **Backend Alignment**: CLI now matches backend API data model
- ✅ **Protobuf Evolution**: Proper message versioning with new fields
- ✅ **Future-Proof**: Integration model supports additional integration types

## 🚀 **Ready for Review**

This refactoring provides:

- ✅ **Complete Integration Model**: All three operations updated to use integration terminology
- ✅ **Protobuf Alignment**: Message types match backend API schema
- ✅ **Enhanced UX**: Name-based revocation and clearer command examples
- ✅ **Code Quality**: Improved validation, error handling, and documentation
- ✅ **Backward Compatibility Awareness**: Clear migration path for existing users

The enterprise API keys management system is now fully aligned with the integration-based architecture, providing a more intuitive and maintainable foundation for Public API key management.

## 🔄 **Latest Changes (Commit 52dcffd)**

### **Simplified Integration Model: SIEM-Only Support**

The latest commit simplifies the integration model by restricting API key generation to **SIEM integration only**, removing support for CSPM and BILLING integrations. This change ensures consistency with the current backend capabilities and provides a clearer, more focused API.

#### **Key Changes**

1. **Integration Validation Simplified**
   - **Before**: Supported three integrations: `SIEM (1)`, `CSPM (2)`, `BILLING (3)`
   - **After**: Only supports `SIEM (1)`
   - Updated validation logic to reject non-SIEM integration types

2. **Updated Examples and Documentation**
   ```bash
   # Before: Multiple integration types
   --integrations "SIEM:2,CSPM:1,BILLING:2"
   
   # After: SIEM-only
   --integrations "SIEM:2"
   ```

3. **Timestamp Adjustment**
   - Reduced `issuedDate` offset from `+3000ms` to `+300ms` for more accurate timestamp synchronization

4. **Enhanced Error Handling**
   - Added error message parsing to extract meaningful error details
   - Improved error logging by extracting content between parentheses
   - Better user experience with cleaner error messages

5. **Test Suite Updates**
   - Updated all unit tests to use `--integrations` parameter instead of `--roles`
   - Removed test cases for CSPM and BILLING integrations
   - Updated mock data to reflect SIEM-only model
   - Added `get_enterprise_id()` mocking to prevent unnecessary API calls in tests
   - Updated expected outputs to match new table headers (removed "Token" column, changed "Roles" to "Integration")
   - Simplified multi-integration test to single SIEM integration

#### **Files Modified in Latest Commit**

```
keepercommander/commands/enterprise_api_keys.py    # Integration validation simplified
unit-tests/test_command_enterprise_api_keys.py     # Test suite updated for SIEM-only model
```

#### **Updated Command Examples**

```bash
# Generate SIEM API key with read-write access (30-day expiration)
public-api-key generate --name "SIEM Integration" --integrations "SIEM:2" --expires 30d

# Generate SIEM API key with read-only access (24-hour expiration)
public-api-key generate --name "Temp Access" --integrations "SIEM:1" --expires 24h

# Generate permanent SIEM API key with read-only access
public-api-key generate --name "Monitoring Tool" --integrations "SIEM:1" --expires never

# Generate SIEM API key and save to JSON
public-api-key generate --name "Backup Tool" --integrations "SIEM:2" --expires 1y --format json --output backup_key.json
```

#### **Integration Types (Updated)**

| Integration Name | ID | Description | Status |
|-----------------|-----|-------------|--------|
| **SIEM** | 1 | Security Information and Event Management | ✅ **Supported** |
| ~~CSPM~~ | ~~2~~ | ~~Cloud Security Posture Management~~ | ❌ **Removed** |
| ~~BILLING~~ | ~~3~~ | ~~Billing and usage management~~ | ❌ **Removed** |

**Action Types** (unchanged):
- **1 = READ** - Read-only access
- **2 = READ_WRITE** - Full read/write access

#### **Breaking Changes in Latest Commit**

1. **Integration Validation**: Attempts to use `CSPM` or `BILLING` integrations will now fail with a clear error message
2. **Help Text**: All examples now show SIEM-only usage
3. **Error Messages**: Updated to reflect single integration requirement

#### **Migration Notes**

If you were using CSPM or BILLING integrations in previous versions:

```bash
# This will NO LONGER WORK:
public-api-key generate --name "Multi" --integrations "SIEM:2,CSPM:1,BILLING:2"

# Use this instead:
public-api-key generate --name "SIEM Access" --integrations "SIEM:2"
```

---

**Latest Commit**: `52dcffd` - Refactor API key generation and revocation to exclusively use 'SIEM' integration  
**Previous Commit**: `2c7e0ba` - Refactor API key management commands to use 'integrations' instead of 'roles'  
**Branch**: `KC-947`  
**Total Files Changed**: 13 files, 511 insertions(+), 263 deletions(-)

