### PR TITLE
feat(pam tunnel): add --foreground, --background, --run flags and cross-process tunnel registry

### DIFF
--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -3,6 +3,7 @@ import enum
 import json
 import logging
 import os
+import re
 import secrets
 import socket
 import string
@@ -52,6 +53,54 @@ except ImportError:
         ConnectionClosed = None
         WEBSOCKETS_VERSION = None
         print("websockets library not available - install with: pip install websockets", file=sys.stderr)
+
+# Regex for SDP attribute: a=keeper-webrtc:X.Y.Z (injected by keeper-pam-webrtc-rs)
+_KEEPER_WEBRTC_VERSION_RE = re.compile(r"a=keeper-webrtc:(\S+)", re.IGNORECASE)
+
+
+def parse_keeper_webrtc_version_from_sdp(sdp):
+    """
+    Parse keeper-pam-webrtc-rs version from SDP attribute a=keeper-webrtc:X.Y.Z.
+
+    The attribute is injected by the Rust module in both offer and answer.
+    Handles SDP that may be base64-encoded.
+
+    Args:
+        sdp: SDP string (plain or base64-encoded).
+
+    Returns:
+        Version string (e.g. "2.1.4") or None if not found.
+    """
+    if not sdp or not isinstance(sdp, str):
+        return None
+    text = sdp
+    if "\n" not in sdp and "\r" not in sdp and len(sdp) > 20:
+        try:
+            decoded = base64.b64decode(sdp, validate=True)
+            text = decoded.decode("utf-8", errors="replace")
+        except Exception:
+            pass
+    m = _KEEPER_WEBRTC_VERSION_RE.search(text)
+    return m.group(1) if m else None
+
+
+def set_remote_description_and_parse_version(tube_registry, tube_id, sdp, is_answer):
+    """
+    Call tube_registry.set_remote_description and parse/store remote keeper-pam-webrtc
+    version when is_answer=True. Ensures version is always parsed regardless of which
+    code path delivered the SDP (WebSocket, HTTP, different JSON keys).
+    Returns the parsed version or None.
+    """
+    tube_registry.set_remote_description(tube_id, sdp, is_answer=is_answer)
+    remote_ver = None
+    if is_answer:
+        remote_ver = parse_keeper_webrtc_version_from_sdp(sdp)
+        session = get_tunnel_session(tube_id)
+        if session and remote_ver:
+            session.remote_webrtc_version = remote_ver
+            logging.debug("Remote keeper-pam-webrtc version from SDP: %s", remote_ver)
+    return remote_ver
+
 
 # Constants
 NONCE_LENGTH = 12

--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -2,9 +2,7 @@ import base64
 import enum
 import json
 import logging
-import re
 import os
-import threading
 import secrets
 import socket
 import string
@@ -55,54 +53,6 @@ except ImportError:
         WEBSOCKETS_VERSION = None
         print("websockets library not available - install with: pip install websockets", file=sys.stderr)
 
-# Regex for SDP attribute: a=keeper-webrtc:X.Y.Z (injected by keeper-pam-webrtc-rs)
-_KEEPER_WEBRTC_VERSION_RE = re.compile(r"a=keeper-webrtc:(\S+)", re.IGNORECASE)
-
-
-def parse_keeper_webrtc_version_from_sdp(sdp):
-    """
-    Parse keeper-pam-webrtc-rs version from SDP attribute a=keeper-webrtc:X.Y.Z.
-
-    The attribute is injected by the Rust module in both offer and answer.
-    Handles SDP that may be base64-encoded.
-
-    Args:
-        sdp: SDP string (plain or base64-encoded).
-
-    Returns:
-        Version string (e.g. "2.1.4") or None if not found.
-    """
-    if not sdp or not isinstance(sdp, str):
-        return None
-    text = sdp
-    if "\n" not in sdp and "\r" not in sdp and len(sdp) > 20:
-        try:
-            decoded = base64.b64decode(sdp, validate=True)
-            text = decoded.decode("utf-8", errors="replace")
-        except Exception:
-            pass
-    m = _KEEPER_WEBRTC_VERSION_RE.search(text)
-    return m.group(1) if m else None
-
-
-def set_remote_description_and_parse_version(tube_registry, tube_id, sdp, is_answer):
-    """
-    Call tube_registry.set_remote_description and parse/store remote keeper-pam-webrtc
-    version when is_answer=True. Ensures version is always parsed regardless of which
-    code path delivered the SDP (WebSocket, HTTP, different JSON keys).
-    Returns the parsed version or None.
-    """
-    tube_registry.set_remote_description(tube_id, sdp, is_answer=is_answer)
-    remote_ver = None
-    if is_answer:
-        remote_ver = parse_keeper_webrtc_version_from_sdp(sdp)
-        session = get_tunnel_session(tube_id)
-        if session and remote_ver:
-            session.remote_webrtc_version = remote_ver
-            logging.debug("Remote keeper-pam-webrtc version from SDP: %s", remote_ver)
-    return remote_ver
-
-
 # Constants
 NONCE_LENGTH = 12
 MAIN_NONCE_LENGTH = 16
@@ -115,6 +65,7 @@ VERIFY_SSL = bool(os.environ.get("VERIFY_SSL", "TRUE") == "TRUE")
 # ICE candidate buffering - store until SDP answer is received
 
 # Global conversation key management for multiple concurrent tunnels
+import threading
 _CONVERSATION_KEYS_LOCK = threading.Lock()
 _GLOBAL_CONVERSATION_KEYS = {}  # conversationId -> symmetric_key mapping
 
@@ -384,6 +335,7 @@ def _configure_rust_logger_levels(current_is_debug: bool, log_level: int):
         # CRITICAL: Ensure root logger has a handler
         # pyo3_log sends Rust logs to Python loggers, but if loggers have no handlers,
         # messages are lost even if propagate=True
+        import sys
         if not root_logger.handlers:
             # Add a console handler if none exists
             console_handler = logging.StreamHandler(sys.stderr)
@@ -704,10 +656,8 @@ def get_keeper_tokens(params):
 
 def get_config_uid_from_record(params, vault, record_uid):
     record = vault.KeeperRecord.load(params, record_uid)
-    if record is None:
-        raise CommandError('', f"{bcolors.FAIL}Record {record_uid} not found.{bcolors.ENDC}")
     if not isinstance(record, vault.TypedRecord):
