### PR TITLE
Fix stdout/stderr separation for POSIX-compliant piping

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -335,13 +335,13 @@ def main(from_package=False):
             params.server = resolved_server
         else:
             # Show error and valid options
-            print(f"\nError: '{opts.server}' is not a valid Keeper server.")
-            print('\nValid server codes:')
-            print('  Production: US, EU, AU, CA, JP, GOV')
-            print('  Dev:        US_DEV, EU_DEV, AU_DEV, CA_DEV, JP_DEV, GOV_DEV')
-            print('  QA:         US_QA, EU_QA, AU_QA, CA_QA, JP_QA, GOV_QA')
-            print('\nYou can also use the full hostname (e.g., keepersecurity.com, keepersecurity.eu)')
-            print('')
+            logging.error(f"\nError: '{opts.server}' is not a valid Keeper server.")
+            logging.error('\nValid server codes:')
+            logging.error('  Production: US, EU, AU, CA, JP, GOV')
+            logging.error('  Dev:        US_DEV, EU_DEV, AU_DEV, CA_DEV, JP_DEV, GOV_DEV')
+            logging.error('  QA:         US_QA, EU_QA, AU_QA, CA_QA, JP_QA, GOV_QA')
+            logging.error('\nYou can also use the full hostname (e.g., keepersecurity.com, keepersecurity.eu)')
+            logging.error('')
             sys.exit(1)
 
     if opts.user is not None:
@@ -395,17 +395,17 @@ def main(from_package=False):
 
     # If no command provided, show helpful welcome message
     if not opts.command and not params.commands:
-        print('')
-        print('Keeper Commander - CLI-based vault and admin interface to the Keeper platform')
-        print('')
-        print('To get started:')
-        print('  keeper login          Authenticate to Keeper')
-        print('  keeper shell          Open interactive command shell')
-        print('  keeper supershell     Open full-screen vault browser (TUI)')
-        print('  keeper -h             Show help and available options')
-        print('')
-        print('Learn more at https://docs.keeper.io/en/keeperpam/commander-cli/overview')
-        print('')
+        logging.warning('')
+        logging.warning('Keeper Commander - CLI-based vault and admin interface to the Keeper platform')
+        logging.warning('')
+        logging.warning('To get started:')
+        logging.warning('  keeper login          Authenticate to Keeper')
+        logging.warning('  keeper shell          Open interactive command shell')
+        logging.warning('  keeper supershell     Open full-screen vault browser (TUI)')
+        logging.warning('  keeper -h             Show help and available options')
+        logging.warning('')
+        logging.warning('Learn more at https://docs.keeper.io/en/keeperpam/commander-cli/overview')
+        logging.warning('')
         return
 
     if isinstance(params.timedelay, int) and params.timedelay >= 1 and params.commands:

--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -476,7 +476,7 @@ def force_quit():
             subprocess.run('reset')
         elif os.name == 'nt':
             subprocess.run('cls')
-        print('Auto-logout timer activated.')
+        logging.warning('Auto-logout timer activated.')
     except:
         pass
     os._exit(0)
@@ -734,7 +734,7 @@ def loop(params, skip_init=False, suppress_goodbye=False, new_login=False):  # t
             try:
                 LoginCommand().execute(params, email=params.user, password=params.password, new_login=new_login)
             except KeyboardInterrupt:
-                print('')
+                logging.info('')
             except EOFError:
                 return 0
             except Exception as e:
@@ -742,10 +742,10 @@ def loop(params, skip_init=False, suppress_goodbye=False, new_login=False):  # t
         else:
             if params.device_token:
                 logging.info('Region: %s', params.server)
-            print()
+            logging.info('')
             logging.info("You are not logged in.")
-            print(f'Type {Fore.GREEN}login <email>{Fore.RESET} to authenticate or {Fore.GREEN}server <region>{Fore.RESET} to change data centers.')
-            print(f'Type {Fore.GREEN}?{Fore.RESET} for a list of all available commands.')
+            logging.info(f'Type {Fore.GREEN}login <email>{Fore.RESET} to authenticate or {Fore.GREEN}server <region>{Fore.RESET} to change data centers.')
+            logging.info(f'Type {Fore.GREEN}?{Fore.RESET} for a list of all available commands.')
 
     # Mark that we're in the shell loop (used by supershell to know if it should start a shell on exit)
     params._in_shell_loop = True

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -755,6 +755,10 @@ class Command(CliCommand):
             envvars = params.environment_variables
             args = '' if args is None else args
             if parser:
