### PR TITLE
Enterprise and MSP command improvements

### DIFF
--- a/keepercommander/commands/msp.py
+++ b/keepercommander/commands/msp.py
@@ -434,8 +434,8 @@ class MSPInfoCommand(EnterpriseCommand, MSPMixin):
                     plan = plan_map.get(plan, plan)
                 
                 seats = mc['number_of_seats']
-                if seats > 2000000:
-                    seats = None
+                if seats > 2147483646:
+                    seats = -1
                 
                 if verbose:
                     table.append([mc['mc_enterprise_id'], mc['mc_enterprise_name'], node_path,

--- a/keepercommander/service/util/parse_keeper_response.py
+++ b/keepercommander/service/util/parse_keeper_response.py
@@ -994,7 +994,8 @@ class KeeperResponseParser:
             "cannot assign",
             "cannot move",
             "cannot get",
-            "not integer"
+            "not integer",
+            "expects"
         ]
         
         error_patterns = [


### PR DESCRIPTION
## Summary
This PR introduces several improvements to enterprise management and MSP commands, along with a fix for service mode error handling.

- **[KC-1134](https://keeper.atlassian.net/browse/KC-1134)** – Updated status code for incorrect enforcement policies type value in service-mode.
- **[KC-1135](https://keeper.atlassian.net/browse/KC-1135)** – Added ID while creating enterprise user.
- **[KC-1136](https://keeper.atlassian.net/browse/KC-1136)** – Added `isolated` field support in `enterprise-info (ei -n)` node reports, resolving missing visibility of `toggle_isolated (restrict_visibility)` status in CLI output.  
- **[KC-1137](https://keeper.atlassian.net/browse/KC-1137)** – Fixed the allocated fields for `msp-info` command for unlimited seats.

[KC-1134]: https://keeper.atlassian.net/browse/KC-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1135]: https://keeper.atlassian.net/browse/KC-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1136]: https://keeper.atlassian.net/browse/KC-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1137]: https://keeper.atlassian.net/browse/KC-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