### PR TITLE
Fix MSP addon validations, `msp-update`, and seat handling consistency

### DIFF
--- a/keepercommander/commands/msp.py
+++ b/keepercommander/commands/msp.py
@@ -27,6 +27,11 @@ from ..error import CommandError
 from ..params import KeeperParams
 from ..proto import enterprise_pb2, BI_pb2, APIRequest_pb2
 
+# Addon name constants
+KEPM_ADDON = 'keeper_endpoint_privilege_manager'
+REMOTE_BROWSER_ISOLATION_ADDON = 'remote_browser_isolation'
+CONNECTION_MANAGER_ADDON = 'connection_manager'
+
 
 def register_commands(commands):
     commands['msp-down'] = GetMSPDataCommand()
@@ -468,6 +473,17 @@ class MSPUpdateCommand(EnterpriseCommand):
             product_plan = next((x for x in constants.MSP_PLANS if product_id == x[1].lower()), None)
             if product_plan and product_plan[3] < file_plan[0]:
                 rq['file_plan_type'] = file_plan[1]
+        else:
+            existing_file_plan = current_mc.get('file_plan_type')
+            if existing_file_plan:
+                product_id = rq['product_id'].lower()
+                product_plan = next((x for x in constants.MSP_PLANS if product_id == x[1].lower()), None)
+                if product_plan:
+                    file_plan = next((x for x in constants.MSP_FILE_PLANS if x[1] == existing_file_plan), None)
+                    if file_plan:
+                        base_file_plan_id = product_plan[3]
+                        if file_plan[0] != base_file_plan_id:
+                            rq['file_plan_type'] = existing_file_plan
 
         addons = {}
         for ao in current_mc.get('add_ons', []):
@@ -475,9 +491,9 @@ class MSPUpdateCommand(EnterpriseCommand):
                 continue
             if ao.get('included_in_product') is True:
                 continue
-            addon_name = ao['name']
+            addon_name = ao['name'].lower()  # Normalize to lowercase for consistency
             keep_addon = {
-                'add_on': addon_name
+                'add_on': ao['name']  
             }
             seats = ao.get('seats')
             if seats > 0:
@@ -495,11 +511,21 @@ class MSPUpdateCommand(EnterpriseCommand):
                         raise CommandError('msp-update',f'Addon \"{addon_name}\" is not found')
                     addon_seats = 0
                     if sep == ':' and addon[2] and action == 'add_addon':
-                        try:
-                            addon_seats = int(seats)
-                        except:
-                            raise CommandError('msp-update',
-                                               f'Addon \"{addon_name}\". Number of seats \"{seats}\" is not integer')
+                        if addon_name == KEPM_ADDON and seats.strip() == '-1':
+                            addon_seats = 2147483647  
+                            seats = '2147483647'  
+                        else:
+                            try:
+                                addon_seats = int(seats)
+                            except:
+                                raise CommandError('msp-update',
+                                                   f'Addon \"{addon_name}\". Number of seats \"{seats}\" is not integer')
+                        if addon_name == KEPM_ADDON:
+                            valid_int_seats = {x for x in constants.KEPM_VALID_SEATS if isinstance(x, int)}
+                            if addon_seats not in valid_int_seats and addon_seats != 2147483647:
+                                valid_values = ', '.join(str(x) for x in sorted(valid_int_seats) + ['-1 (for unlimited)'])
+                                raise CommandError('msp-update',
+                                                   f'Addon \"{addon_name}\". Invalid seat value \"{seats}\". Valid values are: {valid_values}')
                     if action == 'add_addon':
                         if permits:
                             if addon_name not in (x.lower() for x in permits['allowed_add_ons']):
@@ -514,6 +540,19 @@ class MSPUpdateCommand(EnterpriseCommand):
                     else:
                         if addon_name in addons:
                             del addons[addon_name]
+        
+        addon_names = {name.lower() for name in addons.keys()}
+        if REMOTE_BROWSER_ISOLATION_ADDON in addon_names:
+            if CONNECTION_MANAGER_ADDON not in addon_names:
+                raise CommandError('msp-update',
+                                   f'Addon \"{REMOTE_BROWSER_ISOLATION_ADDON}\" requires \"{CONNECTION_MANAGER_ADDON}\" to be selected')
+            cm_addon = addons.get(CONNECTION_MANAGER_ADDON)
+            if cm_addon:
+                cm_seats = cm_addon.get('seats', 0)
+                if not cm_seats or cm_seats == 0:
+                    raise CommandError('msp-update',
+                                       f'Addon \"{REMOTE_BROWSER_ISOLATION_ADDON}\" requires \"{CONNECTION_MANAGER_ADDON}\" to have seats specified (e.g., {CONNECTION_MANAGER_ADDON}:N)')
+        
         rq['add_ons'] = list(addons.values())
         rs = api.communicate(params, rq)
         if rs['result'] == 'success':
