### PR TITLE
Automate Docker-Service Mode & Slack app configuration

### DIFF
--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -83,7 +83,7 @@ COMMAND_CATEGORIES = {
     # Service Mode REST API
     'Service Mode REST API': {
         'service-create', 'service-add-config', 'service-start', 'service-stop', 'service-status',
-        'service-config-add'
+        'service-config-add', 'service-docker-setup', 'slack-app-setup'
     },
 
     # Email Configuration Commands

--- a/keepercommander/commands/start_service.py
+++ b/keepercommander/commands/start_service.py
@@ -12,6 +12,8 @@
 from ..service.commands.create_service import CreateService
 from ..service.commands.config_operation import AddConfigService
 from ..service.commands.handle_service import StartService, StopService, ServiceStatus
+from ..service.commands.service_docker_setup import ServiceDockerSetupCommand
+from ..service.commands.slack_app_setup import SlackAppSetupCommand
 
 def register_commands(commands):
     commands['service-create'] = CreateService()
@@ -19,6 +21,8 @@ def register_commands(commands):
     commands['service-start'] = StartService()
     commands['service-stop'] = StopService()
     commands['service-status'] = ServiceStatus()
+    commands['service-docker-setup'] = ServiceDockerSetupCommand()
+    commands['slack-app-setup'] = SlackAppSetupCommand()
 
 def register_command_info(aliases, command_info):
     service_classes = [
@@ -26,7 +30,9 @@ def register_command_info(aliases, command_info):
         AddConfigService,
         StartService,
         StopService,
-        ServiceStatus
+        ServiceStatus,
+        ServiceDockerSetupCommand,
+        SlackAppSetupCommand
     ]
     
     for service_class in service_classes:

--- a/keepercommander/service/commands/create_service.py
+++ b/keepercommander/service/commands/create_service.py
@@ -33,6 +33,7 @@ class StreamlineArgs:
     fileformat : Optional[str]
     run_mode: Optional[str]
     queue_enabled: Optional[str]
+    update_vault_record: Optional[str]
     
 class CreateService(Command):
     """Command to create a new service configuration."""
@@ -72,6 +73,7 @@ class CreateService(Command):
         parser.add_argument('-f', '--fileformat', type=str, help='file format')
         parser.add_argument('-rm', '--run_mode', type=str, help='run mode')
         parser.add_argument('-q', '--queue_enabled', type=str, help='enable request queue (y/n)')
+        parser.add_argument('-ur', '--update-vault-record', dest='update_vault_record', type=str, help='CSMD Config record UID to update with service metadata (Docker mode)')
         return parser
     
     def execute(self, params: KeeperParams, **kwargs) -> None:
@@ -86,10 +88,15 @@ class CreateService(Command):
 
             config_data = self.service_config.create_default_config()
 
-            filtered_kwargs = {k: v for k, v in kwargs.items() if k in ['port', 'allowedip', 'deniedip', 'commands', 'ngrok', 'ngrok_custom_domain', 'cloudflare', 'cloudflare_custom_domain', 'certfile', 'certpassword', 'fileformat', 'run_mode', 'queue_enabled']}
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k in ['port', 'allowedip', 'deniedip', 'commands', 'ngrok', 'ngrok_custom_domain', 'cloudflare', 'cloudflare_custom_domain', 'certfile', 'certpassword', 'fileformat', 'run_mode', 'queue_enabled', 'update_vault_record']}
             args = StreamlineArgs(**filtered_kwargs)
             self._handle_configuration(config_data, params, args)
-            self._create_and_save_record(config_data, params, args)
+            api_key = self._create_and_save_record(config_data, params, args)
+            
+            if args.update_vault_record and api_key:
+                actual_service_url = self._get_service_url(config_data)
+                self._update_vault_record_with_metadata(params, args.update_vault_record, actual_service_url, api_key)
+            
             self._upload_and_start_service(params)
 
         except ValidationError as e:
@@ -107,7 +114,7 @@ class CreateService(Command):
             self.config_handler.handle_interactive_config(config_data, params)
             self.security_handler.configure_security(config_data)
     
-    def _create_and_save_record(self, config_data: Dict[str, Any], params: KeeperParams, args: StreamlineArgs) -> None:
+    def _create_and_save_record(self, config_data: Dict[str, Any], params: KeeperParams, args: StreamlineArgs) -> Optional[str]:
         if args.port is None:
             self.config_handler._configure_run_mode(config_data)
         
@@ -122,7 +129,60 @@ class CreateService(Command):
         if config_data.get("tls_certificate") == "y":
             self.service_config.save_cert_data(config_data, 'create')
         
+        # Return the API key for Docker mode
+        return record.get('api-key')
+        
     def _upload_and_start_service(self, params: KeeperParams) -> None:
         self.service_config.update_or_add_record(params)
         from ..core.service_manager import ServiceManager
         ServiceManager.start_service()
+    
+    def _get_service_url(self, config_data: Dict[str, Any]) -> str:
+        """Determine the actual service URL (ngrok, cloudflare, or localhost)"""
+        # Priority: ngrok > cloudflare > localhost
+        if config_data.get("ngrok_public_url"):
+            return config_data["ngrok_public_url"]
+        elif config_data.get("cloudflare_public_url"):
+            return config_data["cloudflare_public_url"]
+        else:
+            # Fallback to localhost with correct protocol
+            port = config_data.get("port", 8080)
+            protocol = "https" if config_data.get("tls_certificate") == "y" else "http"
+            return f"{protocol}://localhost:{port}"
+    
+    def _update_vault_record_with_metadata(self, params: KeeperParams, record_uid: str, service_url: str, api_key: str) -> None:
+        """Update CSMD Config vault record with service URL and API key as custom fields (Docker mode only)"""
+        try:
+            from ... import vault, record_management, api
+            
+            logger.debug(f"Updating vault record {record_uid} with service metadata...")
+            
+            # Load the CSMD Config record
+            record = vault.KeeperRecord.load(params, record_uid)
+            
+            # Add custom fields for service URL and API key
+            # service_url as URL field, api_key as secret field (hidden)
+            custom_fields = [
+                vault.TypedField.new_field('url', service_url, 'service_url'),
+                vault.TypedField.new_field('secret', api_key, 'api_key'),
+            ]
+            
+            # Preserve existing custom fields if any
+            if hasattr(record, 'custom') and record.custom:
+                # Remove old service_url and api_key fields if they exist
+                existing_fields = [f for f in record.custom if f.label not in ['service_url', 'api_key']]
+                record.custom = existing_fields + custom_fields
+            else:
+                record.custom = custom_fields
+            
+            # Update the record
+            record_management.update_record(params, record)
+            params.sync_data = True
+            api.sync_down(params)
+            
+            logger.debug(f"Successfully updated vault record with service metadata")
+            
+        except Exception as e:
+            logger.error(f"Failed to update vault record with service metadata: {e}")
+            # Don't fail the whole service-create if vault update fails
+            logger.warning(f"Could not update vault record with service metadata: {e}")

