### PR TITLE
Fix login prompts invisible in batch mode, suppress noisy auth message

### DIFF
--- a/keepercommander/auth/console_ui.py
+++ b/keepercommander/auth/console_ui.py
@@ -3,6 +3,7 @@ import getpass
 import logging
 import pyperclip
 import re
+import sys
 import webbrowser
 from typing import Optional, List
 
@@ -10,6 +11,11 @@ from colorama import Fore, Style
 from . import login_steps
 from .. import utils
 from ..error import KeeperApiError
+
+
+def _stderr(msg=''):
+    """Print interactive prompt text to stderr so it's always visible and never pollutes stdout."""
+    print(msg, file=sys.stderr)
 
 
 class ConsoleLoginUi(login_steps.LoginUi):
@@ -23,38 +29,38 @@ class ConsoleLoginUi(login_steps.LoginUi):
 
     def on_device_approval(self, step):
         if self._show_device_approval_help:
-            logging.info(f"\n{Fore.YELLOW}Device Approval Required{Fore.RESET}\n")
-            logging.info(f"{Fore.CYAN}Select an approval method:{Fore.RESET}")
-            logging.info(f"  {Fore.GREEN}1{Fore.RESET}. Email - Send approval link to your email")
-            logging.info(f"  {Fore.GREEN}2{Fore.RESET}. Keeper Push - Send notification to an approved device")
-            logging.info(f"  {Fore.GREEN}3{Fore.RESET}. 2FA Push - Send code via your 2FA method")
-            logging.info("")
-            logging.info(f"  {Fore.GREEN}c{Fore.RESET}. Enter code - Enter a verification code")
-            logging.info(f"  {Fore.GREEN}q{Fore.RESET}. Cancel login")
-            logging.info("")
+            _stderr(f"\n{Fore.YELLOW}Device Approval Required{Fore.RESET}\n")
+            _stderr(f"{Fore.CYAN}Select an approval method:{Fore.RESET}")
+            _stderr(f"  {Fore.GREEN}1{Fore.RESET}. Email - Send approval link to your email")
+            _stderr(f"  {Fore.GREEN}2{Fore.RESET}. Keeper Push - Send notification to an approved device")
+            _stderr(f"  {Fore.GREEN}3{Fore.RESET}. 2FA Push - Send code via your 2FA method")
+            _stderr("")
+            _stderr(f"  {Fore.GREEN}c{Fore.RESET}. Enter code - Enter a verification code")
+            _stderr(f"  {Fore.GREEN}q{Fore.RESET}. Cancel login")
+            _stderr("")
             self._show_device_approval_help = False
         else:
-            logging.info(f"\n{Fore.YELLOW}Waiting for device approval.{Fore.RESET}")
-            logging.info(f"{Fore.CYAN}Check email, SMS, or push notification on the approved device.{Fore.RESET}")
-            logging.info(f"Enter {Fore.GREEN}c <code>{Fore.RESET} to submit a verification code.\n")
+            _stderr(f"\n{Fore.YELLOW}Waiting for device approval.{Fore.RESET}")
+            _stderr(f"{Fore.CYAN}Check email, SMS, or push notification on the approved device.{Fore.RESET}")
+            _stderr(f"Enter {Fore.GREEN}c <code>{Fore.RESET} to submit a verification code.\n")
 
         try:
             selection = input(f'{Fore.GREEN}Selection{Fore.RESET} (or Enter to check status): ').strip().lower()
 
             if selection == '1' or selection == 'email_send' or selection == 'es':
                 step.send_push(login_steps.DeviceApprovalChannel.Email)
-                logging.info(f"\n{Fore.GREEN}Email sent to {step.username}{Fore.RESET}")
-                logging.info("Click the approval link in the email, then press Enter.\n")
+                _stderr(f"\n{Fore.GREEN}Email sent to {step.username}{Fore.RESET}")
+                _stderr("Click the approval link in the email, then press Enter.\n")
 
             elif selection == '2' or selection == 'keeper_push' or selection == 'kp':
                 step.send_push(login_steps.DeviceApprovalChannel.KeeperPush)
-                logging.info(f"\n{Fore.GREEN}Push notification sent.{Fore.RESET}")
-                logging.info("Approve on your device, then press Enter.\n")
+                _stderr(f"\n{Fore.GREEN}Push notification sent.{Fore.RESET}")
+                _stderr("Approve on your device, then press Enter.\n")
 
             elif selection == '3' or selection == '2fa_send' or selection == '2fs':
                 step.send_push(login_steps.DeviceApprovalChannel.TwoFactor)