@@ -932,6 +971,7 @@ class MSPAddCommand(EnterpriseCommand):
         addons = kwargs.get('addon')
         if isinstance(addons, list):
             rq['add_ons'] = []
+            addon_data = {}  # Track addon name -> seat count for validation
             for v in addons:
                 addon_name, sep, seats = v.partition(':')
                 addon_name = addon_name.lower()
@@ -945,17 +985,38 @@ class MSPAddCommand(EnterpriseCommand):
                         return
                 addon_seats = 0
                 if sep == ':' and addon[2]:
-                    try:
-                        addon_seats = int(seats)
-                    except:
-                        logging.warning('Addon \"%s\". Number of seats \"%s\" is not integer', addon_name, seats)
-                        return
+                    if addon_name == KEPM_ADDON and seats.strip() == '-1':
+                        addon_seats = 2147483647  # Use max int for unlimited, similar to seats handling
+                    else:
+                        try:
+                            addon_seats = int(seats)
+                        except:
+                            logging.warning('Addon \"%s\". Number of seats \"%s\" is not integer', addon_name, seats)
+                            return
+                    if addon_name == KEPM_ADDON:
+                        valid_int_seats = {x for x in constants.KEPM_VALID_SEATS if isinstance(x, int)}
+                        if addon_seats not in valid_int_seats and addon_seats != 2147483647:
+                            valid_values = ', '.join(str(x) for x in sorted(valid_int_seats) + ['-1 (for unlimited)'])
+                            logging.warning('Addon \"%s\". Invalid seat value \"%s\". Valid values are: %s', addon_name, seats, valid_values)
+                            return
                 rqa = {
                     'add_on': addon[0]
                 }
                 if addon_seats > 0:
                     rqa['seats'] = addon_seats
+                    addon_data[addon_name] = addon_seats
+                else:
+                    addon_data[addon_name] = 0
                 rq['add_ons'].append(rqa)
+
+            # Validate that Remote Browser Isolation requires Keeper Connection Manager with seats
+            if REMOTE_BROWSER_ISOLATION_ADDON in addon_data:
+                if CONNECTION_MANAGER_ADDON not in addon_data:
+                    logging.warning('Addon \"%s\" requires \"%s\" to be selected', REMOTE_BROWSER_ISOLATION_ADDON, CONNECTION_MANAGER_ADDON)
+                    return
+                if addon_data[CONNECTION_MANAGER_ADDON] == 0:
+                    logging.warning('Addon \"%s\" requires \"%s\" to have seats specified (e.g., %s:N)', REMOTE_BROWSER_ISOLATION_ADDON, CONNECTION_MANAGER_ADDON, CONNECTION_MANAGER_ADDON)
+                    return
 
         company_id = -1
         rs = api.communicate(params, rq)

--- a/keepercommander/constants.py
+++ b/keepercommander/constants.py
@@ -49,6 +49,8 @@ MSP_ADDONS = [
     ('keeper_endpoint_privilege_manager', 'Keeper Endpoint Privilege Manager (KEPM)', True, 'KEPM'),
 ]
 
+KEPM_VALID_SEATS = {1, 25, 50, 100, 500, 1000, 5000, 10000}
+
 
 class PrivilegeScope(enum.IntEnum):
     All = 1,


### PR DESCRIPTION
## Description

This PR adds missing validations and standardizes seat handling for MSP addons to prevent invalid configurations and align CLI behavior with the Admin Console.

## Changes

- **KEPM seat validation**
  - Added validation for allowed KEPM (`keeper_endpoint_privilege_manager`) seat values: `1, 25, 50, 100, 500, 1000, 5000, 10000, -1 (for unlimited)`
  - Rejected invalid seat values in `msp-add` and `msp-update`
  - Improved error messages to list valid options

- **Remote Browser Isolation dependency**
  - Enforced `connection_manager` as a required dependency when `remote_browser_isolation` is selected
 
- **Fixed inconsistency in `msp-update` command**
  - Aligned validation and seat handling behavior with `msp-add`
  - Ensured addon dependencies and seat constraints are enforced consistently during updates