--- a/keepercommander/service/commands/service_docker_setup.py
+++ b/keepercommander/service/commands/service_docker_setup.py
@@ -1,0 +1,318 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Standalone Docker service mode setup command.
+"""
+
+import argparse
+import os
+from dataclasses import asdict
+from typing import Dict, Any
+
+from ...commands.base import Command, raise_parse_exception, suppress_exit
+from ...display import bcolors
+from ...error import CommandError
+from ..config.config_validation import ConfigValidator, ValidationError
+from ..docker import (
+    DockerSetupBase, DockerSetupConstants, DockerSetupPrinter,
+    SetupResult, ServiceConfig, DockerComposeBuilder
+)
+
+
+service_docker_setup_parser = argparse.ArgumentParser(
+    prog='service-docker-setup',
+    description='Automate Docker service mode setup with KSM configuration',
+    formatter_class=argparse.RawDescriptionHelpFormatter
+)
+service_docker_setup_parser.add_argument(
+    '--folder-name', dest='folder_name', type=str, default=DockerSetupConstants.DEFAULT_FOLDER_NAME,
+    help=f'Name for the shared folder (default: "{DockerSetupConstants.DEFAULT_FOLDER_NAME}")'
+)
+service_docker_setup_parser.add_argument(
+    '--app-name', dest='app_name', type=str, default=DockerSetupConstants.DEFAULT_APP_NAME,
+    help=f'Name for the secrets manager app (default: "{DockerSetupConstants.DEFAULT_APP_NAME}")'
+)
+service_docker_setup_parser.add_argument(
+    '--record-name', dest='record_name', type=str, default=DockerSetupConstants.DEFAULT_RECORD_NAME,
+    help=f'Name for the config record (default: "{DockerSetupConstants.DEFAULT_RECORD_NAME}")'
+)
+service_docker_setup_parser.add_argument(
+    '--config-path', dest='config_path', type=str,
+    help='Path to config.json file (default: ~/.keeper/config.json)'
+)
+service_docker_setup_parser.add_argument(
+    '--timeout', dest='timeout', type=str, default=DockerSetupConstants.DEFAULT_TIMEOUT,
+    help=f'Device timeout setting (default: {DockerSetupConstants.DEFAULT_TIMEOUT})'
+)
+service_docker_setup_parser.add_argument(
+    '--skip-device-setup', dest='skip_device_setup', action='store_true',
+    help='Skip device registration and setup if already configured'
+)
+service_docker_setup_parser.error = raise_parse_exception
+service_docker_setup_parser.exit = suppress_exit
+
+
+class ServiceDockerSetupCommand(Command, DockerSetupBase):
+    """Automated Docker service mode setup command"""
+
+    def get_parser(self):
+        return service_docker_setup_parser
+
+    def execute(self, params, **kwargs):
+        """Main execution flow for standalone command"""
+        # Parse arguments
+        config_path = self._get_config_path(kwargs.get('config_path'))
+        
+        # Print header
+        DockerSetupPrinter.print_header("Docker Setup")
+        
+        # Run core setup steps (inherited from DockerSetupBase)
+        setup_result = self.run_setup_steps(
+            params=params,
+            folder_name=kwargs.get('folder_name', DockerSetupConstants.DEFAULT_FOLDER_NAME),
+            app_name=kwargs.get('app_name', DockerSetupConstants.DEFAULT_APP_NAME),
+            record_name=kwargs.get('record_name', DockerSetupConstants.DEFAULT_RECORD_NAME),
+            config_path=config_path,
+            timeout=kwargs.get('timeout', DockerSetupConstants.DEFAULT_TIMEOUT),
+            skip_device_setup=kwargs.get('skip_device_setup', False)
+        )
+        
+        # Get service configuration
+        DockerSetupPrinter.print_completion("Docker Setup Complete!")
+        service_config = self.get_service_configuration(params)
+        
+        # Generate docker-compose.yml
+        self.generate_and_save_docker_compose(setup_result, service_config)
+        DockerSetupPrinter.print_completion("Service Mode Configuration Complete!")
+        
+        # Print success message
+        self.print_standalone_success_message(setup_result, service_config, config_path)
+        
+        return
+
+    def get_service_configuration(self, params) -> ServiceConfig:
+        """Interactively get service configuration from user"""
+        DockerSetupPrinter.print_header("Service Mode Configuration")
+        
+        # Port
+        port = self._get_port_config()
+        
+        # Commands
+        commands = self._get_commands_config(params)
+        
+        # Queue mode
+        queue_enabled = self._get_queue_config()
+        
+        # Tunneling options (ngrok/cloudflare are mutually exclusive)
+        ngrok_config = self._get_ngrok_config()
+        
+        if not ngrok_config['ngrok_enabled']:
+            cloudflare_config = self._get_cloudflare_config()
+            
+            # TLS only if no tunneling
+            if not cloudflare_config['cloudflare_enabled']:
+                tls_config = self._get_tls_config()
+            else:
+                tls_config = {'tls_enabled': False, 'cert_file': '', 'cert_password': ''}
+        else:
+            cloudflare_config = {
+                'cloudflare_enabled': False, 'cloudflare_tunnel_token': '', 'cloudflare_custom_domain': ''
+            }
+            tls_config = {'tls_enabled': False, 'cert_file': '', 'cert_password': ''}
+        
+        return ServiceConfig(
+            port=port,
+            commands=commands,
+            queue_enabled=queue_enabled,
+            ngrok_enabled=ngrok_config['ngrok_enabled'],
+            ngrok_auth_token=ngrok_config['ngrok_auth_token'],
+            ngrok_custom_domain=ngrok_config['ngrok_custom_domain'],
+            cloudflare_enabled=cloudflare_config['cloudflare_enabled'],
+            cloudflare_tunnel_token=cloudflare_config['cloudflare_tunnel_token'],
+            cloudflare_custom_domain=cloudflare_config['cloudflare_custom_domain'],
+            tls_enabled=tls_config['tls_enabled'],
+            cert_file=tls_config['cert_file'],
+            cert_password=tls_config['cert_password']
+        )
+
+    def generate_docker_compose_yaml(self, setup_result: SetupResult, config: ServiceConfig) -> str:
+        """Generate docker-compose.yml content for Commander service"""
+        builder = DockerComposeBuilder(setup_result, asdict(config))
+        return builder.build()
+
+    def generate_and_save_docker_compose(self, setup_result: SetupResult, config: ServiceConfig) -> str:
+        """Generate and save docker-compose.yml file"""
+        print(f"\n{bcolors.BOLD}Generating docker-compose.yml...{bcolors.ENDC}")
+        yaml_content = self.generate_docker_compose_yaml(setup_result, config)
+        compose_file = os.path.join(os.getcwd(), 'docker-compose.yml')
+        
+        with open(compose_file, 'w') as f:
+            f.write(yaml_content)
+        
+        DockerSetupPrinter.print_success(f"docker-compose.yml created at {compose_file}", indent=True)
+        
+        return compose_file
+
+    def print_standalone_success_message(self, setup_result: SetupResult, config: ServiceConfig, config_path: str) -> None:
+        """Print success message for standalone service-docker-setup command"""
+        print(f"\n{bcolors.BOLD}Resources Created:{bcolors.ENDC}")
+        DockerSetupPrinter.print_phase1_resources(setup_result)
+        
+        self._print_next_steps(config, config_path)
+
+    def _print_next_steps(self, config: ServiceConfig, config_path: str) -> None:
+        """Print next steps for deployment"""
+        DockerSetupPrinter.print_common_deployment_steps(str(config.port), config_path)
+        print()  # Add trailing newline
+
+    # ========================
+    # Configuration Input Methods
+    # ========================
+
+    def _get_port_config(self) -> int:
+        """Get and validate port configuration"""
+        print(f"{bcolors.BOLD}\nPort:{bcolors.ENDC}")
+        print(f"  The port on which Commander Service will listen")
+        while True:
+            port_input = input(f"{bcolors.OKBLUE}Port [Press Enter for {DockerSetupConstants.DEFAULT_PORT}]:{bcolors.ENDC} ").strip() or str(DockerSetupConstants.DEFAULT_PORT)
+            try:
+                return ConfigValidator.validate_port(port_input)
+            except ValidationError as e:
+                print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+
+    def _get_commands_config(self, params) -> str:
+        """Get and validate commands configuration"""
+        from ..config.service_config import ServiceConfig
+        
+        service_config = ServiceConfig()
+        
+        print(f"\n{bcolors.BOLD}Allowed Commands:{bcolors.ENDC}")
+        print(f"  Enter comma-separated commands (e.g., search,share-record,record-add)")
+        
+        while True:
+            commands = input(f"{bcolors.OKBLUE}Commands [Press Enter for '{DockerSetupConstants.DEFAULT_COMMANDS}']:{bcolors.ENDC} ").strip() or DockerSetupConstants.DEFAULT_COMMANDS
+            
+            try:
+                return service_config.validate_command_list(commands, params)
+            except ValidationError as e:
+                print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                print(f"{bcolors.WARNING}Please try again with valid commands.{bcolors.ENDC}")
+
+    def _get_queue_config(self) -> bool:
+        """Get queue mode configuration"""
+        print(f"\n{bcolors.BOLD}Queue Mode:{bcolors.ENDC}")
+        print(f"  Queue mode enables async API (v2) for better performance")
+        queue_input = input(f"{bcolors.OKBLUE}Enable queue mode? [Press Enter for Yes] (y/n):{bcolors.ENDC} ").strip().lower()
+        return queue_input != 'n'
+
+    def _get_ngrok_config(self) -> Dict[str, Any]:
+        """Get ngrok configuration"""
+        print(f"\n{bcolors.BOLD}Ngrok Tunneling (optional):{bcolors.ENDC}")
+        print(f"  Generate a public URL for your service using ngrok")
+        use_ngrok = input(f"{bcolors.OKBLUE}Enable ngrok? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'ngrok_enabled': use_ngrok, 'ngrok_auth_token': '', 'ngrok_custom_domain': ''}
+        
+        if use_ngrok:
+            while True:
+                token = input(f"{bcolors.OKBLUE}Ngrok auth token:{bcolors.ENDC} ").strip()
+                try:
+                    config['ngrok_auth_token'] = ConfigValidator.validate_ngrok_token(token)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+            
+            # Validate custom domain if provided (ngrok allows subdomain prefixes)
+            domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
+            if domain:
+                while True:
+                    try:
+                        config['ngrok_custom_domain'] = ConfigValidator.validate_domain(domain, require_tld=False)
+                        break
+                    except ValidationError as e:
+                        print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                        domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
+                        if not domain:
+                            break
+        
+        return config
+
+    def _get_cloudflare_config(self) -> Dict[str, Any]:
+        """Get Cloudflare configuration"""
+        print(f"\n{bcolors.BOLD}Cloudflare Tunneling (optional):{bcolors.ENDC}")
+        print(f"  Generate a public URL for your service using Cloudflare")
+        use_cloudflare = input(f"{bcolors.OKBLUE}Enable Cloudflare? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'cloudflare_enabled': use_cloudflare, 'cloudflare_tunnel_token': '', 'cloudflare_custom_domain': ''}
+        
+        if use_cloudflare:
+            while True:
+                token = input(f"{bcolors.OKBLUE}Cloudflare tunnel token:{bcolors.ENDC} ").strip()
+                try:
+                    config['cloudflare_tunnel_token'] = ConfigValidator.validate_cloudflare_token(token)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+            
+            while True:
+                domain = input(f"{bcolors.OKBLUE}Cloudflare custom domain:{bcolors.ENDC} ").strip()
+                try:
+                    config['cloudflare_custom_domain'] = ConfigValidator.validate_domain(domain)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+        
+        return config
+
+    def _get_tls_config(self) -> Dict[str, Any]:
+        """Get TLS configuration"""
+        print(f"\n{bcolors.BOLD}TLS Certificate (optional):{bcolors.ENDC}")
+        print(f"  Use custom TLS certificate for HTTPS")
+        use_tls = input(f"{bcolors.OKBLUE}Enable TLS? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'tls_enabled': use_tls, 'cert_file': '', 'cert_password': ''}
+        
+        if use_tls:
+            while True:
+                cert_file = input(f"{bcolors.OKBLUE}Certificate file path:{bcolors.ENDC} ").strip()
+                try:
+                    if cert_file and os.path.exists(cert_file):
+                        config['cert_file'] = ConfigValidator.validate_cert_file(cert_file)
+                        break
+                    print(f"{bcolors.FAIL}Error: Certificate file not found{bcolors.ENDC}")
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+            
+            # Certificate password validation (optional)
+            cert_password = input(f"{bcolors.OKBLUE}Certificate password:{bcolors.ENDC} ").strip()
+            if cert_password:
+                while True:
+                    try:
+                        config['cert_password'] = ConfigValidator.validate_certpassword(cert_password)
+                        break
+                    except ValidationError as e:
+                        print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                        cert_password = input(f"{bcolors.OKBLUE}Certificate password:{bcolors.ENDC} ").strip()
+                        if not cert_password:
+                            break
+        
+        return config
+
+    def _get_config_path(self, config_path: str = None) -> str:
+        """Get and validate config file path"""
+        if not config_path:
+            config_path = os.path.expanduser('~/.keeper/config.json')
+        
+        if not os.path.isfile(config_path):
+            raise CommandError('service-docker-setup', f'Config file not found: {config_path}')
+        
+        return config_path

--- a/keepercommander/service/commands/slack_app_setup.py
+++ b/keepercommander/service/commands/slack_app_setup.py
@@ -1,0 +1,393 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+import argparse
+import os
+from dataclasses import asdict
+from typing import Dict, Any, Tuple, Optional
+
+from ...commands.base import Command, raise_parse_exception, suppress_exit
+from ...display import bcolors
+from ...error import CommandError
+from ... import api, vault, record_management
+from .service_docker_setup import ServiceDockerSetupCommand
+from ..config.config_validation import ConfigValidator, ValidationError
+from ..docker import (
+    SetupResult, DockerSetupPrinter, DockerSetupConstants,
+    ServiceConfig, SlackConfig, DockerComposeBuilder
+)
+
+slack_app_setup_parser = argparse.ArgumentParser(
+    prog='slack-app-setup',
+    description='Automate Slack App integration setup with Commander Service Mode',
+    formatter_class=argparse.RawDescriptionHelpFormatter
+)
+slack_app_setup_parser.add_argument(
+    '--folder-name', dest='folder_name', type=str, default=DockerSetupConstants.DEFAULT_FOLDER_NAME,
+    help=f'Name for the shared folder (default: "{DockerSetupConstants.DEFAULT_FOLDER_NAME}")'
+)
+slack_app_setup_parser.add_argument(
+    '--app-name', dest='app_name', type=str, default=DockerSetupConstants.DEFAULT_APP_NAME,
+    help=f'Name for the secrets manager app (default: "{DockerSetupConstants.DEFAULT_APP_NAME}")'
+)
+slack_app_setup_parser.add_argument(
+    '--config-record-name', dest='config_record_name', type=str, default=DockerSetupConstants.DEFAULT_RECORD_NAME,
+    help=f'Name for the config record (default: "{DockerSetupConstants.DEFAULT_RECORD_NAME}")'
+)
+slack_app_setup_parser.add_argument(
+    '--slack-record-name', dest='slack_record_name', type=str, default=DockerSetupConstants.DEFAULT_SLACK_RECORD_NAME,
+    help=f'Name for the Slack config record (default: "{DockerSetupConstants.DEFAULT_SLACK_RECORD_NAME}")'
+)
+slack_app_setup_parser.add_argument(
+    '--config-path', dest='config_path', type=str,
+    help='Path to config.json file (default: ~/.keeper/config.json)'
+)
+slack_app_setup_parser.add_argument(
+    '--timeout', dest='timeout', type=str, default=DockerSetupConstants.DEFAULT_TIMEOUT,
+    help=f'Device timeout setting (default: {DockerSetupConstants.DEFAULT_TIMEOUT})'
+)
+slack_app_setup_parser.add_argument(
+    '--skip-device-setup', dest='skip_device_setup', action='store_true',
+    help='Skip device registration and setup if already configured'
+)
+slack_app_setup_parser.error = raise_parse_exception
+slack_app_setup_parser.exit = suppress_exit
+
+
+class SlackAppSetupCommand(Command):
+    """Automated Slack App integration setup command"""
+
+    def get_parser(self):
+        return slack_app_setup_parser
+
+    def execute(self, params, **kwargs):
+        """Main execution flow for Slack integration setup"""
+        # Phase 1: Run base Docker setup
+        print(f"\n{bcolors.BOLD}Phase 1: Running Docker Service Mode Setup{bcolors.ENDC}")
+        
+        setup_result, service_config, config_path = self._run_base_docker_setup(params, kwargs)
+        
+        DockerSetupPrinter.print_completion("Service Mode Configuration Complete!")
+        
+        # Phase 2: Slack-specific setup
+        print(f"\n{bcolors.BOLD}Phase 2: Slack App Integration Setup{bcolors.ENDC}")
+        
+        slack_record_uid, slack_config = self._run_slack_setup(
+            params,
+            setup_result,
+            service_config,
+            kwargs.get('slack_record_name', DockerSetupConstants.DEFAULT_SLACK_RECORD_NAME)
+        )
+        
+        # Print consolidated success message
+        self._print_success_message(setup_result, service_config, slack_record_uid, slack_config, config_path)
+        
+        return
+
+    def _run_base_docker_setup(self, params, kwargs: Dict[str, Any]) -> Tuple[SetupResult, Dict[str, Any], str]:
+        """
+        Run the base Docker setup using ServiceDockerSetupCommand.
+        Returns (SetupResult, service_config, config_path)
+        """
+        docker_cmd = ServiceDockerSetupCommand()
+        
+        # Determine config path
+        config_path = kwargs.get('config_path') or os.path.expanduser('~/.keeper/config.json')
+        if not os.path.isfile(config_path):
+            raise CommandError('slack-app-setup', f'Config file not found: {config_path}')
+        
+        # Print header
+        DockerSetupPrinter.print_header("Docker Setup")
+        
+        # Run core setup steps (Steps 1-7)
+        setup_result = docker_cmd.run_setup_steps(
+            params=params,
+            folder_name=kwargs.get('folder_name', DockerSetupConstants.DEFAULT_FOLDER_NAME),
+            app_name=kwargs.get('app_name', DockerSetupConstants.DEFAULT_APP_NAME),
+            record_name=kwargs.get('config_record_name', DockerSetupConstants.DEFAULT_RECORD_NAME),
+            config_path=config_path,
+            timeout=kwargs.get('timeout', DockerSetupConstants.DEFAULT_TIMEOUT),
+            skip_device_setup=kwargs.get('skip_device_setup', False)
+        )
+        
+        DockerSetupPrinter.print_completion("Docker Setup Complete!")
+        
+        # Get simplified service configuration for Slack App
+        service_config = self._get_slack_service_configuration()
+        
+        # Generate initial docker-compose.yml
+        docker_cmd.generate_and_save_docker_compose(setup_result, service_config)
+        
+        return setup_result, service_config, config_path
+
+    def _get_slack_service_configuration(self) -> ServiceConfig:
+        """Get simplified service configuration for Slack App (only port needed)"""
+        DockerSetupPrinter.print_header("Service Mode Configuration")
+        
+        # Only ask for port with validation
+        print(f"{bcolors.BOLD}Port:{bcolors.ENDC}")
+        print(f"  The port on which Commander Service will listen")
+        while True:
+            port_input = input(f"{bcolors.OKBLUE}Port [Press Enter for {DockerSetupConstants.DEFAULT_PORT}]:{bcolors.ENDC} ").strip() or str(DockerSetupConstants.DEFAULT_PORT)
+            try:
+                port = ConfigValidator.validate_port(port_input)
+                break
+            except ValidationError as e:
+                print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+        
+        # Fixed configuration for Slack App
+        return ServiceConfig(
+            port=port,
+            commands='search,share-record,share-folder,record-add,one-time-share,pedm,device-approve,get',
+            queue_enabled=True,  # Always enable queue mode (v2 API)
+            ngrok_enabled=False,
+            ngrok_auth_token='',
+            ngrok_custom_domain='',
+            cloudflare_enabled=False,
+            cloudflare_tunnel_token='',
+            cloudflare_custom_domain='',
+            tls_enabled=False,
+            cert_file='',
+            cert_password=''
+        )
+
+    def _run_slack_setup(self, params, setup_result: SetupResult, service_config: ServiceConfig,
+                        slack_record_name: str) -> Tuple[str, SlackConfig]:
+        """
+        Run Slack-specific setup steps.
+        Returns (slack_record_uid, slack_config)
+        """
+        # Get Slack configuration
+        DockerSetupPrinter.print_header("Slack App Configuration")
+        slack_config = self._get_slack_configuration()
+        
+        # Create Slack record
+        DockerSetupPrinter.print_step(1, 2, f"Creating Slack config record '{slack_record_name}'...")
+        slack_record_uid = self._create_slack_record(
+            params,
+            slack_record_name,
+            setup_result.folder_uid,
+            slack_config
+        )
+        
+        # Update docker-compose.yml
+        DockerSetupPrinter.print_step(2, 2, "Updating docker-compose.yml with Slack App service...")
+        self._update_docker_compose_yaml(setup_result, service_config, slack_record_uid)
+        
+        return slack_record_uid, slack_config
+
+    def _get_slack_configuration(self) -> SlackConfig:
+        """Interactively get Slack configuration from user"""
+        # Slack App Token
+        print(f"\n{bcolors.BOLD}SLACK_APP_TOKEN:{bcolors.ENDC}")
+        print(f"  App-level token for Slack App")
+        slack_app_token = self._prompt_with_validation(
+            "Token (starts with xapp-):",
+            lambda t: t and t.startswith('xapp-') and len(t) >= 90,
+            "Invalid Slack App Token (must start with 'xapp-' and be at least 90 chars)"
+        )
+        
+        # Slack Bot Token
+        print(f"\n{bcolors.BOLD}SLACK_BOT_TOKEN:{bcolors.ENDC}")
+        print(f"  Bot token for Slack workspace")
+        slack_bot_token = self._prompt_with_validation(
+            "Token (starts with xoxb-):",
+            lambda t: t and t.startswith('xoxb-') and len(t) >= 50,
+            "Invalid Slack Bot Token (must start with 'xoxb-' and be at least 50 chars)"
+        )
+        
+        # Slack Signing Secret
+        print(f"\n{bcolors.BOLD}SLACK_SIGNING_SECRET:{bcolors.ENDC}")
+        print(f"  Signing secret for verifying Slack requests")
+        slack_signing_secret = self._prompt_with_validation(
+            "Secret:",
+            lambda s: s and len(s) == 32,
+            "Invalid Slack Signing Secret (must be exactly 32 characters)"
+        )
+        
+        # Approvals Channel ID
+        print(f"\n{bcolors.BOLD}APPROVALS_CHANNEL_ID:{bcolors.ENDC}")
+        print(f"  Slack channel ID for approval notifications")
+        approvals_channel_id = self._prompt_with_validation(
+            "Channel ID (starts with C):",
+            lambda c: c and c.startswith('C'),
+            "Invalid Approvals Channel ID (must start with 'C')"
+        )
+        
+        # PEDM Integration (optional)
+        print(f"\n{bcolors.BOLD}PEDM (Endpoint Privilege Manager) Integration (optional):{bcolors.ENDC}")
+        print(f"  Integrate with Keeper PEDM for privilege elevation")
+        pedm_enabled = input(f"{bcolors.OKBLUE}Enable PEDM? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        pedm_polling_interval = 120
+        if pedm_enabled:
+            interval_input = input(f"{bcolors.OKBLUE}PEDM polling interval in seconds [Press Enter for 120]:{bcolors.ENDC} ").strip()
+            pedm_polling_interval = int(interval_input) if interval_input else 120
+        
+        # Device Approval Integration (optional)
+        print(f"\n{bcolors.BOLD}SSO Cloud Device Approval Integration (optional):{bcolors.ENDC}")
+        print(f"  Approve SSO Cloud device registrations via Slack")
+        device_approval_enabled = input(f"{bcolors.OKBLUE}Enable Device Approval? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        device_approval_polling_interval = 120
+        if device_approval_enabled:
+            interval_input = input(f"{bcolors.OKBLUE}Device approval polling interval in seconds [Press Enter for 120]:{bcolors.ENDC} ").strip()
+            device_approval_polling_interval = int(interval_input) if interval_input else 120
+        
+        print(f"\n{bcolors.OKGREEN}{bcolors.BOLD}✓ Slack Configuration Complete!{bcolors.ENDC}")
+        
+        return SlackConfig(
+            slack_app_token=slack_app_token,
+            slack_bot_token=slack_bot_token,
+            slack_signing_secret=slack_signing_secret,
+            approvals_channel_id=approvals_channel_id,
+            pedm_enabled=pedm_enabled,
+            pedm_polling_interval=pedm_polling_interval,
+            device_approval_enabled=device_approval_enabled,
+            device_approval_polling_interval=device_approval_polling_interval
+        )
+
+    def _prompt_with_validation(self, prompt: str, validator, error_msg: str) -> str:
+        """Helper method to prompt user input with validation"""
+        while True:
+            value = input(f"{bcolors.OKBLUE}{prompt}{bcolors.ENDC} ").strip()
+            if validator(value):
+                return value
+            print(f"{bcolors.FAIL}Error: {error_msg}{bcolors.ENDC}")
+
+    def _create_slack_record(self, params, record_name: str, folder_uid: str,
+                            slack_config: SlackConfig) -> str:
+        """Create or update Slack configuration record"""
+        # Check if record exists
+        record_uid = self._find_existing_record(params, folder_uid, record_name)
+        
+        if record_uid:
+            DockerSetupPrinter.print_success("Using existing record (will update with custom fields)")
+        else:
+            # Create new record
+            record_uid = self._create_basic_slack_record(params, folder_uid, record_name)
+        
+        # Update record with custom fields
+        self._update_slack_record_fields(params, record_uid, slack_config)
+        
+        DockerSetupPrinter.print_success(f"Slack config record ready (UID: {record_uid})")
+        return record_uid
+
+    def _find_existing_record(self, params, folder_uid: str, record_name: str) -> Optional[str]:
+        """Find existing record by name in folder"""
+        if folder_uid in params.subfolder_record_cache:
+            for rec_uid in params.subfolder_record_cache[folder_uid]:
+                rec = api.get_record(params, rec_uid)
+                if rec.title == record_name:
+                    return rec_uid
+        return None
+
+    def _create_basic_slack_record(self, params, folder_uid: str, record_name: str) -> str:
+        """Create a basic login record for Slack configuration"""
+        try:
+            from ..config.cli_handler import CommandHandler
+            
+            cli_handler = CommandHandler()
+            cmd_add = f"record-add --folder='{folder_uid}' --title='{record_name}' --record-type=login"
+            cli_handler.execute_cli_command(params, cmd_add)
+            
+            api.sync_down(params)
+            
+            # Find the created record
+            record_uid = self._find_existing_record(params, folder_uid, record_name)
+            if not record_uid:
+                raise CommandError('slack-app-setup', 'Failed to find created Slack record')
+            
+            return record_uid
+        except Exception as e:
+            raise CommandError('slack-app-setup', f'Failed to create Slack record: {str(e)}')
+
+    def _update_slack_record_fields(self, params, record_uid: str, slack_config: SlackConfig) -> None:
+        """Update record with Slack configuration custom fields"""
+        try:
+            record = vault.KeeperRecord.load(params, record_uid)
+            
+            # Add custom fields (secret fields are masked, text fields are visible)
+            record.custom = [
+                vault.TypedField.new_field('secret', slack_config.slack_app_token, 'slack_app_token'),
+                vault.TypedField.new_field('secret', slack_config.slack_bot_token, 'slack_bot_token'),
+                vault.TypedField.new_field('secret', slack_config.slack_signing_secret, 'slack_signing_secret'),
+                vault.TypedField.new_field('text', slack_config.approvals_channel_id, 'approvals_channel_id'),
+                vault.TypedField.new_field('text', 'true' if slack_config.pedm_enabled else 'false', 'pedm_enabled'),
+                vault.TypedField.new_field('text', str(slack_config.pedm_polling_interval), 'pedm_polling_interval'),
+                vault.TypedField.new_field('text', 'true' if slack_config.device_approval_enabled else 'false', 'device_approval_enabled'),
+                vault.TypedField.new_field('text', str(slack_config.device_approval_polling_interval), 'device_approval_polling_interval'),
+            ]
+            
+            record_management.update_record(params, record)
+            params.sync_data = True
+            api.sync_down(params)
+            
+        except Exception as e:
+            raise CommandError('slack-app-setup', f'Failed to update Slack record fields: {str(e)}')
+
+    def _update_docker_compose_yaml(self, setup_result: SetupResult, service_config: ServiceConfig, 
+                                     slack_record_uid: str) -> None:
+        """Regenerate docker-compose.yml with Slack app service"""
+        compose_file = os.path.join(os.getcwd(), 'docker-compose.yml')
+        
+        if not os.path.exists(compose_file):
+            raise CommandError('slack-app-setup', f'docker-compose.yml not found at {compose_file}')
+        
+        try:
+            # Check if slack-app already exists
+            with open(compose_file, 'r') as f:
+                content = f.read()
+            
+            if 'slack-app:' in content:
+                DockerSetupPrinter.print_warning("slack-app service already exists in docker-compose.yml")
+                return
+            
+            # Regenerate docker-compose.yml with both Commander and Slack App
+            builder = DockerComposeBuilder(setup_result, asdict(service_config))
+            yaml_content = builder.add_slack_service(slack_record_uid).build()
+            
+            with open(compose_file, 'w') as f:
+                f.write(yaml_content)
+            
+            DockerSetupPrinter.print_success("docker-compose.yml updated successfully")
+            
+        except Exception as e:
+            raise CommandError('slack-app-setup', f'Failed to update docker-compose.yml: {str(e)}')
+
+    def _print_success_message(self, setup_result: SetupResult, service_config: ServiceConfig,
+                               slack_record_uid: str, slack_config: SlackConfig, config_path: str) -> None:
+        """Print consolidated success message for both phases"""
+        print(f"\n{bcolors.OKGREEN}{bcolors.BOLD}✓ Slack App Integration Setup Complete!{bcolors.ENDC}\n")
+
+        # Resources created
+        print(f"{bcolors.BOLD}Resources Created:{bcolors.ENDC}")
+        print(f"  {bcolors.BOLD}Phase 1 - Commander Service:{bcolors.ENDC}")
+        DockerSetupPrinter.print_phase1_resources(setup_result, indent="    ")
+        print(f"  {bcolors.BOLD}Phase 2 - Slack App:{bcolors.ENDC}")
+        print(f"    • Slack Config Record: {bcolors.OKBLUE}{slack_record_uid}{bcolors.ENDC}")
+        print(f"    • Approvals Channel: {bcolors.OKBLUE}{slack_config.approvals_channel_id}{bcolors.ENDC}")
+        print(f"    • PEDM Integration: {bcolors.OKBLUE}{'true' if slack_config.pedm_enabled else 'false'}{bcolors.ENDC}")
+        print(f"    • Device Approval: {bcolors.OKBLUE}{'true' if slack_config.device_approval_enabled else 'false'}{bcolors.ENDC}")
+        
+        # Next steps
+        self._print_next_steps(service_config, config_path)
+
+    def _print_next_steps(self, service_config: ServiceConfig, config_path: str) -> None:
+        """Print deployment next steps for Slack integration"""
+        DockerSetupPrinter.print_common_deployment_steps(str(service_config.port), config_path)
+        
+        # Slack-specific logs
+        print(f"  {bcolors.OKGREEN}docker logs keeper-slack-app{bcolors.ENDC} - View Slack App logs")
+
+        # Slack-specific commands
+        print(f"\n{bcolors.BOLD}Slack Commands Available:{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}• /keeper-request-record{bcolors.ENDC} - Request access to a record")
+        print(f"  {bcolors.OKGREEN}• /keeper-request-folder{bcolors.ENDC} - Request access to a folder")
+        print(f"  {bcolors.OKGREEN}• /keeper-one-time-share{bcolors.ENDC} - Request a one-time share link\n")

--- a/keepercommander/service/config/config_validation.py
+++ b/keepercommander/service/config/config_validation.py
@@ -20,7 +20,7 @@ from ..util.exceptions import ValidationError
 
 class ConfigValidator:
     """Validator class for service configuration"""
-    MIN_PORT = 0
+    MIN_PORT = 1024  # Minimum non-privileged port
     MAX_PORT = 65535
 
     @staticmethod
@@ -123,9 +123,16 @@ class ConfigValidator:
         return token
 
     @staticmethod
-    def validate_domain(domain: str) -> str:
-        """Validate domain name format"""
-        logger.debug(f"Validating domain: {domain}")
+    def validate_domain(domain: str, require_tld: bool = True) -> str:
+        """
+        Validate domain name format.
+        
+        Args:
+            domain: Domain name to validate
+            require_tld: If True, requires a full domain with TLD (e.g., example.com)
+                        If False, allows subdomain prefixes (e.g., myapp for ngrok)
+        """
+        logger.debug(f"Validating domain: {domain} (require_tld={require_tld})")
         
         if not domain or not domain.strip():
             raise ValidationError("Domain cannot be empty")
@@ -147,8 +154,8 @@ class ConfigValidator:
             if label.startswith('-') or label.endswith('-'):
                 raise ValidationError(f"Domain label '{label}' cannot start or end with hyphen")
         
-        if '.' not in domain:
-            raise ValidationError("Please provide a valid domain name")
+        if require_tld and '.' not in domain:
+            raise ValidationError("Please provide a valid domain name (e.g., example.com)")
             
         logger.debug("Domain validation successful")
         return domain

--- a/keepercommander/service/config/service_config.py
+++ b/keepercommander/service/config/service_config.py
@@ -250,6 +250,9 @@ class ServiceConfig:
             logger.debug("Validating ngrok configuration")
             self.validator.validate_ngrok_token(config_data.ngrok_auth_token)
 
+            if config_data.ngrok_custom_domain:
+                self.validator.validate_domain(config_data.ngrok_custom_domain, require_tld=False)
+
         if config_data.cloudflare == 'y':
             logger.debug("Validating cloudflare configuration")
             self.validator.validate_cloudflare_token(config_data.cloudflare_tunnel_token)

--- a/keepercommander/service/docker/__init__.py
+++ b/keepercommander/service/docker/__init__.py
@@ -1,0 +1,37 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Docker integration module for Keeper Commander Service Mode.
+
+This module provides reusable components for Docker-based integrations:
+- Constants and configuration models
+- Setup orchestration logic
+- Output formatting utilities
+- Docker Compose generation
+"""
+
+from .models import DockerSetupConstants, SetupResult, ServiceConfig, SlackConfig, SetupStep
+from .printer import DockerSetupPrinter
+from .setup_base import DockerSetupBase
+from .compose_builder import DockerComposeBuilder
+
+__all__ = [
+    'DockerSetupConstants',
+    'SetupResult',
+    'ServiceConfig',
+    'SlackConfig',
+    'SetupStep',
+    'DockerSetupPrinter',
+    'DockerSetupBase',
+    'DockerComposeBuilder',
+]
+

