### PR TITLE
Service mode parser response and security improvements

### DIFF
--- a/keepercommander/commands/convert.py
+++ b/keepercommander/commands/convert.py
@@ -46,7 +46,7 @@ def register_command_info(aliases, command_info):
 
 convert_parser = argparse.ArgumentParser(prog='convert', description='Convert record(s) to use record types')
 convert_parser.add_argument(
-    '-t', '--record-type', '--record_type', dest='record_type', action='store', help='Convert to record type'
+    '-t', '--record-type', dest='record_type', action='store', help='Convert to record type (default: login)'
 )
 convert_parser.add_argument(
     '-q', '--quiet', dest='quiet', action='store_true', help="Don't display info about records matched and converted"
@@ -79,7 +79,7 @@ convert_all_parser = argparse.ArgumentParser(
     description='Convert all legacy General records in the vault to a typed record format'
 )
 convert_all_parser.add_argument(
-    '-t', '--record-type', '--record_type', dest='record_type', action='store',
+    '-t', '--record-type', dest='record_type', action='store',
     help='Target record type (default: login)'
 )
 convert_all_parser.add_argument(

--- a/keepercommander/service/app.py
+++ b/keepercommander/service/app.py
@@ -12,7 +12,8 @@
 from flask import Flask
 import logging
 from werkzeug.middleware.proxy_fix import ProxyFix
-from .decorators.security import limiter
+from .decorators.security import limiter, is_behind_proxy
+from .decorators.api_logging import SSLHandshakeFilter
 from .api.routes import init_routes
 from .decorators.logging import logger
 
@@ -21,35 +22,25 @@ def create_app():
     """Create and configure the Keeper Commander Service."""
     logger.debug("Initializing Keeper Commander Service")
 
-    # Custom logging filter to replace SSL handshake errors with user-friendly message
-    class SSLHandshakeFilter(logging.Filter):
-        def filter(self, record):
-            # Replace "Bad request version" errors with a clearer message
-            if hasattr(record, 'getMessage'):
-                message = record.getMessage()
-                if "Bad request version" in message and any(ord(c) > 127 for c in message):
-                    # Replace the ugly SSL handshake error with a user-friendly message
-                    record.msg = "HTTPS request received but HTTPS protocol is not enabled on this service"
-                    record.args = ()
-            return True
-    
     log = logging.getLogger('werkzeug')
     log.setLevel(logging.ERROR)
     log.addFilter(SSLHandshakeFilter())
     
     app = Flask(__name__)
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1, x_prefix=1)
-    
+
+    if is_behind_proxy():
+        app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+
     try:
         logger.debug("Configuring rate limiter")
         limiter.init_app(app)
-        
+
         logger.debug("Initializing API routes")
         init_routes(app)
-        
+
         print("Keeper Commander Service initialization complete")
         return app
-        
+
     except Exception as e:
         logger.error(f"Failed to initialize Keeper Commander Service: {str(e)}")
         raise

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -97,7 +97,7 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
         return f'keeper-service-{self.get_integration_name().lower()}'
 
     def get_service_commands(self) -> str:
-        return 'search,share-record,share-folder,record-add,one-time-share,epm,pedm,device-approve,get,server'
+        return 'search,share-record,share-folder,share-report,record-add,one-time-share,epm,pedm,device-approve,get,tree,server'
 
     # -- Parser (auto-built from name, cached per subclass) ----------
 

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -86,11 +86,11 @@ class ServiceManager:
             
             if queue_enabled == "y":
                 print(
-                    f"Commander Service starting on {protocol}://localhost:{port}/api/v2/ "
-                    f"(legacy sync compatibility available at {protocol}://localhost:{port}/api/v1/executecommand)"
+                    f"Commander Service (async) is starting on \033[1m{protocol}://localhost:{port}/api/v2/executecommand-async\033[0m\n"
+                    f"Legacy (sync) compatibility is available at \033[1m{protocol}://localhost:{port}/api/v1/executecommand\033[0m"
                 )
             else:
-                print(f"Commander Service starting on {protocol}://localhost:{port}/api/v1/")
+                print(f"Commander Service starting on \033[1m{protocol}://localhost:{port}/api/v1/executecommand\033[0m")
             
             ngrok_pid = NgrokConfigurator.configure_ngrok(config_data, service_config)
             cloudflare_pid = None

--- a/keepercommander/service/decorators/api_logging.py
+++ b/keepercommander/service/decorators/api_logging.py
@@ -9,12 +9,24 @@
 # Contact: ops@keepersecurity.com
 #
 
+import logging
 from functools import wraps
 from typing import Callable, Any
 from flask import request
 import time
 import re
 from .logging import logger
+
+
+class SSLHandshakeFilter(logging.Filter):
+    """Replace cryptic SSL handshake errors with a user-friendly message."""
+    def filter(self, record):
+        if hasattr(record, 'getMessage'):
+            message = record.getMessage()
+            if "Bad request version" in message and any(ord(c) > 127 for c in message):
+                record.msg = "HTTPS request received but HTTPS protocol is not enabled on this service"
+                record.args = ()
+        return True
 
 def sanitize_password_in_command(data):
     """Sanitize password values in command string and filedata"""

--- a/keepercommander/service/decorators/auth.py
+++ b/keepercommander/service/decorators/auth.py
@@ -9,6 +9,7 @@
 # Contact: ops@keepersecurity.com
 #
 
+import hmac
 from functools import wraps
 from flask import request
 from datetime import datetime
@@ -28,7 +29,7 @@ def auth_check(fn):
             }, 401
 
         stored_key = ConfigReader.read_config('api-key', api_key)
