### PR TITLE
fix EPM | --machine-filter flag not working in Commander CLI

### DIFF
--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1051,9 +1051,8 @@ class PedmPolicyMixin:
 
         collection_lookup: Dict[str, Union[str, List[str]]] = {}
         for c in plugin.collections.get_all_entities():
-            if c.collection_type not in col_types: continue
             collection_lookup[c.collection_uid] = c.collection_uid
-            if c.collection_type >= 100:
+            if c.collection_type in col_types and c.collection_type >= 100:
                 collection_name: Optional[str] = c.collection_data.get('Name')
                 if not collection_name:
                     continue
@@ -1073,12 +1072,12 @@ class PedmPolicyMixin:
             if col_value == '*':
                 result.append(col_value)
             elif col_value:
-                cv = collection_lookup[col_value]
+                cv = collection_lookup.get(col_value)
                 if not cv:
-                    cv = collection_lookup[col_value.lower()]
+                    cv = collection_lookup.get(col_value.lower())
                 if not cv:
-                    raise base.CommandError(f'collection value "{col_value}" cannot be resolved')
-                if isinstance(cv, str):
+                    result.append(col_value)
+                elif isinstance(cv, str):
                     result.append(cv)
                 else:
                     raise base.CommandError(f'collection value "{col_value}" is not unique. Use collection UID')
@@ -1274,7 +1273,7 @@ class PedmPolicyMixin:
                 if f == 'USER':
                     policy_filter[filter_name] = PedmPolicyAddCommand.resolve_collections(plugin, [3, 6, 103], p_filter)
                 elif f == 'MACHINE':
-                    policy_filter[filter_name] = PedmPolicyAddCommand.resolve_collections(plugin, [1, 101], p_filter)
+                    policy_filter[filter_name] = PedmPolicyAddCommand.resolve_collections(plugin, [1, 101, 201], p_filter)
                 elif f == 'APP':
                     policy_filter[filter_name] = PedmPolicyAddCommand.resolve_collections(plugin, [2, 102], p_filter)
                 elif f == 'DATE':

--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1335,7 +1335,7 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         parser.add_argument('--policy-type', dest='policy_type', action='store', default='elevation',
                             choices=['elevation', 'file_access', 'command', 'least_privilege'],
                             help='Policy type')
-        parser.add_argument('--policy-name', dest='policy_name', action='store',
+        parser.add_argument('--policy-name', dest='policy_name', action='store', required=True,
                             help='Policy name')
         parser.add_argument('--control', dest='control', action='append',
                             choices=['allow', 'deny', 'audit', 'notify', 'mfa', 'justify', 'approval'],
@@ -1431,6 +1431,14 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         policy_filter = PedmPolicyMixin.get_policy_filter(plugin, **kwargs)
         if policy_filter:
             policy_data.update(policy_filter)
+
+        if policy_type in ('PrivilegeElevation', 'FileAccess', 'CommandLine'):
+            missing = [name for name, key in (('user', 'UserCheck'), ('machine', 'MachineCheck'), ('application', 'ApplicationCheck'))
+                       if not policy_filter.get(key)]
+            if missing:
+                raise base.CommandError(
+                    f'At least one machine, application, and user collection required to save this policy type. '
+                    f'Missing: {", ".join(missing)}. Use --user-filter, --machine-filter, --app-filter.')
 
         for filter_name in ('UserCheck', 'MachineCheck', 'ApplicationCheck', 'DateCheck', 'TimeCheck', 'DayCheck'):
             f = policy_data.get(filter_name)


### PR DESCRIPTION
### Summary

epm policy add/edit failed with a KeyError when using --machine-filter with a collection UID that existed on the server but was not present in the local synced collection cache.

### Changes
Pass unresolved collection UIDs through to the server instead of failing client-side. Also fixes KeyError on missing keys and adds type 201 (CustomMachineCollection) to machine filter type list.