--- a/keepercommander/service/docker/compose_builder.py
+++ b/keepercommander/service/docker/compose_builder.py
@@ -1,0 +1,204 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Builder class for generating docker-compose.yml configuration
+"""
+import os
+from typing import Dict, Any, List
+
+
+class DockerComposeBuilder:
+    """Builder for docker-compose.yml content with support for Commander and Slack App services"""
+    
+    def __init__(self, setup_result, config: Dict[str, Any]):
+        """
+        Initialize the builder
+        
+        Args:
+            setup_result: Results from Docker setup containing UIDs and KSM config (SetupResult object)
+            config: Service configuration dictionary
+        """
+        self.setup_result = setup_result
+        self.config = config
+        self._service_cmd_parts: List[str] = []
+        self._volumes: List[str] = []
+        self._services: Dict[str, Dict[str, Any]] = {}
+    
+    def build(self) -> str:
+        """
+        Build the complete docker-compose.yml content
+        
+        Returns:
+            YAML content as a string
+        """
+        if 'commander' not in self._services:
+            self._services['commander'] = self._build_commander_service()
+        return self.to_yaml()
+    
+    def build_dict(self) -> Dict[str, Any]:
+        """
+        Build the docker-compose structure as a dictionary
+        
+        Returns:
+            Dictionary structure ready for YAML serialization
+        """
+        if 'commander' not in self._services:
+            self._services['commander'] = self._build_commander_service()
+        return {'services': self._services}
+    
+    def add_slack_service(self, slack_record_uid: str) -> 'DockerComposeBuilder':
+        """
+        Add Slack App service to the compose configuration
+        
+        Args:
+            slack_record_uid: UID of the Slack config record
+            
+        Returns:
+            Self for method chaining
+        """
+        # Ensure commander service exists first
+        if 'commander' not in self._services:
+            self._services['commander'] = self._build_commander_service()
+        # Add slack service
+        self._services['slack-app'] = self._build_slack_service(slack_record_uid)
+        return self
+    
+    def _build_commander_service(self) -> Dict[str, Any]:
+        """Build the Commander service configuration"""
+        self._build_service_command()
+        
+        service = {
+            'container_name': 'keeper-service',
+            'ports': [f"{self.config['port']}:{self.config['port']}"],
+            'image': 'keeper/commander:latest',
+            'command': ' '.join(self._service_cmd_parts),
+            'healthcheck': self._build_healthcheck(),
+            'restart': 'unless-stopped'
+        }
+        
+        if self._volumes:
+            service['volumes'] = self._volumes
+        
+        return service
+    
+    def _build_slack_service(self, slack_record_uid: str) -> Dict[str, Any]:
+        """Build the Slack App service configuration"""
+        return {
+            'container_name': 'keeper-slack-app',
+            'image': 'keeper/slack-app:latest',
+            'environment': {
+                'KSM_CONFIG': self.setup_result.b64_config,
+                'COMMANDER_RECORD': self.setup_result.record_uid,
+                'SLACK_RECORD': slack_record_uid
+            },
+            'depends_on': {
+                'commander': {
+                    'condition': 'service_healthy'
+                }
+            },
+            'restart': 'unless-stopped'
+        }
+    
+    def _build_service_command(self) -> None:
+        """Build the service-create command parts"""
+        port = self.config['port']
+        commands = self.config['commands']
+        queue_enabled = self.config.get('queue_enabled', True)
+        
+        self._service_cmd_parts = [
+            f"service-create -p {port}",
+            f"-c '{commands}'",
+            "-f json",
+            f"-q {'y' if queue_enabled else 'n'}"
+        ]
+        
+        self._add_tunneling_options()
+        self._add_tls_options()
+        self._add_docker_options()
+    
+    def _add_tunneling_options(self) -> None:
+        """Add ngrok and Cloudflare tunneling options"""
+        # Ngrok configuration
+        if self.config.get('ngrok_enabled') and self.config.get('ngrok_token'):
+            self._service_cmd_parts.append(f"-ng {self.config['ngrok_token']}")
+            if self.config.get('ngrok_domain'):
+                self._service_cmd_parts.append(f"-cd {self.config['ngrok_domain']}")
+        
+        # Cloudflare configuration
+        if self.config.get('cloudflare_enabled') and self.config.get('cloudflare_token'):
+            self._service_cmd_parts.append(f"-cf {self.config['cloudflare_token']}")
+            if self.config.get('cloudflare_domain'):
+                self._service_cmd_parts.append(f"-cfd {self.config['cloudflare_domain']}")
+    
+    def _add_tls_options(self) -> None:
+        """Add TLS certificate options and volumes"""
+        if self.config.get('tls_enabled') and self.config.get('cert_file'):
+            cert_file = self.config['cert_file']
+            cert_basename = os.path.basename(cert_file)
+            
+            self._service_cmd_parts.append(f"-crtf /certs/{cert_basename}")
+            if self.config.get('cert_password'):
+                self._service_cmd_parts.append(f"-crtp {self.config['cert_password']}")
+            
+            # Add volume mount for certificate
+            self._volumes.append(f"{cert_file}:/certs/{cert_basename}:ro")
+    
+    def _add_docker_options(self) -> None:
+        """Add Docker-specific parameters (KSM config, record UIDs)"""
+        self._service_cmd_parts.extend([
+            f"-ur {self.setup_result.record_uid}",
+            f"--ksm-config {self.setup_result.b64_config}",
+            f"--record {self.setup_result.record_uid}"
+        ])
+    
+    def _build_healthcheck(self) -> Dict[str, Any]:
+        """Build the healthcheck configuration"""
+        port = self.config['port']
+        
+        # Build the Python script as a single-line command
+        health_script = (
+            f"python -c \"import sys, urllib.request; "
+            f"sys.exit(0 if urllib.request.urlopen('http://localhost:{port}/health', timeout=2).status == 200 else 1)\""
+        )
+        
+        return {
+            'test': ['CMD-SHELL', health_script],
+            'interval': '60s',
+            'timeout': '3s',
+            'start_period': '10s',
+            'retries': 30
+        }
+    
+    def to_yaml(self) -> str:
+        """
+        Convert the docker-compose structure to YAML string
+        
+        Returns:
+            YAML formatted string
+        """
+        try:
+            import yaml
+        except ImportError:
+            # Fallback if PyYAML is not installed
+            raise ImportError("PyYAML is required for YAML generation. Install it with: pip install PyYAML")
+        
+        compose_dict = self.build_dict()
+        
+        # Use yaml.dump with proper settings
+        return yaml.dump(
+            compose_dict,
+            default_flow_style=False,
+            sort_keys=False,
+            indent=2,
+            width=float("inf")  # Prevent line wrapping
+        )
+

--- a/keepercommander/service/docker/models.py
+++ b/keepercommander/service/docker/models.py
@@ -1,0 +1,101 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Data models and constants for Docker setup.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+# ========================
+# Constants
+# ========================
+
+class DockerSetupConstants:
+    """Constants for Docker setup command"""
+    # Default resource names
+    DEFAULT_FOLDER_NAME = 'CSMD Folder'
+    DEFAULT_APP_NAME = 'CSMD KSM App'
+    DEFAULT_RECORD_NAME = 'CSMD Config'
+    DEFAULT_SLACK_RECORD_NAME = 'CSMD Slack Config'
+    
+    # Default service configuration
+    DEFAULT_PORT = 8900
+    DEFAULT_COMMANDS = 'tree,ls'
+    DEFAULT_TIMEOUT = '30d'
+    
+    # Essential config keys
+    RECORD_UID_KEY = 'record_uid'
+    KSM_CONFIG_KEY = 'ksm_config'
+
+
+# ========================
+# Enums
+# ========================
+
+
+class SetupStep(Enum):
+    """Enumeration for setup steps"""
+    DEVICE_SETUP = 1
+    CREATE_FOLDER = 2
+    CREATE_RECORD = 3
+    UPLOAD_CONFIG = 4
+    CREATE_KSM_APP = 5
+    SHARE_FOLDER = 6
+    CREATE_CLIENT = 7
+
+
+# ========================
+# Data Classes
+# ========================
+
+@dataclass
+class SetupResult:
+    """Container for setup results that can be reused by integration commands"""
+    folder_uid: str
+    folder_name: str
+    app_uid: str
+    app_name: str
+    record_uid: str
+    b64_config: str
+
+
+@dataclass
+class ServiceConfig:
+    """Service configuration for Docker deployment"""
+    port: int
+    commands: str
+    queue_enabled: bool
+    ngrok_enabled: bool
+    ngrok_auth_token: str
+    ngrok_custom_domain: str
+    cloudflare_enabled: bool
+    cloudflare_tunnel_token: str
+    cloudflare_custom_domain: str
+    tls_enabled: bool
+    cert_file: str
+    cert_password: str
+
+
+@dataclass
+class SlackConfig:
+    """Slack App configuration for Docker deployment"""
+    slack_app_token: str
+    slack_bot_token: str
+    slack_signing_secret: str
+    approvals_channel_id: str
+    pedm_enabled: bool = False
+    pedm_polling_interval: int = 120
+    device_approval_enabled: bool = False
+    device_approval_polling_interval: int = 120
+

--- a/keepercommander/service/docker/printer.py
+++ b/keepercommander/service/docker/printer.py
@@ -1,0 +1,84 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Output formatting utilities for Docker setup commands.
+"""
+
+from ...display import bcolors
+from .models import SetupResult
+
+
+class DockerSetupPrinter:
+    """Utility class for consistent formatting across docker setup commands"""
+    
+    @staticmethod
+    def print_header(title: str) -> None:
+        """Print a formatted header"""
+        separator = "═" * 59
+        print(f"\n{bcolors.BOLD}{separator}{bcolors.ENDC}")
+        print(f"{bcolors.BOLD}    {title}{bcolors.ENDC}")
+        print(f"{bcolors.BOLD}{separator}{bcolors.ENDC}")
+    
+    @staticmethod
+    def print_step(step_num: int, total_steps: int, message: str) -> None:
+        """Print a step indicator"""
+        print(f"\n{bcolors.OKBLUE}[{step_num}/{total_steps}]{bcolors.ENDC} {message}")
+    
+    @staticmethod
+    def print_success(message: str, indent: bool = True) -> None:
+        """Print a success message"""
+        prefix = "  " if indent else ""
+        print(f"{prefix}{bcolors.OKGREEN}✓{bcolors.ENDC}  {message}")
+    
+    @staticmethod
+    def print_warning(message: str, indent: bool = True) -> None:
+        """Print a warning message"""
+        prefix = "  " if indent else ""
+        print(f"{prefix}{bcolors.WARNING}⚠{bcolors.ENDC}  {message}")
+    
+    @staticmethod
+    def print_completion(message: str) -> None:
+        """Print a completion message"""
+        print(f"\n{bcolors.OKGREEN}{bcolors.BOLD}✓ {message}{bcolors.ENDC}")
+    
+    @staticmethod
+    def print_phase1_resources(setup_result: SetupResult, indent: str = "  ") -> None:
+        """Print Phase 1 resources created (folder, app, record, config)"""
+        print(f"{indent}• Shared Folder: {bcolors.OKBLUE}{setup_result.folder_name}{bcolors.ENDC}")
+        print(f"{indent}• KSM App: {bcolors.OKBLUE}{setup_result.app_name}{bcolors.ENDC} (with edit permissions)")
+        print(f"{indent}• Config Record: {bcolors.OKBLUE}{setup_result.record_uid}{bcolors.ENDC}")
+        print(f"{indent}• KSM Base64 Config: {bcolors.OKGREEN}✓ Generated{bcolors.ENDC}")
+    
+    @staticmethod
+    def print_common_deployment_steps(port: str, config_path: str = None) -> None:
+        """Print common deployment steps (header + steps 1-5)"""
+        DockerSetupPrinter.print_header("Next Steps to Deploy")
+        
+        print(f"\n{bcolors.BOLD}Step 1: Quit from this session{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}quit{bcolors.ENDC}")
+        
+        config_file = config_path if config_path else '~/.keeper/config.json'
+        print(f"\n{bcolors.BOLD}Step 2: Delete the local config.json file{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}rm {config_file}{bcolors.ENDC}")
+        print(f"  Why? Prevents device token conflicts - Docker will download its own config.")
+        
+        print(f"\n{bcolors.BOLD}Step 3: Review docker-compose.yml{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}cat docker-compose.yml{bcolors.ENDC}")
+        
+        print(f"\n{bcolors.BOLD}Step 4: Start the services{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}docker compose up -d{bcolors.ENDC}")
+        
+        print(f"\n{bcolors.BOLD}Step 5: Check services health{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}docker ps{bcolors.ENDC} - View container status")
+        print(f"  {bcolors.OKGREEN}docker logs keeper-service{bcolors.ENDC} - View Commander logs")
+        print(f"  {bcolors.OKGREEN}curl http://localhost:{port}/health{bcolors.ENDC} - Test health endpoint")
+

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -1,0 +1,318 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""
+Core setup logic for Docker-based integrations.
+
+This module provides the reusable base class for setting up
+Commander Service Mode with Docker and KSM.
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+
+from ...commands.folder import FolderMakeCommand
+from ...commands.ksm import KSMCommand
+from ... import api, vault, utils, attachment, record_management, loginv3
+from ...error import CommandError
+
+from .models import SetupResult, SetupStep
+from .printer import DockerSetupPrinter
+
+
+class DockerSetupBase:
+    """Base class for Docker setup with reusable core logic"""
+
+    def run_setup_steps(self, params, folder_name: str, app_name: str, record_name: str,
+                       config_path: str, timeout: str, skip_device_setup: bool = False) -> SetupResult:
+        """
+        Core setup steps that can be reused by integration commands.
+        Returns a SetupResult object containing all the created resources.
+        """
+        # Total number of steps
+        total_steps = len(SetupStep)
+        
+        # Step 1: Device setup
+        if not skip_device_setup:
+            DockerSetupPrinter.print_step(SetupStep.DEVICE_SETUP.value, total_steps, "Checking device settings...")
+            self._setup_device(params, timeout)
+        else:
+            DockerSetupPrinter.print_step(SetupStep.DEVICE_SETUP.value, total_steps, "Skipping device setup (--skip-device-setup)")
+
+        # Step 2: Create shared folder
+        DockerSetupPrinter.print_step(SetupStep.CREATE_FOLDER.value, total_steps, f"Creating shared folder '{folder_name}'...")
+        folder_uid = self._create_shared_folder(params, folder_name)
+
+        # Step 3: Create config record
+        DockerSetupPrinter.print_step(SetupStep.CREATE_RECORD.value, total_steps, f"Creating record '{record_name}'...")
+        record_uid = self._create_config_record(params, record_name, folder_uid)
+
+        # Step 4: Upload config file
+        DockerSetupPrinter.print_step(SetupStep.UPLOAD_CONFIG.value, total_steps, "Uploading config.json attachment...")
+        self._upload_config_file(params, record_uid, config_path)
+
+        # Step 5: Create KSM app
+        DockerSetupPrinter.print_step(SetupStep.CREATE_KSM_APP.value, total_steps, f"Creating Secrets Manager app '{app_name}'...")
+        app_uid = self._create_ksm_app(params, app_name)
+
+        # Step 6: Share folder with app
+        DockerSetupPrinter.print_step(SetupStep.SHARE_FOLDER.value, total_steps, "Sharing folder with app...")
+        self._share_folder_with_app(params, app_uid, folder_uid)
+
+        # Step 7: Create client device
+        DockerSetupPrinter.print_step(SetupStep.CREATE_CLIENT.value, total_steps, "Creating client device and generating config...")
+        b64_config = self._create_client_device(params, app_uid, app_name)
+
+        return SetupResult(
+            folder_uid=folder_uid,
+            folder_name=folder_name,
+            app_uid=app_uid,
+            app_name=app_name,
+            record_uid=record_uid,
+            b64_config=b64_config
+        )
+
+    # ========================
+    # Core Setup Methods
+    # ========================
+
+    def _setup_device(self, params, timeout: str) -> None:
+        """Check and setup device registration, persistent login, and timeout"""
+        from ...commands.utils import ThisDeviceCommand
+        
+        try:
+            device_info = ThisDeviceCommand.get_device_info(params)
+            
+            # Device registration
+            if not device_info.get('data_key_present', False):
+                DockerSetupPrinter.print_warning("Device not registered")
+                loginv3.LoginV3API.register_encrypted_data_key_for_device(params)
+                DockerSetupPrinter.print_success("Device registered successfully")
+            else:
+                DockerSetupPrinter.print_success("Device already registered")
+
+            # Persistent login
+            if not device_info.get('persistent_login', False):
+                DockerSetupPrinter.print_warning("Persistent login disabled")
+                loginv3.LoginV3API.set_user_setting(params, 'persistent_login', '1')
+                DockerSetupPrinter.print_success("Persistent login enabled")
+            else:
+                DockerSetupPrinter.print_success("Persistent login already enabled")
+
+            # Timeout
+            DockerSetupPrinter.print_success(f"Setting logout timeout to {timeout}...")
+            ThisDeviceCommand().execute(params, ops=['timeout', timeout])
+
+        except Exception as e:
+            raise CommandError('docker-setup', f'Device setup failed: {str(e)}')
+
+    def _create_shared_folder(self, params, folder_name: str) -> str:
+        """Create shared folder or return existing one"""
+        # Check if folder exists
+        for folder_uid, folder in params.folder_cache.items():
+            if folder.name == folder_name and folder_uid in params.shared_folder_cache:
+                DockerSetupPrinter.print_success("Using existing shared folder")
+                return folder_uid
+
+        # Create new folder
+        try:
+            folder_cmd = FolderMakeCommand()
+            folder_uid = folder_cmd.execute(
+                params,
+                folder=folder_name,
+                shared_folder=True,
+                manage_users=True,
+                manage_records=True,
+                can_edit=True,
+                can_share=True
+            )
+            api.sync_down(params)
+            DockerSetupPrinter.print_success(f"Shared folder created successfully (UID: {folder_uid})")
+            return folder_uid
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to create shared folder: {str(e)}')
+
+    def _create_config_record(self, params, record_name: str, folder_uid: str) -> str:
+        """Create a config record or return existing one"""
+        # Check if record exists
+        if folder_uid in params.subfolder_record_cache:
+            for rec_uid in params.subfolder_record_cache[folder_uid]:
+                rec = api.get_record(params, rec_uid)
+                if rec.title == record_name:
+                    DockerSetupPrinter.print_success("Using existing record")
+                    return rec_uid
+
+        # Create new record
+        try:
+            record = vault.KeeperRecord.create(params, 'login')
+            record.record_uid = utils.generate_uid()
+            record.record_key = utils.generate_aes_key()
+            record.title = record_name
+            record.type_name = 'login'
+            
+            record_management.add_record_to_folder(params, record, folder_uid)
+            api.sync_down(params)
+            
+            DockerSetupPrinter.print_success(f"Record created successfully (UID: {record.record_uid})")
+            return record.record_uid
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to create record: {str(e)}')
+
+    def _upload_config_file(self, params, record_uid: str, config_path: str) -> None:
+        """Upload config.json as attachment to the record"""
+        temp_config_path = None
+        try:
+            # Clean the config first
+            cleaned_config_path = self._clean_config_json(config_path)
+            if cleaned_config_path != config_path:
+                temp_config_path = cleaned_config_path
+            
+            record = vault.KeeperRecord.load(params, record_uid)
+            if not isinstance(record, (vault.PasswordRecord, vault.TypedRecord)):
+                raise CommandError('docker-setup', 'Invalid record type for attachments')
+
+            # Upload attachment
+            upload_task = attachment.FileUploadTask(cleaned_config_path)
+            upload_task.title = 'config.json'
+            
+            attachment.upload_attachments(params, record, [upload_task])
+            record_management.update_record(params, record)
+            params.sync_data = True
+            api.sync_down(params)
+            
+            DockerSetupPrinter.print_success("Config file uploaded successfully")
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to upload config file: {str(e)}')
+        finally:
+            if temp_config_path and os.path.exists(temp_config_path):
+                try:
+                    os.unlink(temp_config_path)
+                except OSError as e:
+                    # Log or handle specifically
+                    print(f"Warning: Could not delete temporary config file: {e}")
+                    pass
+
+    def _clean_config_json(self, config_path: str) -> str:
+        """Clean config.json by keeping only essential authentication keys"""
+        try:
+            with open(config_path, 'r') as f:
+                config_data = json.load(f)
+            
+            # Essential keys for authentication
+            essential_keys = {
+                'server', 'user', 'device_token', 'private_key',
+                'device_id', 'clone_code', 'session_token', 'data_key'
+            }
+            
+            cleaned_config = {k: v for k, v in config_data.items() if k in essential_keys}
+            removed_count = len(config_data) - len(cleaned_config)
+            
+            if removed_count > 0:
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp_file:
+                    json.dump(cleaned_config, tmp_file, indent=2)
+                    temp_path = tmp_file.name
+                
+                DockerSetupPrinter.print_success(
+                    f"Config cleaned (kept {len(cleaned_config)} essential keys, removed {removed_count} non-essential)"
+                )
+                return temp_path
+            else:
+                DockerSetupPrinter.print_success("Config is already minimal")
+                return config_path
+                
+        except Exception as e:
+            DockerSetupPrinter.print_warning(f"Could not clean config: {str(e)}")
+            return config_path
+
+    def _create_ksm_app(self, params, app_name: str) -> str:
+        """Create KSM app or return existing one"""
+        # Check if app exists
+        existing_app = KSMCommand.get_app_record(params, app_name)
+        if existing_app:
+            DockerSetupPrinter.print_success("Using existing app")
+            return existing_app.get('record_uid')
+
+        # Create new app
+        try:
+            # Suppress KSM command output
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                KSMCommand.add_new_v5_app(params, app_name, force_to_add=False, format_type='table')
+            finally:
+                sys.stdout = old_stdout
+            
+            api.sync_down(params)
+            
+            app_rec = KSMCommand.get_app_record(params, app_name)
+            if not app_rec:
+                raise CommandError('docker-setup', 'Failed to retrieve created app')
+            
+            app_uid = app_rec.get('record_uid')
+            DockerSetupPrinter.print_success(f"App created successfully (UID: {app_uid})")
+            return app_uid
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to create KSM app: {str(e)}')
+
+    def _share_folder_with_app(self, params, app_uid: str, folder_uid: str) -> None:
+        """Share the folder with the KSM app"""
+        try:
+            app_rec = KSMCommand.get_app_record(params, app_uid)
+            if not app_rec:
+                raise CommandError('docker-setup', 'App not found')
+
+            # Suppress output
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                KSMCommand.add_app_share(
+                    params,
+                    secret_uids=[folder_uid],
+                    app_name_or_uid=app_uid,
+                    is_editable=True
+                )
+            finally:
+                sys.stdout = old_stdout
+            
+            DockerSetupPrinter.print_success("Folder shared with app successfully")
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to share folder with app: {str(e)}')
+
+    def _create_client_device(self, params, app_uid: str, app_name: str) -> str:
+        """Create client device and return b64 config"""
+        try:
+            client_name = f"{app_name} Docker Client"
+            
+            tokens_and_devices = KSMCommand.add_client(
+                params=params,
+                app_name_or_uid=app_uid,
+                count=1,
+                unlock_ip=True,
+                first_access_expire_on=60,
+                access_expire_in_min=None,
+                client_name=client_name,
+                config_init='b64',
+                silent=True
+            )
+            
+            if not tokens_and_devices or len(tokens_and_devices) == 0:
+                raise CommandError('docker-setup', 'Failed to generate client device')
+
+            b64_config = tokens_and_devices[0]['config']
+            DockerSetupPrinter.print_success("Client device created successfully")
+            
+            return b64_config
+        except Exception as e:
+            raise CommandError('docker-setup', f'Failed to create client device: {str(e)}')
+