-                logging.info(f"\n{Fore.GREEN}2FA code sent.{Fore.RESET}")
-                logging.info("Enter the code using option 'c'.\n")
+                _stderr(f"\n{Fore.GREEN}2FA code sent.{Fore.RESET}")
+                _stderr("Enter the code using option 'c'.\n")
 
             elif selection == 'c' or selection.startswith('c '):
                 # Support both "c" (prompts for code) and "c <code>" (code inline)
@@ -67,23 +73,23 @@ class ConsoleLoginUi(login_steps.LoginUi):
                     # Try email code first, then 2FA
                     try:
                         step.send_code(login_steps.DeviceApprovalChannel.Email, code_input)
-                        logging.info(f"{Fore.GREEN}Successfully verified email code.{Fore.RESET}")
+                        _stderr(f"{Fore.GREEN}Successfully verified email code.{Fore.RESET}")
                     except KeeperApiError:
                         try:
                             step.send_code(login_steps.DeviceApprovalChannel.TwoFactor, code_input)
-                            logging.info(f"{Fore.GREEN}Successfully verified 2FA code.{Fore.RESET}")
+                            _stderr(f"{Fore.GREEN}Successfully verified 2FA code.{Fore.RESET}")
                         except KeeperApiError as e:
                             logging.warning(f"{Fore.YELLOW}Invalid code. Please try again.{Fore.RESET}")
 
             elif selection.startswith("email_code="):
                 code = selection.replace("email_code=", "")
                 step.send_code(login_steps.DeviceApprovalChannel.Email, code)
-                logging.info(f"{Fore.GREEN}Successfully verified email code.{Fore.RESET}")
+                _stderr(f"{Fore.GREEN}Successfully verified email code.{Fore.RESET}")
 
             elif selection.startswith("2fa_code="):
                 code = selection.replace("2fa_code=", "")
                 step.send_code(login_steps.DeviceApprovalChannel.TwoFactor, code)
-                logging.info(f"{Fore.GREEN}Successfully verified 2FA code.{Fore.RESET}")
+                _stderr(f"{Fore.GREEN}Successfully verified 2FA code.{Fore.RESET}")
 
             elif selection == 'q':
                 step.cancel()
@@ -120,13 +126,13 @@ class ConsoleLoginUi(login_steps.LoginUi):
         channels = step.get_channels()
 
         if self._show_two_factor_help:
-            logging.info(f"\n{Fore.YELLOW}Two-Factor Authentication Required{Fore.RESET}\n")
-            logging.info(f"{Fore.CYAN}Select your 2FA method:{Fore.RESET}")
+            _stderr(f"\n{Fore.YELLOW}Two-Factor Authentication Required{Fore.RESET}\n")
+            _stderr(f"{Fore.CYAN}Select your 2FA method:{Fore.RESET}")
             for i in range(len(channels)):
                 channel = channels[i]
-                logging.info(f"  {Fore.GREEN}{i+1}{Fore.RESET}. {ConsoleLoginUi.two_factor_channel_to_desc(channel.channel_type)} {channel.channel_name} {channel.phone}")
-            logging.info(f"  {Fore.GREEN}q{Fore.RESET}. Cancel login")
-            logging.info("")
+                _stderr(f"  {Fore.GREEN}{i+1}{Fore.RESET}. {ConsoleLoginUi.two_factor_channel_to_desc(channel.channel_type)} {channel.channel_name} {channel.phone}")
+            _stderr(f"  {Fore.GREEN}q{Fore.RESET}. Cancel login")
+            _stderr("")
             self._show_device_approval_help = False
 
         channel = None    # type: Optional[login_steps.TwoFactorChannelInfo]
@@ -153,7 +159,7 @@ class ConsoleLoginUi(login_steps.LoginUi):
             mfa_prompt = True
             try:
                 step.send_push(channel.channel_uid, login_steps.TwoFactorPushAction.TextMessage)
-                logging.info(f'\n{Fore.GREEN}SMS sent successfully.{Fore.RESET}\n')
+                _stderr(f'\n{Fore.GREEN}SMS sent successfully.{Fore.RESET}\n')
             except KeeperApiError:
                 logging.warning("Was unable to send SMS.")
         elif channel.channel_type == login_steps.TwoFactorChannel.SecurityKey:
