### PR TITLE
Feature/concurrent v1 v2 service mode

### DIFF
--- a/keepercommander/service/README.md
+++ b/keepercommander/service/README.md
@@ -118,9 +118,9 @@ My Vault> service-stop
 
 ### API Versioning
 
-The service provides two API versions based on queue configuration:
-- **`/api/v2/`** - Queue enabled (default): Asynchronous request processing with enhanced features
-- **`/api/v1/`** - Queue disabled (legacy): Direct synchronous execution 
+The service exposes different endpoints depending on queue configuration:
+- **Queue enabled (`queue_enabled: y`, default)**: `/api/v2/` is available for asynchronous request processing, and `/api/v1/executecommand` remains available as a synchronous compatibility endpoint backed by the same queue worker.
+- **Queue disabled (`queue_enabled: n`)**: `/api/v1/` runs in standalone legacy mode with direct synchronous execution only.
 
 ### Request Queue System
 
@@ -785,7 +785,7 @@ docker run -d -p <port>:<port> \
 ### Execute Command Endpoint
 
    ```bash
-   # Queue enabled (v2 - async)
+   # Queue enabled: native v2 async endpoint
    curl --location 'http://localhost:<port>/api/v2/executecommand-async' \
    --header 'Content-Type: application/json' \
    --header 'api-key: <your-api-key>' \
@@ -793,7 +793,7 @@ docker run -d -p <port>:<port> \
       "command": "<command>"
    }'
    
-   # Queue disabled (v1 - direct)  
+   # Queue enabled or disabled: v1 synchronous endpoint
    curl --location 'http://localhost:<port>/api/v1/executecommand' \
    --header 'Content-Type: application/json' \
    --header 'api-key: <your-api-key>' \

--- a/keepercommander/service/api/command.py
+++ b/keepercommander/service/api/command.py
@@ -18,8 +18,55 @@ from ..decorators.logging import logger
 from ..core.request_queue import queue_manager
 from ..util.request_validation import RequestValidator
 
-def create_legacy_command_blueprint():
-    """Create legacy blueprint for direct/synchronous command execution (non-queue mode)."""
+
+def _prepare_command_request():
+    """Validate the request body and build the command to execute."""
+    json_error = RequestValidator.validate_request_json()
+    if json_error:
+        return None, [], json_error
+
+    command, validation_error = RequestValidator.validate_and_escape_command(request.json)
+    if validation_error:
+        return None, [], validation_error
+
+    processed_command, temp_files = RequestValidator.process_file_data(request.json, command)
+    return processed_command, temp_files, None
+
+
+def _submit_queue_request(processed_command: str, temp_files: list, wait_for_completion: bool):
+    """Submit a request to the queue, optionally waiting for the result."""
+    request_submitted = False
+    try:
+        request_id = queue_manager.submit_request(processed_command, temp_files)
+        request_submitted = True
+    except queue.Full:
+        RequestValidator.cleanup_temp_files(temp_files)
+        return (jsonify({
+            "status": "error",
+            "error": "Error: Request queue is full. Please try again later."
+        }), 503), False
+
+    if wait_for_completion:
+        result_data = queue_manager.wait_for_result(request_id)
+        if result_data is None:
+            return (jsonify({
+                "status": "error",
+                "error": "Error: Request not found after submission"
+            }), 500), request_submitted
+
+        response, status_code = result_data
+        return (response if isinstance(response, bytes) else jsonify(response), status_code), request_submitted
+
+    return (jsonify({
+        "success": True,
+        "request_id": request_id,
+        "status": "queued",
+        "message": "Request queued successfully. Use /api/v2/status/<request_id> to check progress, /api/v2/result/<request_id> to get results, or /api/v2/queue/status for queue info."
+    }), 202), request_submitted
+
+
+def create_legacy_command_blueprint(use_queue: bool = False):
+    """Create legacy blueprint for synchronous command execution."""
     bp = Blueprint("legacy_command_bp", __name__)
     
     @bp.after_request
@@ -31,24 +78,24 @@ def create_legacy_command_blueprint():
     @bp.route("/executecommand", methods=["POST"])
     @unified_api_decorator()
     def execute_command_direct(**kwargs) -> Tuple[Union[Response, bytes], int]:
-        """Execute command directly and return result immediately (V1 API behavior)."""
+        """Execute a command immediately, optionally via the v2 request queue."""
         temp_files = []
+        queued_request_submitted = False
         try:
-            json_error = RequestValidator.validate_request_json()
-            if json_error:
-                return json_error
-            
-            command, validation_error = RequestValidator.validate_and_escape_command(request.json)
-            if validation_error:
-                return validation_error
-            
-            # Process file data if present
-            processed_command, temp_files = RequestValidator.process_file_data(request.json, command)
-                
+            processed_command, temp_files, request_error = _prepare_command_request()
+            if request_error:
+                return request_error
+
+            if use_queue:
+                response_data, queued_request_submitted = _submit_queue_request(
+                    processed_command, temp_files, wait_for_completion=True
+                )
+                return response_data
+
             response, status_code = CommandExecutor.execute(processed_command)
-            
+
             # If we get a busy response, add v1-specific message
-            if (isinstance(response, dict) and 
+            if (isinstance(response, dict) and
                 "temporarily busy" in str(response.get("error", "")).lower()):
                 response["message"] = "Note: api/v1/executecommand only supports a single request at a time."
                 status_code = 503
@@ -59,8 +106,9 @@ def create_legacy_command_blueprint():
             logger.error(f"Error executing command: {e}")
             return jsonify({"status": "error", "error": f"Error: {str(e)}"}), 500
         finally:
-            # Clean up temporary files
-            RequestValidator.cleanup_temp_files(temp_files)
+            # Queue-backed compatibility requests clean up files in the worker after submission.
+            if not use_queue or not queued_request_submitted:
+                RequestValidator.cleanup_temp_files(temp_files)
 
     return bp
 
@@ -74,37 +122,14 @@ def create_command_blueprint():
         """Submit a command for execution and return request ID immediately."""
         temp_files = []
         try:
-            json_error = RequestValidator.validate_request_json()
-            if json_error:
-                return json_error
-            
-            command, validation_error = RequestValidator.validate_and_escape_command(request.json)
-            if validation_error:
-                return validation_error
-            
-            # Process file data if present
-            processed_command, temp_files = RequestValidator.process_file_data(request.json, command)
-            
-            # Submit to queue and return request ID immediately
-            try:
-                request_id = queue_manager.submit_request(processed_command, temp_files)
-                return jsonify({
-                    "success": True,
-                    "request_id": request_id,
-                    "status": "queued",
-                    "message": "Request queued successfully. Use /api/v2/status/<request_id> to check progress, /api/v2/result/<request_id> to get results, or /api/v2/queue/status for queue info."
-                }), 202  # 202 Accepted
-            except queue.Full:
-                # Clean up temp files if queue is full
-                RequestValidator.cleanup_temp_files(temp_files)
-                return jsonify({
-                    "status": "error", 
-                    "error": "Error: Request queue is full. Please try again later."
-                }), 503  # 503 Service Unavailable
-                
+            processed_command, temp_files, request_error = _prepare_command_request()
+            if request_error:
+                return request_error
+
+            response_data, _ = _submit_queue_request(processed_command, temp_files, wait_for_completion=False)
+            return response_data
         except Exception as e:
             logger.error(f"Error submitting request: {e}")
-            # Clean up temp files on error
             RequestValidator.cleanup_temp_files(temp_files)
             return jsonify({"status": "error", "error": f"{str(e)}"}), 500
 

--- a/keepercommander/service/api/routes.py
+++ b/keepercommander/service/api/routes.py
@@ -16,22 +16,25 @@ from .onboarding import create_onboarding_blueprint
 from ..decorators.logging import logger, debug_decorator
 
 def _setup_queue_mode(app: Flask) -> None:
-    """Setup queue mode with v2 API endpoints."""
+    """Setup queue mode with native v2 and synchronous v1 compatibility endpoints."""
     from ..core.request_queue import queue_manager
     queue_manager.start()
 
     command_bp = create_command_blueprint()
     app.register_blueprint(command_bp, url_prefix='/api/v2')
 
+    legacy_bp = create_legacy_command_blueprint(use_queue=True)
+    app.register_blueprint(legacy_bp, url_prefix='/api/v1')
+
     # Register onboarding endpoints
     onboarding_bp = create_onboarding_blueprint()
     app.register_blueprint(onboarding_bp, url_prefix='/api/v2')
 
-    logger.debug("Started queue manager and registered command blueprint with URL prefix '/api/v2'")
+    logger.debug("Started queue manager and registered /api/v2 plus synchronous /api/v1 compatibility endpoints")
 
 def _setup_legacy_mode(app: Flask) -> None:
     """Setup legacy mode with v1 API endpoints."""
-    legacy_bp = create_legacy_command_blueprint()
+    legacy_bp = create_legacy_command_blueprint(use_queue=False)
     app.register_blueprint(legacy_bp, url_prefix='/api/v1')
     logger.info("Using /api/v1 - Enable queue mode (-q y) for /api/v2")
 
@@ -56,7 +59,7 @@ def init_routes(app: Optional[Flask] = None) -> None:
         queue_enabled = config_data.get("queue_enabled", "y")  # Default to enabled
         
         if queue_enabled == "y":
-            logger.debug("Queue enabled - setting up v2 API with request queue")
+            logger.debug("Queue enabled - setting up v2 API with request queue and v1 compatibility")
             _setup_queue_mode(app)
         else:
             logger.debug("Queue disabled - setting up v1 API with direct execution")

--- a/keepercommander/service/core/request_queue.py
+++ b/keepercommander/service/core/request_queue.py
@@ -192,6 +192,10 @@ class RequestQueueManager:
                     return request.result, status_code
                 elif request.status == RequestStatus.FAILED:
                     return {"error": request.error_message}, 500
+                elif request.status == RequestStatus.EXPIRED:
+                    return {
+                        "error": request.error_message or "Error: Request expired before execution"
+                    }, 504
             return None
 
     @debug_decorator
@@ -219,16 +223,48 @@ class RequestQueueManager:
             if status_info.get("status") == RequestStatus.EXPIRED.value:
                 return {
                     "status": "error",
-                    "error": "Error: Request timed out while waiting for result"
+                    "error": status_info.get("error_message") or "Error: Request timed out while waiting for result"
                 }, 504
 
             if time.monotonic() >= deadline:
+                if status_info.get("status") == RequestStatus.QUEUED.value:
+                    error_message = "Error: Request expired before execution while waiting for result"
+                    if self._expire_queued_request(request_id, error_message):
+                        return {
+                            "status": "error",
+                            "error": error_message
+                        }, 504
+
                 return {
                     "status": "error",
                     "error": "Error: Request did not complete within the synchronous wait window"
                 }, 504
 
             time.sleep(DEFAULT_SYNC_WAIT_POLL_INTERVAL)
+
+    def _expire_queued_request(self, request_id: str, error_message: str) -> bool:
+        """Expire a queued request so the worker will not execute it later."""
+        from ..util.request_validation import RequestValidator
+
+        expired_request = None
+        with self.data_lock:
+            request = self.active_requests.get(request_id)
+            if request is None or request.status != RequestStatus.QUEUED:
+                return False
+
+            request.status = RequestStatus.EXPIRED
+            request.completed_at = datetime.now()
+            request.error_message = error_message
+            expired_request = request
+
+            del self.active_requests[request_id]
+            self.completed_requests[request_id] = request
+
+        if expired_request and expired_request.temp_files:
+            RequestValidator.cleanup_temp_files(expired_request.temp_files)
+
+        logger.warning(f"Request {request_id} expired before execution")
+        return True
     
     @debug_decorator
     def get_queue_status(self) -> Dict[str, Any]:
@@ -254,6 +290,10 @@ class RequestQueueManager:
             try:
                 # Get next request from queue (blocking with timeout)
                 request = self.request_queue.get(timeout=1.0)
+                if request.status == RequestStatus.EXPIRED:
+                    logger.info(f"Skipping expired request {request.request_id}")
+                    self.request_queue.task_done()
+                    continue
                 self._process_request(request)
                 self.request_queue.task_done()
                 
@@ -316,23 +356,22 @@ class RequestQueueManager:
     def _cleanup_expired_requests(self):
         """Clean up expired and old completed requests."""
         now = datetime.now()
-        
+
+        expired_ids = []
         with self.data_lock:
-            # Find expired active requests
-            expired_ids = []
             for request_id, request in self.active_requests.items():
                 if request.status == RequestStatus.QUEUED:
                     age = (now - request.created_at).total_seconds()
                     if age > self.request_timeout:
-                        request.status = RequestStatus.EXPIRED
                         expired_ids.append(request_id)
-            
-            # Move expired requests to completed
-            for request_id in expired_ids:
-                request = self.active_requests.pop(request_id)
-                self.completed_requests[request_id] = request
-                logger.warning(f"Request {request_id} expired after {self.request_timeout}s")
-            
+
+        for request_id in expired_ids:
+            self._expire_queued_request(
+                request_id,
+                f"Error: Request expired after waiting more than {self.request_timeout}s in queue"
+            )
+
+        with self.data_lock:
             # Clean up old completed requests
             cutoff_time = now - timedelta(seconds=self.result_retention)
             old_ids = []

--- a/keepercommander/service/core/request_queue.py
+++ b/keepercommander/service/core/request_queue.py
@@ -26,6 +26,7 @@ from ..decorators.logging import logger, debug_decorator
 DEFAULT_QUEUE_MAX_SIZE = 100
 DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes in seconds
 DEFAULT_RESULT_RETENTION = 3600  # 1 hour in seconds
+DEFAULT_SYNC_WAIT_POLL_INTERVAL = 0.1
 
 
 class RequestStatus(Enum):
@@ -192,6 +193,42 @@ class RequestQueueManager:
                 elif request.status == RequestStatus.FAILED:
                     return {"error": request.error_message}, 500
             return None
+
+    @debug_decorator
+    def wait_for_result(self, request_id: str, timeout: Optional[float] = None) -> Optional[Tuple[Any, int]]:
+        """Wait synchronously for a queued request result.
+
+        Args:
+            request_id: The unique request identifier
+            timeout: Maximum seconds to wait. Defaults to the queue request timeout.
+
+        Returns:
+            Tuple of (result, status_code), or None if the request vanished unexpectedly.
+        """
+        deadline = time.monotonic() + (timeout if timeout is not None else self.request_timeout)
+
+        while True:
+            result_data = self.get_request_result(request_id)
+            if result_data is not None:
+                return result_data
+
+            status_info = self.get_request_status(request_id)
+            if status_info is None:
+                return None
+
+            if status_info.get("status") == RequestStatus.EXPIRED.value:
+                return {
+                    "status": "error",
+                    "error": "Error: Request timed out while waiting for result"
+                }, 504
+
+            if time.monotonic() >= deadline:
+                return {
+                    "status": "error",
+                    "error": "Error: Request did not complete within the synchronous wait window"
+                }, 504
+
+            time.sleep(DEFAULT_SYNC_WAIT_POLL_INTERVAL)
     
     @debug_decorator
     def get_queue_status(self) -> Dict[str, Any]:

--- a/keepercommander/service/core/request_queue.py
+++ b/keepercommander/service/core/request_queue.py
@@ -204,7 +204,8 @@ class RequestQueueManager:
 
         Args:
             request_id: The unique request identifier
-            timeout: Maximum seconds to wait. Defaults to the queue request timeout.
+            timeout: Maximum seconds to wait while the request remains queued.
+                Once processing starts, continue waiting for completion.
 
         Returns:
             Tuple of (result, status_code), or None if the request vanished unexpectedly.
@@ -234,11 +235,11 @@ class RequestQueueManager:
                             "status": "error",
                             "error": error_message
                         }, 504
-
-                return {
-                    "status": "error",
-                    "error": "Error: Request did not complete within the synchronous wait window"
-                }, 504
+                if status_info.get("status") != RequestStatus.PROCESSING.value:
+                    return {
+                        "status": "error",
+                        "error": "Error: Request did not complete within the synchronous wait window"
+                    }, 504
 
             time.sleep(DEFAULT_SYNC_WAIT_POLL_INTERVAL)
 

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -79,13 +79,18 @@ class ServiceManager:
             
             is_running = True
             queue_enabled = config_data.get("queue_enabled", "y")
-            api_version = "v2" if queue_enabled == "y" else "v1"
             
             # Check if SSL is configured to determine the correct protocol
             ssl_context = cls.get_ssl_context(config_data)
             protocol = "https" if ssl_context else "http"
             
-            print(f"Commander Service starting on {protocol}://localhost:{port}/api/{api_version}/")
+            if queue_enabled == "y":
+                print(
+                    f"Commander Service starting on {protocol}://localhost:{port}/api/v2/ "
+                    f"(legacy sync compatibility available at {protocol}://localhost:{port}/api/v1/executecommand)"
+                )
+            else:
+                print(f"Commander Service starting on {protocol}://localhost:{port}/api/v1/")
             
             ngrok_pid = NgrokConfigurator.configure_ngrok(config_data, service_config)
             cloudflare_pid = None

--- a/unit-tests/service/test_api_routes.py
+++ b/unit-tests/service/test_api_routes.py
@@ -1,0 +1,77 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    import unittest
+    from unittest import mock
+    from flask import Blueprint, Flask
+
+    from keepercommander.service.api.command import create_command_blueprint, create_legacy_command_blueprint
+    from keepercommander.service.api.routes import init_routes
+
+
+    def passthrough_decorator():
+        def decorator(fn):
+            return fn
+        return decorator
+
+
+    class TestServiceApiRoutes(unittest.TestCase):
+        def test_queue_mode_registers_v1_and_v2_routes(self):
+            app = Flask(__name__)
+            onboarding_bp = Blueprint("test_onboarding", __name__)
+
+            with mock.patch('keepercommander.service.api.command.unified_api_decorator', passthrough_decorator), \
+                 mock.patch('keepercommander.service.api.routes.create_onboarding_blueprint', return_value=onboarding_bp), \
+                 mock.patch('keepercommander.service.core.request_queue.queue_manager.start') as mock_start, \
+                 mock.patch('keepercommander.service.config.service_config.ServiceConfig.load_config', return_value={"queue_enabled": "y"}):
+                init_routes(app)
+
+            routes = {rule.rule for rule in app.url_map.iter_rules()}
+            self.assertIn('/api/v1/executecommand', routes)
+            self.assertIn('/api/v2/executecommand-async', routes)
+            self.assertIn('/api/v2/status/<request_id>', routes)
+            self.assertIn('/api/v2/result/<request_id>', routes)
+            self.assertIn('/api/v2/queue/status', routes)
+            self.assertIn('/health', routes)
+            mock_start.assert_called_once()
+
+        def test_legacy_mode_registers_only_v1_route(self):
+            app = Flask(__name__)
+
+            with mock.patch('keepercommander.service.api.command.unified_api_decorator', passthrough_decorator), \
+                 mock.patch('keepercommander.service.config.service_config.ServiceConfig.load_config', return_value={"queue_enabled": "n"}):
+                init_routes(app)
+
+            routes = {rule.rule for rule in app.url_map.iter_rules()}
+            self.assertIn('/api/v1/executecommand', routes)
+            self.assertNotIn('/api/v2/executecommand-async', routes)
+
+        def test_v1_compatibility_route_waits_for_queue_result(self):
+            app = Flask(__name__)
+
+            with mock.patch('keepercommander.service.api.command.unified_api_decorator', passthrough_decorator), \
+                 mock.patch('keepercommander.service.api.command.queue_manager.submit_request', return_value='req-1') as mock_submit, \
+                 mock.patch('keepercommander.service.api.command.queue_manager.wait_for_result', return_value=({"status": "success", "data": {"command": "ls"}}, 200)) as mock_wait:
+                app.register_blueprint(create_legacy_command_blueprint(use_queue=True), url_prefix='/api/v1')
+                response = app.test_client().post('/api/v1/executecommand', json={"command": "ls"})
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.headers.get('X-API-Legacy'), 'true')
+            self.assertEqual(response.get_json(), {"status": "success", "data": {"command": "ls"}})
+            mock_submit.assert_called_once_with('ls', [])
+            mock_wait.assert_called_once_with('req-1')
+
+        def test_v1_direct_route_keeps_legacy_execution_path(self):
+            app = Flask(__name__)
+
+            with mock.patch('keepercommander.service.api.command.unified_api_decorator', passthrough_decorator), \
+                 mock.patch('keepercommander.service.api.command.CommandExecutor.execute', return_value=({"status": "success", "data": {"command": "ls"}}, 200)) as mock_execute, \
+                 mock.patch('keepercommander.service.api.command.queue_manager.submit_request') as mock_submit:
+                app.register_blueprint(create_legacy_command_blueprint(use_queue=False), url_prefix='/api/v1')
+                response = app.test_client().post('/api/v1/executecommand', json={"command": "ls"})
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.headers.get('X-API-Legacy'), 'true')
+            self.assertEqual(response.get_json(), {"status": "success", "data": {"command": "ls"}})
+            mock_execute.assert_called_once_with('ls')
+            mock_submit.assert_not_called()

--- a/unit-tests/service/test_queue_concurrency.py
+++ b/unit-tests/service/test_queue_concurrency.py
@@ -1,0 +1,186 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    import queue
+    import threading
+    import time
+    import unittest
+    from unittest import mock
+    from flask import Flask
+
+    from keepercommander.service.api.command import create_command_blueprint, create_legacy_command_blueprint
+    from keepercommander.service.core.request_queue import (
+        DEFAULT_QUEUE_MAX_SIZE,
+        DEFAULT_REQUEST_TIMEOUT,
+        DEFAULT_RESULT_RETENTION,
+        RequestQueueManager,
+    )
+
+
+    def passthrough_decorator():
+        def decorator(fn):
+            return fn
+        return decorator
+
+
+    class TestQueueConcurrency(unittest.TestCase):
+        def setUp(self):
+            self.manager = RequestQueueManager()
+            self._reset_manager()
+
+        def tearDown(self):
+            self._reset_manager()
+
+        def _reset_manager(self):
+            self.manager.stop()
+            self.manager.request_queue = queue.Queue(maxsize=DEFAULT_QUEUE_MAX_SIZE)
+            self.manager.active_requests = {}
+            self.manager.completed_requests = {}
+            self.manager.worker_thread = None
+            self.manager.is_running = False
+            self.manager.current_request_id = None
+            self.manager.request_timeout = DEFAULT_REQUEST_TIMEOUT
+            self.manager.result_retention = DEFAULT_RESULT_RETENTION
+
+        def _create_app(self, include_v2=False):
+            app = Flask(__name__)
+            with mock.patch('keepercommander.service.api.command.unified_api_decorator', passthrough_decorator):
+                app.register_blueprint(create_legacy_command_blueprint(use_queue=True), url_prefix='/api/v1')
+                if include_v2:
+                    app.register_blueprint(create_command_blueprint(), url_prefix='/api/v2')
+            return app
+
+        def test_queue_manager_serializes_concurrent_submissions(self):
+            state_lock = threading.Lock()
+            inflight = {"count": 0, "max": 0}
+            results = {}
+
+            def fake_execute(command):
+                with state_lock:
+                    inflight["count"] += 1
+                    inflight["max"] = max(inflight["max"], inflight["count"])
+
+                time.sleep(0.05)
+
+                with state_lock:
+                    inflight["count"] -= 1
+
+                return {"status": "success", "data": {"command": command}}, 200
+
+            with mock.patch('keepercommander.service.core.request_queue.CommandExecutor.execute', side_effect=fake_execute):
+                self.manager.start()
+
+                def submit_and_wait(index):
+                    request_id = self.manager.submit_request(f"cmd-{index}")
+                    results[index] = self.manager.wait_for_result(request_id, timeout=2)
+
+                threads = [threading.Thread(target=submit_and_wait, args=(i,)) for i in range(5)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            self.assertEqual(inflight["max"], 1)
+            self.assertEqual(len(results), 5)
+            for index in range(5):
+                payload, status_code = results[index]
+                self.assertEqual(status_code, 200)
+                self.assertEqual(payload["data"]["command"], f"cmd-{index}")
+
+        def test_v1_and_v2_share_single_queue_worker(self):
+            app = self._create_app(include_v2=True)
+            state_lock = threading.Lock()
+            inflight = {"count": 0, "max": 0}
+            outputs = {}
+            start_barrier = threading.Barrier(3)
+
+            def fake_execute(command):
+                with state_lock:
+                    inflight["count"] += 1
+                    inflight["max"] = max(inflight["max"], inflight["count"])
+
+                time.sleep(0.05)
+
+                with state_lock:
+                    inflight["count"] -= 1
+
+                return {"status": "success", "data": {"command": command}}, 200
+
+            with mock.patch('keepercommander.service.api.command.queue_manager', self.manager), \
+                 mock.patch('keepercommander.service.core.request_queue.CommandExecutor.execute', side_effect=fake_execute):
+                self.manager.start()
+
+                def call_v1():
+                    with app.test_client() as client:
+                        start_barrier.wait()
+                        response = client.post('/api/v1/executecommand', json={"command": "legacy-cmd"})
+                        outputs["v1"] = (response.status_code, response.get_json(), response.headers.get('X-API-Legacy'))
+
+                def call_v2():
+                    with app.test_client() as client:
+                        start_barrier.wait()
+                        response = client.post('/api/v2/executecommand-async', json={"command": "async-cmd"})
+                        response_data = response.get_json()
+                        outputs["v2_submit"] = (response.status_code, response_data)
+                        outputs["v2_result"] = self.manager.wait_for_result(response_data["request_id"], timeout=2)
+
+                v1_thread = threading.Thread(target=call_v1)
+                v2_thread = threading.Thread(target=call_v2)
+                v1_thread.start()
+                v2_thread.start()
+                start_barrier.wait()
+                v1_thread.join()
+                v2_thread.join()
+
+            self.assertEqual(inflight["max"], 1)
+            self.assertEqual(outputs["v1"][0], 200)
+            self.assertEqual(outputs["v1"][1]["data"]["command"], "legacy-cmd")
+            self.assertEqual(outputs["v1"][2], "true")
+            self.assertEqual(outputs["v2_submit"][0], 202)
+            self.assertEqual(outputs["v2_submit"][1]["status"], "queued")
+            self.assertEqual(outputs["v2_result"][1], 200)
+            self.assertEqual(outputs["v2_result"][0]["data"]["command"], "async-cmd")
+
+        def test_timed_out_v1_request_does_not_execute_after_expiration(self):
+            app = self._create_app(include_v2=False)
+            request_timeout = 0.1
+            self.manager.request_timeout = request_timeout
+
+            first_started = threading.Event()
+            release_first = threading.Event()
+            executed_commands = []
+            executed_lock = threading.Lock()
+
+            def fake_execute(command):
+                with executed_lock:
+                    executed_commands.append(command)
+
+                if command == "first":
+                    first_started.set()
+                    release_first.wait(timeout=2)
+
+                return {"status": "success", "data": {"command": command}}, 200
+
+            with mock.patch('keepercommander.service.api.command.queue_manager', self.manager), \
+                 mock.patch('keepercommander.service.core.request_queue.CommandExecutor.execute', side_effect=fake_execute):
+                self.manager.start()
+
+                def call_first():
+                    with app.test_client() as client:
+                        return client.post('/api/v1/executecommand', json={"command": "first"})
+
+                first_thread = threading.Thread(target=call_first)
+                first_thread.start()
+                self.assertTrue(first_started.wait(timeout=1))
+
+                with app.test_client() as client:
+                    second_response = client.post('/api/v1/executecommand', json={"command": "second"})
+
+                self.assertEqual(second_response.status_code, 504)
+
+                release_first.set()
+                first_thread.join()
+                time.sleep(request_timeout + 0.1)
+
+            self.assertIn("first", executed_commands)
+            self.assertNotIn("second", executed_commands)

--- a/unit-tests/service/test_queue_concurrency.py
+++ b/unit-tests/service/test_queue_concurrency.py
@@ -184,3 +184,26 @@ if sys.version_info >= (3, 8):
 
             self.assertIn("first", executed_commands)
             self.assertNotIn("second", executed_commands)
+
+        def test_processing_v1_request_waits_past_queue_timeout(self):
+            app = self._create_app(include_v2=False)
+            request_timeout = 0.1
+            self.manager.request_timeout = request_timeout
+
+            started_processing = threading.Event()
+
+            def fake_execute(command):
+                started_processing.set()
+                time.sleep(request_timeout + 0.15)
+                return {"status": "success", "data": {"command": command}}, 200
+
+            with mock.patch('keepercommander.service.api.command.queue_manager', self.manager), \
+                 mock.patch('keepercommander.service.core.request_queue.CommandExecutor.execute', side_effect=fake_execute):
+                self.manager.start()
+
+                with app.test_client() as client:
+                    response = client.post('/api/v1/executecommand', json={"command": "slow-command"})
+
+            self.assertTrue(started_processing.is_set())
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.get_json()["data"]["command"], "slow-command")


### PR DESCRIPTION
  ## Summary

  This changes Service Mode so queue-enabled deployments can serve both API versions concurrently:

  - `/api/v2/*` remains the native queue-backed API
  - `/api/v1/executecommand` is now available as a synchronous compatibility endpoint backed by the same queue worker
  - `queue_enabled = n` still preserves the original standalone direct `v1` behavior

  This lets existing `v1` integrations continue working while newer `v2` clients use queue mode in the same service instance.

  ## Problem

  Historically Service Mode exposed either:

  - `v1` direct mode, or
  - `v2` queue mode

  but not both at the same time.

  That made queue-enabled deployments harder to adopt when existing consumers still depended on `v1`.

  During local concurrency testing, this branch also uncovered and fixes a race where a queued `v1` compatibility request could return `504` to the caller and still execute later once the worker reached it.

  ## Changes

  - Register `/api/v1/executecommand` alongside `/api/v2/*` when queue mode is enabled
  - Route queue-enabled `v1` requests through the same request queue used by `v2`
  - Keep legacy direct execution unchanged when `queue_enabled = n`
  - Share request validation / filedata preparation logic between `v1` compatibility and `v2`
  - Add synchronous waiting support for queued compatibility requests
  - Expire timed-out queued `v1` compatibility requests before execution
  - Skip expired queued requests in the worker so late execution cannot occur
  - Update service startup messaging and README to describe the new behavior

  ## Testing

  Ran locally without logging into Keeper:

  - `python3 -m unittest -q unit-tests.service.test_api_routes`
  - `python3 -m unittest -q unit-tests.service.test_queue_concurrency`
  - `python3 -m unittest -q unit-tests.service.test_service_manager unit-tests.service.test_service_config unit-tests.service.test_create_service unit-tests.service.test_config_operation`

  Added coverage for:

  - queue-enabled route registration exposing both `v1` and `v2`
  - queue-disabled route registration preserving standalone `v1`
  - queue-backed synchronous `v1` compatibility behavior
  - concurrent `v1` and `v2` requests sharing a single worker
  - timeout/race handling so expired queued `v1` requests do not execute later