### PR TITLE
Add Enforcement and Managed Node Details to enterprise-info Roles and Prevent PAM records for One-Time Shares

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -2398,6 +2398,13 @@ class OneTimeShareCreateCommand(Command):
         urls = {}    # type: Dict[str, str]
         for record_name in record_names:
             record_uid = OneTimeShareCommand.resolve_record(params, record_name)
+            
+            record = api.get_record(params, record_uid)
+            if record and hasattr(record, 'record_type'):
+                pam_record_types = {'pamDatabase', 'pamDirectory', 'pamMachine', 'pamUser', 'pamRemoteBrowser'}
+                if record.record_type in pam_record_types:
+                    raise CommandError('one-time-share', 'One-Time Shares are currently not available for PAM records.')
+
             record_key = params.record_cache[record_uid]['record_key_unencrypted']
 
             client_key = utils.generate_aes_key()


### PR DESCRIPTION
## Summary
Enhanced the `enterprise-info` command to display detailed role information, including enforcements, managed nodes, and associated permissions.

## Changes
- Added new role columns:
  - `enforcement_count`
  - `enforcements`
  - `managed_node_count`
  - `managed_nodes` (with cascade info)
  - `managed_nodes_permissions`

- Supported output formats:
  - **JSON**: Structured role, node, and privilege data
  - **Table**: Readable hierarchical role and privilege view

- Added validation to prevent users from creating one-time shares for PAM (Privileged Access Management) records, as this feature is not currently supported for PAM record types.