### PR TITLE
Fix MSP node resolution and enforcement JSON output

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -1014,7 +1014,10 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                             row.append(len(enforcements))
                         elif column == 'enforcements':
                             enforcements = role_enforcements.get(role_id, {})
-                            row.append(list(enforcements.keys()))
+                            if kwargs.get('format') == 'json':
+                                row.append(dict(enforcements))
+                            else:
+                                row.append(list(enforcements.keys()))
                         elif column == 'managed_node_count':
                             row.append(len(managed_nodes_list))
                         elif column == 'managed_nodes':
@@ -1147,6 +1150,10 @@ class EnterpriseNodeCommand(EnterpriseCommand):
                         n.append(node)
                     else:
                         node_lookup[node_name] = [n, node]
+                if not node.get('parent_id'):
+                    ent_name = params.enterprise['enterprise_name'].lower()
+                    if ent_name not in node_lookup:
+                        node_lookup[ent_name] = node
 
         parent_id = None
         if kwargs.get('parent'):

--- a/keepercommander/service/util/request_validation.py
+++ b/keepercommander/service/util/request_validation.py
@@ -67,8 +67,8 @@ class RequestValidator:
         # Check if command contains FILEDATA placeholder and request has filedata
         if "FILEDATA" in command and "filedata" in request_data:
             filedata = request_data.get("filedata")
-            if not isinstance(filedata, dict):
-                logger.warning("filedata must be a JSON object")
+            if not isinstance(filedata, (dict, list)):
+                logger.warning("filedata must be a JSON object or array")
                 return processed_command, temp_files
             
             try:


### PR DESCRIPTION
## Summary
This PR resolves issues related to MSP node creation and enforcement output in enterprise commands.

### 1. Root Node Resolution (MSP)
The root node is now registered using the enterprise name, allowing it to be referenced correctly by name when assigning a parent during MSP node creation.

### 2. Enforcement Output in enterprise-info
Updated the `enterprise-info` command to return complete enforcement key-value pairs when `--format json` is used.  
Previously, only enforcement keys were returned in JSON output.

### 3. Add filedata support in enterprise-role for enforcement
Added filedata support in enterprise-role for set enforcement policies in service mode.