### PR TITLE
Add tunneling options to slack-app-setup and enhance service mode configuration

### DIFF
--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -51,7 +51,7 @@ class MasterPasswordReentryEnforcer:
         operation = operation.strip()[:100]  # Limit length and strip whitespace
         # Bypass enforcement when running in service mode
         if params and hasattr(params, 'service_mode') and params.service_mode:
-            logging.info(f"Bypassing master password enforcement for operation '{operation}' - running in service mode")
+            logging.debug(f"Bypassing master password enforcement for operation '{operation}' - running in service mode")
             return False
 
         if not params or not params.enforcements:

--- a/keepercommander/service/commands/service_config_handlers.py
+++ b/keepercommander/service/commands/service_config_handlers.py
@@ -65,6 +65,9 @@ class ServiceConfigHandler:
         cloudflare_enabled = "y" if args.cloudflare else "n"
         
         # Implement the same logic as interactive mode
+        ngrok_public_url = ""
+        cloudflare_public_url = ""
+        
         if ngrok_enabled == "y":
             # ngrok enabled → disable cloudflare and TLS
             cloudflare_enabled = "n"
@@ -73,6 +76,14 @@ class ServiceConfigHandler:
             tls_enabled = "n"
             certfile = ""
             certpassword = ""
+            # Construct ngrok public URL from custom domain
+            if args.ngrok_custom_domain:
+                ngrok_domain = args.ngrok_custom_domain.strip()
+                # If it's just a subdomain (no dots), append .ngrok.io
+                if '.' not in ngrok_domain:
+                    ngrok_public_url = f"https://{ngrok_domain}.ngrok.io"
+                else:
+                    ngrok_public_url = f"https://{ngrok_domain}"
             logger.debug("Ngrok enabled - disabling cloudflare and TLS")
         elif cloudflare_enabled == "y":
             # cloudflare enabled → disable TLS, but validate required fields
@@ -86,6 +97,8 @@ class ServiceConfigHandler:
             certpassword = ""
             cloudflare_token = self.service_config.validator.validate_cloudflare_token(args.cloudflare)
             cloudflare_domain = self.service_config.validator.validate_domain(args.cloudflare_custom_domain)
+            # Construct cloudflare public URL from custom domain
+            cloudflare_public_url = f"https://{cloudflare_domain}"
             logger.debug("Cloudflare enabled - disabling TLS")
         else:
             # Both ngrok and cloudflare disabled → allow TLS
@@ -95,6 +108,21 @@ class ServiceConfigHandler:
             cloudflare_token = ""
             cloudflare_domain = ""
             logger.debug("No tunnels enabled - TLS configuration allowed")
+
+        # Handle advanced security options
+        rate_limiting = ""
+        if args.ratelimit:
+            rate_limiting = self.service_config.validator.validate_rate_limit(args.ratelimit)
+        
+        encryption_enabled = "n"
+        encryption_key = ""
+        if args.encryption_key:
+            encryption_enabled = "y"
+            encryption_key = self.service_config.validator.validate_encryption_key(args.encryption_key)
+        
+        # Validate token expiration format if provided (actual usage is in record creation)
+        if args.token_expiration:
+            self.service_config.validator.parse_expiration_time(args.token_expiration)
 
         config_data.update({
             "port": self.service_config.validator.validate_port(args.port),
@@ -106,15 +134,20 @@ class ServiceConfigHandler:
                 if ngrok_enabled == "y" else ""
             ),
             "ngrok_custom_domain": args.ngrok_custom_domain if ngrok_enabled == "y" else "",
+            "ngrok_public_url": ngrok_public_url,
             "cloudflare": cloudflare_enabled,
             "cloudflare_tunnel_token": cloudflare_token,
             "cloudflare_custom_domain": cloudflare_domain,
+            "cloudflare_public_url": cloudflare_public_url,
             "tls_certificate": tls_enabled,
             "certfile": certfile,
             "certpassword": certpassword,
             "fileformat": args.fileformat,  # Keep original logic - can be None
             "run_mode": run_mode,
-            "queue_enabled": queue_enabled
+            "queue_enabled": queue_enabled,
+            "rate_limiting": rate_limiting,
+            "encryption": encryption_enabled,
+            "encryption_private_key": encryption_key
         })
 
     @debug_decorator
@@ -150,6 +183,7 @@ class ServiceConfigHandler:
             config_data["cloudflare"] = "n"
             config_data["cloudflare_tunnel_token"] = ""
             config_data["cloudflare_custom_domain"] = ""
