### PR TITLE
Update dockerfile with gcc package required for MLKEM C compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         openssl \
-        ca-certificates && \
+        ca-certificates \
+        gcc \
+        libc6-dev && \
     pip install --no-cache-dir --upgrade pip setuptools wheel && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -460,7 +460,7 @@ class ShareFolderCommand(Command):
                             logging.warning('Share invitation has been sent to \'%s\'', username)
                         logging.warning('Please repeat this command when invitation is accepted.')
                     keys = params.key_cache.get(email)
-                    if keys and keys.rsa or keys.ec:
+                    if keys and (keys.rsa or keys.ec):
                         uo.manageRecords = curr_sf.get('default_manage_records') is True if mr is None else folder_pb2.BOOLEAN_TRUE if mr == 'on' else folder_pb2.BOOLEAN_FALSE
                         uo.manageUsers = curr_sf.get('default_manage_users') is True if mu is None else folder_pb2.BOOLEAN_TRUE if mu == 'on' else folder_pb2.BOOLEAN_FALSE
                         sf_key = curr_sf.get('shared_folder_key_unencrypted')  # type: Optional[bytes]

--- a/keepercommander/rest_api.py
+++ b/keepercommander/rest_api.py
@@ -165,6 +165,7 @@ def execute_rest(context, endpoint, payload):
                     qrc_success = True
                 except Exception as e:
                     logging.warning(f"QRC encryption failed ({e}), falling back to EC encryption")
+                    context.disable_qrc()
         
         # Fallback to EC encryption if QRC not available or failed
         if not qrc_success:


### PR DESCRIPTION
## Dockerfile update for QRC support

### Changes

- Added `gcc` and `libc6-dev` to Dockerfile for ML-KEM C extension compilation
- Fixed QRC fallback to properly disable QRC for the session when encryption fails
- Fixed operator precedence bug in `share_folder` command ([KC-1061](https://keeper.atlassian.net/browse/KC-1061))

[KC-1061]: https://keeper.atlassian.net/browse/KC-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