### PR TITLE
`msp-info` command enhancement

### DIFF
--- a/keepercommander/commands/msp.py
+++ b/keepercommander/commands/msp.py
@@ -413,7 +413,8 @@ class MSPInfoCommand(EnterpriseCommand, MSPMixin):
                         if seats > 0:
                             addon_def = next((x for x in constants.MSP_ADDONS if x[0] == addon_name), None)
                             if addon_def and addon_def[2]:  # addon_def[2] indicates if seats are supported
-                                addon_list.append(f"{addon_name}:{seats}")
+                                display_seats = -1 if seats == 2147483647 else seats
+                                addon_list.append(f"{addon_name}:{display_seats}")
                             else:
                                 addon_list.append(addon_name)
                         else:


### PR DESCRIPTION
## Description

This PR enhances the `msp-info` command to improve usability.

## Changes

- **Include node name in verbose output**
  - Added `node_name` field to `msp-info --format json -v` response.

- **Support single managed company lookup**
  - Added `-mc / --managed-company` parameter to filter and fetch a specific managed company by name or ID.
  - Works with both verbose (`-v`) and non-verbose JSON output.

- **Include addon seat counts in verbose output**
  - Updated `msp-info --format json -v` to return addons with their seat counts (e.g., `connection_manager:2`) instead of only addon names.
  - Aligns CLI output with managed company creation input and Admin Console display.
