### PR TITLE
Corrected typo in CLI manual

### DIFF
--- a/keepercommander/commands/risk_management.py
+++ b/keepercommander/commands/risk_management.py
@@ -20,8 +20,8 @@ class RiskManagementReportCommand(base.GroupCommand):
         self.register_command('security-benchmarks-get', RiskManagementSecurityBenchmarksGetCommand(), 'Get the list of security benchmark set for the calling enterprise', 'sbg')
         self.register_command('security-benchmarks-set', RiskManagementSecurityBenchmarksSetCommand(), 'Set a list of security benchmark. Corresponding audit events will be logged', 'sbs')
         #Backward compatibility
-        self.register_command('user', RiskManagementEnterpriseStatDetailsCommand(), 'Show Risk Management User report (absolete)', 'u')
-        self.register_command('alert', RiskManagementSecurityAlertsSummaryCommand(), 'Show Risk Management Alert report (absolete)', 'a')
+        self.register_command('user', RiskManagementEnterpriseStatDetailsCommand(), 'Show Risk Management User report (obsolete)', 'u')
+        self.register_command('alert', RiskManagementSecurityAlertsSummaryCommand(), 'Show Risk Management Alert report (obsolete)', 'a')
 
 
 rmd_enterprise_stat_parser = argparse.ArgumentParser(prog='risk-management enterprise-stat', description='Risk management enterprise stat', parents=[base.report_output_parser])


### PR DESCRIPTION
When running `risk-management`, the manual offers a description of all available reports, two of which are marked as 'absolete' instead of 'obsolete'