### PR TITLE
Fix TypeError when loading records with null fields or custom fields

### DIFF
--- a/keepercommander/vault.py
+++ b/keepercommander/vault.py
@@ -876,8 +876,8 @@ class TypedRecord(KeeperRecord):
         self.type_name = sanitize_str_field_value(data.get('type')).strip()
         self.title = sanitize_str_field_value(data.get('title')).strip()
         self.notes = sanitize_str_field_value(data.get('notes'))
-        self.fields.extend((TypedField(x) for x in data.get('fields', [])))
-        self.custom.extend((TypedField(x) for x in data.get('custom', [])))
+        self.fields.extend((TypedField(x) for x in (data.get('fields') or [])))
+        self.custom.extend((TypedField(x) for x in (data.get('custom') or [])))
 
     def enumerate_fields(self):
         # type: () -> Iterable[Tuple[str, Union[None, str, List[str]]]]


### PR DESCRIPTION
## Description

Fixes Github Issue #1791 : `TypeError: 'NoneType' object is not iterable` when loading records that have `fields` or `custom` keys with `null` values.

### Changes

Changed from `data.get('fields', [])` to `(data.get('fields') or [])`

**This handles all cases:**
- Missing key → None or [] → []
- null value → null or [] → []
- Empty array → [] or [] → []
- Array with items → [items] or [] → [items]