### PR TITLE
Add support for importing stringified JSON

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -463,9 +463,6 @@ class ApplyMembershipCommand(Command):
 
     def execute(self, params, **kwargs):
         file_name = kwargs.get('name') or 'shared_folder_membership.json'
-        if not os.path.exists(file_name):
-            logging.warning('Shared folder membership file "%s" not found', file_name)
-            return
 
         shared_folders = []  # type: List[SharedFolder]
         teams = []     # type: List[Team]

--- a/keepercommander/importer/importer.py
+++ b/keepercommander/importer/importer.py
@@ -400,15 +400,18 @@ class BaseFileImporter(BaseImporter, abc.ABC):
 
     def execute(self, name, **kwargs):
         # type: (str, ...) -> Iterable[Union[Record, SharedFolder, File]]
+        try:
+            json.loads(name)
+            path = name
+        except ValueError as e:    
+            path = os.path.expanduser(name)
+            if not os.path.isfile(path):
+                ext = self.extension()
+                if ext:
+                    path = path + '.' + ext
 
-        path = os.path.expanduser(name)
-        if not os.path.isfile(path):
-            ext = self.extension()
-            if ext:
-                path = path + '.' + ext
-
-        if not os.path.isfile(path):
-            raise CommandError('import', f'File \'{name}\' does not exist')
+            if not os.path.isfile(path):
+                raise CommandError('import', f'File \'{name}\' does not exist')
 
         yield from self.do_import(path, **kwargs)
 

--- a/keepercommander/importer/json/json.py
+++ b/keepercommander/importer/json/json.py
@@ -162,19 +162,26 @@ class ZipAttachment(Attachment):
 class KeeperJsonImporter(BaseFileImporter, KeeperJsonMixin):
     def do_import(self, filename, **kwargs):
         users_only = kwargs.get('users_only') or False
-        if not os.path.isfile(filename):
-            zip_name = pathlib.Path(filename).with_suffix('.zip').name
-            if os.path.isfile(zip_name):
-                if zipfile.is_zipfile(zip_name):
-                    filename = zip_name
-        file_path = pathlib.Path(filename)
-        zip_archive = file_path.suffix == '.zip'
-        if zip_archive:
-            with zipfile.ZipFile(filename, 'r') as zf:
-                export = json.loads(zf.read('export.json'))
-        else:
-            with open(filename, "r", encoding='utf-8') as jf:
-                export = json.load(jf)
+        try:
+            export = json.loads(filename)
+            zip_archive = False
+            logging.info("Extracted JSON from object")
+        except ValueError as e:
+            if not os.path.isfile(filename):
+                zip_name = pathlib.Path(filename).with_suffix('.zip').name
+                if os.path.isfile(zip_name):
+                    if zipfile.is_zipfile(zip_name):
+                        filename = zip_name
+            file_path = pathlib.Path(filename)
+            zip_archive = file_path.suffix == '.zip'
+            if zip_archive:
+                with zipfile.ZipFile(filename, 'r') as zf:
+                    export = json.loads(zf.read('export.json'))
+                    logging.info("Extracted JSON from archive")
+            else:
+                with open(filename, "r", encoding='utf-8') as jf:
+                    export = json.load(jf)
+                    logging.info("Extracted JSON from file")
 
         records = None
         folders = None


### PR DESCRIPTION
The JSON import command requires a physical file holding sensitive data:
- JSON
- ZIP

Added support for passing stringified JSON as the filename, which will import the data without needing to store it in a file. This improves security, SDK use-cases, integrations with ephemeral storage.

Example command syntax:
>CLI
```
import --format json "[{\"title\":\"JSON record title\",\"login\":\"example_login\"}]"
```
>SDK
```
from keepercommander.importer.imp_exp import _import

data = json.dumps(list_records)
_import(params, 'json', data)
```
Support for strings added to:
`import` command (JSON format only)
`apply-membership` command