--- a/unit-tests/service/test_config_validation.py
+++ b/unit-tests/service/test_config_validation.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 8):
 
         def test_validate_port_valid(self):
             """Test port validation with valid port numbers"""
-            test_ports = [80, 443, 8080, 1024, 65535]
+            test_ports = [1024, 8080, 8900, 9000, 65535]
             for port in test_ports:
                 with self.subTest(port=port):
                     with patch('socket.socket') as mock_socket:
@@ -23,7 +23,7 @@ if sys.version_info >= (3, 8):
 
         def test_validate_port_invalid_number(self):
             """Test port validation with invalid port numbers"""
-            invalid_ports = [-1, 65536, 'abc', '']
+            invalid_ports = [-1, 0, 80, 443, 1023, 65536, 'abc', '']
             for port in invalid_ports:
                 with self.subTest(port=port):
                     with self.assertRaises(ValidationError):

--- a/unit-tests/service/test_create_service.py
+++ b/unit-tests/service/test_create_service.py
@@ -41,7 +41,7 @@ if sys.version_info >= (3, 8):
         def test_handle_configuration_streamlined(self):
             """Test streamlined configuration handling."""
             config_data = self.command.service_config.create_default_config()
-            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y')
+            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
                 self.command._handle_configuration(config_data, self.params, args)
