### PR TITLE
Support automating password reset on login

### DIFF
--- a/keepercommander/loginv3.py
+++ b/keepercommander/loginv3.py
@@ -48,7 +48,7 @@ class LoginV3Flow:
         logging.info("Falling back to default authentication...")
         return LoginV3API.startLoginMessage(params, encryptedDeviceToken, cloneCode=clone_code_bytes, loginType=login_type)
 
-    def login(self, params, new_device=False, new_login=False, new_password_if_reset_required=None):   # type: (KeeperParams, bool, bool) -> None
+    def login(self, params, new_device=False, new_login=False, new_password_if_reset_required=None):   # type: (KeeperParams, bool, bool, string) -> None
 
         logging.debug("Login v3 Start as '%s'", params.user)
 


### PR DESCRIPTION
During the login flow, the API can respond with ACCOUNT_RECOVERY status, where the Master Password must be reset during the flow. Currently, this can only be done with manual CLI input.

This commit adds support for a `new_password_if_reset_required` parameter in the `LoginV3Flow.login` method, which will automatically set the new Master Password as this string if the API returns the ACCOUNT_RECOVERY response.

Replication steps:
- Create an active user with `create-user` command
- Attempt to log into this user's vault using the keepercommander SDK.
```
user_params = KeeperParams()
user_params.user = 'user@email.com'
user_params.password = 'password'
api.login(user_params)
```
An unskippable prompt to reset the password appears, which can only be avoided by modifying the native login flow.