### PR TITLE
Added --purge flag to rm command to differentiate remove vs. delete

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -2664,7 +2664,7 @@ class RecordRemoveCommand(Command):
 
             if not force:
                 print(f'This will permanently delete {len(record_uids)} record(s) for ALL users.')
-                np = base.user_choice('Do you want to proceed?', 'yn', default='n')
+                np = base.user_choice('Do you want to proceed?', 'y/n', default='n')
                 if np.lower() != 'y':
                     return
             success_count = 0

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -2620,21 +2620,21 @@ class RecordRemoveCommand(Command):
                                             records_to_delete.append((folder, record_uid))
                 if len(records_to_delete) == orig_len:
                     # Fallback: global title search so records in shared folders are also found.
-                    matches = []
                     for record_uid in params.record_cache:
                         record = vault.KeeperRecord.load(params, record_uid)
                         if record and record.title.casefold() == name.casefold():
-                            matches.append(record_uid)
-                    if len(matches) > 1:
-                        lines = [f'  {uid}' for uid in matches]
-                        raise CommandError('rm', f'"{name}" matches {len(matches)} records. '
-                                           f'Use a UID to identify the record:\n' + '\n'.join(lines))
-                    for record_uid in matches:
-                        for folder in find_all_folders(params, record_uid):
-                            records_to_delete.append((folder, record_uid))
+                            for folder in find_all_folders(params, record_uid):
+                                records_to_delete.append((folder, record_uid))
                 if len(records_to_delete) == orig_len:
                     raise CommandError('rm', f'No record found matching "{name}". '
                                        f'Provide a valid record title, path, or UID.')