+                # Update prog to match alias name (e.g., 'find-password' instead of 'clipboard-copy')
+                alias_cmd = d.get('command')
+                if alias_cmd and alias_cmd != parser.prog:
+                    parser.prog = alias_cmd
                 args = expand_cmd_args(args, envvars)
                 args = normalize_output_param(args)
                 if self.support_extra_parameters():

--- a/keepercommander/display.py
+++ b/keepercommander/display.py
@@ -8,6 +8,7 @@
 # Contact: ops@keepersecurity.com
 #
 import json
+import logging
 import shutil
 from typing import Tuple, List, Union, Optional
 
@@ -69,19 +70,19 @@ def keeper_colorize(text, color):
 
 def show_government_warning():
     """Display U.S. Government Information System warning for GOV environments."""
-    print('')
-    print(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
-    print(f'{bcolors.WARNING}U.S. GOVERNMENT INFORMATION SYSTEM{bcolors.ENDC}')
-    print(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
-    print('')
-    print('You are about to access a U.S. Government Information System. Although the')
-    print('encrypted vault adheres to a zero-knowledge security architecture, system')
-    print('access logs are subject to monitoring, recording and audit. Unauthorized')
-    print('use of this system is prohibited and may result in civil and criminal')
-    print('penalties. Your use of this system indicates your acknowledgement and consent.')
-    print('')
-    print(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
-    print('')
+    logging.warning('')
+    logging.warning(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
+    logging.warning(f'{bcolors.WARNING}U.S. GOVERNMENT INFORMATION SYSTEM{bcolors.ENDC}')
+    logging.warning(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
+    logging.warning('')
+    logging.warning('You are about to access a U.S. Government Information System. Although the')
+    logging.warning('encrypted vault adheres to a zero-knowledge security architecture, system')
+    logging.warning('access logs are subject to monitoring, recording and audit. Unauthorized')
+    logging.warning('use of this system is prohibited and may result in civil and criminal')
+    logging.warning('penalties. Your use of this system indicates your acknowledgement and consent.')
+    logging.warning('')
+    logging.warning(f'{bcolors.WARNING}' + '=' * 80 + f'{bcolors.ENDC}')
+    logging.warning('')
 
 
 def welcome():
@@ -300,27 +301,27 @@ def post_login_summary(record_count=0, breachwatch_count=0, show_tips=True):
     DIM = Fore.WHITE
     WARN = Fore.YELLOW
 
-    print()
+    logging.info('')
 
     # Vault summary
     if record_count > 0:
-        print(f"  {ACCENT}✓{Fore.RESET} Decrypted {record_count} records")
+        logging.info(f"  {ACCENT}✓{Fore.RESET} Decrypted {record_count} records")
 
     # BreachWatch warning
     if breachwatch_count > 0:
-        print(f"  {WARN}⚠ {breachwatch_count} high-risk passwords{Fore.RESET} - run {ACCENT}breachwatch list{Fore.RESET}")
+        logging.info(f"  {WARN}⚠ {breachwatch_count} high-risk passwords{Fore.RESET} - run {ACCENT}breachwatch list{Fore.RESET}")
 
     if show_tips:
-        print()
-        print(f"  {DIM}Quick Start:{Fore.RESET}")
-        print(f"    {ACCENT}ls{Fore.RESET}            List records")
-        print(f"    {ACCENT}ls -l -f{Fore.RESET}      List folders")
-        print(f"    {ACCENT}cd <UID>{Fore.RESET}      Change folder")
-        print(f"    {ACCENT}get <UID>{Fore.RESET}     Get record or folder info")
-        print(f"    {ACCENT}supershell{Fore.RESET}    Launch vault TUI")
-        print(f"    {ACCENT}search{Fore.RESET} <text> Search your vault")
-        print(f"    {ACCENT}this-device{Fore.RESET}   Configure device settings")
-        print(f"    {ACCENT}whoami{Fore.RESET}        Display account info")
-        print(f"    {ACCENT}?{Fore.RESET}             List all commands")
+        logging.info('')
+        logging.info(f"  {DIM}Quick Start:{Fore.RESET}")
+        logging.info(f"    {ACCENT}ls{Fore.RESET}            List records")
+        logging.info(f"    {ACCENT}ls -l -f{Fore.RESET}      List folders")
+        logging.info(f"    {ACCENT}cd <UID>{Fore.RESET}      Change folder")
+        logging.info(f"    {ACCENT}get <UID>{Fore.RESET}     Get record or folder info")
+        logging.info(f"    {ACCENT}supershell{Fore.RESET}    Launch vault TUI")
+        logging.info(f"    {ACCENT}search{Fore.RESET} <text> Search your vault")
+        logging.info(f"    {ACCENT}this-device{Fore.RESET}   Configure device settings")
+        logging.info(f"    {ACCENT}whoami{Fore.RESET}        Display account info")
+        logging.info(f"    {ACCENT}?{Fore.RESET}             List all commands")
 
-    print()
+    logging.info('')

--- a/keepercommander/loginv3.py
+++ b/keepercommander/loginv3.py
@@ -385,11 +385,11 @@ class LoginV3Flow:
                 raise Exception(msg)
             elif resp.sessionTokenType == APIRequest_pb2.ACCOUNT_RECOVERY:
                 if new_password_if_reset_required:
-                    print('Resetting expired Master Password.\n')
+                    logging.info('Resetting expired Master Password.\n')
                     LoginV3API.change_master_password(params, new_password_if_reset_required) # always returns False
                     return False
                 elif new_password_if_reset_required is None:
-                    print('Your Master Password has expired, you are required to change it before you can login.\n')
+                    logging.info('Your Master Password has expired, you are required to change it before you can login.\n')
                     if LoginV3Flow.change_master_password(params):
                         return False
                 # Return exception if password change fails
@@ -491,7 +491,7 @@ class LoginV3Flow:
 
         try:
             while True:
-                print('Please choose a new Master Password.')
+                logging.info('Please choose a new Master Password.')
                 password = getpass.getpass(prompt='... {0:>24}: '.format('Master Password'), stream=None).strip()
                 if not password:
                     raise KeyboardInterrupt()
@@ -786,7 +786,7 @@ class LoginV3Flow:
         backup_type = rs.backupKeyType
 
         if backup_type == APIRequest_pb2.BKT_SEC_ANSWER:
-            print(f'Security Question: {rs.securityQuestion}')
+            logging.info(f'Security Question: {rs.securityQuestion}')
             answer = getpass.getpass(prompt='Answer: ', stream=None)
             if not answer:
                 return
@@ -794,7 +794,7 @@ class LoginV3Flow:
             auth_hash = crypto.derive_keyhash_v1(recovery_phrase, rs.salt, rs.iterations)
         elif backup_type == APIRequest_pb2.BKT_PASSPHRASE_HASH:
             p = PassphrasePrompt()
-            print('Please enter your Recovery Phrase ')
+            logging.info('Please enter your Recovery Phrase ')
             if os.isatty(0):
                 phrase = prompt('Recovery Phrase: ', lexer=p, completer=p, key_bindings=p.kb, validator=p,
                                 validate_while_typing=False, editing_mode=EditingMode.VI, wrap_lines=True,

--- a/keepercommander/versioning.py
+++ b/keepercommander/versioning.py
@@ -112,7 +112,7 @@ def welcome_print_version(params):
     elif not ver_info.get('is_up_to_date'):
         from colorama import Fore
         current = ver_info.get('current_github_version')
-        print(f"{Fore.YELLOW}Update available: v{current} (you have v{this_app_version}). Type 'version' for details.{Fore.RESET}\n")
+        logging.warning(f"{Fore.YELLOW}Update available: v{current} (you have v{this_app_version}). Type 'version' for details.{Fore.RESET}\n")
     else:
         pass
         # print("Your version of the Commander CLI is %s." % this_app_version)


### PR DESCRIPTION
  Status and informational messages (login success, update notices, share
  request prompts, device confirmations, etc.) were being printed to stdout
  via print(), polluting piped output. For example, `keeper find-password
  <record> | pbcopy` would capture login messages along with the password.

  Changed all non-data print() calls to use logging (info/warning/error)
  which routes to stderr. In batch mode the log level is WARNING, so
  info-level messages are automatically suppressed while errors and
  warnings remain visible on stderr without polluting stdout.

  Also fixed alias help text: running `find-password -h` now correctly
  shows `usage: find-password` instead of `usage: clipboard-copy` by
  setting parser.prog to the alias name in execute_args().