### PR TITLE
Add certifi as explicit dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asciitree
 bcrypt
+certifi
 colorama
 prompt_toolkit
 pycryptodomex

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ include_package_data = True
 install_requires =
     asciitree
     bcrypt
+    certifi
     colorama
     cryptography>=41.0.0
     fido2>=2.0.0; python_version>='3.10'


### PR DESCRIPTION
Fix ModuleNotFoundError when importing certifi in __main__.py. While certifi is typically installed as a transitive dependency of requests, it should be explicitly declared since it is directly imported and used in the get_ssl_cert_file() function.
