### PR TITLE
DR-1173 Add configuration UID param to `pam action service` commands.

### DIFF
--- a/keepercommander/commands/discover/job_start.py
+++ b/keepercommander/commands/discover/job_start.py
@@ -101,7 +101,6 @@ class PAMGatewayActionDiscoverJobStartCommand(PAMGatewayActionDiscoverCommandBas
 
         # Load the configuration record and get the gateway_uid from the facade.
         gateway = kwargs.get('gateway')
-        gateway_context = None
         try:
             gateway_context = GatewayContext.from_gateway(params=params,
                                                           gateway=gateway,

--- a/keepercommander/commands/pam_service/list.py
+++ b/keepercommander/commands/pam_service/list.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import argparse
-from ..discover import PAMGatewayActionDiscoverCommandBase, GatewayContext
+from ..discover import PAMGatewayActionDiscoverCommandBase, GatewayContext, MultiConfigurationException, multi_conf_msg
 from ...display import bcolors
 from ... import vault
 from ...discovery_common.user_service import UserService
@@ -20,6 +20,8 @@ class PAMActionServiceListCommand(PAMGatewayActionDiscoverCommandBase):
     # The record to base everything on.
     parser.add_argument('--gateway', '-g', required=True, dest='gateway', action='store',
                         help='Gateway name or UID')
+    parser.add_argument('--configuration-uid', '-c', required=False, dest='configuration_uid',
+                        action='store', help='PAM configuration UID, if gateway has multiple.')
 
     def get_parser(self):
         return PAMActionServiceListCommand.parser
@@ -28,13 +30,15 @@ class PAMActionServiceListCommand(PAMGatewayActionDiscoverCommandBase):
 
         gateway = kwargs.get("gateway")
 
-        gateway_context = GatewayContext.from_gateway(params, gateway)
-        if gateway_context is None:
-            print(f"{bcolors.FAIL}Could not find the gateway configuration for {gateway}.")
-            return
-
-        if gateway_context is None:
-            print(f"  {self._f('Cannot get gateway information. Gateway may not be up.')}")
+        try:
+            gateway_context = GatewayContext.from_gateway(params=params,
+                                                          gateway=gateway,
+                                                          configuration_uid=kwargs.get('configuration_uid'))
+            if gateway_context is None:
+                print(f"{bcolors.FAIL}Could not find the gateway configuration for {gateway}.{bcolors.ENDC}")
+                return
+        except MultiConfigurationException as err:
+            multi_conf_msg(gateway, err)
             return
 
         user_service = UserService(record=gateway_context.configuration, params=params, fail_on_corrupt=False,
@@ -61,22 +65,24 @@ class PAMActionServiceListCommand(PAMGatewayActionDiscoverCommandBase):
                         }
                     text = f"{resource_record.title} ({resource_record.record_uid}) :"
                     comma = ""
-                    if acl.is_service is True:
+                    if acl.is_service:
                         text += f" {bcolors.OKGREEN}Services{bcolors.ENDC}"
                         comma = ","
-                    if acl.is_task is True:
+                    if acl.is_task:
                         text += f"{comma} {bcolors.OKGREEN}Scheduled Tasks{bcolors.ENDC}"
-                    if acl.is_iis_pool is True:
+                    if acl.is_iis_pool:
                         text += f"{comma} {bcolors.OKGREEN}IIS Pools{bcolors.ENDC}"
-                    comma = ","
                     service_map[user_record.record_uid]["machines"].append(text)
 
         print("")
+        printed_something = False
         print(self._h("User Mapping"))
         for user_uid in service_map:
             user = service_map[user_uid]
+            printed_something = True
             print(f"  {self._b(user['title'])} ({user_uid})")
             for machine in user["machines"]:
                 print(f"    * {machine}")
             print("")
-
+        if not printed_something:
+            print(f"  {bcolors.FAIL}There are no service mappings.{bcolors.ENDC}")


### PR DESCRIPTION
Allow the user to select configuration UID if gateway has multiple configurations for `pam action service` commands.