-        raise CommandError('', f"{bcolors.FAIL}Record {record_uid} is not v3/typed record.{bcolors.ENDC}")
+        raise CommandError('', f"{bcolors.FAIL}Record {record_uid} not found.{bcolors.ENDC}")
     record_type = record.record_type
     if record_type not in "pamMachine pamDatabase pamDirectory pamRemoteBrowser".split():
         raise CommandError('', f"{bcolors.FAIL}This record's type is not supported for tunnels. "
@@ -1186,36 +1136,40 @@ def route_message_to_rust(response_item, tube_registry):
                         except (json.JSONDecodeError, TypeError):
                             pass  # Not a simple JSON string, continue with normal processing
 
-                        try:
-                            data_json = json.loads(data_text)
-                        except (json.JSONDecodeError, TypeError):
-                            data_json = None
+                        data_json = json.loads(data_text)
 
-                        # Fallback: decrypted data may be raw SDP
-                        answer_sdp = None
-                        if isinstance(data_json, dict):
-                            logging.debug(f"🔓 Decrypted payload type: {data_json.get('type', 'unknown')}, keys: {list(data_json.keys())}")
-                            answer_sdp = data_json.get('answer') or data_json.get('sdp')
-                        elif data_text.strip().startswith('v=') and 'm=' in data_text:
-                            answer_sdp = data_text.strip()
-                            logging.debug("Decrypted data appears to be raw SDP (not JSON), using as answer")
+                        # Ensure data_json is a dictionary before processing
+                        if not isinstance(data_json, dict):
+                            logging.debug(f"Data is not a dictionary (got {type(data_json).__name__}), treating as acknowledgment: {data_json}")
+                            return
 
-                        if answer_sdp:
-                            logging.debug(f"Found SDP answer, sending to Rust for conversation: {conversation_id}")
-                            # Try to find tube ID - gateway may have converted URL-safe base64 to standard
-                            tube_id = tube_registry.tube_id_from_connection_id(conversation_id)
-                            if not tube_id:
-                                url_safe_conversation_id = conversation_id.replace('+', '-').replace('/', '_').rstrip('=')
-                                tube_id = tube_registry.tube_id_from_connection_id(url_safe_conversation_id)
-                                if tube_id:
-                                    logging.debug(f"Found tube using URL-safe conversion: {url_safe_conversation_id}")
+                        # Log what type of data we received
+                        logging.debug(f"🔓 Decrypted payload type: {data_json.get('type', 'unknown')}, keys: {list(data_json.keys())}")
 
-                            if not tube_id:
-                                logging.error(f"No tube ID found for conversation: {conversation_id} (also tried URL-safe version)")
-                            else:
-                                set_remote_description_and_parse_version(tube_registry, tube_id, answer_sdp, is_answer=True)
+                        if "answer" in data_json:
+                            answer_sdp = data_json.get('answer')
+
+                            if answer_sdp:
+                                logging.debug(f"Found SDP answer, sending to Rust for conversation: {conversation_id}")
+                                # Send decrypted SDP answer to Rust
+
+                                # Try to find tube ID - gateway may have converted URL-safe base64 to standard
+                                tube_id = tube_registry.tube_id_from_connection_id(conversation_id)
+                                if not tube_id:
+                                    # Try URL-safe version (convert + to -, / to _, remove =)
+                                    url_safe_conversation_id = conversation_id.replace('+', '-').replace('/', '_').rstrip('=')
+                                    tube_id = tube_registry.tube_id_from_connection_id(url_safe_conversation_id)
+                                    if tube_id:
+                                        logging.debug(f"Found tube using URL-safe conversion: {url_safe_conversation_id}")
+
+                                if not tube_id:
+                                    logging.error(f"No tube ID found for conversation: {conversation_id} (also tried URL-safe version)")
+                                    return
+
+                                tube_registry.set_remote_description(tube_id, answer_sdp, is_answer=True)
                                 logging.debug("Connection state: SDP answer received, connecting...")
 
+                                # Send any buffered local ICE candidates now that we have the answer
                                 session = get_tunnel_session(tube_id)
                                 if session and session.buffered_ice_candidates:
                                     if hasattr(session, 'signal_handler') and session.signal_handler:
@@ -1535,17 +1489,17 @@ class TunnelSignalHandler:
 
             # Detailed logging for specific states
             if new_state == 'disconnected':
-                logging.debug(f"Connection disconnected for tube {tube_id} - ICE restart may be attempted by Rust")
+                logging.warning(f"Connection disconnected for tube {tube_id} - ICE restart may be attempted by Rust")
 
             elif new_state == 'failed':
-                logging.debug(f"Connection failed for tube {tube_id} - ICE restart may be attempted by Rust")
+                logging.error(f"Connection failed for tube {tube_id} - ICE restart may be attempted by Rust")
 
             elif new_state == 'connected':
                 logging.debug(
                     f"Connection established/restored for tube {tube_id} "
                     f"(conversation_id={conversation_id_from_signal or self.conversation_id})"
                 )
-                logging.debug("Connection state: connected")
+                logging.debug(f"Connection state: connected")
 
                 # CRITICAL: Mark connection as connected - IMMEDIATELY stop sending ICE candidates
                 self.connection_connected = True
@@ -1653,9 +1607,9 @@ class TunnelSignalHandler:
                         logging.debug(f"Stopping dedicated WebSocket for tunnel {tube_id}")
                         session.websocket_stop_event.set()  # Signal WebSocket to close
                         # Give it a moment to close gracefully
-                        session.websocket_thread.join(timeout=5.0)
+                        session.websocket_thread.join(timeout=2.0)
                         if session.websocket_thread.is_alive():
-                            logging.debug(f"Dedicated WebSocket for tunnel {tube_id} did not close in time")
+                            logging.warning(f"Dedicated WebSocket for tunnel {tube_id} did not close in time")
                         else:
                             logging.debug(f"Dedicated WebSocket closed for tunnel {tube_id}")
 
@@ -1680,9 +1634,9 @@ class TunnelSignalHandler:
                         logging.debug(f"Stopping dedicated WebSocket for failed tunnel {tube_id}")
                         session.websocket_stop_event.set()  # Signal WebSocket to close
                         # Give it a moment to close gracefully
-                        session.websocket_thread.join(timeout=5.0)
+                        session.websocket_thread.join(timeout=2.0)
                         if session.websocket_thread.is_alive():
-                            logging.debug(f"Dedicated WebSocket for tunnel {tube_id} did not close in time")
+                            logging.warning(f"Dedicated WebSocket for tunnel {tube_id} did not close in time")
                         else:
                             logging.debug(f"Dedicated WebSocket closed for failed tunnel {tube_id}")
 
@@ -2515,14 +2469,13 @@ def start_rust_tunnel(params, record_uid, gateway_uid, host, port,
                         decrypted_answer = tunnel_decrypt(symmetric_key, encrypted_answer)
                         answer_data = json.loads(decrypted_answer)
 
-                        if 'answer' in answer_data or 'sdp' in answer_data:
-                            answer_sdp = answer_data.get('answer') or answer_data.get('sdp')
-                            if answer_sdp:
-                                logging.debug("Non-trickle ICE: Received SDP answer via HTTP, setting in Rust")
-                                set_remote_description_and_parse_version(tube_registry, commander_tube_id, answer_sdp, is_answer=True)
-                                logging.debug("Non-trickle ICE: SDP answer set successfully")
+                        if 'answer' in answer_data:
+                            answer_sdp = answer_data['answer']
+                            logging.debug(f"Non-trickle ICE: Received SDP answer via HTTP, setting in Rust")
+                            tube_registry.set_remote_description(commander_tube_id, answer_sdp, is_answer=True)
+                            logging.debug("Non-trickle ICE: SDP answer set successfully")
                         else:
-                            logging.error(f"Non-trickle ICE: No 'answer' or 'sdp' field in decrypted data: {answer_data}")
+                            logging.error(f"Non-trickle ICE: No 'answer' field in decrypted data: {answer_data}")
                     else:
                         logging.error(f"Non-trickle ICE: No 'data' field in payload JSON: {payload_json}")
                 else:

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -771,7 +771,7 @@ class PAMTunnelStartCommand(Command):
             bg_deadline = time.time() + connect_timeout + PARENT_GRACE_SECONDS
             bg_info = None
             while time.time() < bg_deadline:
-                for entry in list_registered_tunnels():
+                for entry in list_registered_tunnels(clean_stale=False):
                     if entry.get('pid') == bg_proc.pid and entry.get('record_uid') == record_uid:
                         bg_info = entry
                         break
@@ -816,6 +816,9 @@ class PAMTunnelStartCommand(Command):
                 print(f"    or:   kill -SIGTERM $(cat {pid_file})")
             print(f"{bcolors.OKBLUE}Use 'pam tunnel list' from any Commander session "
                   f"to see this tunnel.{bcolors.ENDC}")
+            if platform.system() == 'Windows':
+                print(f"{bcolors.WARNING}Note: On Windows, tunnel stop uses hard termination. "
+                      f"WebRTC cleanup is best-effort.{bcolors.ENDC}")
             return
 
         result = start_rust_tunnel(params, record_uid, gateway_uid, host, port, seed, target_host, target_port, socks, trickle_ice, record.title, allow_supply_host=allow_supply_host, two_factor_value=two_factor_value)
@@ -856,6 +859,9 @@ class PAMTunnelStartCommand(Command):
                     return
 
                 print(f"{bcolors.OKGREEN}Tunnel ready{bcolors.ENDC}  {host}:{port} -> {target_host}:{target_port}")
+                if platform.system() == 'Windows':
+                    print(f"{bcolors.WARNING}Note: On Windows, tunnel stop uses hard termination. "
+                          f"WebRTC cleanup is best-effort.{bcolors.ENDC}")
                 print(f"{bcolors.OKBLUE}Running:{bcolors.ENDC} {run_command}\n")
 
                 cmd_exit = 1

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -10,23 +10,31 @@
 #
 
 import argparse
-import datetime
-import http.client
+import json
 import logging
 import os
-import socket
-import ssl
-import struct
+import platform
+import signal
+import subprocess
 import sys
+import threading
 import time
-from typing import List, Optional, Tuple
-from keeper_secrets_manager_core.utils import bytes_to_base64, base64_to_bytes, url_safe_str_to_bytes
+from keeper_secrets_manager_core.utils import bytes_to_base64, base64_to_bytes
 
 from .base import Command, GroupCommand, dump_report_data, RecordMixin
 from .tunnel.port_forward.TunnelGraph import TunnelDAG
 from .tunnel.port_forward.tunnel_helpers import find_open_port, get_config_uid, get_keeper_tokens, \
     get_or_create_tube_registry, get_gateway_uid_from_record, resolve_record, resolve_pam_config, resolve_folder, \
-    remove_field, start_rust_tunnel, get_tunnel_session, CloseConnectionReasons, create_rust_webrtc_settings
+    remove_field, start_rust_tunnel, get_tunnel_session, unregister_tunnel_session, CloseConnectionReasons, \
+    wait_for_tunnel_connection, create_rust_webrtc_settings
+from .tunnel_registry import (
+    PARENT_GRACE_SECONDS,
+    is_pid_alive,
+    list_registered_tunnels,
+    register_tunnel,
+    stop_tunnel_process,
+    unregister_tunnel,
+)
 from .. import api, vault, record_management
 from ..display import bcolors
 from ..error import CommandError
@@ -34,6 +42,7 @@ from ..params import LAST_RECORD_UID
 from ..subfolder import find_folders
 from ..utils import value_to_boolean
 from ..constants import get_keeper_server_hostname
+
 
 # Group Commands
 class PAMTunnelCommand(GroupCommand):
@@ -74,72 +83,64 @@ class PAMTunnelListCommand(Command):
         return PAMTunnelListCommand.pam_cmd_parser
 
     def execute(self, params, **kwargs):
-        # Try to get active tunnels from Rust PyTubeRegistry
-        # Logger initialization is handled by get_or_create_tube_registry()
+        table = []
+        headers = ['Record', 'Remote Target', 'Local Address', 'Tunnel ID', 'Conversation ID', 'Status']
+
+        # In-process tunnels from the Rust PyTubeRegistry
         tube_registry = get_or_create_tube_registry(params)
-        if tube_registry:
-            if not tube_registry.has_active_tubes():
-                logging.warning(f"{bcolors.OKBLUE}No Tunnels running{bcolors.ENDC}")
-                return
-
-            table = []
-            headers = ['Record', 'Remote Target', 'Local Address', 'Tunnel ID', 'Conversation ID', 'Status']
-
-            # Get all tube IDs
+        in_process_tube_ids = set()
+        if tube_registry and tube_registry.has_active_tubes():
             tube_ids = tube_registry.all_tube_ids()
-
             for tube_id in tube_ids:
-                # Get conversation IDs for this tube
+                in_process_tube_ids.add(tube_id)
                 conversation_ids = tube_registry.get_conversation_ids_by_tube_id(tube_id)
-
-                # Get tunnel session for detailed info
                 tunnel_session = get_tunnel_session(tube_id)
 
-                # Record title
                 record_title = tunnel_session.record_title if tunnel_session and tunnel_session.record_title else f"{bcolors.WARNING}unknown{bcolors.ENDC}"
 
-                # Remote target
                 if tunnel_session and tunnel_session.target_host and tunnel_session.target_port:
                     remote_target = f"{tunnel_session.target_host}:{tunnel_session.target_port}"
                 else:
                     remote_target = f"{bcolors.WARNING}unknown{bcolors.ENDC}"
 
-                # Local listening address
                 if tunnel_session and tunnel_session.host and tunnel_session.port:
                     local_addr = f"{bcolors.OKGREEN}{tunnel_session.host}:{tunnel_session.port}{bcolors.ENDC}"
                 else:
                     local_addr = f"{bcolors.WARNING}unknown{bcolors.ENDC}"
 
-                # Tunnel ID (tube_id) - this is what's needed for stopping
-                tunnel_id = tube_id
-
-                # Conversation ID - WebRTC signaling identifier
                 conv_id = conversation_ids[0] if conversation_ids else (tunnel_session.conversation_id if tunnel_session else 'none')
 
-                # Connection state
                 try:
                     state = tube_registry.get_connection_state(tube_id)
                     status_color = f"{bcolors.OKGREEN}" if state.lower() == "connected" else f"{bcolors.WARNING}"
                     status = f"{status_color}{state}{bcolors.ENDC}"
-                except:
+                except Exception:
                     status = f"{bcolors.WARNING}unknown{bcolors.ENDC}"
 
-                row = [
-                    record_title,
-                    remote_target,
-                    local_addr,
-                    tunnel_id,
-                    conv_id,
-                    status,
-                ]
-                table.append(row)
+                table.append([record_title, remote_target, local_addr, tube_id, conv_id, status])
 
-            dump_report_data(table, headers, fmt='table', filename="", row_number=False, column_width=None)
-        else:
-            # Rust WebRTC library is required for tunnel operations
-            print(f"{bcolors.FAIL}This command requires the Rust WebRTC library (keeper_pam_webrtc_rs).{bcolors.ENDC}")
-            print(f"{bcolors.OKBLUE}Please ensure the keeper_pam_webrtc_rs module is installed and available.{bcolors.ENDC}")
+        # Cross-process tunnels from the file-based registry
+        for entry in list_registered_tunnels():
+            if entry.get('tube_id') in in_process_tube_ids:
+                continue
+            pid = entry.get('pid')
+            rec = entry.get('record_title') or entry.get('record_uid', '?')
+            th = entry.get('target_host')
+            tp = entry.get('target_port')
+            remote = f"{th}:{tp}" if th and tp else f"{bcolors.WARNING}n/a{bcolors.ENDC}"
+            h = entry.get('host', '127.0.0.1')
+            p = entry.get('port', '?')
+            local = f"{bcolors.OKGREEN}{h}:{p}{bcolors.ENDC}"
+            tid = entry.get('tube_id', '')
+            mode = entry.get('mode', '?')
+            status = f"{bcolors.OKGREEN}{mode} (PID {pid}){bcolors.ENDC}"
+            table.append([rec, remote, local, tid, '', status])
+
+        if not table:
+            logging.warning(f"{bcolors.OKBLUE}No Tunnels running{bcolors.ENDC}")
             return
+
+        dump_report_data(table, headers, fmt='table', filename="", row_number=False, column_width=None)
 
 
 class PAMTunnelStopCommand(Command):
@@ -195,6 +196,22 @@ class PAMTunnelStopCommand(Command):
             if tube_id:
                 matching_tubes = [tube_id]
 
+        # Fall back to file-based registry (cross-process tunnels)
+        if not matching_tubes:
+            for entry in list_registered_tunnels():
+                if uid in (entry.get('tube_id', ''), entry.get('record_uid', ''),
+                           entry.get('record_title', '')):
+                    pid = entry.get('pid')
+                    if pid and is_pid_alive(pid):
+                        if stop_tunnel_process(pid):
+                            print(f"{bcolors.OKGREEN}Sent stop signal to tunnel process "
+                                  f"(PID {pid}, {entry.get('mode', '?')} mode){bcolors.ENDC}")
+                        else:
+                            print(f"{bcolors.FAIL}Failed to signal PID {pid}{bcolors.ENDC}")
+                    else:
+                        unregister_tunnel(pid)
+                    return
+
         if not matching_tubes:
             raise CommandError('tunnel stop', f"No active tunnels found matching '{uid}'")
 
@@ -225,43 +242,48 @@ class PAMTunnelStopCommand(Command):
             raise CommandError('tunnel stop', f"Failed to stop any tunnels matching '{uid}'")
 
     def _stop_all_tunnels(self, params):
-        """Stop all active tunnels"""
-        tube_registry = get_or_create_tube_registry(params)
-        if not tube_registry:
-            raise CommandError('tunnel stop', 'This command requires the Rust WebRTC library')
+        """Stop all active tunnels (in-process and cross-process)."""
+        stopped_count = 0
+        failed_count = 0
 
-        # Get all active tunnel IDs
-        all_tube_ids = tube_registry.all_tube_ids()
-        
-        if not all_tube_ids:
+        # In-process tunnels
+        tube_registry = get_or_create_tube_registry(params)
+        if tube_registry:
+            all_tube_ids = tube_registry.all_tube_ids()
+            if all_tube_ids:
+                print(f"{bcolors.WARNING}Stopping {len(all_tube_ids)} in-process tunnel(s):{bcolors.ENDC}")
+                for tube_id in all_tube_ids:
+                    try:
+                        tube_registry.close_tube(tube_id, reason=CloseConnectionReasons.Normal)
+                        print(f"  {bcolors.OKGREEN}Stopped: {tube_id}{bcolors.ENDC}")
+                        stopped_count += 1
+                    except Exception as e:
+                        print(f"  {bcolors.FAIL}Failed: {tube_id}: {e}{bcolors.ENDC}")
+                        failed_count += 1
+
+        # Cross-process tunnels from file registry
+        registered = list_registered_tunnels()
+        if registered:
+            print(f"{bcolors.WARNING}Stopping {len(registered)} external tunnel(s):{bcolors.ENDC}")
+            for entry in registered:
+                pid = entry.get('pid')
+                if stop_tunnel_process(pid):
+                    print(f"  {bcolors.OKGREEN}Sent stop signal to PID {pid} "
+                          f"({entry.get('mode', '?')} mode, {entry.get('host')}:{entry.get('port')}){bcolors.ENDC}")
+                    stopped_count += 1
+                else:
+                    print(f"  {bcolors.FAIL}Failed to signal PID {pid}{bcolors.ENDC}")
+                    failed_count += 1
+                    unregister_tunnel(pid)
+
+        if stopped_count == 0 and failed_count == 0:
             print(f"{bcolors.WARNING}No active tunnels to stop.{bcolors.ENDC}")
             return
 
-        # Confirm with user
-        print(f"{bcolors.WARNING}About to stop {len(all_tube_ids)} active tunnel(s):{bcolors.ENDC}")
-        for tube_id in all_tube_ids:
-            print(f"  - {tube_id}")
-        
-        # Stop all tunnels
-        stopped_count = 0
-        failed_count = 0
-        for tube_id in all_tube_ids:
-            try:
-                tube_registry.close_tube(tube_id, reason=CloseConnectionReasons.Normal)
-                print(f"{bcolors.OKGREEN}Stopped tunnel: {tube_id}{bcolors.ENDC}")
-                stopped_count += 1
-            except Exception as e:
-                print(f"{bcolors.FAIL}Failed to stop tunnel {tube_id}: {e}{bcolors.ENDC}")
-                failed_count += 1
-
-        # Summary
         if stopped_count > 0:
             print(f"\n{bcolors.OKGREEN}Successfully stopped {stopped_count} tunnel(s).{bcolors.ENDC}")
         if failed_count > 0:
             print(f"{bcolors.FAIL}Failed to stop {failed_count} tunnel(s).{bcolors.ENDC}")
-        
-        if stopped_count == 0:
-            raise CommandError('tunnel stop', 'Failed to stop any tunnels')
 
 
 class PAMTunnelEditCommand(Command):
@@ -503,6 +525,30 @@ class PAMTunnelStartCommand(Command):
     pam_cmd_parser.add_argument('--no-trickle-ice', '-nti', required=False, dest='no_trickle_ice', action='store_true',
                                 help='Disable trickle ICE for WebRTC connections. By default, trickle ICE is enabled '
                                      'for real-time candidate exchange.')
+    pam_cmd_parser.add_argument('--foreground', '-fg', required=False, dest='foreground', action='store_true',
+                                help='Keep the tunnel running in the foreground, blocking until '
+                                     'SIGTERM/SIGINT/Ctrl+C is received. Use this flag when running '
+                                     'tunnels from scripts, systemd services, or any non-interactive '
+                                     'context where the process would otherwise exit immediately.')
+    pam_cmd_parser.add_argument('--pid-file', required=False, dest='pid_file', action='store',
+                                help='Write the process PID to a file when using --foreground. '
+                                     'Enables stopping the tunnel from another terminal via '
+                                     'kill -SIGTERM $(cat <pid-file>). The file is removed on shutdown.')
+    pam_cmd_parser.add_argument('--run', '-R', required=False, dest='run_command', action='store',
+                                help='Shell command to execute while tunnel is active. '
+                                     'The command runs via the system shell (supports pipes, redirects, env vars). '
+                                     'The tunnel is stopped and Commander exits with the command\'s exit code. '
+                                     "Example: --run 'pg_dump -h localhost -p 5432 mydb > backup.sql'")
+    pam_cmd_parser.add_argument('--timeout', required=False, dest='connect_timeout', action='store',
+                                type=int, default=30,
+                                help='Seconds to wait for the tunnel to connect before giving up '
+                                     '(used with --foreground, --background, and --run). Default: 30')
+    pam_cmd_parser.add_argument('--background', '-bg', required=False, dest='background', action='store_true',
+                                help='Start the tunnel in a background process, wait for '
+                                     'connection readiness, then return control to the caller. '
+                                     'The tunnel continues running independently. Use --pid-file '
+                                     'to write the daemon PID for later shutdown. Use '
+                                     "'pam tunnel list' / 'pam tunnel stop' from any session.")
 
     def get_parser(self):
         return PAMTunnelStartCommand.pam_cmd_parser
@@ -581,8 +627,12 @@ class PAMTunnelStartCommand(Command):
             target_host = kwargs.get('target_host')
             target_port = kwargs.get('target_port')
 
-            # If not provided via command line, prompt interactively
+            # If not provided via command line, prompt interactively (or error in batch mode)
             if not target_host:
+                if params.batch_mode:
+                    raise CommandError('tunnel start',
+                                       'Target host is required in non-interactive mode. '
+                                       'Use --target-host <HOST> --target-port <PORT>')
                 print(f"{bcolors.WARNING}This resource requires you to supply the target host and port.{bcolors.ENDC}")
                 try:
                     target_host = input(f"{bcolors.OKBLUE}Enter target hostname or IP address: {bcolors.ENDC}").strip()
@@ -594,6 +644,10 @@ class PAMTunnelStartCommand(Command):
                     return
 
             if not target_port:
+                if params.batch_mode:
+                    raise CommandError('tunnel start',
+                                       'Target port is required in non-interactive mode. '
+                                       'Use --target-host <HOST> --target-port <PORT>')
                 try:
                     target_port_str = input(f"{bcolors.OKBLUE}Enter target port number: {bcolors.ENDC}").strip()
                     if not target_port_str:
@@ -656,11 +710,284 @@ class PAMTunnelStartCommand(Command):
 
         # Use Rust WebRTC implementation with configurable trickle ICE
         trickle_ice = not no_trickle_ice
+
+        # Validate mutual exclusivity of mode flags
+        background = kwargs.get('background', False)
+        foreground = kwargs.get('foreground', False)
+        run_command = kwargs.get('run_command')
+        mode_flags = sum(bool(f) for f in [background, foreground, run_command])
+        if mode_flags > 1:
+            raise CommandError('tunnel start',
+                               '--foreground, --background, and --run are mutually exclusive. '
+                               'Use only one at a time.')
+
+        # --background: launch a separate Commander process with --foreground,
+        # then poll the file-based tunnel registry for readiness.
+        if background:
+            if not params.batch_mode:
+                print(f"\n{bcolors.OKBLUE}Note: --background is not needed inside the interactive shell.{bcolors.ENDC}")
+                print(f"{bcolors.OKBLUE}The tunnel is already running and will persist until you exit the shell.{bcolors.ENDC}")
+                print(f"{bcolors.OKBLUE}Use 'pam tunnel list' to see active tunnels, 'pam tunnel stop' to stop them.{bcolors.ENDC}\n")
+                return
+
+            connect_timeout = kwargs.get('connect_timeout', 30)
+            pid_file = kwargs.get('pid_file')
+
+            bg_cmd = [sys.executable, '-m', 'keepercommander']
+            if params.config_filename:
+                bg_cmd.extend(['--config', os.path.abspath(params.config_filename)])
+            if hasattr(params, 'server') and params.server:
+                bg_cmd.extend(['--server', params.server])
+
+            tunnel_parts = ['pam', 'tunnel', 'start', record_uid,
+                            '--port', str(port), '--foreground',
+                            '--timeout', str(connect_timeout)]
+            if host and host != '127.0.0.1':
+                tunnel_parts.extend(['--host', host])
+            if target_host:
+                tunnel_parts.extend(['--target-host', str(target_host)])
+            if target_port:
+                tunnel_parts.extend(['--target-port', str(target_port)])
+            if pid_file:
+                tunnel_parts.extend(['--pid-file', pid_file])
+            if no_trickle_ice:
+                tunnel_parts.append('--no-trickle-ice')
+            bg_cmd.append(' '.join(tunnel_parts))
+
+            print(f"{bcolors.OKBLUE}Starting tunnel in background...{bcolors.ENDC}")
+            try:
+                bg_proc = subprocess.Popen(
+                    bg_cmd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.PIPE,
+                    start_new_session=True,
+                )
+            except Exception as e:
+                raise CommandError('tunnel start', f'Failed to launch background process: {e}')
+
+            # Parent waits longer than child to account for process startup time.
+            # The child's --timeout controls the actual WebRTC connection timeout.
+            bg_deadline = time.time() + connect_timeout + PARENT_GRACE_SECONDS
+            bg_info = None
+            while time.time() < bg_deadline:
+                for entry in list_registered_tunnels():
+                    if entry.get('pid') == bg_proc.pid and entry.get('record_uid') == record_uid:
+                        bg_info = entry
+                        break
+                if bg_info:
+                    break
+                poll_code = bg_proc.poll()
+                if poll_code is not None:
+                    stderr_output = ''
+                    try:
+                        stderr_output = bg_proc.stderr.read().decode('utf-8', errors='replace').strip()
+                    except Exception:
+                        pass
+                    print(f"{bcolors.FAIL}Background tunnel process exited before tunnel was ready "
+                          f"(code {poll_code}){bcolors.ENDC}")
+                    if stderr_output:
+                        print(f"{bcolors.FAIL}{stderr_output}{bcolors.ENDC}")
+                    elif poll_code == 0:
+                        print(f"{bcolors.FAIL}Process exited before registry registration. "
+                              f"Check WebRTC connectivity and gateway logs.{bcolors.ENDC}")
+                    return
+                time.sleep(0.5)
+
+            if not bg_info:
+                print(f"{bcolors.FAIL}Tunnel did not become ready within the timeout{bcolors.ENDC}")
+                try:
+                    bg_proc.terminate()
+                except Exception:
+                    pass
+                return
+
+            print(f"\n{bcolors.OKGREEN}Tunnel running in background{bcolors.ENDC}")
+            print(f"  Record:     {bg_info.get('record_title') or record_uid}")
+            if bg_info.get('tube_id'):
+                print(f"  Tube ID:    {bg_info['tube_id']}")
+            print(f"  Listening:  {host}:{port}")
+            print(f"  Daemon PID: {bg_proc.pid}")
+            if pid_file:
+                print(f"  PID file:   {pid_file}")
+            print(f"\n{bcolors.OKGREEN}To stop: pam tunnel stop {record_uid}  or  "
+                  f"kill -SIGTERM {bg_proc.pid}{bcolors.ENDC}")
+            if pid_file:
+                print(f"    or:   kill -SIGTERM $(cat {pid_file})")
+            print(f"{bcolors.OKBLUE}Use 'pam tunnel list' from any Commander session "
+                  f"to see this tunnel.{bcolors.ENDC}")
+            return
+
         result = start_rust_tunnel(params, record_uid, gateway_uid, host, port, seed, target_host, target_port, socks, trickle_ice, record.title, allow_supply_host=allow_supply_host, two_factor_value=two_factor_value)
-        
+
         if result and result.get("success"):
-            # The helper will show endpoint table when local socket is actually listening
-            pass
+            connect_timeout = kwargs.get('connect_timeout', 30)
+
+            if run_command:
+                run_tube_id = result.get("tube_id")
+                run_tube_registry = result.get("tube_registry")
+
+                print(f"{bcolors.OKBLUE}Waiting for tunnel to connect (timeout: {connect_timeout}s)...{bcolors.ENDC}")
+                conn_status = wait_for_tunnel_connection(result, timeout=connect_timeout, show_progress=False)
+
+                if not conn_status.get("connected"):
+                    err = conn_status.get("error", "Connection failed")
+                    print(f"{bcolors.FAIL}Tunnel did not connect: {err}{bcolors.ENDC}")
+                    if run_tube_registry and run_tube_id:
+                        try:
+                            run_tube_registry.close_tube(run_tube_id, reason=CloseConnectionReasons.Normal)
+                            unregister_tunnel_session(run_tube_id)
+                        except Exception:
+                            pass
+                    return
+
+                try:
+                    register_tunnel(os.getpid(), record_uid, run_tube_id, host, port,
+                                    target_host, target_port, mode='run',
+                                    record_title=record.title if record else None)
+                except CommandError as reg_err:
+                    print(f"{bcolors.FAIL}{reg_err}{bcolors.ENDC}")
+                    if run_tube_registry and run_tube_id:
+                        try:
+                            run_tube_registry.close_tube(run_tube_id, reason=CloseConnectionReasons.Normal)
+                            unregister_tunnel_session(run_tube_id)
+                        except Exception:
+                            pass
+                    return
+
+                print(f"{bcolors.OKGREEN}Tunnel ready{bcolors.ENDC}  {host}:{port} -> {target_host}:{target_port}")
+                print(f"{bcolors.OKBLUE}Running:{bcolors.ENDC} {run_command}\n")
+
+                cmd_exit = 1
+                try:
+                    # shell=True is intentional: --run commands need shell features (pipes, redirects, env vars).
+                    # The user is already authenticated to Keeper and controls the command string.
+                    proc = subprocess.run(run_command, shell=True)
+                    cmd_exit = proc.returncode if proc.returncode is not None else 1
+                except KeyboardInterrupt:
+                    cmd_exit = 130
+                except Exception as run_err:
+                    logging.warning("Error running command: %s", run_err)
+                    cmd_exit = 1
+                finally:
+                    unregister_tunnel()
+                    print(f"\n{bcolors.OKBLUE}Stopping tunnel {run_tube_id or record_uid}...{bcolors.ENDC}")
+                    try:
+                        if run_tube_registry and run_tube_id:
+                            run_tube_registry.close_tube(run_tube_id, reason=CloseConnectionReasons.Normal)
+                            unregister_tunnel_session(run_tube_id)
+                        print(f"{bcolors.OKGREEN}Tunnel stopped.{bcolors.ENDC}")
+                    except Exception as stop_err:
+                        logging.warning("Error stopping tunnel: %s", stop_err)
+
+                raise SystemExit(cmd_exit)
+
+            elif foreground:
+                if not params.batch_mode:
+                    print(f"\n{bcolors.OKBLUE}Note: --foreground is not needed inside the interactive shell.{bcolors.ENDC}")
+                    print(f"{bcolors.OKBLUE}The tunnel is already running and will persist until you exit the shell.{bcolors.ENDC}")
+                    print(f"{bcolors.OKBLUE}Use 'pam tunnel list' to see active tunnels, 'pam tunnel stop' to stop them.{bcolors.ENDC}\n")
+                else:
+                    fg_tube_id = result.get("tube_id")
+                    fg_tube_registry = result.get("tube_registry")
+                    fg_shutdown = threading.Event()
+                    pid_file = kwargs.get('pid_file')
+
+                    def _fg_signal_handler(signum, _frame):
+                        sig_name = signal.Signals(signum).name if hasattr(signal, 'Signals') else str(signum)
+                        print(f"\n{bcolors.WARNING}Received {sig_name}, stopping tunnel...{bcolors.ENDC}")
+                        fg_shutdown.set()
+
+                    prev_sigterm = signal.signal(signal.SIGTERM, _fg_signal_handler)
+                    prev_sigint = signal.signal(signal.SIGINT, _fg_signal_handler)
+                    prev_sighup = None
+                    if hasattr(signal, 'SIGHUP'):
+                        prev_sighup = signal.signal(signal.SIGHUP, _fg_signal_handler)
+
+                    print(f"{bcolors.OKBLUE}Waiting for tunnel to connect (timeout: {connect_timeout}s)...{bcolors.ENDC}")
+                    conn_status = wait_for_tunnel_connection(result, timeout=connect_timeout, show_progress=False)
+
+                    if not conn_status.get("connected"):
+                        signal.signal(signal.SIGTERM, prev_sigterm)
+                        signal.signal(signal.SIGINT, prev_sigint)
+                        if prev_sighup is not None:
+                            signal.signal(signal.SIGHUP, prev_sighup)
+                        err = conn_status.get("error", "Connection failed")
+                        print(f"{bcolors.FAIL}Tunnel did not connect: {err}{bcolors.ENDC}")
+                        if fg_tube_registry and fg_tube_id:
+                            try:
+                                fg_tube_registry.close_tube(fg_tube_id, reason=CloseConnectionReasons.Normal)
+                                unregister_tunnel_session(fg_tube_id)
+                            except Exception:
+                                pass
+                        return
+
+                    if pid_file:
+                        try:
+                            with open(pid_file, 'w') as pf:
+                                pf.write(str(os.getpid()))
+                        except Exception as e:
+                            logging.warning("Could not write PID file '%s': %s", pid_file, e)
+                            pid_file = None
+
+                    try:
+                        register_tunnel(os.getpid(), record_uid, fg_tube_id, host, port,
+                                        target_host, target_port, mode='foreground',
+                                        record_title=record.title if record else None)
+                    except CommandError as reg_err:
+                        print(f"{bcolors.FAIL}{reg_err}{bcolors.ENDC}")
+                        signal.signal(signal.SIGTERM, prev_sigterm)
+                        signal.signal(signal.SIGINT, prev_sigint)
+                        if prev_sighup is not None:
+                            signal.signal(signal.SIGHUP, prev_sighup)
+                        if fg_tube_registry and fg_tube_id:
+                            try:
+                                fg_tube_registry.close_tube(fg_tube_id, reason=CloseConnectionReasons.Normal)
+                                unregister_tunnel_session(fg_tube_id)
+                            except Exception:
+                                pass
+                        return
+
+                    print(f"\n{bcolors.OKGREEN}Tunnel running in foreground mode{bcolors.ENDC}")
+                    print(f"  Record:     {record_uid}")
+                    if fg_tube_id:
+                        print(f"  Tube ID:    {fg_tube_id}")
+                    print(f"  Listening:  {host}:{port}")
+                    print(f"  PID:        {os.getpid()}")
+                    if pid_file:
+                        print(f"  PID file:   {pid_file}")
+                    print(f"\n{bcolors.OKGREEN}To stop: kill -SIGTERM {os.getpid()}  (or Ctrl+C)  or  pam tunnel stop {record_uid}{bcolors.ENDC}\n")
+                    if platform.system() == 'Windows':
+                        print(f"{bcolors.WARNING}Note: On Windows, tunnel stop uses hard termination. "
+                              f"WebRTC cleanup is best-effort.{bcolors.ENDC}\n")
+
+                    try:
+                        fg_shutdown.wait()
+                    except KeyboardInterrupt:
+                        pass
+                    finally:
+                        unregister_tunnel()
+                        signal.signal(signal.SIGTERM, prev_sigterm)
+                        signal.signal(signal.SIGINT, prev_sigint)
+                        if prev_sighup is not None:
+                            signal.signal(signal.SIGHUP, prev_sighup)
+                        print(f"\n{bcolors.OKBLUE}Stopping tunnel {fg_tube_id or record_uid}...{bcolors.ENDC}")
+                        try:
+                            if fg_tube_registry and fg_tube_id:
+                                fg_tube_registry.close_tube(fg_tube_id, reason=CloseConnectionReasons.Normal)
+                                unregister_tunnel_session(fg_tube_id)
+                            else:
+                                stop_cmd = PAMTunnelStopCommand()
+                                stop_cmd.execute(params, uid=record_uid)
+                            print(f"{bcolors.OKGREEN}Tunnel stopped.{bcolors.ENDC}")
+                        except Exception as fg_err:
+                            logging.warning("Error stopping tunnel during foreground shutdown: %s", fg_err)
+                        finally:
+                            if pid_file:
+                                try:
+                                    os.remove(pid_file)
+                                except OSError:
+                                    pass
         else:
             # Print failure message
             error_msg = result.get("error", "Unknown error") if result else "Failed to start tunnel"
@@ -673,15 +1000,12 @@ class PAMTunnelStartCommand(Command):
 
 
 class PAMTunnelDiagnoseCommand(Command):
-    # ── parser ────────────────────────────────────────────────────────────────
-    pam_cmd_parser = argparse.ArgumentParser(
-        prog='pam tunnel diagnose',
-        description='Diagnose network connectivity for KeeperPAM. '
-                    'When run without a record the command tests connectivity using only the '
-                    'logged-in session (krelay server, HTTPS API, WebSocket, UDP port range). '
-                    'When a record is supplied the full WebRTC peer connection test is also run.')
-    pam_cmd_parser.add_argument('record', type=str, nargs='?', default=None,
-                                help='Optional: Record UID of a PAM resource for the full WebRTC peer connection test')
+    pam_cmd_parser = argparse.ArgumentParser(prog='pam tunnel diagnose', 
+                                           description='Diagnose network connectivity to krelay server. '
+                                                       'Tests DNS resolution, TCP/UDP connectivity, AWS infrastructure, '
+                                                       'and WebRTC peer connection setup for IT troubleshooting.')
+    pam_cmd_parser.add_argument('record', type=str, action='store', 
+                                help='The Record UID of the PAM resource record to test connectivity for')
     pam_cmd_parser.add_argument('--timeout', '-t', required=False, dest='timeout', action='store',
                                 type=int, default=30,
                                 help='Test timeout in seconds (default: 30)')
@@ -691,266 +1015,22 @@ class PAMTunnelDiagnoseCommand(Command):
                                 choices=['table', 'json'], default='table',
                                 help='Output format: table (human-readable) or json (machine-readable)')
     pam_cmd_parser.add_argument('--test', required=False, dest='test_filter', action='store',
-                                help='Comma-separated list of specific WebRTC tests to run. Available: '
+                                help='Comma-separated list of specific tests to run. Available: '
                                      'dns_resolution,aws_connectivity,tcp_connectivity,udp_binding,'
                                      'ice_configuration,webrtc_peer_connection')
 
     def get_parser(self):
         return PAMTunnelDiagnoseCommand.pam_cmd_parser
 
-    # ── ANSI helpers ──────────────────────────────────────────────────────────
-    @staticmethod
-    def _use_color() -> bool:
-        return sys.stdout.isatty() and os.environ.get('NO_COLOR') is None
-
-    @staticmethod
-    def _c(code: str, text: str) -> str:
-        return f'\033[{code}m{text}\033[0m' if PAMTunnelDiagnoseCommand._use_color() else text
-
-    @classmethod
-    def _green(cls, t: str) -> str:  return cls._c('92', t)
-    @classmethod
-    def _bright(cls, t: str) -> str: return cls._c('1;92', t)
-    @classmethod
-    def _dim(cls, t: str) -> str:    return cls._c('2;32', t)
-    @classmethod
-    def _red(cls, t: str) -> str:    return cls._c('1;91', t)
-    @classmethod
-    def _check(cls) -> str:          return cls._bright('\u2713')
-    @classmethod
-    def _cross(cls) -> str:          return cls._red('\u2717')
-    @classmethod
-    def _bullet(cls) -> str:         return cls._bright('\u25ba')
-    @classmethod
-    def _sep(cls, w: int = 76) -> str:   return cls._dim('\u2500' * w)
-    @classmethod
-    def _dsep(cls, w: int = 78) -> str:  return cls._dim('\u2550' * w)
-
-    # ── output helpers ────────────────────────────────────────────────────────
-    _W = 80  # output width
-
-    @classmethod
-    def _print_header(cls):
-        title = 'KeeperPAM  \u00b7  Gateway Network Readiness Tester'
-        inner = cls._W - 2
-        pad_l = (inner - len(title)) // 2
-        pad_r = inner - len(title) - pad_l
-        print(cls._bright('\u2554' + '\u2550' * inner + '\u2557'))
-        print(cls._bright('\u2551' + ' ' * pad_l + title + ' ' * pad_r + '\u2551'))
-        print(cls._bright('\u255a' + '\u2550' * inner + '\u255d'))
-
-    @classmethod
-    def _print_result(cls, name: str, passed: bool, detail: str, ms: int, indent: int = 4):
-        icon = cls._check() if passed else cls._cross()
-        ms_str = cls._dim(f'  {ms}ms')
-        body = f'{cls._green(name)}  \u00b7  {cls._green(detail)}' if detail else cls._green(name)
-        print(f'{" " * indent}{icon}  {body}{ms_str}')
-
-    # ── STUN ──────────────────────────────────────────────────────────────────
-    _MAGIC_COOKIE = 0x2112A442
-    _STUN_PORT = 3478
-    _UDP_SAMPLE_PORTS = [49152, 50000, 52000, 55000, 58000, 61000, 63000, 65535]
-
-    @classmethod
-    def _stun_request(cls, msg_type: int = 0x0001) -> bytes:
-        return struct.pack('!HHI12s', msg_type, 0, cls._MAGIC_COOKIE, os.urandom(12))
-
-    @classmethod
-    def _recv_stun(cls, sock: socket.socket, timeout: float = 5.0) -> bytes:
-        buf = b''
-        deadline = time.monotonic() + timeout
-        try:
-            if sock.type == socket.SOCK_DGRAM:
-                sock.settimeout(max(0.1, deadline - time.monotonic()))
-                buf, _ = sock.recvfrom(2048)
-            else:
-                while len(buf) < 20:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        break
-                    sock.settimeout(remaining)
-                    chunk = sock.recv(2048)
-                    if not chunk:
-                        break
-                    buf += chunk
-        except (socket.timeout, OSError):
-            pass
-        return buf
-
-    @classmethod
-    def _parse_stun(cls, data: bytes) -> dict:
-        out: dict = {}
-        if len(data) < 20:
-            return out
-        msg_type, _msg_len, magic = struct.unpack('!HHI', data[:8])
-        if magic != cls._MAGIC_COOKIE:
-            return out
-        msg_class = ((msg_type >> 7) & 0x2) | ((msg_type >> 4) & 0x1)
-        out['is_success'] = msg_class == 2
-        out['is_error'] = msg_class == 3
-        offset = 20
-        while offset + 4 <= len(data):
-            attr_type, attr_len = struct.unpack('!HH', data[offset:offset + 4])
-            offset += 4
-            attr = data[offset:offset + attr_len]
-            if attr_type == 0x0020 and len(attr) >= 8 and attr[1] == 0x01:
-                xip = struct.unpack('!I', attr[4:8])[0] ^ cls._MAGIC_COOKIE
-                out['ext_ip'] = socket.inet_ntoa(struct.pack('!I', xip))
-            elif attr_type == 0x0001 and len(attr) >= 8 and attr[1] == 0x01:
-                out.setdefault('ext_ip', socket.inet_ntoa(attr[4:8]))
-            elif attr_type == 0x0009 and len(attr) >= 4:
-                out['error_code'] = (attr[2] & 0x07) * 100 + attr[3]
-            offset += (attr_len + 3) & ~3
-        return out
-
-    # ── individual Python-side tests ──────────────────────────────────────────
-    @classmethod
-    def _test_https(cls, hostname: str, port: int = 443) -> Tuple[bool, str, int]:
-        """Returns (passed, detail, ms)."""
-        t0 = time.monotonic()
-        conn = None
-        try:
-            ctx = ssl.create_default_context()
-            conn = http.client.HTTPSConnection(hostname, port=port, context=ctx, timeout=10)
-            conn.request('GET', '/', headers={'User-Agent': 'keeper-pam-diagnose/1.0'})
-            resp = conn.getresponse()
-            ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 600, f'HTTP {resp.status}  (reachable)', ms
-        except Exception as exc:
-            return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
-        finally:
-            if conn:
-                try: conn.close()
-                except Exception: pass
-
-    @classmethod
-    def _test_websocket(cls, hostname: str, port: int = 443) -> Tuple[bool, str, int]:
-        """HTTP Upgrade probe — any 4xx means the server is reachable."""
-        t0 = time.monotonic()
-        conn = None
-        try:
-            ctx = ssl.create_default_context()
-            conn = http.client.HTTPSConnection(hostname, port=port, context=ctx, timeout=10)
-            conn.request('GET', '/', headers={
-                'Upgrade': 'websocket',
-                'Connection': 'Upgrade',
-                'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
-                'Sec-WebSocket-Version': '13',
-                'User-Agent': 'keeper-pam-diagnose/1.0',
-            })
-            resp = conn.getresponse()
-            ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 600, f'HTTP {resp.status}', ms
-        except Exception as exc:
-            return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
-        finally:
-            if conn:
-                try: conn.close()
-                except Exception: pass
-
-    @classmethod
-    def _test_tcp_stun(cls, hostname: str) -> Tuple[bool, str, int, Optional[str]]:
-        """Returns (passed, detail, ms, ext_ip)."""
-        t0 = time.monotonic()
-        sock = None
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(10)
-            sock.connect((hostname, cls._STUN_PORT))
-            sock.sendall(cls._stun_request(0x0001))
-            parsed = cls._parse_stun(cls._recv_stun(sock))
-            ms = int((time.monotonic() - t0) * 1000)
-            ext_ip = parsed.get('ext_ip')
-            detail = f'external IP  {ext_ip}' if ext_ip else 'TCP connected'
-            return True, detail, ms, ext_ip
-        except Exception as exc:
-            return False, str(exc)[:60], int((time.monotonic() - t0) * 1000), None
-        finally:
-            if sock:
-                try: sock.close()
-                except Exception: pass
-
-    @classmethod
-    def _test_udp_stun(cls, hostname: str) -> Tuple[bool, str, int, Optional[str]]:
-        """Returns (passed, detail, ms, ext_ip)."""
-        t0 = time.monotonic()
-        sock = None
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.settimeout(5)
-            sock.sendto(cls._stun_request(0x0001), (hostname, cls._STUN_PORT))
-            parsed = cls._parse_stun(cls._recv_stun(sock))
-            ms = int((time.monotonic() - t0) * 1000)
-            ext_ip = parsed.get('ext_ip')
-            if ext_ip:
-                return True, f'external IP  {ext_ip}', ms, ext_ip
-            return False, 'no STUN response', ms, None
-        except Exception as exc:
-            return False, str(exc)[:60], int((time.monotonic() - t0) * 1000), None
-        finally:
-            if sock:
-                try: sock.close()
-                except Exception: pass
-
-    @classmethod
-    def _test_turn(cls, hostname: str) -> Tuple[bool, str, int]:
-        """Send unauthenticated TURN Allocate; expect 401 = reachable."""
-        t0 = time.monotonic()
-        sock = None
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(10)
-            sock.connect((hostname, cls._STUN_PORT))
-            sock.sendall(cls._stun_request(0x0003))  # Allocate
-            parsed = cls._parse_stun(cls._recv_stun(sock))
-            ms = int((time.monotonic() - t0) * 1000)
-            if parsed.get('is_error') and parsed.get('error_code') == 401:
-                detail = 'reachable  \u00b7  auth required'
-            elif parsed.get('is_success') or parsed.get('is_error'):
-                detail = 'reachable'
-            else:
-                detail = 'TCP connected'
-            return True, detail, ms
-        except Exception as exc:
-            return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
-        finally:
-            if sock:
-                try: sock.close()
-                except Exception: pass
-
-    @classmethod
-    def _test_udp_port(cls, ip: str, port: int, timeout: float = 1.5) -> Tuple[bool, int]:
-        """Returns (reachable, ms). Timeout = no ICMP unreachable = assumed open."""
-        import errno as _errno
-        t0 = time.monotonic()
-        sock = None
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.settimeout(timeout)
-            sock.sendto(cls._stun_request(0x0001), (ip, port))
-            try:
-                sock.recvfrom(512)
-            except socket.timeout:
-                pass  # no response = assume open
-            except OSError as oserr:
-                ms = int((time.monotonic() - t0) * 1000)
-                if oserr.errno in (_errno.ECONNREFUSED, _errno.ENETUNREACH, _errno.EHOSTUNREACH):
-                    return False, ms
-            return True, int((time.monotonic() - t0) * 1000)
-        except Exception:
-            return False, int((time.monotonic() - t0) * 1000)
-        finally:
-            if sock:
-                try: sock.close()
-                except Exception: pass
-
-    # ── execute ───────────────────────────────────────────────────────────────
     def execute(self, params, **kwargs):
         record_name = kwargs.get('record')
         timeout = kwargs.get('timeout', 30)
         verbose = kwargs.get('verbose', False)
         output_format = kwargs.get('format', 'table')
         test_filter = kwargs.get('test_filter')
+        
+        if not record_name:
+            raise CommandError('pam tunnel diagnose', '"record" parameter is required.')
 
         server = params.server  # e.g. "keepersecurity.com" or "https://qa.keepersecurity.com"
         server_host = get_keeper_server_hostname(server)
@@ -1051,298 +1131,114 @@ class PAMTunnelDiagnoseCommand(Command):
 
         # ── section 4: WebRTC connectivity (Rust library) ─────────────────────
         tube_registry = get_or_create_tube_registry(params)
-        rust_results = None
+        if not tube_registry:
+            print(f"{bcolors.FAIL}This command requires the Rust WebRTC library (keeper_pam_webrtc_rs).{bcolors.ENDC}")
+            print(f"{bcolors.OKBLUE}Please ensure the keeper_pam_webrtc_rs module is installed and available.{bcolors.ENDC}")
+            return 1
 
-        if tube_registry:
-            print(f'{self._bullet()}  {self._bright("WebRTC Connectivity")}  \u00b7  {self._green("STUN/TURN/ICE/Peer")}')
-            print(f'  {self._sep()}')
+        # Resolve and validate the record
+        api.sync_down(params)
+        record = RecordMixin.resolve_single_record(params, record_name)
+        if not record:
+            print(f"{bcolors.FAIL}Record '{record_name}' not found.{bcolors.ENDC}")
+            return 1
+        if not isinstance(record, vault.TypedRecord):
+            print(f"{bcolors.FAIL}Record '{record_name}' cannot be used for tunneling.{bcolors.ENDC}")
+            return 1
 
-            # Resolve optional record for pam_config_uid
-            if record_name:
-                try:
-                    api.sync_down(params)
-                    record = RecordMixin.resolve_single_record(params, record_name)
-                    if record and isinstance(record, vault.TypedRecord):
-                        encrypted_session_token, encrypted_transmission_key, _ = get_keeper_tokens(params)
-                        pam_config_uid = get_config_uid(params, encrypted_session_token,
-                                                        encrypted_transmission_key, record.record_uid)
-                        if not pam_config_uid:
-                            print(f'    {self._cross()}  {self._red(f"No PAM config found for record {record_name}")}')
-                except Exception as exc:
-                    logging.debug(f'Record lookup failed: {exc}', exc_info=True)
+        record_uid = record.record_uid
+        record_type = record.record_type
+        if record_type not in ("pamMachine pamDatabase pamDirectory pamNetworkConfiguration pamAwsConfiguration "
+                               "pamRemoteBrowser pamAzureConfiguration").split():
+            print(f"{bcolors.FAIL}Record type '{record_type}' is not supported for tunneling.{bcolors.ENDC}")
+            print(f"Supported types: pamMachine, pamDatabase, pamDirectory, pamRemoteBrowser, "
+                  f"pamNetworkConfiguration, pamAwsConfiguration, pamAzureConfiguration")
+            return 1
 
-            # Get TURN credentials
-            turn_username = turn_password = None
-            try:
-                from .pam.router_helper import router_get_relay_access_creds
-                creds = router_get_relay_access_creds(params, expire_sec=60000000)
-                turn_username = creds.username
-                turn_password = creds.password
-            except Exception as exc:
-                logging.debug(f'Could not get TURN credentials: {exc}', exc_info=True)
-
-            settings = {'use_turn': True, 'turn_only': False}
-            if test_filter:
-                allowed = {'dns_resolution', 'aws_connectivity', 'tcp_connectivity',
-                           'udp_binding', 'ice_configuration', 'webrtc_peer_connection'}
-                requested = {t.strip() for t in test_filter.split(',')}
-                invalid = requested - allowed
-                if invalid:
-                    print(f"{bcolors.FAIL}Invalid test names: {', '.join(invalid)}{bcolors.ENDC}")
-                    return 1
-                settings['test_filter'] = list(requested)
-
-            try:
-                rust_results = tube_registry.test_webrtc_connectivity(
-                    krelay_server=krelay_server,
-                    settings=settings,
-                    timeout_seconds=timeout,
-                    username=turn_username,
-                    password=turn_password,
-                )
-                if output_format == 'json':
-                    import json
-                    print(json.dumps(rust_results, indent=2))
-                    return 0
-
-                # Fold Rust test results into the unified pass/fail accounting
-                for test in rust_results.get('test_results', []):
-                    name = test.get('test_name', '?')
-                    ok = test.get('success', False)
-                    ms = int(test.get('duration_ms', 0))
-                    msg = test.get('message', '')
-                    _record(name.replace('_', ' ').title(), ok, msg, ms)
-
-            except Exception as exc:
-                print(f'    {self._cross()}  {self._red(f"WebRTC test failed: {exc}")}')
-                all_passed.append(False)
-                blocked_names.append('webrtc')
-                logging.debug('WebRTC test error', exc_info=True)
-
-            print()
-        else:
-            logging.debug('keeper_pam_webrtc_rs not available; skipping WebRTC section')
-
-        # ── section 5: PAM configuration graph (record-specific) ────────────
-        if record_name:
-            print(f'{self._bullet()}  {self._bright("PAM Configuration")}  \u00b7  {self._green(record_name)}')
-            print(f'  {self._sep()}')
-
-            try:
-                # Ensure vault is synced so the config record is in the local cache
-                api.sync_down(params)
-                record_obj = RecordMixin.resolve_single_record(params, record_name)
-                record_uid = record_obj.record_uid if record_obj else record_name
-
-                _supported_types = ('pamMachine', 'pamDatabase', 'pamDirectory', 'pamRemoteBrowser')
-                rec_type_early = record_obj.record_type if record_obj and isinstance(record_obj, vault.TypedRecord) else None
-                if rec_type_early and rec_type_early not in _supported_types:
-                    print(f'    {self._cross()}  {self._red("Record type")}  {self._green(rec_type_early)}  '
-                          f'{self._red("is not a PAM resource — skipping configuration checks")}')
-                    print(f'    {self._dim("Supported types: " + ", ".join(_supported_types))}')
-                    print()
-                    # Skip to Technical Details
-                    raise StopIteration
-
-                # 1. Config linked — find the PAM config that owns this record
-                enc_session_token, enc_transmission_key, _tx_key = get_keeper_tokens(params)
-                config_uid = get_config_uid(params, enc_session_token, enc_transmission_key, record_uid)
-                if config_uid:
-                    _record('Config linked', True, config_uid, 0)
-                else:
-                    _record('Config linked', False, 'record not found in any PAM config graph', 0)
-
-                if config_uid:
-                    # 2. DAG loaded — fresh tokens required; TunnelDAG's Connection
-                    #    needs its own key pair separate from the get_config_uid call,
-                    #    and transmission_key must be passed so it can decrypt the response
-                    enc_st2, enc_tk2, tx_key2 = get_keeper_tokens(params)
-                    tdag = TunnelDAG(params, enc_st2, enc_tk2, config_uid, is_config=True,
-                                     transmission_key=tx_key2)
-                    dag_ok = tdag.linking_dag.has_graph
-                    vertex_count = len(tdag.linking_dag._vertices) if dag_ok else 0
-                    _record('DAG loaded', dag_ok,
-                            '{} vertices'.format(vertex_count) if dag_ok else 'graph empty — config may be unconfigured',
-                            0)
-
-                    if dag_ok:
-                        # 3. Resource linked — LINK edge from config → resource present
-                        linked = tdag.resource_belongs_to_config(record_uid)
-                        _record('Resource linked', linked,
-                                'LINK edge present' if linked else 'resource not linked to config', 0)
-
-                        rec_type = record_obj.record_type if record_obj else ''
-                        is_rbi = rec_type == 'pamRemoteBrowser'
-
-                        # 4. Config-level settings
-                        con_config = tdag.check_tunneling_enabled_config(enable_connections=True)
-                        _record('Connections at config', con_config,
-                                'connections enabled' if con_config else 'connections disabled at config', 0)
-
-                        if not is_rbi:
-                            tun_config = tdag.check_tunneling_enabled_config(enable_tunneling=True)
-                            _record('Tunneling at config', tun_config,
-                                    'portForwards enabled' if tun_config else 'portForwards disabled at config', 0)
-
-                        # 5. Resource-level settings
-                        con_resource = tdag.check_if_resource_allowed(record_uid, 'connections')
-                        _record('Connections at resource', con_resource,
-                                'connections enabled' if con_resource else 'connections disabled at resource', 0)
-
-                        if not is_rbi:
-                            tun_resource = tdag.check_if_resource_allowed(record_uid, 'portForwards')
-                            _record('Tunneling at resource', tun_resource,
-                                    'portForwards enabled' if tun_resource else 'portForwards disabled at resource', 0)
-
-                        # verbose: dump allowedSettings for config and resource
-                        if verbose:
-                            from .tunnel.port_forward.TunnelGraph import get_vertex_content
-                            _setting_keys = [
-                                ('connections',            'Connections'),
-                                ('portForwards',           'Port Forwards'),
-                                ('rotation',               'Rotation'),
-                                ('sessionRecording',       'Session Recording'),
-                                ('typescriptRecording',    'Typescript Recording'),
-                                ('remoteBrowserIsolation', 'Remote Browser Isolation'),
-                            ]
-                            config_vertex   = tdag.linking_dag.get_vertex(tdag.record.record_uid)
-                            resource_vertex = tdag.linking_dag.get_vertex(record_uid)
-                            cfg_content     = get_vertex_content(config_vertex) or {}
-                            res_content     = get_vertex_content(resource_vertex) or {}
-                            cfg_settings    = cfg_content.get('allowedSettings', {})
-                            res_settings    = res_content.get('allowedSettings', {})
-
-                            _yes = self._bright('on ')
-                            _no  = self._dim('off')
-                            _def = self._dim('---')
-
-                            def _fmt_bool(d, key):
-                                v = d.get(key)
-                                if v is True:  return _yes
-                                if v is False: return _no
-                                return _def
-
-                            print()
-                            print(f'      {self._dim("DAG allowedSettings"):<28}'
-                                  f'{self._dim("Config"):<12}{self._dim("Resource")}')
-                            print(f'      {self._dim("-" * 52)}')
-                            for key, label in _setting_keys:
-                                print(f'      {self._green(label):<28}'
-                                      f'{_fmt_bool(cfg_settings, key):<12}'
-                                      f'{_fmt_bool(res_settings, key)}')
-
-                            # typed field on the vault record — field name differs by record type
-                            def _val(v):
-                                if v is None:  return self._dim('---')
-                                if v is True:  return self._bright('true')
-                                if v is False: return self._dim('false')
-                                return self._green(str(v))
-
-                            print()
-                            if is_rbi:
-                                rbs_field = record_obj.get_typed_field('pamRemoteBrowserSettings') if record_obj else None
-                                rbs = {}
-                                if rbs_field and rbs_field.value:
-                                    rbs = rbs_field.value[0] if isinstance(rbs_field.value[0], dict) else {}
-                                cn = rbs.get('connection', {}) or {}
-                                print(f'      {self._dim("Record pamRemoteBrowserSettings")}')
-                                print(f'      {self._dim("-" * 52)}')
-                                print(f'      {self._green("connection.protocol"):<36}{_val(cn.get("protocol"))}')
-                                print(f'      {self._green("connection.httpCredentialsUid"):<36}{_val(cn.get("httpCredentialsUid") or None)}')
-                                print(f'      {self._green("connection.recordingIncludeKeys"):<36}{_val(cn.get("recordingIncludeKeys"))}')
-                            else:
-                                pam_settings_field = record_obj.get_typed_field('pamSettings') if record_obj else None
-                                ps = {}
-                                if pam_settings_field and pam_settings_field.value:
-                                    ps = pam_settings_field.value[0] if isinstance(pam_settings_field.value[0], dict) else {}
-                                pf = ps.get('portForward', {}) or {}
-                                cn = ps.get('connection', {}) or {}
-                                print(f'      {self._dim("Record pamSettings")}')
-                                print(f'      {self._dim("-" * 52)}')
-                                print(f'      {self._green("portForward.port"):<36}{_val(pf.get("port"))}')
-                                print(f'      {self._green("connection.port"):<36}{_val(cn.get("port"))}')
-                                print(f'      {self._green("connection.protocol"):<36}{_val(cn.get("protocol"))}')
-                                print(f'      {self._green("connection.allowKeeperDBProxy"):<36}{_val(cn.get("allowKeeperDBProxy"))}')
-                                print(f'      {self._green("connection.recordingIncludeKeys"):<36}{_val(cn.get("recordingIncludeKeys"))}')
-                                print(f'      {self._green("allowSupplyHost"):<36}{_val(ps.get("allowSupplyHost"))}')
-                                if ps.get('configUid'):
-                                    print(f'      {self._green("configUid"):<36}{_val(ps.get("configUid"))}')
-
-                # 6. Gateway registered — a controller UID is associated with this config
-                gateway_uid = get_gateway_uid_from_record(params, vault, record_uid)
-                if gateway_uid:
-                    _record('Gateway registered', True, gateway_uid, 0)
-                else:
-                    _record('Gateway registered', False, 'no gateway registered for this config', 0)
-
-                # 7. Gateway online — that gateway is currently connected to krouter
-                if gateway_uid:
-                    try:
-                        from .pam.router_helper import router_get_connected_gateways
-                        online_controllers = router_get_connected_gateways(params)
-                        if online_controllers:
-                            gw_bytes = url_safe_str_to_bytes(gateway_uid)
-                            connected_uids = [c.controllerUid for c in online_controllers.controllers]
-                            gw_online = gw_bytes in connected_uids
-                            _record('Gateway online', gw_online,
-                                    'connected to krouter' if gw_online else 'gateway offline or unreachable', 0)
-                        else:
-                            _record('Gateway online', False, 'could not retrieve connected gateways', 0)
-                    except Exception as exc:
-                        _record('Gateway online', False, str(exc)[:60], 0)
-
-            except StopIteration:
-                pass  # unsupported record type — already printed, skip gracefully
-            except Exception as exc:
-                print(f'    {self._cross()}  {self._red("PAM graph check failed: " + str(exc)[:70])}')
-                all_passed.append(False)
-                blocked_names.append('pam-graph')
-                logging.debug('PAM graph check error', exc_info=True)
-
-            print()
-
-        # ── section 6: technical details ──────────────────────────────────────
-        print(f'{self._bullet()}  {self._bright("Technical Details")}')
-        print(f'  {self._sep()}')
-
+        # Get the krelay server from the PAM configuration
         try:
-            fqdn = socket.getfqdn()
-            local_ip = socket.gethostbyname(socket.gethostname())
-        except Exception:
-            fqdn = socket.gethostname()
-            local_ip = '?'
+            encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
+            pam_config_uid = get_config_uid(params, encrypted_session_token, encrypted_transmission_key, record_uid)
+            
+            if not pam_config_uid:
+                print(f"{bcolors.FAIL}No PAM Configuration found for record '{record_name}'.{bcolors.ENDC}")
+                print(f"Please configure the record with: {bcolors.OKBLUE}pam tunnel edit {record_uid} --config [ConfigUID]{bcolors.ENDC}")
+                return 1
 
-        passed_total = sum(1 for v in all_passed if v)
-        total_checks = len(all_passed)
-        duration_s = time.monotonic() - t_overall_start
-        blocked_str = 'none \u2013 all paths open' if not blocked_names else ', '.join(blocked_names)
+            # The krelay server hostname is constructed from the params.server
+            krelay_server = f"krelay.{params.server}"
+            
+        except Exception as e:
+            print(f"{bcolors.FAIL}Failed to get PAM configuration: {e}{bcolors.ENDC}")
+            return 1
 
-        col = 10
-        print(f'  {self._dim("Machine"):<{col}}{self._green(fqdn)}  \u00b7  {self._green(local_ip)}')
-        if public_ip:
-            print(f'  {self._dim("Public IP"):<{col}}{self._green(public_ip)} {self._dim("via STUN")}')
-        print(f'  {self._dim("Duration"):<{col}}{self._green(f"{duration_s:.1f}s")}  \u00b7  '
-              f'{self._green(f"{passed_total}/{total_checks} checks")}')
-        print(f'  {self._dim("Blocked"):<{col}}{self._green(blocked_str)}')
+        # Build test settings
+        settings = {
+            "use_turn": True,
+            "turn_only": False
+        }
 
-        print()
-        print(f'  {self._dsep()}')
-        print()
+        # Parse test filter if provided
+        if test_filter:
+            allowed_tests = {'dns_resolution', 'aws_connectivity', 'tcp_connectivity', 
+                           'udp_binding', 'ice_configuration', 'webrtc_peer_connection'}
+            requested_tests = set(test.strip() for test in test_filter.split(','))
+            invalid_tests = requested_tests - allowed_tests
+            if invalid_tests:
+                print(f"{bcolors.FAIL}Invalid test names: {', '.join(invalid_tests)}{bcolors.ENDC}")
+                print(f"Available tests: {', '.join(sorted(allowed_tests))}")
+                return 1
+            settings["test_filter"] = list(requested_tests)
 
-        if passed_total == total_checks:
-            summary = "GATEWAY READY  \u00b7  {} / {} checks passed".format(passed_total, total_checks)
-            print(f'  {self._check()}  {self._bright(summary)}')
-        else:
-            summary = "GATEWAY NOT READY  \u00b7  {} / {} checks passed".format(passed_total, total_checks)
-            print(f'  {self._cross()}  {self._red(summary)}')
-            for name in blocked_names:
-                print(f'       {self._red(name)}')
+        print(f"{bcolors.OKBLUE}Starting network connectivity diagnosis for krelay server: {krelay_server}{bcolors.ENDC}")
+        print(f"Record: {record.title} ({record_uid})")
+        print(f"Timeout: {timeout}s")
+        print("")
 
-        print()
-        print(f'  {self._dsep()}')
-        print()
+        # Get TURN credentials for the connectivity test
+        try:
+            webrtc_settings = create_rust_webrtc_settings(
+                params, host="127.0.0.1", port=0, 
+                target_host="test", target_port=22, 
+                socks=False, nonce=os.urandom(32)
+            )
+            turn_username = webrtc_settings.get("turn_username")
+            turn_password = webrtc_settings.get("turn_password")
+        except Exception as e:
+            print(f"{bcolors.WARNING}Could not get TURN credentials: {e}{bcolors.ENDC}")
+            turn_username = None
+            turn_password = None
 
-        return 0 if passed_total == total_checks else 1
+        # Run the connectivity test
+        try:
+            results = tube_registry.test_webrtc_connectivity(
+                krelay_server=krelay_server,
+                settings=settings,
+                timeout_seconds=timeout,
+                username=turn_username,
+                password=turn_password
+            )
+            
+            if output_format == 'json':
+                import json
+                print(json.dumps(results, indent=2))
+                return 0
+            else:
+                # Use the built-in formatter for human-readable output
+                formatted_output = tube_registry.format_connectivity_results(results, detailed=verbose)
+                print(formatted_output)
+                
+                # Return appropriate exit code
+                overall_result = results.get('overall_result', {})
+                if overall_result.get('success', False):
+                    return 0
+                else:
+                    return 1
+                    
+        except Exception as e:
+            print(f"{bcolors.FAIL}Network connectivity test failed: {e}{bcolors.ENDC}")
+            logging.debug(f"Full error details: {e}", exc_info=True)
+            return 1
 
 
 class PAMConnectionEditCommand(Command):

--- a/keepercommander/commands/tunnel_registry.py
+++ b/keepercommander/commands/tunnel_registry.py
@@ -37,11 +37,16 @@ logger = logging.getLogger(__name__)
 #: Parent poll allowance beyond the child's ``--timeout`` for ``--background`` (process startup).
 PARENT_GRACE_SECONDS = 10
 
+# Not thread-safe; concurrent first-access may double-clean (harmless, idempotent).
 _registry_dir_initialized = False
 
 
 def normalize_bind_host(host) -> str:
-    """Normalize host for duplicate local bind detection (best-effort)."""
+    """Normalize host for duplicate local bind detection (best-effort).
+
+    Only handles common aliases; ``0.0.0.0`` vs ``127.0.0.1`` conflicts
+    are caught at the OS bind level, not here.
+    """
     if host is None:
         return ''
     h = str(host).strip().lower()
@@ -113,11 +118,15 @@ def register_tunnel(
     try:
         p_int = int(port)
     except (TypeError, ValueError):
-        p_int = port
+        p_int = None
     for entry in existing:
         if entry.get('pid') == pid:
             continue
-        if normalize_bind_host(entry.get('host')) == nh and int(entry.get('port') or 0) == int(p_int):
+        try:
+            entry_port = int(entry.get('port') or 0)
+        except (TypeError, ValueError):
+            continue
+        if p_int is not None and normalize_bind_host(entry.get('host')) == nh and entry_port == p_int:
             raise CommandError(
                 'pam tunnel start',
                 f'Port {port} on {host} is already in use by tunnel PID {entry.get("pid")} '

--- a/keepercommander/commands/tunnel_registry.py
+++ b/keepercommander/commands/tunnel_registry.py
@@ -1,0 +1,230 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Secrets Manager
+# Copyright 2023 Keeper Security Inc.
+#
+
+"""Cross-process file-based tunnel session registry.
+
+Each foreground/background/run tunnel writes JSON metadata to
+<tempdir>/keeper-tunnel-sessions/<pid>.json so ``pam tunnel list`` and
+``pam tunnel stop`` can discover tunnels across Commander processes.
+
+The registry lives under the system temp directory rather than ~/.keeper/
+so it survives credential removal/replacement. Temp directories are
+cleared on reboot, matching tunnel lifecycle (tunnels do not survive reboots).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import signal
+import tempfile
+import time
+from pathlib import Path
+
+from ..error import CommandError
+
+logger = logging.getLogger(__name__)
+
+#: Parent poll allowance beyond the child's ``--timeout`` for ``--background`` (process startup).
+PARENT_GRACE_SECONDS = 10
+
+_registry_dir_initialized = False
+
+
+def normalize_bind_host(host) -> str:
+    """Normalize host for duplicate local bind detection (best-effort)."""
+    if host is None:
+        return ''
+    h = str(host).strip().lower()
+    if h == 'localhost':
+        return '127.0.0.1'
+    return h
+
+
+def tunnel_registry_dir() -> Path:
+    """Return (and create) the tunnel session registry directory."""
+    global _registry_dir_initialized
+    base = Path(tempfile.gettempdir()) / 'keeper-tunnel-sessions'
+    existed = base.exists()
+    base.mkdir(parents=True, exist_ok=True)
+    if os.name != 'nt':
+        try:
+            os.chmod(base, 0o700)
+        except OSError:
+            pass
+    if not _registry_dir_initialized:
+        _registry_dir_initialized = True
+        if existed:
+            _clean_stale_registry_files(base)
+    return base
+
+
+def _clean_stale_registry_files(reg_dir: Path) -> None:
+    """Remove dead or corrupt JSON entries under reg_dir."""
+    try:
+        for fname in os.listdir(reg_dir):
+            if not fname.endswith('.json'):
+                continue
+            fpath = reg_dir / fname
+            try:
+                with open(fpath, encoding='utf-8') as f:
+                    data = json.load(f)
+                pid = data.get('pid')
+                if pid and is_pid_alive(pid):
+                    continue
+                os.remove(fpath)
+            except Exception as exc:
+                logger.debug('Removing corrupt tunnel registry file %s: %s', fpath, exc)
+                try:
+                    os.remove(fpath)
+                except OSError:
+                    pass
+    except OSError:
+        pass
+
+
+def register_tunnel(
+    pid,
+    record_uid,
+    tube_id,
+    host,
+    port,
+    target_host=None,
+    target_port=None,
+    mode='foreground',
+    record_title=None,
+):
+    """Write a JSON file for an active tunnel so other processes can see it.
+
+    Uses atomic write (temp file + rename) so readers never see partial data.
+    Stale entries are cleaned before duplicate checks (Issue 6 / 7).
+    """
+    existing = list_registered_tunnels(clean_stale=True)
+    nh = normalize_bind_host(host)
+    try:
+        p_int = int(port)
+    except (TypeError, ValueError):
+        p_int = port
+    for entry in existing:
+        if entry.get('pid') == pid:
+            continue
+        if normalize_bind_host(entry.get('host')) == nh and int(entry.get('port') or 0) == int(p_int):
+            raise CommandError(
+                'pam tunnel start',
+                f'Port {port} on {host} is already in use by tunnel PID {entry.get("pid")} '
+                f'(record {entry.get("record_uid")}). '
+                f'Use "pam tunnel stop {entry.get("record_uid")}" first.',
+            )
+
+    reg_dir = tunnel_registry_dir()
+    path = reg_dir / f'{pid}.json'
+    data = {
+        'pid': pid,
+        'record_uid': record_uid,
+        'tube_id': tube_id,
+        'host': host,
+        'port': port,
+        'target_host': target_host,
+        'target_port': target_port,
+        'mode': mode,
+        'record_title': record_title,
+        'started': time.strftime('%Y-%m-%d %H:%M:%S'),
+    }
+    tmp_path = path.with_suffix('.json.tmp')
+    try:
+        with open(tmp_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f)
+        os.replace(tmp_path, path)
+    except Exception as exc:
+        logger.debug('Could not write tunnel registry file %s: %s', path, exc)
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+def unregister_tunnel(pid=None):
+    """Remove the registry file for a tunnel (defaults to current PID)."""
+    pid = pid or os.getpid()
+    path = tunnel_registry_dir() / f'{pid}.json'
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def is_pid_alive(pid) -> bool:
+    """Return True if a process with the given PID is still running."""
+    if os.name == 'nt':
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.OpenProcess(0x100000, False, pid)  # SYNCHRONIZE
+        if handle:
+            kernel32.CloseHandle(handle)
+            return True
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def stop_tunnel_process(pid: int) -> bool:
+    """Send termination to a tunnel process. Returns True if a signal was sent.
+
+    On Unix, sends SIGTERM for graceful shutdown (target cleans registry/WebRTC).
+    On Windows, SIGTERM maps to TerminateProcess; the registry row is removed
+    here because the target cannot run cleanup handlers.
+    """
+    if not is_pid_alive(pid):
+        return False
+    try:
+        if platform.system() == 'Windows':
+            unregister_tunnel(pid)
+        os.kill(pid, signal.SIGTERM)
+        return True
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+
+
+def list_registered_tunnels(clean_stale=True):
+    """Read registry files. Optionally remove dead or corrupt entries.
+
+    Returns a list of dicts for tunnels whose owning process is still alive.
+    """
+    reg_dir = tunnel_registry_dir()
+    result = []
+    try:
+        fnames = os.listdir(reg_dir)
+    except OSError:
+        return result
+    for fname in fnames:
+        if not fname.endswith('.json'):
+            continue
+        fpath = reg_dir / fname
+        try:
+            with open(fpath, encoding='utf-8') as f:
+                data = json.load(f)
+            pid = data.get('pid')
+            if pid and is_pid_alive(pid):
+                result.append(data)
+            elif clean_stale:
+                os.remove(fpath)
+        except Exception as exc:
+            logger.debug('Removing corrupt tunnel registry file %s: %s', fpath, exc)
+            if clean_stale:
+                try:
+                    os.remove(fpath)
+                except OSError:
+                    pass
+    return result

--- a/unit-tests/test_tunnel_registry.py
+++ b/unit-tests/test_tunnel_registry.py
@@ -1,0 +1,250 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# Unit tests for tunnel_registry and pam tunnel start parser / batch-mode guard.
+#
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import keepercommander.commands.tunnel_registry as tunnel_registry_mod
+from keepercommander.commands.tunnel_registry import (
+    PARENT_GRACE_SECONDS,
+    is_pid_alive,
+    list_registered_tunnels,
+    normalize_bind_host,
+    register_tunnel,
+    stop_tunnel_process,
+    unregister_tunnel,
+)
+from keepercommander.error import CommandError
+
+if sys.version_info < (3, 8):
+    raise unittest.SkipTest('pam tunnel tests require Python 3.8+')
+
+
+def _patch_registry_dir(testcase, tmp: Path):
+    """Point tunnel_registry_dir at tmp for the duration of a test."""
+    patcher = mock.patch.object(
+        tunnel_registry_mod,
+        'tunnel_registry_dir',
+        return_value=tmp,
+    )
+    patcher.start()
+    testcase.addCleanup(patcher.stop)
+    tunnel_registry_mod._registry_dir_initialized = False
+
+
+class TestNormalizeBindHost(unittest.TestCase):
+    def test_localhost_maps(self):
+        self.assertEqual(normalize_bind_host('localhost'), '127.0.0.1')
+        self.assertEqual(normalize_bind_host('LOCALHOST'), '127.0.0.1')
+
+    def test_other_preserved_lower(self):
+        self.assertEqual(normalize_bind_host('10.0.0.5'), '10.0.0.5')
+
+
+class TestTunnelRegistryDir(unittest.TestCase):
+    def test_creates_with_permissions(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        _patch_registry_dir(self, tmp)
+        d = tunnel_registry_mod.tunnel_registry_dir()
+        self.assertTrue(d.exists())
+        self.assertEqual(d, tmp)
+
+
+class TestRegisterUnregister(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        _patch_registry_dir(self, self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_register_writes_json_unregister_removes(self):
+        register_tunnel(
+            12345, 'rec1', 'tube1', '127.0.0.1', 5432,
+            target_host='host', target_port=22, mode='foreground',
+            record_title='t',
+        )
+        self.assertTrue((self.tmp / '12345.json').exists())
+        with open(self.tmp / '12345.json', encoding='utf-8') as f:
+            data = json.load(f)
+        self.assertEqual(data['record_uid'], 'rec1')
+        self.assertEqual(data['tube_id'], 'tube1')
+        self.assertEqual(data['port'], 5432)
+        unregister_tunnel(12345)
+        self.assertFalse((self.tmp / '12345.json').exists())
+
+
+class TestListRegisteredTunnels(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        _patch_registry_dir(self, self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_list_removes_stale_entries_when_clean(self):
+        dead_pid = 999999991
+        p = self.tmp / f'{dead_pid}.json'
+        with open(p, 'w', encoding='utf-8') as f:
+            json.dump({'pid': dead_pid, 'record_uid': 'x', 'host': '127.0.0.1', 'port': 1}, f)
+        out = list_registered_tunnels(clean_stale=True)
+        self.assertFalse(p.exists())
+        self.assertEqual(out, [])
+
+
+class TestIsPidAlive(unittest.TestCase):
+    def test_current_process_alive(self):
+        self.assertTrue(is_pid_alive(os.getpid()))
+
+    def test_nonexistent_pid(self):
+        self.assertFalse(is_pid_alive(999999997))
+
+
+class TestDuplicatePortDetection(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        _patch_registry_dir(self, self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @mock.patch('keepercommander.commands.tunnel_registry.is_pid_alive', return_value=True)
+    def test_duplicate_host_port_raises(self, _mock_alive):
+        register_tunnel(
+            111, 'a', 't1', '127.0.0.1', 5432, mode='foreground',
+        )
+        with self.assertRaises(CommandError) as ctx:
+            register_tunnel(
+                222, 'b', 't2', 'localhost', 5432, mode='foreground',
+            )
+        msg = str(ctx.exception)
+        self.assertIn('pam tunnel start', msg)
+        self.assertIn('5432', msg)
+        self.assertIn('111', msg)
+        self.assertIn('pam tunnel stop', msg)
+
+
+class TestStopTunnelProcess(unittest.TestCase):
+    def test_dead_pid_returns_false(self):
+        self.assertFalse(stop_tunnel_process(999999996))
+
+
+class TestPamTunnelStartParser(unittest.TestCase):
+    def test_defaults(self):
+        from keepercommander.commands.tunnel_and_connections import PAMTunnelStartCommand
+        p = PAMTunnelStartCommand.pam_cmd_parser
+        ns = p.parse_args(['recuid'])
+        self.assertFalse(ns.foreground)
+        self.assertFalse(ns.background)
+        self.assertIsNone(ns.run_command)
+        self.assertEqual(ns.connect_timeout, 30)
+        self.assertIsNone(ns.pid_file)
+
+    def test_flags_parse(self):
+        from keepercommander.commands.tunnel_and_connections import PAMTunnelStartCommand
+        p = PAMTunnelStartCommand.pam_cmd_parser
+        ns = p.parse_args([
+            'recuid', '-fg', '--pid-file', '/tmp/p.pid', '--timeout', '60',
+            '-R', 'echo hi',
+        ])
+        self.assertTrue(ns.foreground)
+        self.assertEqual(ns.pid_file, '/tmp/p.pid')
+        self.assertEqual(ns.connect_timeout, 60)
+        self.assertEqual(ns.run_command, 'echo hi')
+
+    def test_mutual_exclusive_flags_parse_together(self):
+        from keepercommander.commands.tunnel_and_connections import PAMTunnelStartCommand
+        p = PAMTunnelStartCommand.pam_cmd_parser
+        ns = p.parse_args(['recuid', '--foreground', '--background'])
+        self.assertTrue(ns.foreground)
+        self.assertTrue(ns.background)
+
+
+class _DummyTypedRecord:
+    """Stand-in for vault.TypedRecord when patching isinstance checks."""
+
+
+class TestBatchModeTargetHostPort(unittest.TestCase):
+    @mock.patch('keepercommander.commands.tunnel_and_connections.vault.TypedRecord', _DummyTypedRecord)
+    @mock.patch('keepercommander.commands.tunnel_and_connections.find_open_port')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_or_create_tube_registry')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.vault.KeeperRecord.load')
+    def test_input_not_called_batch_missing_target_host(
+        self, mock_load, mock_sync, mock_tr, mock_fop,
+    ):
+        mock_tr.return_value = mock.MagicMock()
+        mock_fop.return_value = 5432
+
+        pam = mock.MagicMock()
+        pam.get_default_value.return_value = {'allowSupplyHost': True, 'portForward': {'port': 22}}
+        rec = _DummyTypedRecord()
+        rec.record_uid = 'rec1'
+        rec.get_typed_field = lambda name, *a, **kw: pam if name == 'pamSettings' else None
+
+        mock_load.return_value = rec
+
+        from keepercommander.commands.tunnel_and_connections import PAMTunnelStartCommand
+        p = mock.MagicMock()
+        p.batch_mode = True
+        p.config_filename = None
+        p.server = None
+
+        with mock.patch('builtins.input', side_effect=AssertionError('input must not be called')):
+            cmd = PAMTunnelStartCommand()
+            with self.assertRaises(CommandError) as ctx:
+                cmd.execute(
+                    p,
+                    uid='rec1',
+                    host='127.0.0.1',
+                    port=5432,
+                    target_host=None,
+                    target_port=None,
+                    no_trickle_ice=False,
+                    foreground=False,
+                    background=False,
+                    run_command=None,
+                    connect_timeout=30,
+                    pid_file=None,
+                )
+        msg = str(ctx.exception)
+        self.assertIn('--target-host', msg)
+        self.assertIn('--target-port', msg)
+
+
+class TestParentGraceConstant(unittest.TestCase):
+    def test_parent_grace_seconds(self):
+        self.assertEqual(PARENT_GRACE_SECONDS, 10)
+
+
+class TestListCleanStaleFalse(unittest.TestCase):
+    """Stale files are listed but not deleted when clean_stale=False."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        _patch_registry_dir(self, self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_clean_stale_false_keeps_dead_file(self):
+        dead_pid = 999999992
+        p = self.tmp / f'{dead_pid}.json'
+        with open(p, 'w', encoding='utf-8') as f:
+            json.dump({'pid': dead_pid, 'record_uid': 'x', 'host': '127.0.0.1', 'port': 1}, f)
+        out = list_registered_tunnels(clean_stale=False)
+        self.assertTrue(p.exists())
+        self.assertEqual(out, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/test_tunnel_registry.py
+++ b/unit-tests/test_tunnel_registry.py
@@ -174,13 +174,15 @@ class _DummyTypedRecord:
 
 
 class TestBatchModeTargetHostPort(unittest.TestCase):
+    @mock.patch('keepercommander.commands.workflow.check_workflow_and_prompt_2fa',
+                return_value=(True, None), create=True)
     @mock.patch('keepercommander.commands.tunnel_and_connections.vault.TypedRecord', _DummyTypedRecord)
     @mock.patch('keepercommander.commands.tunnel_and_connections.find_open_port')
     @mock.patch('keepercommander.commands.tunnel_and_connections.get_or_create_tube_registry')
     @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
     @mock.patch('keepercommander.commands.tunnel_and_connections.vault.KeeperRecord.load')
     def test_input_not_called_batch_missing_target_host(
-        self, mock_load, mock_sync, mock_tr, mock_fop,
+        self, mock_load, mock_sync, mock_tr, mock_fop, mock_wf,
     ):
         mock_tr.return_value = mock.MagicMock()
         mock_fop.return_value = 5432
@@ -189,6 +191,7 @@ class TestBatchModeTargetHostPort(unittest.TestCase):
         pam.get_default_value.return_value = {'allowSupplyHost': True, 'portForward': {'port': 22}}
         rec = _DummyTypedRecord()
         rec.record_uid = 'rec1'
+        rec.title = 'rec1-title'
         rec.get_typed_field = lambda name, *a, **kw: pam if name == 'pamSettings' else None
 
         mock_load.return_value = rec


### PR DESCRIPTION
## Summary

Add `--foreground` / `-fg`, `--pid-file`, `--run` / `-R`, and `--timeout` flags to `pam tunnel start` that enable tunnels to be used in non-interactive contexts: shell scripts, systemd services, CI/CD pipelines, and headless automation -- without requiring an interactive `keeper shell` session.

- **`--foreground`**: Blocks the Commander process after the tunnel connects, keeping it alive until `SIGTERM`/`SIGINT`/`Ctrl+C`. Now waits for the WebRTC connection to reach `"connected"` state before printing the status banner and writing the PID file.
- **`--pid-file`**: Writes the process PID to a file for external signal-based management.
- **`--run <COMMAND>`**: Starts the tunnel, waits for connection, executes the given shell command, stops the tunnel, and exits with the command's exit code. Ideal for single-script workflows.
- **`--timeout <SECONDS>`**: Controls how long to wait for the tunnel to connect (default: 30s). Used with `--foreground`, `--background`, and `--run`.
- **`--background` / `-bg`**: Launches a separate Commander process with `--foreground`, polls the file-based tunnel registry for readiness, then returns control to the caller. The tunnel continues running as an independent background process. Works on all platforms.
- **Batch mode fix**: When `--target-host`/`--target-port` are missing in non-interactive mode, raises `CommandError` instead of calling `input()` (which hangs in batch/script contexts).
- **Cross-process tunnel visibility**: File-based tunnel registry (`<tempdir>/keeper-tunnel-sessions/`) enables `pam tunnel list` to discover tunnels from any Commander session. `pam tunnel stop <RECORD_UID>` sends `SIGTERM` to the owning process. Stale entries (dead PIDs) are auto-cleaned.

## Motivation

Currently, `pam tunnel start` works only inside an interactive `keeper shell` session because tunnels run as in-process background threads (spawned by `start_rust_tunnel()` via `keeper_pam_webrtc_rs`). When Commander is invoked in single-command mode (`keeper "pam tunnel start <UID>"`), `PAMTunnelStartCommand.execute()` returns after starting the tunnel, Commander exits, and all tunnel threads die with the process.

This is a common pain point for users automating infrastructure with Keeper PAM:

- **Headless servers** (NUCs, embedded devices) that need persistent tunnels to databases or other resources
- **CI/CD pipelines** that need ephemeral tunnels for deployment tasks (e.g., `pg_dump` through a tunnel)
- **systemd services** that manage tunnel lifecycle with auto-restart
- **Bash/automation scripts** that start a tunnel, run commands against it, then stop the tunnel

## Changes

**File:** `keepercommander/commands/tunnel_and_connections.py` (1 file changed)

1. **New imports:** `signal`, `subprocess`, `threading` (all stdlib); `unregister_tunnel_session`, `wait_for_tunnel_connection` (from `tunnel_helpers`)

2. **New arguments** on `PAMTunnelStartCommand.pam_cmd_parser`:
   ```python
   pam_cmd_parser.add_argument('--foreground', '-fg', ...)
   pam_cmd_parser.add_argument('--pid-file', ...)
   pam_cmd_parser.add_argument('--run', '-R', dest='run_command', ...)
   pam_cmd_parser.add_argument('--timeout', dest='connect_timeout', type=int, default=30, ...)
   pam_cmd_parser.add_argument('--background', '-bg', ...)
   ```

3. **`--background` logic** (subprocess-based, before `start_rust_tunnel()`):
   - Builds a `keeper` command with `--foreground` and all user-supplied flags
   - Launches it via `subprocess.Popen(start_new_session=True)` as an independent process
   - Polls the file-based tunnel registry (`<tempdir>/keeper-tunnel-sessions/`) for readiness
   - Once the subprocess registers, prints connection info and returns
   - If the subprocess exits early, reports the error
   - Works on all platforms (Linux, macOS, Windows)

4. **`--run` logic** (new branch, checked before `--foreground`):
   - Starts the tunnel, waits for WebRTC connection via `wait_for_tunnel_connection(result, timeout=connect_timeout)`
   - On connected: prints endpoint summary, executes command via `subprocess.run(command, shell=True)`
   - On command completion: stops tunnel via `close_tube()` + `unregister_tunnel_session()`
   - Exits with the command's exit code via `sys.exit(proc.returncode)`
   - On `KeyboardInterrupt`: exits with code 130

5. **`--foreground` connection readiness**: Before printing the status banner and writing the PID file, calls `wait_for_tunnel_connection(result, timeout=connect_timeout)` to ensure the tunnel is actually usable.

6. **Interactive shell detection:** When `--foreground` or `--background` is used inside `keeper shell` (interactive mode, `batch_mode=False`), the blocking logic is skipped and a message informs the user that tunnels already persist in the shell.

7. **File-based tunnel registry**: New module-level functions (`_register_tunnel`, `_unregister_tunnel`, `_list_registered_tunnels`, `_tunnel_registry_dir`, `_is_pid_alive`) manage JSON metadata files in `<tempdir>/keeper-tunnel-sessions/`. Each foreground/background/run tunnel registers on connect and unregisters on cleanup.

8. **Enhanced `PAMTunnelListCommand`**: Now reads both the in-process `PyTubeRegistry` and the file-based registry. Cross-process tunnels appear in the listing with their mode and PID. Stale entries (dead PIDs) are auto-cleaned.

9. **Enhanced `PAMTunnelStopCommand`**: When a tunnel is not found in the in-process registry, falls back to the file registry and sends `SIGTERM` to the owning process. `--all` also stops cross-process tunnels.

10. **Batch mode fix for `--target-host`/`--target-port`**: When `params.batch_mode` is `True` and these values are missing, raises `CommandError` instead of calling `input()`, which would hang in scripts.

No other files are modified. No new external dependencies are introduced. Only Python stdlib modules (`json`, `signal`, `subprocess`, `threading`, `time`) are used.

## Usage

```bash
# Simplest single-command workflow
keeper pam tunnel start <UID> --port 5432 --run "pg_dump -h localhost -p 5432 mydb > backup.sql"

# Multiple commands: daemonize, work, stop
keeper pam tunnel start <UID> --port 5432 --background --pid-file /tmp/tunnel.pid
pg_dump -h localhost -p 5432 mydb > backup.sql
psql -h localhost -p 5432 -c "VACUUM ANALYZE"
kill -SIGTERM $(cat /tmp/tunnel.pid)

# With custom connection timeout
keeper pam tunnel start <UID> --port 5432 --run "my_command" --timeout 60

# Run tunnel in foreground -- stays alive until killed
keeper pam tunnel start <UID> --port 5432 --foreground

# With PID file for external management
keeper pam tunnel start <UID> --port 5432 --foreground --pid-file /tmp/tunnel.pid

# Background it in a script (manual pattern)
keeper pam tunnel start <UID> --port 5432 --foreground --pid-file /tmp/tunnel.pid &
sleep 5
pg_dump -h localhost -p 5432 mydb > backup.sql
kill -SIGTERM $(cat /tmp/tunnel.pid)

# As a systemd service
# [Service]
# ExecStart=/usr/bin/keeper pam tunnel start <UID> --port 5432 --foreground --pid-file /run/keeper-tunnel.pid
# ExecStop=/bin/kill -SIGTERM $MAINPID
# PIDFile=/run/keeper-tunnel.pid

# Inside keeper shell (--foreground is gracefully skipped):
# My Vault> pam tunnel start <UID> --port 5432 --foreground
# Note: --foreground is not needed inside the interactive shell.
# The tunnel is already running. Use 'pam tunnel list' / 'pam tunnel stop'.
```

## Testing

- [x] **Parser: `--foreground` accepted** -- argument parser recognizes the flag
- [x] **Parser: `-fg` shorthand accepted** -- short form works
- [x] **Parser: defaults to `False`** -- without the flag, `foreground` is `False`
- [x] **Parser: `--pid-file` accepted** -- argument parser recognizes the flag
- [x] **Parser: `--pid-file` defaults to `None`** -- without the flag, `pid_file` is `None`
- [x] **Parser: `--run` accepted** -- argument parser recognizes the flag, stores string value
- [x] **Parser: `--run` defaults to `None`** -- without the flag, `run_command` is `None`
- [x] **Parser: `--run` with `--port`** -- `--run` and `--port` work together
- [x] **Parser: `--timeout` accepted** -- argument parser recognizes the flag, stores int value
- [x] **Parser: `--timeout` defaults to 30** -- without the flag, `connect_timeout` is `30`
- [x] **Parser: `--timeout` custom value** -- `--timeout 120` sets `connect_timeout` to `120`
- [x] **Parser: `--background` accepted** -- argument parser recognizes the flag
- [x] **Parser: `-bg` shorthand accepted** -- short form works
- [x] **Parser: `--background` defaults to `False`** -- without the flag, `background` is `False`
- [x] **Parser: `--background` with `--pid-file`** -- both flags work together
- [x] **Parser: compatible with existing args** -- `--host`, `--port`, `--no-trickle-ice`, `--target-host`, `--target-port` all work alongside new flags
- [x] **Import: `unregister_tunnel_session`** -- importable from `tunnel_and_connections`
- [x] **Import: `_stop_tunnel_process`** -- importable from `tunnel_and_connections`
- [x] **Parser: mutual exclusivity** -- `--foreground`, `--background`, `--run` all parse individually but runtime rejects combinations
- [ ] **Integration: tunnel persists** -- tunnel stays alive in single-command mode when `--foreground` is set
- [ ] **Integration: `--run` executes and exits** -- tunnel starts, command runs, tunnel stops, exit code propagated
- [x] **Registry: tunnels registered on connect** -- JSON metadata written to `<tempdir>/keeper-tunnel-sessions/`
- [x] **Registry: tunnels unregistered on cleanup** -- JSON file removed on shutdown
- [x] **Registry: stale PID cleanup** -- dead PIDs auto-cleaned on `tunnel list`
- [ ] **Integration: `tunnel list` shows cross-process tunnels** -- tunnels visible from any Commander session
- [ ] **Integration: `tunnel stop` stops cross-process tunnels** -- sends SIGTERM to owning process
- [ ] **Integration: `--background` daemonizes and returns** -- tunnel starts, waits, daemonizes, returns prompt
- [ ] **Integration: `--foreground` waits for connection** -- status banner only prints after WebRTC connection is established
- [ ] **Integration: SIGTERM stops cleanly** -- `kill -SIGTERM` triggers `close_tube()` and process exits 0
- [ ] **Integration: Ctrl+C stops cleanly** -- `KeyboardInterrupt` triggers the same clean shutdown
- [ ] **Integration: PID file written and cleaned up** -- file created on start, removed on stop
- [ ] **Integration: interactive shell skip** -- `--foreground` inside `keeper shell` prints info message, does not block
- [ ] **Integration: batch mode error** -- missing `--target-host`/`--target-port` in batch mode raises `CommandError`
- [ ] **Backward compat: without flag** -- behavior is identical to current master when new flags are not used
- [ ] **systemd: works as service** -- `Type=simple` systemd unit starts, runs, and stops cleanly

## Backward Compatibility

- All new flags (`--foreground`, `--pid-file`, `--run`, `--timeout`, `--background`) are **optional** and default to `False`/`None`/`None`/`30`/`False`
- When not set, the `execute()` method follows the **exact same code path** as before (the replaced `pass` was a no-op)
- The batch mode error for missing `--target-host`/`--target-port` only triggers when `params.batch_mode` is `True` and the resource requires host/port supply -- interactive shell users still get the `input()` prompt
- No changes to the argument parser's existing arguments
- `PAMTunnelListCommand` and `PAMTunnelStopCommand` are enhanced to read the file-based registry but continue to work identically for in-process tunnels
- No changes to `PAMTunnelEditCommand`, `PAMTunnelDiagnoseCommand`, or any other command
- No new external dependencies; only `json`, `signal`, `subprocess`, `threading`, `time` from stdlib
- No changes to the `PAMTunnelCommand` group command registration
- `--foreground`, `--background`, and `--run` are mutually exclusive (enforced at runtime)