@@ -50,7 +50,7 @@ if sys.version_info >= (3, 8):
         def test_handle_configuration_interactive(self):
             """Test interactive configuration handling."""
             config_data = self.command.service_config.create_default_config()
-            args =  StreamlineArgs(port=None, commands=None, ngrok=None, allowedip='' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled=None)
+            args =  StreamlineArgs(port=None, commands=None, ngrok=None, allowedip='' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled=None, update_vault_record=None)
             
             with patch.object(self.command.config_handler, 'handle_interactive_config') as mock_interactive, \
                 patch.object(self.command.security_handler, 'configure_security') as mock_security:
@@ -61,7 +61,7 @@ if sys.version_info >= (3, 8):
         def test_create_and_save_record(self):
             """Test record creation and saving."""
             config_data = self.command.service_config.create_default_config()
-            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y')
+            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
             
             with patch.object(self.command.service_config, 'create_record') as mock_create_record, \
                 patch.object(self.command.service_config, 'save_config') as mock_save_config:
@@ -81,7 +81,7 @@ if sys.version_info >= (3, 8):
                 
         def test_validation_error_handling(self):
             """Test handling of validation errors during execution."""
-            args =  StreamlineArgs(port=-1, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y')
+            args =  StreamlineArgs(port=-1, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
             
             with patch('builtins.print') as mock_print:
                 with patch.object(self.command.service_config, 'create_default_config') as mock_create_config:
@@ -106,7 +106,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -128,7 +129,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -152,7 +154,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -176,7 +179,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -211,7 +215,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -257,7 +262,8 @@ if sys.version_info >= (3, 8):
                                         certpassword='',
                                         fileformat='json',
                                         run_mode='foreground',
-                                        queue_enabled='y'
+                                        queue_enabled='y',
+                                        update_vault_record=None
                                     )
                                     
                                     # Verify that the error was printed
@@ -279,7 +285,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -303,7 +310,8 @@ if sys.version_info >= (3, 8):
                 certpassword='', 
                 fileformat='json', 
                 run_mode='foreground', 
-                queue_enabled='y'
+                queue_enabled='y',
+                update_vault_record=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:


### PR DESCRIPTION
## Add `service-docker-setup` and `slack-app-setup` commands

### Overview
Automates Commander Service Mode and Slack App Docker deployment setup, eliminating manual configuration steps.

### New Commands

**`service-docker-setup`**
- Automates KSM app and client device creation
- Creates shared folder and config record with service credentials
- Generates docker-compose.yml with user-specified configuration

**`slack-app-setup`**
- Extends `service-docker-setup` for Slack App integration
- Prompts for Slack credentials (app token, bot token, signing secret, channel ID)
- Stores all credentials as custom fields in Vault records
- Updates docker-compose.yml with Slack App service configuration

### Key Changes
- **Eliminated .env dependency**: All secrets stored in Vault, accessed via KSM
- **Single KSM config**: Both Commander and Slack App use the same KSM authentication
- **Auto vault updates**: Service URL and API key automatically added as custom fields to config record
- **Interactive setup**: Step-by-step prompts for all configuration parameters