+                # Check across both path-based and fallback results: if multiple distinct
+                # record UIDs were matched by title, require the user to specify a UID.
+                found_uids = list({uid for _, uid in records_to_delete[orig_len:]})
+                if len(found_uids) > 1:
+                    lines = [f'  {uid}' for uid in found_uids]
+                    raise CommandError('rm', f'"{name}" matches {len(found_uids)} records. '
+                                       f'Use a UID to identify the record:\n' + '\n'.join(lines))
 
         vault_changed = False
         force = kwargs.get('force') or False

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -202,6 +202,8 @@ clipboard_copy_parser.add_argument('record', nargs='?', type=str, action='store'
 
 rm_parser = argparse.ArgumentParser(prog='rm', description='Remove or delete a record from the vault')
 rm_parser.add_argument('-f', '--force', dest='force', action='store_true', help='do not prompt')
+rm_parser.add_argument('--purge', dest='purge', action='store_true',
+                        help='permanently delete the record for ALL users (default: remove only from your vault)')
 rm_parser.add_argument('records', nargs='*', type=str, help='record path or UID. Can be repeated.')
 
 
@@ -2617,50 +2619,116 @@ class RecordRemoveCommand(Command):
                                         if record.title.casefold() == record_name.casefold():
                                             records_to_delete.append((folder, record_uid))
                 if len(records_to_delete) == orig_len:
-                    raise CommandError('rm', f'Record {name} cannot be resolved')
+                    # Fallback: global title search so records in shared folders are also found.
+                    matches = []
+                    for record_uid in params.record_cache:
+                        record = vault.KeeperRecord.load(params, record_uid)
+                        if record and record.title.casefold() == name.casefold():
+                            matches.append(record_uid)
+                    if len(matches) > 1:
+                        lines = [f'  {uid}' for uid in matches]
+                        raise CommandError('rm', f'"{name}" matches {len(matches)} records. '
+                                           f'Use a UID to identify the record:\n' + '\n'.join(lines))
+                    for record_uid in matches:
+                        for folder in find_all_folders(params, record_uid):
+                            records_to_delete.append((folder, record_uid))
+                if len(records_to_delete) == orig_len:
+                    raise CommandError('rm', f'No record found matching "{name}". '
+                                       f'Provide a valid record title, path, or UID.')
 
         vault_changed = False
-        while len(records_to_delete) > 0:
-            rq = {
-                'command': 'pre_delete',
-                'objects': []
-            }
+        force = kwargs.get('force') or False
+        purge = kwargs.get('purge') or False
 
-            chunk = records_to_delete[:rq_obj_limit]
-            records_to_delete = records_to_delete[rq_obj_limit:]
-            for folder, record_uid in chunk:
-                del_obj = {
-                    'delete_resolution': 'unlink',
-                    'object_uid': record_uid,
-                    'object_type': 'record'
-                }
-                if folder.type in {BaseFolderNode.RootFolderType, BaseFolderNode.UserFolderType}:
-                    del_obj['from_type'] = 'user_folder'
-                    if folder.type == BaseFolderNode.UserFolderType:
-                        del_obj['from_uid'] = folder.uid
+        if purge:
+            # Hard-delete records for ALL users: deduplicate UIDs across folders
+            record_uids = list({uid for _, uid in records_to_delete})
+
+            # Only the record owner may permanently delete a record
+            non_owned = []
+            owned_uids = []
+            for uid in record_uids:
+                ro = params.record_owner_cache.get(uid)
+                if ro and ro.owner:
+                    owned_uids.append(uid)
                 else:
-                    del_obj['from_type'] = 'shared_folder_folder'
-                    del_obj['from_uid'] = folder.uid
-                rq['objects'].append(del_obj)
+                    record = vault.KeeperRecord.load(params, uid)
+                    title = record.title if record else uid
+                    non_owned.append(title)
+            if non_owned:
+                for title in non_owned:
+                    logging.warning('Cannot permanently delete "%s": you are not the record owner.', title)
+            if not owned_uids:
+                return
+            record_uids = owned_uids
 
-            rs = api.communicate(params, rq)
-            if rs['result'] == 'success':
-                pdr = rs['pre_delete_response']
+            if not force:
+                print(f'This will permanently delete {len(record_uids)} record(s) for ALL users.')
+                np = base.user_choice('Do you want to proceed?', 'yn', default='n')
+                if np.lower() != 'y':
+                    return
+            success_count = 0
+            while record_uids:
+                chunk = record_uids[:rq_obj_limit]
+                record_uids = record_uids[rq_obj_limit:]
+                rq = {
+                    'command': 'record_update',
+                    'delete_records': chunk
+                }
+                rs = api.communicate(params, rq)
+                if 'delete_records' in rs:
+                    for status in rs['delete_records']:
+                        if status.get('status') == 'success':
+                            success_count += 1
+                        else:
+                            logging.warning('Failed to delete record %s: %s',
+                                            status.get('uid', ''), status.get('status', ''))
+            if success_count:
+                logging.info('%d record(s) permanently deleted for all users.', success_count)
+                api.sync_down(params)
+                vault_changed = True
+        else:
+            # Remove records from your vault only (unlink), leaving them intact for other users
+            while len(records_to_delete) > 0:
+                rq = {
+                    'command': 'pre_delete',
+                    'objects': []
+                }
 
-                force = kwargs.get('force') or False
-                np = 'y'
-                if force is not True:
-                    summary = pdr['would_delete']['deletion_summary']
-                    for x in summary:
-                        print(x)
-                    np = base.user_choice('Do you want to proceed with deletion?', 'yn', default='n')
-                if np.lower() == 'y':
-                    rq = {
-                        'command': 'delete',
-                        'pre_delete_token': pdr['pre_delete_token']
+                chunk = records_to_delete[:rq_obj_limit]
+                records_to_delete = records_to_delete[rq_obj_limit:]
+                for folder, record_uid in chunk:
+                    del_obj = {
+                        'delete_resolution': 'unlink',
+                        'object_uid': record_uid,
+                        'object_type': 'record'
                     }
-                    api.communicate(params, rq)
-                    vault_changed = True
+                    if folder.type in {BaseFolderNode.RootFolderType, BaseFolderNode.UserFolderType}:
+                        del_obj['from_type'] = 'user_folder'
+                        if folder.type == BaseFolderNode.UserFolderType:
+                            del_obj['from_uid'] = folder.uid
+                    else:
+                        del_obj['from_type'] = 'shared_folder_folder'
+                        del_obj['from_uid'] = folder.uid
+                    rq['objects'].append(del_obj)
+
+                rs = api.communicate(params, rq)
+                if rs['result'] == 'success':
+                    pdr = rs['pre_delete_response']
+
+                    np = 'y'
+                    if force is not True:
+                        summary = pdr['would_delete']['deletion_summary']
+                        for x in summary:
+                            print(x)
+                        np = base.user_choice('Do you want to proceed with removal?', 'yn', default='n')
+                    if np.lower() == 'y':
+                        rq = {
+                            'command': 'delete',
+                            'pre_delete_token': pdr['pre_delete_token']
+                        }
+                        api.communicate(params, rq)
+                        vault_changed = True
 
         if vault_changed:
             BreachWatch.save_reused_pw_count(params)


### PR DESCRIPTION
### Summary
Made changes to the rm command addressing the lack of distinction between removing a record from your own vault versus permanently deleting it for all users.

### Changes

- Added a --purge flag to rm that permanently hard-deletes a record for all users via record_update/delete_records, while keeping the default rm behavior as a vault-only removal (unlink). Only the record owner can use --purge on a given record; non-owned records are skipped with a warning.
- Fixed rm failing to resolve records by title when the record lives in a shared folder, by adding a global fallback search across all vault folders when the path-based lookup finds no match.
- When multiple records share the same title, rm now errors with a list of matching UIDs and asks the user to re-run with a specific UID, instead of acting on all of them at once. This check now applies regardless of whether the records were found via the primary path-based lookup or the shared folder fallback.
- Added sync_down after a successful --purge so the local cache reflects deletions immediately.
- vault_changed and BreachWatch cleanup are now only triggered when at least one record is confirmed deleted, and a success log shows how many records were permanently removed.