@@ -176,7 +182,7 @@ class ConsoleLoginUi(login_steps.LoginUi):
                     }
                     step.duration = login_steps.TwoFactorDuration.EveryLogin
                     step.send_code(channel.channel_uid, json.dumps(signature))
-                    logging.info(f'{Fore.GREEN}Security key verified.{Fore.RESET}')
+                    _stderr(f'{Fore.GREEN}Security key verified.{Fore.RESET}')
 
             except ImportError as e:
                 from ..yubikey import display_fido2_warning
@@ -226,7 +232,7 @@ class ConsoleLoginUi(login_steps.LoginUi):
                         'Ask Every 24 hours' if mfa_expiration == login_steps.TwoFactorDuration.Every24Hours else
                         'Ask Every 30 days',
                         "|".join(allowed_expirations))
-                    logging.info(prompt_exp)
+                    _stderr(prompt_exp)
 
                 try:
                     answer = input(f'\n{Fore.GREEN}Enter 2FA Code: {Fore.RESET}')
@@ -262,16 +268,16 @@ class ConsoleLoginUi(login_steps.LoginUi):
             step.duration = mfa_expiration
             try:
                 step.send_code(channel.channel_uid, otp_code)
-                logging.info(f'{Fore.GREEN}2FA code verified.{Fore.RESET}')
+                _stderr(f'{Fore.GREEN}2FA code verified.{Fore.RESET}')
             except KeeperApiError:
                 logging.warning(f'{Fore.YELLOW}Invalid 2FA code. Please try again.{Fore.RESET}')
 
     def on_password(self, step):
         if self._show_password_help:
-            logging.info(f'{Fore.CYAN}Enter master password for {Fore.WHITE}{step.username}{Fore.RESET}')
+            _stderr(f'{Fore.CYAN}Enter master password for {Fore.WHITE}{step.username}{Fore.RESET}')
 
         if self._failed_password_attempt > 0:
-            logging.info(f'{Fore.YELLOW}Forgot password? Type "recover"<Enter>{Fore.RESET}')
+            _stderr(f'{Fore.YELLOW}Forgot password? Type "recover"<Enter>{Fore.RESET}')
 
         password = getpass.getpass(prompt=f'{Fore.GREEN}Password: {Fore.RESET}', stream=None)
         if not password:
@@ -298,19 +304,19 @@ class ConsoleLoginUi(login_steps.LoginUi):
             wb = None
 
         sp_url = step.sso_login_url
-        logging.info(f'\n{Fore.CYAN}SSO Login URL:{Fore.RESET}\n{sp_url}\n')
+        _stderr(f'\n{Fore.CYAN}SSO Login URL:{Fore.RESET}\n{sp_url}\n')
         if self._show_sso_redirect_help:
-            logging.info(f'{Fore.CYAN}Navigate to SSO Login URL with your browser and complete login.{Fore.RESET}')
-            logging.info(f'{Fore.CYAN}Copy the returned SSO Token and paste it here.{Fore.RESET}')
-            logging.info(f'{Fore.YELLOW}TIP: Click "Copy login token" button on the SSO Connect page.{Fore.RESET}')
-            logging.info('')
-            logging.info(f'  {Fore.GREEN}a{Fore.RESET}. SSO User with a Master Password')
-            logging.info(f'  {Fore.GREEN}c{Fore.RESET}. Copy SSO Login URL to clipboard')
+            _stderr(f'{Fore.CYAN}Navigate to SSO Login URL with your browser and complete login.{Fore.RESET}')
+            _stderr(f'{Fore.CYAN}Copy the returned SSO Token and paste it here.{Fore.RESET}')
+            _stderr(f'{Fore.YELLOW}TIP: Click "Copy login token" button on the SSO Connect page.{Fore.RESET}')
+            _stderr('')
+            _stderr(f'  {Fore.GREEN}a{Fore.RESET}. SSO User with a Master Password')
+            _stderr(f'  {Fore.GREEN}c{Fore.RESET}. Copy SSO Login URL to clipboard')
             if wb:
