### PR TITLE
  Improve SuperShell focus indicators and CLI search algorithm

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -486,12 +486,28 @@ def search_records(params, searchstring):
     return search_results
 
 
-def search_shared_folders(params, searchstring):
-    """Search shared folders """
+def search_shared_folders(params, searchstring, use_regex=False):
+    """Search shared folders.
 
-    p = re.compile(searchstring.lower())
+    Args:
+        params: KeeperParams
+        searchstring: Search string (tokens or regex depending on use_regex)
+        use_regex: If True, treat as regex. If False (default), token-based search.
+    """
+    search_results = []
 
-    search_results = [] 
+    if not searchstring:
+        return search_results
+
+    if use_regex:
+        p = re.compile(searchstring.lower())
+        match_func = lambda target: p.search(target)
+    else:
+        # Token-based search: all tokens must match
+        tokens = [t.lower() for t in searchstring.split() if t.strip()]
+        if not tokens:
+            return search_results
+        match_func = lambda target: all(token in target for token in tokens)
 
     for shared_folder_uid in params.shared_folder_cache:
 
@@ -499,29 +515,45 @@ def search_shared_folders(params, searchstring):
         sf = get_shared_folder(params, shared_folder_uid)
         target = sf.to_lowerstring()
 
-        if p.search(target):
+        if match_func(target):
             logging.debug('Search success')
             search_results.append(sf)
-     
+
     return search_results
 
 
-def search_teams(params, searchstring):
-    """Search teams """
+def search_teams(params, searchstring, use_regex=False):
+    """Search teams.
 
-    p = re.compile(searchstring.lower())
+    Args:
+        params: KeeperParams
+        searchstring: Search string (tokens or regex depending on use_regex)
+        use_regex: If True, treat as regex. If False (default), token-based search.
+    """
+    search_results = []
 
-    search_results = [] 
+    if not searchstring:
+        return search_results
+
+    if use_regex:
+        p = re.compile(searchstring.lower())
+        match_func = lambda target: p.search(target)
+    else:
+        # Token-based search: all tokens must match
+        tokens = [t.lower() for t in searchstring.split() if t.strip()]
+        if not tokens:
+            return search_results
+        match_func = lambda target: all(token in target for token in tokens)
 
     for team_uid in params.team_cache:
         team = get_team(params, team_uid)
 
         target = team.to_lowerstring()
 
-        if p.search(target):
+        if match_func(target):
             logging.debug('Search success')
             search_results.append(team)
-     
+
     return search_results
 
 

--- a/keepercommander/commands/discover/result_process.py
+++ b/keepercommander/commands/discover/result_process.py
@@ -234,7 +234,7 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
         }
 
         # Set all the PAM Records
-        records = list(vault_extensions.find_records(params, "pam*"))
+        records = list(vault_extensions.find_records(params, "pam*", use_regex=True))
         for record in records:
             # If the record type is not part of the cache, skip the record
             if record.record_type not in cache:


### PR DESCRIPTION
  SuperShell improvements:
  - Add green left border indicator showing which pane is currently active
  - Add search-active class to show indicator when search bar is focused
  - Fix Shift+Tab in shell input to cycle to shell output pane
  - Add ShellOutputHandler for vim-style scrolling (j/k, Ctrl+d/u) in shell output
  - Check clipboard availability before attempting password copy

  CLI search improvements:
  - Change search command to use token-based matching by default
  - Tokens can appear in any order: "aws prod" matches "production aws server"
  - Add --regex flag for legacy regex-based search behavior
  - Extend token-based search to shared folders and teams
  - Update PAM/discover commands to use use_regex=True for regex patterns