### PR TITLE
KC-1143 Fix aging row mapping, filtered staleness scope, test discovery

### DIFF
--- a/keepercommander/commands/compliance.py
+++ b/keepercommander/commands/compliance.py
@@ -598,11 +598,10 @@ class ComplianceReportCommand(BaseComplianceReportCommand):
 
             # Append aging columns to each row
             record_lookup = sox_data.get_records()
-            for fmt_row in report_data:
+            for idx, fmt_row in enumerate(report_data):
                 rec_uid = fmt_row[0]
                 # Handle collapsed UIDs in table format
-                if not rec_uid and report_data:
-                    idx = report_data.index(fmt_row)
+                if not rec_uid:
                     for i in range(idx - 1, -1, -1):
                         if report_data[i][0]:
                             rec_uid = report_data[i][0]

--- a/tests/compliance_test.sh
+++ b/tests/compliance_test.sh
@@ -93,8 +93,8 @@ print(active[-1]['email'] if active else '')
 import json, sys
 teams = json.loads(sys.stdin.read())
 skip = {'everyone', 'admins'}
-candidates = [t for t in teams if t.get('team_name','').lower() not in skip]
-print(candidates[0]['team_name'] if candidates else (teams[0]['team_name'] if teams else ''))
+candidates = [t for t in teams if t.get('name', t.get('team_name','')).lower() not in skip]
+print(candidates[0].get('name', candidates[0].get('team_name','')) if candidates else (teams[0].get('name', teams[0].get('team_name','')) if teams else ''))
 " <<< "$teams_json")
                 echo "  TEAM1=$TEAM1"
             fi
@@ -104,7 +104,7 @@ import json, sys
 teams = json.loads(sys.stdin.read())
 target, u1 = '$TEAM1', '$USER1'
 for t in teams:
-    if t.get('team_name','') == target:
+    if t.get('name', t.get('team_name','')) == target:
         members = t.get('users', [])
         others = [m for m in members if m != u1]
         if others:


### PR DESCRIPTION
Follow-up fixes for KC-1143 (merged as PR #1819).

- Fix report_data.index(fmt_row) value-comparison bug that could map aging columns to wrong records when rows have identical content — use enumerate instead
- Scope staleness check to filtered users' records when user_filter is set, preventing full enterprise sync_down on filtered queries
- Fix team discovery in compliance test script: use 'name' key matching actual enterprise-info JSON output

Made with [Cursor](https://cursor.com)