### PR TITLE
Added `msp-update` `--name/-n` parameter for updating node, Fix msp `--file-plan` command for 1TB/10TB storage

### DIFF
--- a/keepercommander/commands/msp.py
+++ b/keepercommander/commands/msp.py
@@ -69,6 +69,7 @@ msp_info_parser.add_argument('-v', '--verbose', dest='verbose', action='store_tr
 msp_update_parser = argparse.ArgumentParser(prog='msp-update', usage='msp-update',
                                             description='Modify a Managed Company license')
 msp_update_parser.add_argument('--node', dest='node', action='store', help='node name or node ID')
+msp_update_parser.add_argument('-n', '--name', dest='name', action='store', help='update managed company name')
 msp_update_parser.add_argument('-p', '--plan', dest='plan', action='store',
                                choices=[x[1] for x in constants.MSP_PLANS],
                                help=f'License plan: {", ".join((x[1] for x in constants.MSP_PLANS))}')
@@ -425,6 +426,10 @@ class MSPUpdateCommand(EnterpriseCommand):
                 raise CommandError('msp-update', f'More than one nodes \"{node_name}\" are found')
             rq['node_id'] = nodes[0]['node_id']
 
+        new_name = kwargs.get('name')
+        if new_name:
+            rq['enterprise_name'] = new_name
+            
         permits = next((x['msp_permits'] for x in params.enterprise.get('licenses', []) if 'msp_permits' in x), None)
 
         plan_name = kwargs.get('plan')

--- a/keepercommander/constants.py
+++ b/keepercommander/constants.py
@@ -19,8 +19,8 @@ ENTERPRISE_FILE_PLANS = [
 
 MSP_FILE_PLANS = [
     (4, 'STORAGE_100GB', '100GB'),
-    (7, 'STORAGE_1000GB', '1TB'),
-    (8, 'STORAGE_10000GB', '10TB'),
+    (7, 'STORAGE_1TB', '1TB'),
+    (8, 'STORAGE_10TB', '10TB'),
 ]
 
 MSP_PLANS = [


### PR DESCRIPTION
This PR includes two MSP-related updates:

- **KC-1065**: Adds `--name / -n` option to the `msp-update` command to allow updating the managed company name via CLI.
- **KC-1066**: Fixes MSP file storage plan `--file-plan` command parameter for 1TB/10TB storage.