-        if not stored_key or api_key.strip() != stored_key.strip():
+        if not stored_key or not hmac.compare_digest(api_key.strip(), stored_key.strip()):
             return {
                 'status': 'error',
                 'error': 'Please provide a valid api key'

--- a/keepercommander/service/decorators/security.py
+++ b/keepercommander/service/decorators/security.py
@@ -24,58 +24,47 @@ limiter = Limiter(
 )
     
 def is_allowed_ip(ip_addr, allowed_ips_str, denied_ips_str):
-    """Check if the given IP address is blocked."""
-    logger.debug(f"allowed_ips_str :{allowed_ips_str}")
-    logger.debug(f"denied_ips_str : {denied_ips_str}")
-    logger.debug(f"requested ip_addr : {ip_addr}")
-    
-    ip_allow_list = allowed_ips_str.split(',') if allowed_ips_str else []
-    ip_deny_list = denied_ips_str.split(',') if denied_ips_str else []
-    try:
-        # Check if the IP is in the allow list first
-        if ip_allow_list:
-            for allow_ip in ip_allow_list:
-                if is_ip_in_range(ip_addr, allow_ip.strip()):
-                    return True  # IP allowed
-        # If ip_allow is empty, skip this check
-        elif not ip_allow_list:
-         # If ip_allow is empty, deny if IP is in deny list
-            for deny_ip in ip_deny_list:
-                if is_ip_in_range(ip_addr, deny_ip.strip()):
-                    return False  # IP denied
-        # If ip_allow is empty and ip_deny is not empty, check if IP is in deny list
-        if ip_deny_list:
-            for deny_ip in ip_deny_list:
-                if is_ip_in_range(ip_addr, deny_ip.strip()):
-                    return False  # IP denied
-                
-        ip_addr = ipaddress.ip_address(ip_addr)
-    except ValueError:
+    """Check if the given IP address is allowed based on allow/deny lists.
+
+    Rules:
+    - No lists configured → allow all
+    - Deny list only → allow unless explicitly denied
+    - Allow list (with or without deny list) → must be in allow list AND not in deny list
+    """
+    logger.debug(f"allowed_ips_str: {allowed_ips_str}")
+    logger.debug(f"denied_ips_str: {denied_ips_str}")
+    logger.debug(f"requested ip_addr: {ip_addr}")
+
+    allow_list = [ip.strip() for ip in allowed_ips_str.split(',') if ip.strip()] if allowed_ips_str else []
+    deny_list = [ip.strip() for ip in denied_ips_str.split(',') if ip.strip()] if denied_ips_str else []
+
+    if not allow_list and not deny_list:
         return True
 
-    for allowed in allowed_ips_str.split(','):
-        allowed = allowed.strip()
-        try:
-            if ipaddress.ip_address(allowed) == ip_addr:
-                return True
-        except ValueError:
-            try:
-                network = ipaddress.ip_network(allowed, strict=False)
-                if ip_addr in network:
-                    return True
-            except ValueError:
-                continue
-    return False
-
-def is_ip_in_range(ip, ip_range):
     try:
-        # For IP range like 10.10.1.1-10.10.1.255
-        if '-' in ip_range:
-            start_ip, end_ip = ip_range.split('-')
-            return ipaddress.IPv4Address(start_ip) <= ipaddress.IPv4Address(ip) <= ipaddress.IPv4Address(end_ip)
-        else:
-            # For single IP address
-            return ip == ip_range
+        parsed_ip = ipaddress.ip_address(ip_addr)
+    except ValueError:
+        logger.warning(f"Failed to parse IP address: {ip_addr}")
+        return False
+
+    if any(_ip_matches(parsed_ip, entry) for entry in deny_list):
+        return False
+
+    if allow_list:
+        return any(_ip_matches(parsed_ip, entry) for entry in allow_list)
+
+    return True
+
+
+def _ip_matches(parsed_ip, pattern):
+    """Check if a parsed IP matches a pattern (single IP, CIDR network, or dash-range)."""
+    try:
+        if '-' in pattern:
+            start_str, end_str = pattern.split('-', 1)
+            return ipaddress.ip_address(start_str.strip()) <= parsed_ip <= ipaddress.ip_address(end_str.strip())
+        if '/' in pattern:
+            return parsed_ip in ipaddress.ip_network(pattern, strict=False)
+        return parsed_ip == ipaddress.ip_address(pattern)
     except ValueError:
         return False
     
@@ -86,6 +75,17 @@ def get_rate_limit():
 def get_rate_limit_key():
     """Generate rate limit key per IP + endpoint for separate limits per endpoint"""
     return f"{get_remote_address()}:{request.endpoint}"
+
+def is_behind_proxy():
+    """Check if the service is configured behind a reverse proxy (ngrok/cloudflare)."""
+    try:
+        return bool(
+            ConfigReader.read_config('ngrok_public_url')
+            or ConfigReader.read_config('cloudflare_public_url')
+        )
+    except Exception:
+        return False
+
 
 def security_check(fn):
     @wraps(fn)

--- a/keepercommander/service/util/command_util.py
+++ b/keepercommander/service/util/command_util.py
@@ -142,8 +142,6 @@ class CommandExecutor:
             logger.debug(f"After capture_output - return_value: '{return_value}', printed_output: '{sanitized_output}', log_output: '{sanitized_logs}'")
             sanitized_response = sanitize_debug_data(str(response))
             logger.debug(f"Final response: '{sanitized_response}', response type: {type(response)}")
-
-            cli.do_command(params, 'sync-down')
             
             # Always let the parser handle the response (including empty responses and logs)
             response = parse_keeper_response(command, response, log_output)

--- a/keepercommander/service/util/parse_keeper_response.py
+++ b/keepercommander/service/util/parse_keeper_response.py
@@ -9,7 +9,7 @@
 # Contact: ops@keepersecurity.com
 #
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 import re, json
 
 class KeeperResponseParser:
@@ -221,6 +221,56 @@ class KeeperResponseParser:
         return result
 
     @staticmethod
+    def _parse_share_bracket_list(
+        bracket_blob: str, target_key: str = "username"
+    ) -> List[Dict[str, Any]]:
+        """Parse comma-separated [target:perm1,perm2] segments from tree share lines."""
+        entries: List[Dict[str, Any]] = []
+        if not bracket_blob or not bracket_blob.strip():
+            return entries
+        for target, perms_str in re.findall(r'\[([^:]+):([^\]]+)\]', bracket_blob):
+            codes = [p.strip() for p in perms_str.split(',') if p.strip()]
+            entries.append({
+                target_key: target.strip(),
+                "permissions": ",".join(codes),
+            })
+        return entries
+
+    @staticmethod
+    def _parse_tree_share_permissions(name: str) -> Optional[Dict[str, Any]]:
+        """
+        Parse shared-folder permission suffix from a tree line into structured fields.
+
+        CLI format (from folder.formatted_tree): (default:...; user:...; teams:...; users:...)
+        """
+        # Ordered segments from folder.py: default, user, optional teams, optional users
+        m = re.search(
+            r'\(default:([^;]+); user:([^;]+)(?:; teams:([^;]+))?(?:; users:([^)]+))?\)',
+            name,
+        )
+        if not m:
+            return None
+
+        default_val = m.group(1).strip()
+        user_val = m.group(2).strip()
+        teams_seg = (m.group(3) or "").strip()
+        users_seg = (m.group(4) or "").strip()
+
+        share_permissions: Dict[str, Any] = {
+            "default": default_val,
+            "user": user_val,
+        }
+        if teams_seg:
+            share_permissions["teams"] = KeeperResponseParser._parse_share_bracket_list(
+                teams_seg, target_key="name"
+            )
+        if users_seg:
+            share_permissions["users"] = KeeperResponseParser._parse_share_bracket_list(
+                users_seg, target_key="username"
+            )
+        return share_permissions
+
+    @staticmethod
     def _parse_tree_command(response: str) -> Dict[str, Any]:
         """Parse 'tree' command output into structured format."""
         result = {
@@ -307,13 +357,9 @@ class KeeperResponseParser:
                 uid = uid_match.group(1)
             
             # Extract share permissions if present (for -s flag)
-            share_permissions = None
-            perm_match = re.search(r'\(default:([^;]+); user:([^)]+)\)', name)
-            if perm_match:
-                share_permissions = {
-                    "default": perm_match.group(1),
-                    "user": perm_match.group(2)
-                }
+            share_permissions = (
+                KeeperResponseParser._parse_tree_share_permissions(name) if is_shared else None
+            )
             
             # Clean the name from all indicators
             clean_name = name

--- a/unit-tests/service/test_response_parser.py
+++ b/unit-tests/service/test_response_parser.py
@@ -1,6 +1,5 @@
 import sys
 if sys.version_info >= (3, 8):
-  import pytest
   from unittest import TestCase
   from keepercommander.service.util.parse_keeper_response import KeeperResponseParser
 
@@ -48,6 +47,29 @@ if sys.version_info >= (3, 8):
           self.assertEqual(result['data']['tree'][1]['level'], 0)
           self.assertEqual(result['data']['tree'][1]['name'], 'Folder1')
           self.assertEqual(result['data']['tree'][1]['path'], 'Folder1')
+
+      def test_parse_tree_command_share_permissions_structured(self):
+          """tree -s -v: share_permissions splits default/user vs per-user list"""
+          sample_output = """Share Permissions Key:
+======================
+RO = Read-Only
+MU = Can Manage Users
+======================
+My Vault
+ └── Shared Folder (abc123) [SHARED] (default:CE; user:CE; users:[a@x.com:RO],[b@y.com:MU,MR])
+"""
+          result = KeeperResponseParser._parse_tree_command(sample_output)
+          self.assertEqual(result['data']['share_permissions_key'][:2], ['RO = Read-Only', 'MU = Can Manage Users'])
+          entry = result['data']['tree'][0]
+          self.assertTrue(entry['shared'])
+          sp = entry['share_permissions']
+          self.assertEqual(sp['default'], 'CE')
+          self.assertEqual(sp['user'], 'CE')
+          self.assertEqual(len(sp['users']), 2)
+          self.assertEqual(sp['users'][0]['username'], 'a@x.com')
+          self.assertEqual(sp['users'][0]['permissions'], 'RO')
+          self.assertEqual(sp['users'][1]['username'], 'b@y.com')
+          self.assertEqual(sp['users'][1]['permissions'], 'MU,MR')
 
       def test_parse_mkdir_command(self):
           """Test parsing of 'mkdir' command output"""


### PR DESCRIPTION
## Summary
- Improve `tree -s -v` response parsing to correctly handle teams and users in shared folder permissions
- Improve service mode security: API key comparison, refactored IP allow/deny logic with proper CIDR and range support, and conditional `ProxyFix` only when behind a reverse proxy (ngrok/cloudflare)

## Changes
- Use `hmac.compare_digest` for API key validation
- Rewrite `is_allowed_ip` with clear deny-first logic, CIDR network support, and strict IP parsing
- Apply `ProxyFix` only when behind a proxy;
- Structured parsing for tree share permissions (teams/users brackets)
- Add `share-report` and `tree` to integration service commands