### PR TITLE
Fix: EPM policy can not be created without name and mandatory fields.

### DIFF
--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1335,7 +1335,7 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         parser.add_argument('--policy-type', dest='policy_type', action='store', default='elevation',
                             choices=['elevation', 'file_access', 'command', 'least_privilege'],
                             help='Policy type')
-        parser.add_argument('--policy-name', dest='policy_name', action='store',
+        parser.add_argument('--policy-name', dest='policy_name', action='store', required=True,
                             help='Policy name')
         parser.add_argument('--control', dest='control', action='append',
                             choices=['allow', 'deny', 'audit', 'notify', 'mfa', 'justify', 'approval'],
@@ -1431,6 +1431,14 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         policy_filter = PedmPolicyMixin.get_policy_filter(plugin, **kwargs)
         if policy_filter:
             policy_data.update(policy_filter)
+
+        if policy_type in ('PrivilegeElevation', 'FileAccess', 'CommandLine'):
+            missing = [name for name, key in (('user', 'UserCheck'), ('machine', 'MachineCheck'), ('application', 'ApplicationCheck'))
+                       if not policy_filter.get(key)]
+            if missing:
+                raise base.CommandError(
+                    f'At least one machine, application, and user collection required to save this policy type. '
+                    f'Missing: {", ".join(missing)}. Use --user-filter, --machine-filter, --app-filter.')
 
         for filter_name in ('UserCheck', 'MachineCheck', 'ApplicationCheck', 'DateCheck', 'TimeCheck', 'DayCheck'):
             f = policy_data.get(filter_name)


### PR DESCRIPTION
### Summary
Two bug fixes ensuring the Commander CLI matches Admin Console behaviour when creating EPM policies — one preventing silent creation of unnamed policies, and one enforcing mandatory collection filters for certain policy types.

### Changes

- Made --policy-name a required argument in PedmPolicyAddCommand to prevent policies from being silently created with an empty name.
- For policies of type elevation, file_access, or command, creating a policy now requires at least one user, machine, and application collection via --user-filter, --machine-filter, and --app-filter respectively, replicating Admin Console validation. LeastPrivilege policies remain unrestricted.