### PR TITLE
  Improve SuperShell shell pane text selection and help screen

### DIFF
--- a/keepercommander/commands/supershell/screens/help.py
+++ b/keepercommander/commands/supershell/screens/help.py
@@ -17,13 +17,26 @@ class HelpScreen(ModalScreen):
     DEFAULT_CSS = """
     HelpScreen {
         align: center middle;
+        background: rgba(0, 0, 0, 0.8);
+    }
+
+    HelpScreen > Vertical {
+        background: #000000;
+    }
+
+    HelpScreen > Vertical > Horizontal {
+        background: #000000;
+    }
+
+    HelpScreen Static {
+        background: #000000;
     }
 
     #help_container {
         width: 90;
         height: auto;
         max-height: 90%;
-        background: #111111;
+        background: #000000;
         border: solid #444444;
         padding: 1 2;
     }


### PR DESCRIPTION
  Shell pane improvements:
  - Add double-click to select word and copy to clipboard
  - Add double-click + drag to extend selection from word boundaries
  - Auto-copy selected text on mouse release (like Linux terminal)
  - Add theme-aware selection highlight colors Help screen:
  - Fix inconsistent background colors (uniform black)