### PR TITLE
Improve error message for security-alerts-detail event code

### DIFF
--- a/keepercommander/commands/risk_management.py
+++ b/keepercommander/commands/risk_management.py
@@ -170,7 +170,7 @@ class RiskManagementSecurityAlertDetailCommand(enterprise_common.EnterpriseComma
         aet = kwargs.get('aet')
         aetid = event_lookup.get(aet, 0)
         if aetid < 1:
-            raise ValueError(f'Invalid aetid {aetid}: valid aetid > 0')
+            raise base.CommandError('Valid Audit Event code or name required')
         request.auditEventTypeId = aetid
         done = False
         header = [


### PR DESCRIPTION
Current error message is an opaque unexpected error. Updated it to be a CommandError which clarifies what argument is missing/invalid

> Before
`risk-management security-alerts-detail`
`>>An unexpected error occurred: Invalid aetid 0: valid aetid > 0. Type "debug" to toggle verbose error output`

> After
`risk-management security-alerts-detail`
`>>Valid Audit Event code or name required`