### PR TITLE
Add cascade and node privileges to JSON enterprise role

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -2865,7 +2865,7 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                 ret['managed_nodes'] = [{
                     'node_id': x,
                     'node_name': nodes.get(x, None),
-                    'cascade': [x['cascade_node_management'] for x in params.enterprise['managed_nodes'] if x['role_id'] == role_id][0],
+                    'cascade': [y['cascade_node_management'] for y in params.enterprise['managed_nodes'] if y['role_id'] == role_id and y['managed_node_id'] == x][0],
                     'privileges': privileges.get(x, None)
                 } for x in node_ids if x in nodes]
 


### PR DESCRIPTION
Currently running enterprise role in text format yields cascade permissions and node privileges:  
 `er -v 'Keeper Administrator' --format text`
This isn't included in the JSON output:  
`er -v 'Keeper Administrator' --format json`

This commit adds the same logic as the text format (ignoring hidden privileges or MSP privileges if user is not MSP), and shows the result in the following format (verbose flag is not required):
```
"managed_nodes": [
        {
            "node_id": 1067368092532738,
            "node_name": "Demo Node",
            "cascade": true,
            "privileges": [
                "manage_user",
                "manage_nodes",
                "manage_roles",
                "manage_teams",
                "transfer_account",
                "run_reports",
                "manage_bridge",
                "manage_record_types",
                "approve_device",
                "run_compliance_reports",
                "sharing_administrator"
            ]
        }
    ],
```