-                logging.info(f'  {Fore.GREEN}o{Fore.RESET}. Open SSO Login URL in web browser')
-            logging.info(f'  {Fore.GREEN}p{Fore.RESET}. Paste SSO Token from clipboard')
-            logging.info(f'  {Fore.GREEN}q{Fore.RESET}. Cancel SSO login')
-            logging.info('')
+                _stderr(f'  {Fore.GREEN}o{Fore.RESET}. Open SSO Login URL in web browser')
+            _stderr(f'  {Fore.GREEN}p{Fore.RESET}. Paste SSO Token from clipboard')
+            _stderr(f'  {Fore.GREEN}q{Fore.RESET}. Cancel SSO login')
+            _stderr('')
             self._show_sso_redirect_help = False
 
         while True:
@@ -329,7 +335,7 @@ class ConsoleLoginUi(login_steps.LoginUi):
                 token = None
                 try:
                     pyperclip.copy(sp_url)
-                    logging.info('SSO Login URL is copied to clipboard.')
+                    _stderr('SSO Login URL is copied to clipboard.')
                 except:
                     logging.warning('Failed to copy SSO Login URL to clipboard.')
             elif token == 'o':
@@ -355,14 +361,14 @@ class ConsoleLoginUi(login_steps.LoginUi):
 
     def on_sso_data_key(self, step):
         if self._show_sso_data_key_help:
-            logging.info(f'\n{Fore.YELLOW}Device Approval Required for SSO{Fore.RESET}\n')
-            logging.info(f'{Fore.CYAN}Select an approval method:{Fore.RESET}')
-            logging.info(f'  {Fore.GREEN}1{Fore.RESET}. Keeper Push - Send a push notification to your device')
-            logging.info(f'  {Fore.GREEN}2{Fore.RESET}. Admin Approval - Request your admin to approve this device')
-            logging.info('')
-            logging.info(f'  {Fore.GREEN}r{Fore.RESET}. Resume SSO login after device is approved')
-            logging.info(f'  {Fore.GREEN}q{Fore.RESET}. Cancel SSO login')
-            logging.info('')
+            _stderr(f'\n{Fore.YELLOW}Device Approval Required for SSO{Fore.RESET}\n')
+            _stderr(f'{Fore.CYAN}Select an approval method:{Fore.RESET}')
+            _stderr(f'  {Fore.GREEN}1{Fore.RESET}. Keeper Push - Send a push notification to your device')
+            _stderr(f'  {Fore.GREEN}2{Fore.RESET}. Admin Approval - Request your admin to approve this device')
+            _stderr('')
+            _stderr(f'  {Fore.GREEN}r{Fore.RESET}. Resume SSO login after device is approved')
+            _stderr(f'  {Fore.GREEN}q{Fore.RESET}. Cancel SSO login')
+            _stderr('')
             self._show_sso_data_key_help = False
 
         while True:

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -1696,9 +1696,9 @@ class LoginCommand(Command):
                 if not region:
                     # Check extended server list
                     region = next((k for k, v in KEEPER_SERVERS.items() if v == params.server), params.server)
-                logging.info(f'{Fore.CYAN}Data center: {Fore.WHITE}{region}{Fore.RESET}')
-                logging.info(f'{Fore.CYAN}Use {Fore.GREEN}login --server <region>{Fore.CYAN} to change (US, EU, AU, CA, JP, GOV){Fore.RESET}')
-                logging.info('')
+                print(f'{Fore.CYAN}Data center: {Fore.WHITE}{region}{Fore.RESET}', file=sys.stderr)
+                print(f'{Fore.CYAN}Use {Fore.GREEN}login --server <region>{Fore.CYAN} to change (US, EU, AU, CA, JP, GOV){Fore.RESET}', file=sys.stderr)
+                print('', file=sys.stderr)
                 user = input(f'{Fore.GREEN}Email: {Fore.RESET}').strip()
             if not user:
                 return


### PR DESCRIPTION
Interactive login prompts (SSO menu, 2FA method selection, device approval options, password context) were using logging.info() which is suppressed in batch mode (log level=WARNING). Users running commands like `keeper find-password` saw bare "Selection:" prompts with no menu options visible.

Changed all interactive auth UI in console_ui.py and loginv3.py to use print(file=sys.stderr) which is always visible regardless of log level while still keeping output off stdout for clean piping.

Also suppress "Successfully authenticated with Persistent Login" in batch mode since it adds noise to every one-shot command when the user has persistent login enabled.