### PR TITLE
KC-1072: action-report lock dates, compliance pw aging, security-audit record details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dr-logs
 CLAUDE.md
 AGENTS.md
 keeper_db.sqlite
+.keeper-memory-mcp/

--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -262,18 +262,25 @@ class Spinner:
         self.message = message
         self.running = False
         self.thread = None
+        self._last_visible_len = 0
 
     def _animate(self):
         idx = 0
         while self.running:
             frame = self.FRAMES[idx % len(self.FRAMES)]
-            sys.stdout.write(f'\r{Fore.CYAN}{frame}{Fore.RESET} {self.message}')
+            message = self.message or ''
+            visible_len = len(message) + 2  # frame + space + message
+            pad = max(0, self._last_visible_len - visible_len)
+            sys.stdout.write(f'\r{Fore.CYAN}{frame}{Fore.RESET} {message}' + (' ' * pad))
             sys.stdout.flush()
+            self._last_visible_len = visible_len + pad
             idx += 1
             time.sleep(0.08)
         # Clear the line when done
-        sys.stdout.write('\r' + ' ' * (len(self.message) + 4) + '\r')
+        clear_len = max(self._last_visible_len, len(self.message or '') + 2)
+        sys.stdout.write('\r' + ' ' * clear_len + '\r')
         sys.stdout.flush()
+        self._last_visible_len = 0
 
     def start(self):
         self.running = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 radon
 pylint
+pytest

--- a/unit-tests/service/test_service_manager.py
+++ b/unit-tests/service/test_service_manager.py
@@ -68,11 +68,15 @@ if sys.version_info >= (3, 8):
             
             with mock.patch('sys.platform', 'linux'), \
                 mock.patch('os.getpid', return_value=9999), \
-                mock.patch('psutil.Process') as mock_process:
+                mock.patch('psutil.Process') as mock_process, \
+                mock.patch('keepercommander.service.core.service_manager.ServiceManager.kill_process_by_pid', return_value=True) as mock_kill, \
+                mock.patch('keepercommander.service.core.service_manager.ServiceManager.kill_ngrok_processes', return_value=False), \
+                mock.patch('keepercommander.service.core.service_manager.ServiceManager.kill_cloudflare_processes', return_value=False):
                 
                 stop_cmd = StopService()
                 stop_cmd.execute(self.params)
                 
+                mock_kill.assert_called_once_with(12345)
                 mock_process.return_value.terminate.assert_called_once()
                 self.assertFalse(ProcessInfo._env_file.exists())
 


### PR DESCRIPTION
## Summary

Three reporting enhancements for compliance and security auditing:

### 1. Action Report: Lock Date for Blocked Users (`aram.py`)
- New `lock_time` column showing when users were locked
- Auto-included when `--target locked` or explicit `--columns lock_time`
- Queries `lock_user` audit events to find most recent lock timestamp

### 2. Record Access Report: Last Password Change (`compliance.py`)
- New `last_pw_change` column in `--aging` reports
- Queries `record_password_change` audit events
- Falls back to record created date if no password change event exists
- Added progress spinners for long-running aging/access event fetches (silent in batch mode)

### 3. Security Audit: Per-Record Password Strength (`security_audit.py`)
- New `--record-details` flag outputs per-record password strength
- Uses `get_incremental_security_data` endpoint (has `recordUid`, unlike summary endpoint)
- Columns: email, name, record_uid, strength, strength_category, node

## Other Changes
- Guard enterprise license expiration conversion for far-future timestamps (Windows `time_t` limits)
- Add pytest to dev requirements
- Stabilize service stop unit test by mocking OS-specific `os.kill` behavior

## Test Plan
```bash
pytest unit-tests/ -q
```

Note: Full integration tests require `tests/enterprise.json` and `tests/vault.json`

---
🤖 Generated with [Claude Code](https://claude.ai/code)