### PR TITLE
Enable Service Mode Command Alias Validation

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -74,7 +74,12 @@ def display_command_help(show_enterprise=False, show_shell=False, show_legacy=Fa
     from colorama import Fore, Style
     import shutil
 
-    alias_lookup = {x[1]: x[0] for x in aliases.items()}
+    # Build a lookup of command -> list of aliases
+    alias_lookup = {}
+    for alias, command in aliases.items():
+        if command not in alias_lookup:
+            alias_lookup[command] = []
+        alias_lookup[command].append(alias)
     DIM = Fore.WHITE  # Use white for better readability (not too bright, not too dim)
 
     # Get terminal width
@@ -144,8 +149,8 @@ def display_command_help(show_enterprise=False, show_shell=False, show_legacy=Fa
         else:
             commands_in_category = sorted(categorized_commands[category], key=lambda x: x[0])
             for cmd, description in commands_in_category:
-                alias = alias_lookup.get(cmd) or ''
-                alias_str = f' ({alias})' if alias else ''
+                aliases_list = alias_lookup.get(cmd) or []
+                alias_str = f' ({", ".join(sorted(aliases_list))})' if aliases_list else ''
                 cmd_display = f'{cmd}{alias_str}'
                 all_cmd_displays.append((category, cmd_display, description))
                 global_max_width = max(global_max_width, len(cmd_display))

--- a/keepercommander/service/commands/slack_app_setup.py
+++ b/keepercommander/service/commands/slack_app_setup.py
@@ -155,7 +155,7 @@ class SlackAppSetupCommand(Command, DockerSetupBase):
         
         return ServiceConfig(
             port=port,
-            commands='search,share-record,share-folder,record-add,one-time-share,epm,device-approve,get,server',
+            commands='search,share-record,share-folder,record-add,one-time-share,epm,pedm,device-approve,get,server',
             queue_enabled=True,  # Always enable queue mode (v2 API)
             ngrok_enabled=ngrok_config['ngrok_enabled'],
             ngrok_auth_token=ngrok_config['ngrok_auth_token'],

--- a/keepercommander/service/config/cli_handler.py
+++ b/keepercommander/service/config/cli_handler.py
@@ -74,7 +74,7 @@ class CommandHandler:
             params.service_mode = True
             
             from ... import cli
-            cli.do_command(params, 'help')
+            cli.display_command_help(show_enterprise=True, show_shell=False, show_legacy=False)
             return output.getvalue()
         finally:
             sys.stdout = sys.__stdout__


### PR DESCRIPTION
## Enable Service Mode Command Alias Validation

### Overview
Fixes service mode command validation to recognize command aliases (e.g., `pedm`, `ra`, `ss`) in addition to main command names.

### Problem
Service mode commands (`service-create`, `slack-app-setup`) only validated main command names, rejecting commonly used aliases:
```
My Vault> service-create -p 8909 -c pedm,ra,tree
Error: Invalid commands: pedm, ra
```

### Changes
Service mode now accepts command aliases and displays them in validation messages:
- **Command Validator** - Parse comma-separated aliases from help output
- **Help & Error Messages** - Display commands with aliases: `epm (kepm, pedm)`
- **Slack App Setup** - Added `pedm` to default command list