### PR TITLE
Fix record-history command JSON format and revision limit issues

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -1843,11 +1843,13 @@ class RecordHistoryCommand(Command, RecordMixin):
                         rows.append([name, value])
                 modified = datetime.datetime.fromtimestamp(int(rev['client_modified_time'] / 1000.0))
                 rows.append(['Modified', modified])
-                base.dump_report_data(rows, headers=['Name', 'Value'],
-                                 title=f'Record Revision V.{revision}', no_header=True, right_align=(0,))
+                fmt = kwargs.get('format') or ''
+                return base.dump_report_data(rows, headers=['Name', 'Value'],
+                                 title=f'Record Revision V.{revision}', no_header=True, right_align=(0,),
+                                 fmt=fmt, filename=kwargs.get('output'))
 
             elif action == 'diff':
-                count = 5
+                count = length - 1
                 current = vault.KeeperRecord.load(params, history[index])
                 rows = []
                 while count >= 0 and current:
@@ -1901,7 +1903,8 @@ class RecordHistoryCommand(Command, RecordMixin):
                                 lines.append('...')
                             row[index] = '\n'.join(lines)
 
-                base.dump_report_data(rows, headers)
+                fmt = kwargs.get('format') or ''
+                return base.dump_report_data(rows, headers, fmt=fmt, filename=kwargs.get('output'))
 
             elif action == 'restore':
                 if revision == 0:


### PR DESCRIPTION
- Fix --format json parameter not working with --action view and --action diff
- Add missing return statements to properly output JSON/CSV formats
- Remove hardcoded 5-revision limit in diff action to show all revisions