### PR TITLE
PAM Project Extend - Add support for stringified JSON

### DIFF
--- a/keepercommander/commands/pam_import/extend.py
+++ b/keepercommander/commands/pam_import/extend.py
@@ -424,16 +424,21 @@ class PAMProjectExtendCommand(Command):
         if not (configuration and isinstance(configuration, vault.TypedRecord) and configuration.version == 6):
             raise CommandError("pam project extend", f"""PAM configuration not found: "{config_name}" """)
 
-        if not (file_name != "" and os.path.isfile(file_name)):
-            raise CommandError("pam project extend", f"""PAM Import JSON file not found: "{file_name}" """)
-
         data = {}
-        try:
-            with open(file_name, encoding="utf-8") as f:
-                data = json.load(f)
-        except Exception:
-            data = {}
+        if not (file_name != "" and os.path.isfile(file_name)):
+            try:
+                data = json.loads(file_name)
+            except ValueError as e:
+                raise CommandError("pam project extend", f"""PAM Import JSON file not found: "{file_name}" """)
+        
+        if not data:
+            try:
+                with open(file_name, encoding="utf-8") as f:
+                    data = json.load(f)
+            except Exception as e:
+                raise CommandError("pam project extend", f"""Unable to read file "{file_name}": {e}""")
 
+        print(data)
         pam_data = data.get("pam_data") if isinstance(data, dict) else {}
         pam_data = pam_data if isinstance(pam_data, dict) else {}
         users =  pam_data["users"] if isinstance(pam_data.get("users"), list) else []

--- a/keepercommander/commands/pam_import/extend.py
+++ b/keepercommander/commands/pam_import/extend.py
@@ -438,7 +438,6 @@ class PAMProjectExtendCommand(Command):
             except Exception as e:
                 raise CommandError("pam project extend", f"""Unable to read file "{file_name}": {e}""")
 
-        print(data)
         pam_data = data.get("pam_data") if isinstance(data, dict) else {}
         pam_data = pam_data if isinstance(pam_data, dict) else {}
         users =  pam_data["users"] if isinstance(pam_data.get("users"), list) else []


### PR DESCRIPTION
PAM Project Extend command requires physical file with sensitive credential data. This commit adds support for passing stringified JSON data in the filename directly, rather than a filepath.

Command syntax:
>CLI
```
pam project extend -c <config_uid> -f "{\"pam_data\":{\"resources\":[...],\"users\":[...]}
```
>SDK
```
from keepercommander.commands.pam_import.extend PAMProjectExtendCommand

data = json.dumps(list_records)
PAMProjectExtendCommand().execute(params,config=config_uid, file_name=data)
```