+            config_data["cloudflare_public_url"] = ""
             config_data["tls_certificate"] = "n"
             config_data["certfile"] = ""
             config_data["certpassword"] = ""
@@ -174,13 +208,23 @@ class ServiceConfigHandler:
                 try:
                     token = input(self.messages['ngrok_token_prompt'])
                     config_data["ngrok_auth_token"] = self.service_config.validator.validate_ngrok_token(token)
-                    config_data["ngrok_custom_domain"]  = input(self.messages['ngrok_custom_domain_prompt'])
-                    # print(f"ngrok custom domain >> "+{config_data["ngrok_custom_domain"]})
+                    config_data["ngrok_custom_domain"] = input(self.messages['ngrok_custom_domain_prompt'])
+                    # Construct ngrok public URL from custom domain
+                    if config_data["ngrok_custom_domain"]:
+                        ngrok_domain = config_data["ngrok_custom_domain"].strip()
+                        # If it's just a subdomain (no dots), append .ngrok.io
+                        if '.' not in ngrok_domain:
+                            config_data["ngrok_public_url"] = f"https://{ngrok_domain}.ngrok.io"
+                        else:
+                            config_data["ngrok_public_url"] = f"https://{ngrok_domain}"
+                    else:
+                        config_data["ngrok_public_url"] = ""
                     break
                 except ValidationError as e:
                     print(f"{self.validation_messages['invalid_ngrok_token']} {str(e)}")
         else:
             config_data["ngrok_auth_token"] = ""
+            config_data["ngrok_public_url"] = ""
 
     def _configure_cloudflare(self, config_data: Dict[str, Any]) -> None:
         config_data["cloudflare"] = self.service_config._get_yes_no_input(
@@ -201,9 +245,15 @@ class ServiceConfigHandler:
                 error_key='invalid_cloudflare_domain',
                 required=True
             )
+            # Construct cloudflare public URL from custom domain
+            if config_data["cloudflare_custom_domain"]:
+                config_data["cloudflare_public_url"] = f"https://{config_data['cloudflare_custom_domain']}"
+            else:
+                config_data["cloudflare_public_url"] = ""
         else:
             config_data["cloudflare_tunnel_token"] = ""
             config_data["cloudflare_custom_domain"] = ""
+            config_data["cloudflare_public_url"] = ""
         
     def _configure_tls(self, config_data: Dict[str, Any]) -> None:
         config_data["tls_certificate"] = self.service_config._get_yes_no_input(self.messages['tls_certificate'])

--- a/keepercommander/service/commands/service_docker_setup.py
+++ b/keepercommander/service/commands/service_docker_setup.py
@@ -117,17 +117,14 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
         
         if not ngrok_config['ngrok_enabled']:
             cloudflare_config = self._get_cloudflare_config()
-            
-            # TLS only if no tunneling
-            if not cloudflare_config['cloudflare_enabled']:
-                tls_config = self._get_tls_config()
-            else:
-                tls_config = {'tls_enabled': False, 'cert_file': '', 'cert_password': ''}
         else:
             cloudflare_config = {
-                'cloudflare_enabled': False, 'cloudflare_tunnel_token': '', 'cloudflare_custom_domain': ''
+                'cloudflare_enabled': False, 'cloudflare_tunnel_token': '', 
+                'cloudflare_custom_domain': '', 'cloudflare_public_url': ''
             }
-            tls_config = {'tls_enabled': False, 'cert_file': '', 'cert_password': ''}
+        
+        # Advanced security options
+        security_config = self._get_advanced_security_config()
         
         return ServiceConfig(
             port=port,
@@ -136,12 +133,17 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
             ngrok_enabled=ngrok_config['ngrok_enabled'],
             ngrok_auth_token=ngrok_config['ngrok_auth_token'],
             ngrok_custom_domain=ngrok_config['ngrok_custom_domain'],
+            ngrok_public_url=ngrok_config.get('ngrok_public_url', ''),
             cloudflare_enabled=cloudflare_config['cloudflare_enabled'],
             cloudflare_tunnel_token=cloudflare_config['cloudflare_tunnel_token'],
             cloudflare_custom_domain=cloudflare_config['cloudflare_custom_domain'],
-            tls_enabled=tls_config['tls_enabled'],
-            cert_file=tls_config['cert_file'],
-            cert_password=tls_config['cert_password']
+            cloudflare_public_url=cloudflare_config.get('cloudflare_public_url', ''),
+            allowed_ip=security_config['allowed_ip'],
+            denied_ip=security_config['denied_ip'],
+            rate_limit=security_config['rate_limit'],
+            encryption_enabled=security_config['encryption_enabled'],
+            encryption_key=security_config['encryption_key'],
+            token_expiration=security_config['token_expiration']
         )
 
     def generate_docker_compose_yaml(self, setup_result: SetupResult, config: ServiceConfig) -> str:
