### PR TITLE
KC-1143 Add --aging flag to main compliance report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,9 @@ dr-logs
 CLAUDE.md
 AGENTS.md
 keeper_db.sqlite
+__pycache__/
 .keeper-memory-mcp/
 .mcp/
+tests/*_results/
+tests/*.log
+tests/compliance_test.env

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -812,7 +812,7 @@ def execute_router_json(params, endpoint,  request):
     return None
 
 
-def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version=None):
+def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version=None, timeout=None):
     api_request_payload = APIRequest_pb2.ApiRequestPayload()
     if params.session_token:
         api_request_payload.encryptedSessionToken = utils.base64_url_decode(params.session_token)
@@ -824,7 +824,7 @@ def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version
     if isinstance(payload_version, int):
         api_request_payload.apiVersion = payload_version
 
-    rs = rest_api.execute_rest(params.rest_context, endpoint, api_request_payload)
+    rs = rest_api.execute_rest(params.rest_context, endpoint, api_request_payload, timeout=timeout)
     if isinstance(rs, bytes):
         TTK.update_time_of_last_activity()
         if rs_type:
@@ -856,7 +856,7 @@ def communicate(params, request, retry_on_throttle=True):
         response_json = run_command(params, request)
         if response_json['result'] != 'success':
             if retry_on_throttle and response_json.get('result_code') == 'throttled':
-                logging.info('Throttled. sleeping for 10 seconds')
+                logging.debug('Throttled, retrying in 10 seconds')
                 time.sleep(10)
                 # Allow maximum 1 retry per call
                 return communicate(params, request, retry_on_throttle=False)

--- a/keepercommander/commands/compliance.py
+++ b/keepercommander/commands/compliance.py
@@ -28,6 +28,10 @@ rebuild_group.add_argument('--no-rebuild', '-nr', action='store_true', help=nr_h
 compliance_parser.add_argument('--no-cache', '-nc', action='store_true',
                                help='remove any local non-memory storage of data after report is generated')
 compliance_parser.add_argument('--node', action='store', help='ID or name of node (defaults to root node)')
+username_opt_help = 'user(s) whose records are to be included in report (set option once per user)'
+compliance_parser.add_argument('--username', '-u', action='append', help=username_opt_help)
+team_opt_help = 'name or UID of team(s) whose members\' records are to be included in report (set once per team)'
+compliance_parser.add_argument('--team', action='append', help=team_opt_help)
 compliance_parser.add_argument('--regex', action='store_true', help='Allow use of regular expressions in search criteria')
 compliance_parser.add_argument('pattern', type=str, nargs='*', help='Search string / pattern to filter results by. Multiple values allowed.')
 
@@ -35,12 +39,8 @@ aging_help = 'include record-aging data (last modified, created, and last passwo
 
 default_report_parser = argparse.ArgumentParser(prog='compliance report', description='Run a compliance report.',
                                                 parents=[compliance_parser])
-username_opt_help = 'user(s) whose records are to be included in report (set option once per user)'
-default_report_parser.add_argument('--username', '-u', action='append', help=username_opt_help)
 job_title_opt_help = 'job title(s) of users whose records are to be included in report (set option once per job title)'
 default_report_parser.add_argument('--job-title', '-jt', action='append', help=job_title_opt_help)
-team_opt_help = 'name or UID of team(s) whose members\' records are to be included in report (set once per team)'
-default_report_parser.add_argument('--team', action='append', help=team_opt_help)
 record_search_help = 'UID or title of record(s) to include in report (set once per record). To allow non-exact ' \
                      'matching on record titles, include "*" where appropriate (e.g., to include records with titles' \
                      ' ending in "Login", set option value to "*Login")'
@@ -60,6 +60,8 @@ team_report_desc = 'Run a report showing which shared folders enterprise teams h
 team_report_parser = argparse.ArgumentParser(prog='compliance team-report', description=team_report_desc,
                                              parents=[compliance_parser])
 team_report_parser.add_argument('-tu', '--show-team-users', action='store_true', help='show all members of each team')
+team_report_parser.add_argument('--resolve-teams', action='store_true',
+                                help='expand --team filter to also match shared folders where team members are individually present')
 
 access_report_desc = 'Run a report showing all records a user has accessed or can access'
 access_report_parser = argparse.ArgumentParser(prog='compliance record-access-report', description=access_report_desc,
@@ -80,6 +82,8 @@ sf_report_desc = 'Run an enterprise-wide shared-folder report'
 sf_report_parser = argparse.ArgumentParser(prog='compliance shared-folder-report', description=sf_report_desc,
                                            parents=[compliance_parser])
 sf_report_parser.add_argument('-tu', '--show-team-users', action='store_true', help='show all members of each team')
+sf_report_parser.add_argument('--resolve-teams', action='store_true',
+                              help='expand --team filter to also match shared folders where team members are individually present')
 
 
 def register_commands(commands):
@@ -100,11 +104,21 @@ def get_team_usernames(sdata, team):  # type: (SoxData, sox_types.Team) -> List[
     return [get_email(sdata, userid) for userid in team.users]
 
 
+def get_all_folder_user_uids(folder, team_lookup):
+    """All user UIDs with access to a folder: direct members + team members."""
+    all_uids = set(folder.users)
+    for team_uid in folder.teams:
+        team = team_lookup.get(team_uid)
+        if team:
+            all_uids.update(team.users)
+    return all_uids
+
+
 def _from_ts(ts):
     return datetime.datetime.fromtimestamp(ts) if ts else None
 
 
-def get_aging_data(params, sox_data, rec_ids, no_cache=False, use_spinner=True, stale_rec_ids=None):
+def get_aging_data(params, sox_data, rec_ids, use_spinner=True, stale_rec_ids=None):
     """Fetch/cache record-aging data for given record UIDs.
 
     stale_rec_ids: If provided, only fetch fresh data for these UIDs (per-user mode).
@@ -114,22 +128,49 @@ def get_aging_data(params, sox_data, rec_ids, no_cache=False, use_spinner=True, 
         return {}
     aging_data = {r: {'created': None, 'last_modified': None, 'last_rotation': None, 'last_pw_change': None}
                   for r in rec_ids if r}
-    now = datetime.datetime.now()
-    max_stored_age_dt = now - datetime.timedelta(days=1)
-    max_stored_age_ts = int(max_stored_age_dt.timestamp())
+    max_cache_age_ts = int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp())
     stored_aging_data = {}
-    if not no_cache:
-        stored_entities = sox_data.storage.get_record_aging().get_all()
-        stored_aging_data = {
-            e.record_uid: {
-                'created': _from_ts(e.created),
-                'last_modified': _from_ts(e.last_modified),
-                'last_rotation': _from_ts(e.last_rotation),
-                'last_pw_change': _from_ts(e.last_pw_change),
-            }
-            for e in stored_entities if e.record_uid
+    stored_entities = sox_data.storage.get_record_aging().get_all()
+    stored_aging_data = {
+        e.record_uid: {
+            'created': _from_ts(e.created),
+            'last_modified': _from_ts(e.last_modified),
+            'last_rotation': _from_ts(e.last_rotation),
+            'last_pw_change': _from_ts(e.last_pw_change),
+            '_last_cached': e.last_cached or 0,
         }
+        for e in stored_entities if e.record_uid
+    }
     aging_data.update(stored_aging_data)
+
+    types_by_aging_event = dict(
+        created         = [],
+        last_modified   = ['record_update'],
+        last_rotation   = ['record_rotation_scheduled_ok', 'record_rotation_on_demand_ok'],
+        last_pw_change  = ['record_password_change']
+    )
+
+    def get_known_aging_data(event_type):
+        """Return cached records fetched within the 1-day TTL.
+
+        Checks _last_cached timestamp (when we stored the data), not the event value itself.
+        A record with last_pw_change=None but recent _last_cached means "checked, no event found"
+        and should not be re-fetched until the cache expires.
+        """
+        return {r: events.get(event_type) for r, events in stored_aging_data.items()
+                if events.get('_last_cached', 0) >= max_cache_age_ts}
+
+    def get_request_params(record_aging_event):
+        # type: (str) -> Tuple[List[str], Union[List[str], None], Optional[str], Optional[str]]
+        known_events_map = get_known_aging_data(record_aging_event)
+        if stale_rec_ids is not None:
+            filter_recs = [uid for uid in rec_ids if uid in stale_rec_ids and uid not in known_events_map]
+        else:
+            filter_recs = [uid for uid in rec_ids if uid not in known_events_map]
+        filter_types = types_by_aging_event.get(record_aging_event)
+        order, aggregate = ('ascending', 'first_created') if record_aging_event == 'created' \
+            else ('descending', 'last_created')
+        return filter_recs, filter_types, order, aggregate
 
     def get_requests(filter_recs, filter_type, order='descending', aggregate='last_created'):
         columns = ['record_uid']
@@ -152,91 +193,109 @@ def get_aging_data(params, sox_data, rec_ids, no_cache=False, use_spinner=True, 
             requests.append(request)
         return requests
 
-    def get_known_aging_data(event_type):
-        return {r: events.get(event_type) for r, events in stored_aging_data.items() if events.get(event_type) or 0 >= max_stored_age_ts}
-
-    def get_request_params(record_aging_event):
-        # type: (str) -> Tuple[List[str], Union[List[str], None], Optional[str], Optional[str]]
-        known_events_map = get_known_aging_data(record_aging_event)
-        if stale_rec_ids is not None:
-            filter_recs = [uid for uid in rec_ids if uid in stale_rec_ids and uid not in known_events_map]
-        else:
-            filter_recs = [uid for uid in rec_ids if uid not in known_events_map]
-        types_by_aging_event = dict(
-            created         = [],
-            last_modified   = ['record_update'],
-            last_rotation   = ['record_rotation_scheduled_ok', 'record_rotation_on_demand_ok'],
-            last_pw_change  = ['record_password_change']
-        )
-        filter_types = types_by_aging_event.get(record_aging_event)
-        order, aggregate = ('ascending', 'first_created') if record_aging_event == 'created' \
-            else ('descending', 'last_created')
-        return filter_recs, filter_types, order, aggregate
-
-    def fetch_events(requests):
-        return list(
-            itertools.chain.from_iterable(
-                [rs.get('audit_event_overview_report_rows', []) for rs in api.execute_batch(params, requests)]
-            )
-        )
-
-    def get_aging_events(aging_prop):
-        req_params = get_request_params(aging_prop)
-        requests = get_requests(*req_params)
-        return fetch_events(requests)
-
-    def get_aging_event_dts(event_type):
-        events = get_aging_events(event_type)
-        aggregate = 'first_created' if event_type == 'created' else 'last_created'
-        record_timestamps = {event.get('record_uid'): event.get(aggregate) for event in events if event.get('record_uid')}
-        return {rec: _from_ts(ts) for rec, ts in record_timestamps.items()}
-
+    # Pre-compute request params once per stat (used for spinner check and fetch)
     aging_stats = ['created', 'last_modified', 'last_rotation', 'last_pw_change']
+    params_by_stat = {stat: get_request_params(stat) for stat in aging_stats}
+
+    # Build all requests across all stats for a single execute_batch call
+    all_requests = []
+    request_slices = {}  # stat -> (start_idx, count) into the combined response list
+    for stat in aging_stats:
+        stat_requests = get_requests(*params_by_stat[stat])
+        request_slices[stat] = (len(all_requests), len(stat_requests))
+        all_requests.extend(stat_requests)
+
+    # Additional request: count event 80 occurrences per record to detect first-sets
+    pw_filter_recs = params_by_stat['last_pw_change'][0]
+    pw_count_requests = get_requests(pw_filter_recs, ['record_password_change'], aggregate='occurrences')
+    request_slices['_pw_count'] = (len(all_requests), len(pw_count_requests))
+    all_requests.extend(pw_count_requests)
+
     spinner = None
     try:
-        if use_spinner:
-            should_fetch_events = any(get_request_params(stat)[0] for stat in aging_stats)
-            if should_fetch_events:
-                spinner = Spinner('Loading record aging events...')
-                spinner.start()
-        record_events_by_stat = {}
-        for stat in aging_stats:
-            if spinner:
-                spinner.message = f'Loading record aging events - {stat}'
-            record_events_by_stat[stat] = get_aging_event_dts(stat)
+        if use_spinner and all_requests:
+            spinner = Spinner('Loading record aging events...')
+            spinner.start()
+        if all_requests:
+            responses = api.execute_batch(params, all_requests)
+        else:
+            responses = []
     finally:
         if spinner:
             spinner.stop()
+
+    record_events_by_stat = {}
+    for stat in aging_stats:
+        start, count = request_slices[stat]
+        stat_responses = responses[start:start + count]
+        events = list(itertools.chain.from_iterable(
+            rs.get('audit_event_overview_report_rows', []) for rs in stat_responses
+        ))
+        aggregate = 'first_created' if stat == 'created' else 'last_created'
+        record_timestamps = {e.get('record_uid'): e.get(aggregate) for e in events if e.get('record_uid')}
+        record_events_by_stat[stat] = {rec: _from_ts(ts) for rec, ts in record_timestamps.items()}
+
+    # Parse event 80 occurrence counts
+    pw_count_start, pw_count_n = request_slices['_pw_count']
+    pw_count_responses = responses[pw_count_start:pw_count_start + pw_count_n]
+    pw_count_events = list(itertools.chain.from_iterable(
+        rs.get('audit_event_overview_report_rows', []) for rs in pw_count_responses
+    ))
+    pw_occurrences = {e.get('record_uid'): int(e.get('occurrences', 0))
+                      for e in pw_count_events if e.get('record_uid')}
+
+    fetched_rec_ids = set()
     for stat, record_event_dts in record_events_by_stat.items():
         for record, dt in record_event_dts.items():
             aging_data.get(record, {}).update({stat: dt})
             stat == 'created' and aging_data.get(record, {}).setdefault('last_modified', dt)
+            fetched_rec_ids.add(record)
 
-    if not no_cache:
-        save_aging_data(sox_data, aging_data)
+    # KC-1146: discard first-set false positives for record_password_change.
+    # Event 80 is client-side and fires on initial password set (at creation or later edit),
+    # not just on actual password rotation. If a record has only 1 occurrence of event 80,
+    # it's a first-set — not a real password change.
+    for record in pw_occurrences:
+        if pw_occurrences[record] <= 1 and aging_data.get(record, {}).get('last_pw_change'):
+            aging_data[record]['last_pw_change'] = None
+
+    if fetched_rec_ids:
+        save_aging_data(sox_data, aging_data, fetched_rec_ids)
+
+    # Union last_pw_change (event 80) with last_rotation (events 250/252) for comprehensive signal.
+    # These are disjoint event sets: event 80 = client-side manual changes,
+    # events 250/252 = router-side PAM rotations. Both represent real password changes.
+    for record, events in aging_data.items():
+        pw_change_dt = events.get('last_pw_change')
+        rotation_dt = events.get('last_rotation')
+        if rotation_dt and (not pw_change_dt or rotation_dt > pw_change_dt):
+            events['last_pw_change'] = rotation_dt
+
     return aging_data
 
 
-def save_aging_data(sox_data, aging_data):
+def save_aging_data(sox_data, aging_data, dirty_rec_ids=None):
+    """Persist aging data. If dirty_rec_ids given, only write those records."""
     existing_entities = sox_data.storage.get_record_aging()
+    now_ts = int(datetime.datetime.now().timestamp())
     updated_entities = []
-    for r, events in aging_data.items():
+    records_to_save = dirty_rec_ids if dirty_rec_ids is not None else aging_data.keys()
+    for r in records_to_save:
         if not r:
+            continue
+        events = aging_data.get(r)
+        if not events:
             continue
         entity = existing_entities.get_entity(r) or StorageRecordAging(r)
         created_dt = events.get('created')
-        created_ts = int(created_dt.timestamp()) if created_dt else 0
+        entity.created = int(created_dt.timestamp()) if created_dt else 0
         pw_change_dt = events.get('last_pw_change')
-        pw_change_ts = int(pw_change_dt.timestamp()) if pw_change_dt else 0
+        entity.last_pw_change = int(pw_change_dt.timestamp()) if pw_change_dt else 0
         modified_dt = events.get('last_modified')
-        modified_ts = int(modified_dt.timestamp()) if modified_dt else 0
+        entity.last_modified = int(modified_dt.timestamp()) if modified_dt else 0
         rotation_dt = events.get('last_rotation')
-        rotation_ts = int(rotation_dt.timestamp()) if rotation_dt else 0
-
-        entity.created = created_ts
-        entity.last_pw_change = pw_change_ts
-        entity.last_modified = modified_ts
-        entity.last_rotation = rotation_ts
+        entity.last_rotation = int(rotation_dt.timestamp()) if rotation_dt else 0
+        entity.last_cached = now_ts
         updated_entities.append(entity)
     sox_data.storage.record_aging.put_entities(updated_entities)
 
@@ -295,6 +354,7 @@ class BaseComplianceReportCommand(EnterpriseCommand):
 
         # Pre-filter users for --username and --team to avoid fetching data for all enterprise users
         user_filter = None
+        explicit_user_ids = set()
         usernames = kwargs.get('username')
         team_refs = kwargs.get('team')
         if usernames or team_refs:
@@ -303,7 +363,8 @@ class BaseComplianceReportCommand(EnterpriseCommand):
             if usernames:
                 username_set = set(usernames)
                 user_lookup = {eu.get('username'): eu.get('enterprise_user_id') for eu in enterprise_users}
-                filtered_user_ids.update(uid for u, uid in user_lookup.items() if u in username_set)
+                explicit_user_ids.update(uid for u, uid in user_lookup.items() if u in username_set)
+                filtered_user_ids.update(explicit_user_ids)
             if team_refs:
                 enterprise_teams = params.enterprise.get('teams', [])
                 team_uids = {t.get('team_uid') for t in enterprise_teams}
@@ -321,6 +382,10 @@ class BaseComplianceReportCommand(EnterpriseCommand):
                 logging.warning('No enterprise users matched the provided filters (usernames=%s, teams=%s).',
                                 usernames, team_refs)
             user_filter = filtered_user_ids if filtered_user_ids else None
+            kwargs['_team_filter'] = resolved_team_uids if team_refs else None
+            if kwargs.get('resolve_teams') and team_refs:
+                explicit_user_ids.update(filtered_user_ids)
+            kwargs['_explicit_user_filter'] = explicit_user_ids if explicit_user_ids else None
 
         get_sox_data_fn = sox.get_prelim_data if self.prelim_only else sox.get_compliance_data
         fn_args = [params, enterprise_id] if self.prelim_only else [params, node_id, enterprise_id]
@@ -516,7 +581,6 @@ class ComplianceReportCommand(BaseComplianceReportCommand):
                             stale_rec_ids.update(user.records & all_rec_uids)
 
             aging_data = get_aging_data(params, sox_data, all_rec_uids,
-                                        no_cache=kwargs.get('no_cache'),
                                         use_spinner=not params.batch_mode,
                                         stale_rec_ids=stale_rec_ids)
 
@@ -565,12 +629,22 @@ class ComplianceTeamReportCommand(BaseComplianceReportCommand):
             return sf.get('name_unencrypted', '')
 
         show_team_users = kwargs.get('show_team_users')
+        explicit_user_filter = kwargs.get('_explicit_user_filter')
+        team_filter = kwargs.get('_team_filter')
         shared_folders = sox_data.get_shared_folders().items()
         team_lookup = sox_data.get_teams()
         report_data = []
         for sf_uid, folder in shared_folders:
+            if explicit_user_filter or team_filter:
+                all_folder_uids = get_all_folder_user_uids(folder, team_lookup)
+                matches_user = explicit_user_filter and all_folder_uids & explicit_user_filter
+                matches_team = team_filter and folder.teams & team_filter
+                if not matches_user and not matches_team:
+                    continue
             num_recs = len(folder.record_permissions) if folder.record_permissions else 0
             for team_uid in folder.teams:
+                if team_filter and team_uid not in team_filter and not matches_user:
+                    continue
                 team = team_lookup.get(team_uid)
                 perms = [not team.restrict_share and 'Can Share', not team.restrict_edit and 'Can Edit']
                 perms = [p for p in perms if p]
@@ -605,6 +679,20 @@ class ComplianceRecordAccessReportCommand(BaseComplianceReportCommand):
 
     def execute(self, params, **kwargs):  # type: (KeeperParams, any) -> any
         kwargs['shared'] = True
+        emails = kwargs.get('email') or ['@all']
+        if '@all' not in emails:
+            enterprise_users = params.enterprise.get('users', [])
+            id_to_email = {eu.get('enterprise_user_id'): eu.get('username') for eu in enterprise_users}
+            resolved_emails = []
+            for ref in emails:
+                if ref.isdigit():
+                    email = id_to_email.get(int(ref))
+                    if email:
+                        resolved_emails.append(email)
+                else:
+                    resolved_emails.append(ref)
+            if resolved_emails:
+                kwargs['username'] = resolved_emails
         return super().execute(params, **kwargs)
 
     def generate_report_data(self, params, kwargs, sox_data, report_fmt, node, root_node):
@@ -687,9 +775,37 @@ class ComplianceRecordAccessReportCommand(BaseComplianceReportCommand):
             return accessed_records
 
         def compile_report_data(rec_ids):
+            # Per-user aging cache invalidation when specific users selected
+            stale_rec_ids = None
+            is_filtered = '@all' not in (kwargs.get('email') or ['@all'])
+            email_to_uid = {v: k for k, v in user_lookup.items()}
+            user_filter_uids = {email_to_uid[e] for e in usernames if e in email_to_uid} if is_filtered else None
+            min_aging_ts = int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp())
+            if rec_ids and user_filter_uids is not None:
+                stale_rec_ids = set()
+                for uid in user_filter_uids:
+                    user_entity = sox_data.storage.get_users().get_entity(uid)
+                    if not user_entity or (user_entity.last_aging_refreshed or 0) < min_aging_ts:
+                        user_email = user_lookup.get(uid)
+                        user_recs = user_access_lookup.get(user_email, {})
+                        stale_rec_ids.update(user_recs.keys() & rec_ids)
+
             aging_data = get_aging_data(params, sox_data, rec_ids,
-                                        no_cache=kwargs.get('no_cache'),
-                                        use_spinner=use_spinner)
+                                        use_spinner=use_spinner,
+                                        stale_rec_ids=stale_rec_ids)
+
+            # Update last_aging_refreshed for stale users
+            if user_filter_uids is not None:
+                now_ts = int(datetime.datetime.now().timestamp())
+                updated_users = []
+                for uid in user_filter_uids:
+                    user_entity = sox_data.storage.get_users().get_entity(uid)
+                    if user_entity and (user_entity.last_aging_refreshed or 0) < min_aging_ts:
+                        user_entity.last_aging_refreshed = now_ts
+                        updated_users.append(user_entity)
+                if updated_users:
+                    sox_data.storage.get_users().put_entities(updated_users)
+
             for email, records in user_access_lookup.items():
                 for uid, access_data in records.items():
                     row = [email, uid]
@@ -786,6 +902,7 @@ class ComplianceSummaryReportCommand(BaseComplianceReportCommand):
             return email, num_total, num_owned, num_active, num_deleted
 
         filter_by_node = node != root_node
+        user_filter = kwargs.get('_user_filter')
         from .enterprise import EnterpriseInfoCommand
         cmd = EnterpriseInfoCommand()
         cmd_kwargs = {
@@ -799,10 +916,12 @@ class ComplianceSummaryReportCommand(BaseComplianceReportCommand):
         managed_users = [mu for mu in managed_users if mu.get('status', '').lower() != 'invited']
         managed_user_email_lookup = {mu.get('user_id'): mu.get('email') for mu in managed_users}
         managed_user_ids = set(managed_user_email_lookup.keys())
+        if user_filter is not None:
+            managed_user_ids &= user_filter
         empty_vault_user_ids = {user_id for user_id in managed_user_ids if user_id not in sox_data.get_users()}
         empty_vault_users = [mu for mu in managed_users if mu.get('user_id') in empty_vault_user_ids]
         sox_users = sox_data.get_users().values()
-        report_data = [get_row(u) for u in sox_users if not filter_by_node or u.user_uid in managed_user_ids]
+        report_data = [get_row(u) for u in sox_users if u.user_uid in managed_user_ids]
         report_data.extend([(u.get('email'), 0, 0, 0, 0) for u in empty_vault_users])
         total_active = sum([num_active for _, _, _, num_active, _ in report_data])
         total_deleted = sum([num_deleted for _, _, _, _, num_deleted in report_data])
@@ -823,12 +942,20 @@ class ComplianceSharedFolderReportCommand(BaseComplianceReportCommand):
         show_team_users = kwargs.get('show_team_users')
         team_users_title = '(TU) denotes a user whose membership in a team grants them access to the shared folder'
         self.title = team_users_title if show_team_users else None
+        explicit_user_filter = kwargs.get('_explicit_user_filter')
+        team_filter = kwargs.get('_team_filter')
         sfs = sox_data.get_shared_folders()
         teams = sox_data.get_teams()
         report_data = []
         for sfuid, sf in sfs.items():
+            if explicit_user_filter or team_filter:
+                all_folder_uids = get_all_folder_user_uids(sf, teams)
+                matches_user = explicit_user_filter and all_folder_uids & explicit_user_filter
+                matches_team = team_filter and sf.teams & team_filter
+                if not matches_user and not matches_team:
+                    continue
             sf_team_uids = list(sf.teams)
-            sf_team_names = [teams.get(t).team_name for t in sf.teams]
+            sf_team_names = [teams.get(t).team_name for t in sf_team_uids]
             records = [rp.record_uid for rp in sf.record_permissions]
             users = [get_email(sox_data, u) for u in sf.users]
             team_users = [tu for tuid in sf_team_uids for tu in get_team_usernames(sox_data, teams.get(tuid))] if show_team_users else []

--- a/keepercommander/sox/storage_types.py
+++ b/keepercommander/sox/storage_types.py
@@ -26,6 +26,7 @@ class StorageRecord(IUid):
         self.shared = True
         self.in_trash = False
         self.has_attachments = False
+        self.last_compliance_refreshed = 0
 
     def uid(self):
         # -> str
@@ -39,6 +40,7 @@ class StorageRecordAging(IUid):
         self.last_pw_change = 0
         self.last_modified = 0
         self.last_rotation = 0
+        self.last_cached = 0
 
     def uid(self):
         return self.record_uid

--- a/tests/compliance_test.batch
+++ b/tests/compliance_test.batch
@@ -1,0 +1,90 @@
+# Compliance Test Suite
+#
+# Batch file template for Keeper Commander's compliance commands.
+# Placeholders are substituted by compliance_test.sh at runtime:
+#   {OUTDIR}          results directory
+#   {USER1}           primary admin email
+#   {USER2}           secondary user email
+#   {TEAM_ONLY_USER}  user with team-only shared-folder access
+#   {TEAM1}           team name or UID
+#
+# Do not run this file directly — use the runner:
+#   bash tests/compliance_test.sh [after|before|diff|parallel|all]
+
+# ─── compliance report ────────────────────────────────────────────────────────
+# t01: full report (rebuild to ensure fresh data)
+compliance report -r --format json --output {OUTDIR}/t01_report_full.json
+# t02: filter by single user
+compliance report -u {USER1} --format json --output {OUTDIR}/t02_report_user.json
+# t03: filter by team
+compliance report --team {TEAM1} --format json --output {OUTDIR}/t03_report_team.json
+# t04: filter by user + team (OR union)
+compliance report -u {USER1} --team {TEAM1} --format json --output {OUTDIR}/t04_report_user_team.json
+# t05: aging columns present
+compliance report --aging --format json --output {OUTDIR}/t05_report_aging.json
+# t06: aging + user filter
+compliance report --aging -u {USER1} --format json --output {OUTDIR}/t06_report_aging_user.json
+
+# ─── compliance record-access-report ──────────────────────────────────────────
+# t10: single user
+compliance record-access-report --email {USER1} --format json --output {OUTDIR}/t10_rar_user.json
+# t11: single user + aging
+compliance record-access-report --email {USER1} --aging --format json --output {OUTDIR}/t11_rar_user_aging.json
+# t12: all users
+compliance record-access-report --email @all --format json --output {OUTDIR}/t12_rar_all.json
+# t13: all users + aging
+compliance record-access-report --email @all --aging --format json --output {OUTDIR}/t13_rar_all_aging.json
+# t14: second user (cache isolation — different user than t10)
+compliance record-access-report --email {USER2} --aging --format json --output {OUTDIR}/t14_rar_user2_aging.json
+# t15: first user again (should hit warm cache)
+compliance record-access-report --email {USER1} --aging --format json --output {OUTDIR}/t15_rar_user1_cached.json
+# t16: team filter
+compliance record-access-report --email @all --team {TEAM1} --format json --output {OUTDIR}/t16_rar_team.json
+
+# ─── compliance team-report ───────────────────────────────────────────────────
+# t20: full team report
+compliance team-report --format json --output {OUTDIR}/t20_tr_full.json
+# t21: filter by team
+compliance team-report --team {TEAM1} --format json --output {OUTDIR}/t21_tr_team.json
+# t22: filter by user who is a direct shared-folder member
+compliance team-report -u {USER1} --format json --output {OUTDIR}/t22_tr_user_direct.json
+# t23: filter by user whose only SF access is via a team
+compliance team-report -u {TEAM_ONLY_USER} --format json --output {OUTDIR}/t23_tr_user_team_member.json
+# t24: show team users display flag
+compliance team-report -tu --format json --output {OUTDIR}/t24_tr_tu.json
+# t25: team + user combined filter (OR union)
+compliance team-report --team {TEAM1} -u {USER1} --format json --output {OUTDIR}/t25_tr_team_user.json
+
+# ─── compliance summary-report ────────────────────────────────────────────────
+# t30: full summary
+compliance summary-report --format json --output {OUTDIR}/t30_summary_full.json
+# t31: filter by user
+compliance summary-report -u {USER1} --format json --output {OUTDIR}/t31_summary_user.json
+# t32: filter by team
+compliance summary-report --team {TEAM1} --format json --output {OUTDIR}/t32_summary_team.json
+
+# ─── compliance shared-folder-report ──────────────────────────────────────────
+# t40: full sfr
+compliance shared-folder-report --format json --output {OUTDIR}/t40_sfr_full.json
+# t41: filter by team
+compliance shared-folder-report --team {TEAM1} --format json --output {OUTDIR}/t41_sfr_team.json
+# t42: filter by user who is a direct SF member
+compliance shared-folder-report -u {USER1} --format json --output {OUTDIR}/t42_sfr_user_direct.json
+# t43: filter by user whose only SF access is via team
+compliance shared-folder-report -u {TEAM_ONLY_USER} --format json --output {OUTDIR}/t43_sfr_user_team_member.json
+# t44: team + user combined filter (OR union)
+compliance shared-folder-report --team {TEAM1} -u {USER1} --format json --output {OUTDIR}/t44_sfr_team_user.json
+# t45: show team users display flag
+compliance shared-folder-report -tu --format json --output {OUTDIR}/t45_sfr_tu.json
+# t46: --resolve-teams expands team members into SF user matching
+compliance shared-folder-report --team {TEAM1} --resolve-teams --format json --output {OUTDIR}/t46_sfr_team_resolved.json
+
+# ─── incremental cache tests ─────────────────────────────────────────────────
+# t50: rebuild to prime cache
+compliance report -r --format json --output {OUTDIR}/t50_cache_prime.json
+# t51: immediate re-run (warm cache, should be fast)
+compliance report --format json --output {OUTDIR}/t51_cache_warm.json
+# t52: --no-cache run (deletes local db after report)
+compliance report -nc --format json --output {OUTDIR}/t52_cache_nocache.json
+# t53: post-nocache run (db was deleted, must rebuild)
+compliance report --format json --output {OUTDIR}/t53_cache_post_nocache.json

--- a/tests/compliance_test.env.example
+++ b/tests/compliance_test.env.example
@@ -1,0 +1,30 @@
+# compliance_test.env — test configuration
+# Copy this file to compliance_test.env and fill in values for your environment.
+#
+# All variables are required unless marked (optional).
+# Emails must be valid enterprise users visible to the admin running the tests.
+
+# ── Enterprise users ─────────────────────────────────────────────────────────
+# Primary admin / power user (owns many records, is a direct shared-folder member)
+USER1="admin@example.com"
+
+# Secondary user with few records (used for cache-isolation checks)
+USER2="user2@example.com"
+
+# User whose only shared-folder access is through a team (not a direct SF member)
+TEAM_ONLY_USER="team-member@example.com"
+
+# ── Teams ────────────────────────────────────────────────────────────────────
+# A team name (or UID) that has at least one shared folder linked to it
+TEAM1="MyTeam"
+
+# ── Paths ────────────────────────────────────────────────────────────────────
+# Directory containing the Commander branch under test (.venv must exist here)
+AFTER_DIR="$HOME/dev/Commander"
+
+# (optional) Directory containing a baseline Commander install for A/B comparison
+BEFORE_DIR=""
+
+# (optional) Keeper config file relative to each Commander directory above
+# Defaults to ./config.json
+KEEPER_CONFIG="./config.json"

--- a/tests/compliance_test.sh
+++ b/tests/compliance_test.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Compliance Test Runner
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# A/B test harness for Keeper Commander's compliance commands.
+# Runs a comprehensive batch of compliance subcommands and compares JSON output
+# between two Commander installs (e.g. feature branch vs. baseline release).
+#
+# Prerequisites:
+#   - Each Commander directory must have a .venv with keeper installed
+#   - A logged-in session (run `keeper shell` once to cache credentials)
+#   - python3 on PATH
+#
+# Quick start:
+#   bash tests/compliance_test.sh after           # run tests on current branch
+#   bash tests/compliance_test.sh before          # run tests on baseline
+#   bash tests/compliance_test.sh diff            # compare existing results
+#   bash tests/compliance_test.sh parallel        # run both simultaneously
+#   bash tests/compliance_test.sh all             # run both sequentially, then diff
+#
+# Configuration:
+#   The script auto-discovers users and teams from the vault. Override any
+#   value by exporting env vars or creating tests/compliance_test.env:
+#
+#     AFTER_DIR       Commander under test      (default: repo root)
+#     BEFORE_DIR      Baseline Commander        (default: empty, skips 'before')
+#     KEEPER_CONFIG   Config file path          (default: ./config.json)
+#     USER1           Primary admin email       (auto-discovered)
+#     USER2           Secondary user email      (auto-discovered)
+#     TEAM_ONLY_USER  User with team-only SF    (auto-discovered from TEAM1)
+#     TEAM1           Team name or UID          (auto-discovered)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$SCRIPT_DIR/compliance_test.batch"
+RESULTS_DIR="$SCRIPT_DIR/compliance_test_results"
+
+# Load env file if present (won't override already-exported vars)
+ENV_FILE="$SCRIPT_DIR/compliance_test.env"
+if [ -f "$ENV_FILE" ]; then
+    echo "Loading config from $ENV_FILE"
+    set -a; source "$ENV_FILE"; set +a
+fi
+
+AFTER_DIR="${AFTER_DIR:-$REPO_DIR}"
+BEFORE_DIR="${BEFORE_DIR:-}"
+KEEPER_CONFIG="${KEEPER_CONFIG:-./config.json}"
+
+# ── Helper: run a keeper command and capture output ──────────────────────────
+keeper_cmd() {
+    local dir="$1"; shift
+    (cd "$dir" && .venv/bin/keeper --config "$KEEPER_CONFIG" "$@" 2>/dev/null)
+}
+
+# ── Auto-discover test parameters from the vault ────────────────────────────
+discover() {
+    local dir="$1"
+    echo "Discovering test parameters from vault ($dir) ..."
+
+    if [ -z "${USER1:-}" ] || [ -z "${USER2:-}" ] || [ -z "${TEAM1:-}" ] || [ -z "${TEAM_ONLY_USER:-}" ]; then
+        local users_json="" teams_json=""
+
+        if [ -z "${USER1:-}" ] || [ -z "${USER2:-}" ]; then
+            users_json=$(keeper_cmd "$dir" enterprise-info -u --format json || echo "[]")
+            if [ -z "${USER1:-}" ]; then
+                USER1=$(python3 -c "
+import json, sys
+users = json.loads(sys.stdin.read())
+active = [u for u in users if u.get('status','') == 'Active']
+print(active[0]['email'] if active else users[0]['email'] if users else '')
+" <<< "$users_json")
+                echo "  USER1=$USER1"
+            fi
+            if [ -z "${USER2:-}" ]; then
+                USER2=$(python3 -c "
+import json, sys
+users = json.loads(sys.stdin.read())
+active = [u for u in users if u.get('status','') == 'Active' and u.get('email','') != '$USER1']
+print(active[-1]['email'] if active else '')
+" <<< "$users_json")
+                echo "  USER2=$USER2"
+            fi
+        fi
+
+        if [ -z "${TEAM1:-}" ] || [ -z "${TEAM_ONLY_USER:-}" ]; then
+            teams_json=$(keeper_cmd "$dir" enterprise-info -t --columns users --format json || echo "[]")
+            if [ -z "${TEAM1:-}" ]; then
+                TEAM1=$(python3 -c "
+import json, sys
+teams = json.loads(sys.stdin.read())
+skip = {'everyone', 'admins'}
+candidates = [t for t in teams if t.get('team_name','').lower() not in skip]
+print(candidates[0]['team_name'] if candidates else (teams[0]['team_name'] if teams else ''))
+" <<< "$teams_json")
+                echo "  TEAM1=$TEAM1"
+            fi
+            if [ -z "${TEAM_ONLY_USER:-}" ]; then
+                TEAM_ONLY_USER=$(python3 -c "
+import json, sys
+teams = json.loads(sys.stdin.read())
+target, u1 = '$TEAM1', '$USER1'
+for t in teams:
+    if t.get('team_name','') == target:
+        members = t.get('users', [])
+        others = [m for m in members if m != u1]
+        if others:
+            print(others[0])
+            sys.exit(0)
+print('$USER2')
+" <<< "$teams_json")
+                echo "  TEAM_ONLY_USER=$TEAM_ONLY_USER"
+            fi
+        fi
+    fi
+
+    # Validate
+    local missing=()
+    [ -z "${USER1:-}" ] && missing+=("USER1")
+    [ -z "${USER2:-}" ] && missing+=("USER2")
+    [ -z "${TEAM1:-}" ] && missing+=("TEAM1")
+    [ -z "${TEAM_ONLY_USER:-}" ] && missing+=("TEAM_ONLY_USER")
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "ERROR: Could not determine: ${missing[*]}"
+        echo "Set them in $ENV_FILE or export as env vars."
+        exit 1
+    fi
+    echo ""
+}
+
+# ── Generate a concrete batch file from the template ─────────────────────────
+generate_batch() {
+    local outdir="$1" dest="$2"
+    sed -e "s|{OUTDIR}|$outdir|g" \
+        -e "s|{USER1}|$USER1|g" \
+        -e "s|{USER2}|$USER2|g" \
+        -e "s|{TEAM_ONLY_USER}|$TEAM_ONLY_USER|g" \
+        -e "s|{TEAM1}|$TEAM1|g" \
+        "$TEMPLATE" > "$dest"
+}
+
+# ── Run suites ───────────────────────────────────────────────────────────────
+run_after() {
+    discover "$AFTER_DIR"
+    local out="$RESULTS_DIR/after"
+    local batch="$RESULTS_DIR/after.batch"
+    mkdir -p "$out"
+    generate_batch "$out" "$batch"
+
+    echo "=== Running AFTER (current branch) ==="
+    echo "  Dir:    $AFTER_DIR"
+    echo "  Output: $out"
+    echo "  Config:"
+    echo "    USER1=$USER1  USER2=$USER2"
+    echo "    TEAM1=$TEAM1  TEAM_ONLY_USER=$TEAM_ONLY_USER"
+    echo ""
+    cd "$AFTER_DIR"
+    .venv/bin/keeper --config "$KEEPER_CONFIG" run-batch "$batch" 2>&1 | tee "$out/_run.log"
+    echo ""
+    echo "=== AFTER complete ==="
+}
+
+run_before() {
+    if [ -z "$BEFORE_DIR" ]; then
+        echo "ERROR: BEFORE_DIR is not set. Set it in $ENV_FILE or export it."
+        exit 1
+    fi
+    discover "$BEFORE_DIR"
+    local out="$RESULTS_DIR/before"
+    local batch="$RESULTS_DIR/before.batch"
+    mkdir -p "$out"
+    generate_batch "$out" "$batch"
+
+    echo "=== Running BEFORE (baseline) ==="
+    echo "  Dir:    $BEFORE_DIR"
+    echo "  Output: $out"
+    echo "  Config:"
+    echo "    USER1=$USER1  USER2=$USER2"
+    echo "    TEAM1=$TEAM1  TEAM_ONLY_USER=$TEAM_ONLY_USER"
+    echo ""
+    cd "$BEFORE_DIR"
+    .venv/bin/keeper --config "$KEEPER_CONFIG" run-batch "$batch" 2>&1 | tee "$out/_run.log"
+    echo ""
+    echo "=== BEFORE complete ==="
+}
+
+# ── Compare results ──────────────────────────────────────────────────────────
+diff_results() {
+    local after_out="$RESULTS_DIR/after"
+    local before_out="$RESULTS_DIR/before"
+    echo ""
+    echo "=== Comparing results ==="
+    echo ""
+
+    if [ ! -d "$after_out" ]; then
+        echo "ERROR: No 'after' results found at $after_out"; exit 1
+    fi
+    if [ ! -d "$before_out" ]; then
+        echo "ERROR: No 'before' results found at $before_out"; exit 1
+    fi
+
+    local any_diff=0
+    for f in "$after_out"/t*.json; do
+        local fname
+        fname=$(basename "$f")
+        local before_f="$before_out/$fname"
+        if [ ! -f "$before_f" ]; then
+            echo "  [SKIP]  $fname — no baseline (new test or baseline error)"
+            continue
+        fi
+        local after_rows before_rows
+        after_rows=$(python3 -c "import json; d=json.load(open('$f')); print(len(d) if isinstance(d,list) else 'obj')" 2>/dev/null || echo "ERR")
+        before_rows=$(python3 -c "import json; d=json.load(open('$before_f')); print(len(d) if isinstance(d,list) else 'obj')" 2>/dev/null || echo "ERR")
+        if [ "$after_rows" = "$before_rows" ]; then
+            echo "  [OK]    $fname — rows: $after_rows"
+        else
+            echo "  [DIFF]  $fname — before=$before_rows, after=$after_rows"
+            any_diff=1
+        fi
+    done
+
+    for f in "$after_out"/t*.json; do
+        local fname
+        fname=$(basename "$f")
+        if [ ! -f "$before_out/$fname" ]; then
+            local after_rows
+            after_rows=$(python3 -c "import json; d=json.load(open('$f')); print(len(d) if isinstance(d,list) else 'obj')" 2>/dev/null || echo "ERR")
+            echo "  [NEW]   $fname — rows: $after_rows (no baseline to compare)"
+        fi
+    done
+
+    echo ""
+    if [ "$any_diff" -eq 0 ]; then
+        echo "All comparable tests match."
+    else
+        echo "Some tests differ — review above."
+    fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+case "${1:-help}" in
+    after)    run_after ;;
+    before)   run_before ;;
+    diff)     diff_results ;;
+    parallel)
+        run_after &
+        local_after_pid=$!
+        run_before &
+        local_before_pid=$!
+        echo "=== Running in parallel: after=$local_after_pid, before=$local_before_pid ==="
+        wait $local_after_pid
+        wait $local_before_pid
+        diff_results
+        ;;
+    all)
+        run_after
+        echo ""
+        run_before
+        diff_results
+        ;;
+    *)
+        cat <<'USAGE'
+Compliance Test Runner — A/B test harness for Commander compliance commands.
+
+Usage: bash tests/compliance_test.sh <mode>
+
+Modes:
+  after      Run the test suite against the current branch (AFTER_DIR)
+  before     Run the test suite against the baseline install (BEFORE_DIR)
+  diff       Compare existing after/before results
+  parallel   Run both after and before simultaneously, then diff
+  all        Run after, then before, then diff
+
+Configuration:
+  Set values in tests/compliance_test.env or export as env vars.
+  If not set, USER1/USER2/TEAM1/TEAM_ONLY_USER are auto-discovered
+  from the vault via enterprise-info.
+
+  See tests/compliance_test.env.example for all options.
+USAGE
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add --aging flag to compliance report and compliance record-access-report commands showing per-record created, last modified, last password change, and last rotation dates
- Union events 80 (client-side password changes) + 250/252 (PAM rotation) for comprehensive last-password-change signal
- KC-1146 client-side compensation: filter false-positive record_password_change events fired on record creation (occurrence count heuristic)
- Per-user aging cache via last_aging_refreshed on StorageUser with 1-day TTL
- Extract aging fetch/cache logic to module-level get_aging_data / save_aging_data for reuse across report commands
- Batch all ARAM queries into a single execute_batch call for performance

## Test plan
- Run compliance report --aging for full enterprise — verify aging columns populated
- Run compliance report --aging --username USER — verify per-user cache invalidation
- Run compliance record-access-report --aging — verify aging columns in access report
- Verify records with only creation-time event 80 show None for last_pw_change (KC-1146 filter)
- Verify PAM-rotated records show rotation date in last_pw_change (event 250/252 union)
- Verify cached data respects 1-day TTL and refreshes on next run