@@ -214,98 +216,136 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
         queue_input = input(f"{bcolors.OKBLUE}Enable queue mode? [Press Enter for Yes] (y/n):{bcolors.ENDC} ").strip().lower()
         return queue_input != 'n'
 
-    def _get_ngrok_config(self) -> Dict[str, Any]:
-        """Get ngrok configuration"""
-        print(f"\n{bcolors.BOLD}Ngrok Tunneling (optional):{bcolors.ENDC}")
-        print(f"  Generate a public URL for your service using ngrok")
-        use_ngrok = input(f"{bcolors.OKBLUE}Enable ngrok? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+
+    def _get_advanced_security_config(self) -> Dict[str, Any]:
+        """Get advanced security configuration"""
+        print(f"\n{bcolors.BOLD}Advanced Security (optional):{bcolors.ENDC}")
+        print(f"  Configure IP filtering, rate limiting, and response encryption")
+        enable_advanced = input(f"{bcolors.OKBLUE}Enable advanced security? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
         
-        config = {'ngrok_enabled': use_ngrok, 'ngrok_auth_token': '', 'ngrok_custom_domain': ''}
+        config = {
+            'allowed_ip': '0.0.0.0/0,::/0',
+            'denied_ip': '',
+            'rate_limit': '',
+            'encryption_enabled': False,
+            'encryption_key': '',
+            'token_expiration': ''
+        }
         
-        if use_ngrok:
-            while True:
-                token = input(f"{bcolors.OKBLUE}Ngrok auth token:{bcolors.ENDC} ").strip()
-                try:
-                    config['ngrok_auth_token'] = ConfigValidator.validate_ngrok_token(token)
-                    break
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+        if enable_advanced:
+            # IP Allowed List
+            config.update(self._get_ip_allowed_config())
             
-            # Validate custom domain if provided (ngrok allows subdomain prefixes)
-            domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
-            if domain:
-                while True:
-                    try:
-                        config['ngrok_custom_domain'] = ConfigValidator.validate_domain(domain, require_tld=False)
-                        break
-                    except ValidationError as e:
-                        print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                        domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
-                        if not domain:
-                            break
+            # IP Denied List
+            config.update(self._get_ip_denied_config())
+            
+            # Rate Limiting
+            config.update(self._get_rate_limit_config())
+            
+            # Encryption
+            config.update(self._get_encryption_config())
+            
+            # Token Expiration
+            config.update(self._get_token_expiration_config())
         
         return config
 
-    def _get_cloudflare_config(self) -> Dict[str, Any]:
-        """Get Cloudflare configuration"""
-        print(f"\n{bcolors.BOLD}Cloudflare Tunneling (optional):{bcolors.ENDC}")
-        print(f"  Generate a public URL for your service using Cloudflare")
-        use_cloudflare = input(f"{bcolors.OKBLUE}Enable Cloudflare? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+    def _get_ip_allowed_config(self) -> Dict[str, str]:
+        """Get allowed IP configuration"""
+        print(f"\n{bcolors.BOLD}IP Allowed List:{bcolors.ENDC}")
+        print(f"  Comma-separated IPs or CIDR ranges (e.g., 192.168.1.0/24,10.0.0.1)")
         
-        config = {'cloudflare_enabled': use_cloudflare, 'cloudflare_tunnel_token': '', 'cloudflare_custom_domain': ''}
+        ip_list = input(f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} ").strip()
         
-        if use_cloudflare:
+        if ip_list:
             while True:
-                token = input(f"{bcolors.OKBLUE}Cloudflare tunnel token:{bcolors.ENDC} ").strip()
                 try:
-                    config['cloudflare_tunnel_token'] = ConfigValidator.validate_cloudflare_token(token)
-                    break
+                    return {'allowed_ip': ConfigValidator.validate_ip_list(ip_list)}
                 except ValidationError as e:
                     print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-            
+                    ip_list = input(f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} ").strip()
+                    if not ip_list:
+                        break
+        
+        return {'allowed_ip': '0.0.0.0/0,::/0'}
+
+    def _get_ip_denied_config(self) -> Dict[str, str]:
+        """Get denied IP configuration"""
+        print(f"\n{bcolors.BOLD}IP Denied List:{bcolors.ENDC}")
+        print(f"  Comma-separated IPs or CIDR ranges to block")
+        
+        ip_list = input(f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} ").strip()
+        
+        if ip_list:
             while True:
-                domain = input(f"{bcolors.OKBLUE}Cloudflare custom domain:{bcolors.ENDC} ").strip()
                 try:
-                    config['cloudflare_custom_domain'] = ConfigValidator.validate_domain(domain)
+                    return {'denied_ip': ConfigValidator.validate_ip_list(ip_list)}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    ip_list = input(f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} ").strip()
+                    if not ip_list:
+                        break
+        
+        return {'denied_ip': ''}
+
+    def _get_rate_limit_config(self) -> Dict[str, str]:
+        """Get rate limiting configuration"""
+        print(f"\n{bcolors.BOLD}Rate Limiting:{bcolors.ENDC}")
+        print(f"  Format: <number>/<period> (e.g., 10/minute, 100/hour, 1000/day)")
+        
+        rate_limit = input(f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} ").strip()
+        
+        if rate_limit:
+            while True:
+                try:
+                    return {'rate_limit': ConfigValidator.validate_rate_limit(rate_limit)}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    rate_limit = input(f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} ").strip()
+                    if not rate_limit:
+                        break
+        
+        return {'rate_limit': ''}
+
+    def _get_encryption_config(self) -> Dict[str, Any]:
+        """Get encryption configuration"""
+        print(f"\n{bcolors.BOLD}Response Encryption:{bcolors.ENDC}")
+        print(f"  Enable AES-256 encryption for API responses")
+        enable_encryption = input(f"{bcolors.OKBLUE}Enable encryption? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'encryption_enabled': enable_encryption, 'encryption_key': ''}
+        
+        if enable_encryption:
+            print(f"  Encryption key must be exactly 32 alphanumeric characters")
+            while True:
+                key = input(f"{bcolors.OKBLUE}Encryption key (32 chars):{bcolors.ENDC} ").strip()
+                try:
+                    config['encryption_key'] = ConfigValidator.validate_encryption_key(key)
                     break
                 except ValidationError as e:
                     print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
         
         return config
 
-    def _get_tls_config(self) -> Dict[str, Any]:
-        """Get TLS configuration"""
-        print(f"\n{bcolors.BOLD}TLS Certificate (optional):{bcolors.ENDC}")
-        print(f"  Use custom TLS certificate for HTTPS")
-        use_tls = input(f"{bcolors.OKBLUE}Enable TLS? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+    def _get_token_expiration_config(self) -> Dict[str, str]:
+        """Get token expiration configuration"""
+        print(f"\n{bcolors.BOLD}API Token Expiration:{bcolors.ENDC}")
+        print(f"  Format: Xm (minutes), Xh (hours), Xd (days) - e.g., 30m, 24h, 7d")
         
-        config = {'tls_enabled': use_tls, 'cert_file': '', 'cert_password': ''}
+        expiration = input(f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} ").strip()
         
-        if use_tls:
+        if expiration:
             while True:
-                cert_file = input(f"{bcolors.OKBLUE}Certificate file path:{bcolors.ENDC} ").strip()
                 try:
-                    if cert_file and os.path.exists(cert_file):
-                        config['cert_file'] = ConfigValidator.validate_cert_file(cert_file)
-                        break
-                    print(f"{bcolors.FAIL}Error: Certificate file not found{bcolors.ENDC}")
+                    ConfigValidator.parse_expiration_time(expiration)
+                    return {'token_expiration': expiration}
                 except ValidationError as e:
                     print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-            
-            # Certificate password validation (optional)
-            cert_password = input(f"{bcolors.OKBLUE}Certificate password:{bcolors.ENDC} ").strip()
-            if cert_password:
-                while True:
-                    try:
-                        config['cert_password'] = ConfigValidator.validate_certpassword(cert_password)
+                    expiration = input(f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} ").strip()
+                    if not expiration:
                         break
-                    except ValidationError as e:
-                        print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                        cert_password = input(f"{bcolors.OKBLUE}Certificate password:{bcolors.ENDC} ").strip()
-                        if not cert_password:
-                            break
         
-        return config
+        return {'token_expiration': ''}
 
     def _get_config_path(self, config_path: str = None) -> str:
         """Get and validate config file path"""

--- a/keepercommander/service/config/command_validator.py
+++ b/keepercommander/service/config/command_validator.py
@@ -139,7 +139,7 @@ class CommandValidator:
             else:
                 invalid_commands.append(cmd)
                 
-        return ", ".join(validated_commands), invalid_commands
+        return ",".join(validated_commands), invalid_commands
 
     def generate_command_error_message(self, invalid_commands: List[str], command_info: Dict[str, Any]) -> str:
         """Generate helpful error message for invalid commands."""

--- a/keepercommander/service/config/config_validation.py
+++ b/keepercommander/service/config/config_validation.py
@@ -174,6 +174,11 @@ class ConfigValidator:
             msg = ("Invalid rate limit format. Use formats like 'X/minute', 'X/hour', 'X/day', "
                   "'X per minute', 'X per hour', or 'X per day'.")
             raise ValidationError(msg)
+        
+        # Extract the numeric value and check if it's 0
+        numeric_value = int(re.match(r'^\d+', rate_limit).group())
+        if numeric_value == 0:
+            raise ValidationError("Rate limit value cannot be 0. Please specify a positive number.")
             
         logger.debug("Rate limit validation successful")
         return rate_limit

--- a/keepercommander/service/config/service_config.py
+++ b/keepercommander/service/config/service_config.py
@@ -27,7 +27,7 @@ from ...params import KeeperParams
 
 VALID_CERT_EXTENSIONS = {".pem", ".crt", ".cer", ".key"}
 class ServiceConfig:
-    def __init__(self, title: str = 'Commander Service Mode'):
+    def __init__(self, title: str = 'Commander Service Mode Config'):
         self.title = title
         
         self.config = ConfigParser()
@@ -300,10 +300,10 @@ class ServiceConfig:
                 print(f"\nError: {str(e)}")
                 print("\nPlease try again with valid commands.")
 
-    def create_record(self, is_advanced_security_enabled: str, params: KeeperParams, commands: Optional[str] = None) -> Dict[str, Any]:
+    def create_record(self, is_advanced_security_enabled: str, params: KeeperParams, commands: Optional[str] = None, token_expiration: str = None, record_uid: Optional[str] = None) -> Dict[str, Any]:
         """Create a new configuration record."""
         commands = self.validate_command_list(commands, params) if commands else self._get_validated_commands(params)
-        return self.record_handler.create_record(is_advanced_security_enabled, commands)
+        return self.record_handler.create_record(is_advanced_security_enabled, commands, token_expiration, record_uid)
 
     def update_or_add_record(self, params: KeeperParams) -> None:
         """Update existing record or add new one."""

--- a/keepercommander/service/docker/models.py
+++ b/keepercommander/service/docker/models.py
@@ -23,11 +23,15 @@ from enum import Enum
 
 class DockerSetupConstants:
     """Constants for Docker setup command"""
-    # Default resource names
-    DEFAULT_FOLDER_NAME = 'CSMD Folder'
-    DEFAULT_APP_NAME = 'CSMD KSM App'
-    DEFAULT_RECORD_NAME = 'CSMD Config'
-    DEFAULT_SLACK_RECORD_NAME = 'CSMD Slack Config'
+    # Default resource names for service-docker-setup
+    DEFAULT_FOLDER_NAME = 'Commander Service Mode - Docker'
+    DEFAULT_APP_NAME = 'Commander Service Mode - KSM App'
+    DEFAULT_RECORD_NAME = 'Commander Service Mode Docker Config'
+    DEFAULT_CLIENT_NAME = 'Commander Service Mode - KSM App Client'
+    
+    # Default resource names for slack-app-setup
+    DEFAULT_SLACK_FOLDER_NAME = 'Commander Service Mode - Slack App'
+    DEFAULT_SLACK_RECORD_NAME = 'Commander Service Mode Slack App Config'
     
     # Default service configuration
     DEFAULT_PORT = 8900
@@ -82,9 +86,14 @@ class ServiceConfig:
     cloudflare_enabled: bool
     cloudflare_tunnel_token: str
     cloudflare_custom_domain: str
-    tls_enabled: bool
-    cert_file: str
-    cert_password: str
+    allowed_ip: str = '0.0.0.0/0,::/0'
+    denied_ip: str = ''
+    rate_limit: str = ''
+    encryption_enabled: bool = False
+    encryption_key: str = ''
+    token_expiration: str = ''
+    ngrok_public_url: str = ''
+    cloudflare_public_url: str = ''
 
 
 @dataclass

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -18,17 +18,21 @@ Commander Service Mode with Docker and KSM.
 
 import io
 import json
+import logging
 import os
 import sys
 import tempfile
+from typing import Dict, Any
 
 from ...commands.folder import FolderMakeCommand
 from ...commands.ksm import KSMCommand
 from ... import api, vault, utils, attachment, record_management, loginv3
+from ...display import bcolors
 from ...error import CommandError
 
-from .models import SetupResult, SetupStep
+from .models import SetupResult, SetupStep, DockerSetupConstants
 from .printer import DockerSetupPrinter
+from ..config.config_validation import ConfigValidator, ValidationError
 
 
 class DockerSetupBase:
@@ -112,7 +116,13 @@ class DockerSetupBase:
 
             # Timeout
             DockerSetupPrinter.print_success(f"Setting logout timeout to {timeout}...")
-            ThisDeviceCommand().execute(params, ops=['timeout', timeout])
+            # Suppress command output
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                ThisDeviceCommand().execute(params, ops=['timeout', timeout])
+            finally:
+                sys.stdout = old_stdout
 
         except Exception as e:
             raise CommandError('docker-setup', f'Device setup failed: {str(e)}')
@@ -272,9 +282,12 @@ class DockerSetupBase:
             if not app_rec:
                 raise CommandError('docker-setup', 'App not found')
 
-            # Suppress output
+            # Suppress all output (stdout and logging)
             old_stdout = sys.stdout
+            old_log_level = logging.root.level
+            
             sys.stdout = io.StringIO()
+            logging.root.setLevel(logging.CRITICAL + 1)  # Disable all logging
             try:
                 KSMCommand.add_app_share(
                     params,
@@ -284,15 +297,15 @@ class DockerSetupBase:
                 )
             finally:
                 sys.stdout = old_stdout
-            
-            DockerSetupPrinter.print_success("Folder shared with app successfully")
+                logging.root.setLevel(old_log_level)     
+            DockerSetupPrinter.print_success("Folder shared with app")
         except Exception as e:
             raise CommandError('docker-setup', f'Failed to share folder with app: {str(e)}')
 
     def _create_client_device(self, params, app_uid: str, app_name: str) -> str:
         """Create client device and return b64 config"""
         try:
-            client_name = f"{app_name} Docker Client"
+            client_name = DockerSetupConstants.DEFAULT_CLIENT_NAME
             
             tokens_and_devices = KSMCommand.add_client(
                 params=params,
@@ -316,3 +329,73 @@ class DockerSetupBase:
         except Exception as e:
             raise CommandError('docker-setup', f'Failed to create client device: {str(e)}')
 
+    # ========================
+    # Shared Configuration Methods
+    # ========================
+
+    def _get_ngrok_config(self) -> Dict[str, Any]:
+        """Get ngrok configuration"""
+        print(f"\n{bcolors.BOLD}Ngrok Tunneling (optional):{bcolors.ENDC}")
+        print(f"  Generate a public URL for your service using ngrok")
+        use_ngrok = input(f"{bcolors.OKBLUE}Enable ngrok? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'ngrok_enabled': use_ngrok, 'ngrok_auth_token': '', 'ngrok_custom_domain': '', 'ngrok_public_url': ''}
+        
+        if use_ngrok:
+            while True:
+                token = input(f"{bcolors.OKBLUE}Ngrok auth token:{bcolors.ENDC} ").strip()
+                try:
+                    config['ngrok_auth_token'] = ConfigValidator.validate_ngrok_token(token)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+            
+            # Validate custom domain if provided (ngrok allows subdomain prefixes)
+            domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
+            if domain:
+                while True:
+                    try:
+                        config['ngrok_custom_domain'] = ConfigValidator.validate_domain(domain, require_tld=False)
+                        # Construct ngrok public URL
+                        if '.' not in config['ngrok_custom_domain']:
+                            config['ngrok_public_url'] = f"https://{config['ngrok_custom_domain']}.ngrok.io"
+                        else:
+                            config['ngrok_public_url'] = f"https://{config['ngrok_custom_domain']}"
+                        break
+                    except ValidationError as e:
+                        print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                        domain = input(f"{bcolors.OKBLUE}Ngrok custom domain [Press Enter to skip]:{bcolors.ENDC} ").strip()
+                        if not domain:
+                            break
+        
+        return config
+
+    def _get_cloudflare_config(self) -> Dict[str, Any]:
+        """Get Cloudflare configuration"""
+        print(f"\n{bcolors.BOLD}Cloudflare Tunneling (optional):{bcolors.ENDC}")
+        print(f"  Generate a public URL for your service using Cloudflare")
+        use_cloudflare = input(f"{bcolors.OKBLUE}Enable Cloudflare? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
+        
+        config = {'cloudflare_enabled': use_cloudflare, 'cloudflare_tunnel_token': '', 
+                  'cloudflare_custom_domain': '', 'cloudflare_public_url': ''}
+        
+        if use_cloudflare:
+            while True:
+                token = input(f"{bcolors.OKBLUE}Cloudflare tunnel token:{bcolors.ENDC} ").strip()
+                try:
+                    config['cloudflare_tunnel_token'] = ConfigValidator.validate_cloudflare_token(token)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+            
+            while True:
+                domain = input(f"{bcolors.OKBLUE}Cloudflare custom domain:{bcolors.ENDC} ").strip()
+                try:
+                    config['cloudflare_custom_domain'] = ConfigValidator.validate_domain(domain)
+                    # Construct cloudflare public URL
+                    config['cloudflare_public_url'] = f"https://{config['cloudflare_custom_domain']}"
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+        
+        return config

--- a/unit-tests/service/test_config_validation.py
+++ b/unit-tests/service/test_config_validation.py
@@ -83,6 +83,10 @@ if sys.version_info >= (3, 8):
                 'abc',
                 '10/second',
                 '100 by hour',
+                '0/minute',
+                '0/hour',
+                '0/day',
+                '0 per minute',
             ]
             for limit in invalid_limits:
                 with self.subTest(limit=limit):

--- a/unit-tests/service/test_create_service.py
+++ b/unit-tests/service/test_create_service.py
@@ -41,7 +41,7 @@ if sys.version_info >= (3, 8):
         def test_handle_configuration_streamlined(self):
             """Test streamlined configuration handling."""
             config_data = self.command.service_config.create_default_config()
-            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
+            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None, ratelimit=None, encryption_key=None, token_expiration=None)
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
                 self.command._handle_configuration(config_data, self.params, args)
@@ -50,7 +50,7 @@ if sys.version_info >= (3, 8):
         def test_handle_configuration_interactive(self):
             """Test interactive configuration handling."""
             config_data = self.command.service_config.create_default_config()
-            args =  StreamlineArgs(port=None, commands=None, ngrok=None, allowedip='' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled=None, update_vault_record=None)
+            args =  StreamlineArgs(port=None, commands=None, ngrok=None, allowedip='' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled=None, update_vault_record=None, ratelimit=None, encryption_key=None, token_expiration=None)
             
             with patch.object(self.command.config_handler, 'handle_interactive_config') as mock_interactive, \
                 patch.object(self.command.security_handler, 'configure_security') as mock_security:
@@ -61,7 +61,7 @@ if sys.version_info >= (3, 8):
         def test_create_and_save_record(self):
             """Test record creation and saving."""
             config_data = self.command.service_config.create_default_config()
-            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
+            args = StreamlineArgs(port=8080, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None, ratelimit=None, encryption_key=None, token_expiration=None)
             
             with patch.object(self.command.service_config, 'create_record') as mock_create_record, \
                 patch.object(self.command.service_config, 'save_config') as mock_save_config:
@@ -72,7 +72,9 @@ if sys.version_info >= (3, 8):
                 mock_create_record.assert_called_once_with(
                     config_data["is_advanced_security_enabled"],
                     self.params,
-                    args.commands
+                    args.commands,
+                    args.token_expiration,
+                    None  # record_uid (update_vault_record is None)
                 )
                 if(args.fileformat):
                     config_data["fileformat"]= args.fileformat
@@ -81,7 +83,7 @@ if sys.version_info >= (3, 8):
                 
         def test_validation_error_handling(self):
             """Test handling of validation errors during execution."""
-            args =  StreamlineArgs(port=-1, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None)
+            args =  StreamlineArgs(port=-1, commands='record-list', ngrok=None, allowedip='0.0.0.0' ,deniedip='', ngrok_custom_domain=None, cloudflare=None, cloudflare_custom_domain=None, certfile='', certpassword='', fileformat='json', run_mode='foreground', queue_enabled='y', update_vault_record=None, ratelimit=None, encryption_key=None, token_expiration=None)
             
             with patch('builtins.print') as mock_print:
                 with patch.object(self.command.service_config, 'create_default_config') as mock_create_config:
@@ -107,7 +109,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -130,7 +135,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -155,7 +163,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -180,7 +191,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch('builtins.print') as mock_print:
@@ -216,7 +230,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -263,7 +280,10 @@ if sys.version_info >= (3, 8):
                                         fileformat='json',
                                         run_mode='foreground',
                                         queue_enabled='y',
-                                        update_vault_record=None
+                                        update_vault_record=None,
+                                        ratelimit=None,
+                                        encryption_key=None,
+                                        token_expiration=None
                                     )
                                     
                                     # Verify that the error was printed
@@ -286,7 +306,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:
@@ -311,7 +334,10 @@ if sys.version_info >= (3, 8):
                 fileformat='json', 
                 run_mode='foreground', 
                 queue_enabled='y',
-                update_vault_record=None
+                update_vault_record=None,
+                ratelimit=None,
+                encryption_key=None,
+                token_expiration=None
             )
             
             with patch.object(self.command.config_handler, 'handle_streamlined_config') as mock_streamlined:

--- a/unit-tests/service/test_service_config.py
+++ b/unit-tests/service/test_service_config.py
@@ -35,7 +35,7 @@ if sys.version_info >= (3, 8):
         def test_create_default_config(self):
             """Test creation of default configuration."""
             config = self.service_config.create_default_config()
-            self.assertEqual(config["title"], "Commander Service Mode")
+            self.assertEqual(config["title"], "Commander Service Mode Config")
             self.assertIsNone(config["port"])
             self.assertEqual(config["ngrok"], "n")
             self.assertEqual(config["ngrok_auth_token"], "")
@@ -111,7 +111,7 @@ if sys.version_info >= (3, 8):
             """
             params = MagicMock(spec=KeeperParams)
             result = self.service_config.validate_command_list("ls, get", params)
-            self.assertEqual(result, "ls, get")
+            self.assertEqual(result, "ls,get")
 
         @patch.object(ServiceConfig, 'cli_handler')
         def test_validate_command_list_invalid(self, mock_cli_handler):


### PR DESCRIPTION
## Add tunneling options to slack-app-setup and enhance service mode configuration

### Enhancements

1. **Advanced security configuration for streamlined service creation**: Added CLI arguments for rate limiting (`-rl`), encryption (`-ek`), and token expiration (`-te`) to `service-create` command.

2. **Advanced security prompts in service-docker-setup**: Added interactive prompts for advanced security options including IP filtering (allowed/denied lists), rate limiting, response encryption, and token expiration

3. **Tunneling options for slack-app-setup**: Added ngrok and Cloudflare configuration prompts to `slack-app-setup` command. Public URLs are automatically constructed and stored in vault record for slack-app tunnelling reference.

4. **Updated default resource names**: Changed all default names from "CSMD" prefix to "Commander Service Mode" for better clarity:
   - Folders: "Commander Service Mode - Docker" / "Commander Service Mode - Slack App"
   - Config records: "Commander Service Mode Docker Config" / "Commander Service Mode Slack App Config"
   - KSM App: "Commander Service Mode - Docker KSM App"
   - Client device: "Commander Service Mode - Docker KSM App Client"

5. **Security**: Changed Docker port binding from `<port>:<port>` to `127.0.0.1:<port>:<port>` to restrict API access to localhost only, preventing network exposure.

### Bug Fixes

1. **Fixed ngrok/cloudflare URLs left empty in service config.json and vault records**: Previously, `ngrok_public_url` and `cloudflare_public_url` were not being constructed from custom domains. Now correctly builds URLs (e.g., `https://<custom-domain>.ngrok.io` or `https://<subdomain>.<domain>.com`) in both interactive and streamlined modes, and saves them to both `service_config.json` and the vault record's custom fields.

2. **Fixed rate limiting not working correctly for v2 API**: Each API endpoint now has independent rate limit counters, and removed incorrect multiplier logic that was causing premature blocking

3. **Fixed bypass master password message printed during service mode startup**: Removed unnecessary debug/info message that was displayed every time service mode started