### PR TITLE
perf(pam launch): cache TunnelDAG across the launch flow

### DIFF
--- a/keepercommander/commands/pam_launch/connect_timing.py
+++ b/keepercommander/commands/pam_launch/connect_timing.py
@@ -1,0 +1,78 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+# Keeper Commander — PAM launch / WebRTC connect phase timing (debug + env tunable).
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+_LOG = logging.getLogger(__name__)
+
+# Log connect checkpoints at INFO when set (e.g. PAM_CONNECT_TIMING=1), else only at DEBUG.
+_TIMING_FORCE_ENV = 'PAM_CONNECT_TIMING'
+
+
+def connect_timing_log_enabled() -> bool:
+    """True when PAM_CONNECT_TIMING=1 or the module logger is at DEBUG."""
+    if os.environ.get(_TIMING_FORCE_ENV, '').strip().lower() in ('1', 'true', 'yes', 'on'):
+        return True
+    return _LOG.isEnabledFor(logging.DEBUG)
+
+
+class PamConnectTiming:
+    """Monotonic checkpoints for ``pam launch`` / tunnel open (debug or PAM_CONNECT_TIMING=1).
+
+    Usage:
+        tc = PamConnectTiming('pam-launch:webrtc-tunnel')
+        tc.checkpoint('enter')
+        ...
+        tc.checkpoint('relay_creds_ok')
+        ...
+        tc.summary('done')
+    """
+
+    __slots__ = ('_label', '_t0', '_last')
+
+    def __init__(self, label: str = 'pam-launch') -> None:
+        self._label = label
+        self._t0 = time.perf_counter()
+        self._last = self._t0
+
+    def checkpoint(self, phase: str, *, log: Optional[bool] = None) -> None:
+        do_log = connect_timing_log_enabled() if log is None else log
+        now = time.perf_counter()
+        step_ms = (now - self._last) * 1000.0
+        total_ms = (now - self._t0) * 1000.0
+        self._last = now
+        if not do_log:
+            return
+        force = os.environ.get(_TIMING_FORCE_ENV, '').strip().lower() in ('1', 'true', 'yes', 'on')
+        level = logging.INFO if force else logging.DEBUG
+        _LOG.log(
+            level,
+            '%s | %-44s | +%.1f ms (step) | %.1f ms (total)',
+            self._label,
+            phase,
+            step_ms,
+            total_ms,
+        )
+
+    def summary(self, phase: str = 'done') -> None:
+        """Log one line with total elapsed (e.g. at end of tunnel open or command)."""
+        if not connect_timing_log_enabled():
+            return
+        total_ms = (time.perf_counter() - self._t0) * 1000.0
+        force = os.environ.get(_TIMING_FORCE_ENV, '').strip().lower() in ('1', 'true', 'yes', 'on')
+        level = logging.INFO if force else logging.DEBUG
+        _LOG.log(level, '%s | %-44s | TOTAL %.1f ms', self._label, phase, total_ms)

--- a/keepercommander/commands/pam_launch/launch.py
+++ b/keepercommander/commands/pam_launch/launch.py
@@ -33,6 +33,7 @@ from .terminal_connection import (
     _version_at_least,
     _pam_settings_connection_port,
 )
+from .connect_timing import PamConnectTiming
 from .terminal_size import get_terminal_size_pixels, is_interactive_tty, PIXEL_MODE_GUACD, scale_screen_info
 from .terminal_reset import reset_local_terminal_after_pam_session
 from .crlf_merge_delay import (
@@ -51,7 +52,9 @@ from ..tunnel.port_forward.tunnel_helpers import (
     get_tunnel_session,
     unregister_tunnel_session,
     unregister_conversation_key,
+    get_keeper_tokens,
 )
+from ..tunnel.port_forward.TunnelGraph import TunnelDAG
 from .rust_log_filter import (
     enter_pam_launch_terminal_rust_logging,
     exit_pam_launch_terminal_rust_logging,
@@ -450,13 +453,22 @@ class PAMLaunchCommand(Command):
 
         return None
 
-    def find_gateway(self, params: KeeperParams, record_uid: str) -> Optional[Dict]:
+    def find_gateway(
+        self,
+        params: KeeperParams,
+        record_uid: str,
+        tdag: Optional[Any] = None,
+    ) -> Optional[Dict]:
         """
         Find the gateway associated with a PAM record.
 
         Args:
             params: KeeperParams instance
             record_uid: Record UID to find gateway for (must be pre-validated as PAM type)
+            tdag: Optional pre-built TunnelDAG. When provided, the config UID is
+                read from ``tdag.record.record_uid`` instead of fetched again via
+                ``get_config_uid_from_record`` — avoids the extra
+                ``/api/user/get_leafs`` roundtrip.
 
         Returns:
             Dictionary with gateway information including:
@@ -471,7 +483,12 @@ class PAMLaunchCommand(Command):
         """
         # Get the gateway UID from the record
         # Note: Record type validation happens in find_record()
-        gateway_uid = get_gateway_uid_from_record(params, vault, record_uid)
+        if tdag is not None:
+            config_uid = tdag.record.record_uid
+            gateway_uid = self._gateway_uid_from_config(params, config_uid) if config_uid else ''
+        else:
+            gateway_uid = get_gateway_uid_from_record(params, vault, record_uid)
+            config_uid = None  # resolved below when tdag is absent
 
         if not gateway_uid:
             raise CommandError('pam launch', f'No gateway found for record {record_uid}. ')
@@ -491,8 +508,9 @@ class PAMLaunchCommand(Command):
         gateway_name = gateway_proto.controllerName if gateway_proto else 'Unknown'
         logging.debug(f"Found gateway: {gateway_name} ({gateway_uid})")
 
-        # Get the configuration UID
-        config_uid = get_config_uid_from_record(params, vault, record_uid)
+        # Get the configuration UID (already resolved from tdag when present)
+        if config_uid is None:
+            config_uid = get_config_uid_from_record(params, vault, record_uid)
 
         return {
             'gateway_uid': gateway_uid,
@@ -500,6 +518,37 @@ class PAMLaunchCommand(Command):
             'config_uid': config_uid,
             'gateway_proto': gateway_proto
         }
+
+    @staticmethod
+    def _gateway_uid_from_config(params: KeeperParams, pam_config_uid: str) -> str:
+        """Resolve the controller (gateway) UID from a PAM configuration UID.
+
+        Mirrors the second half of
+        ``tunnel_helpers.get_gateway_uid_from_record`` — read ``controllerUid``
+        from the config record's ``pamResources`` field, falling back to the
+        ``pam/get_configuration_controller`` API when the local record is
+        missing the field.
+        """
+        gateway_uid = ''
+        record = vault.KeeperRecord.load(params, pam_config_uid)
+        if record is not None:
+            field = record.get_typed_field('pamResources')
+            value = field.get_default_value(dict) if field is not None else None
+            if value:
+                gateway_uid = value.get('controllerUid', '') or ''
+
+        if not gateway_uid:
+            try:
+                from ..pam.config_helper import configuration_controller_get
+                from ... import utils
+                config_uid_bytes = url_safe_str_to_bytes(pam_config_uid)
+                controller = configuration_controller_get(params, config_uid_bytes)
+                if controller and controller.controllerUid:
+                    gateway_uid = utils.base64_url_encode(controller.controllerUid)
+            except Exception as e:
+                logging.debug('_gateway_uid_from_config: fallback failed: %s', e)
+
+        return gateway_uid
 
     def execute(self, params: KeeperParams, **kwargs):
         """
@@ -509,6 +558,17 @@ class PAMLaunchCommand(Command):
             params: KeeperParams instance containing session state
             **kwargs: Command arguments including 'record' (record path or UID)
         """
+        # Grand-total timer: from command entry through handoff to the interactive
+        # loop. Summary fires in _start_cli_session just before input_handler.start().
+        # Per-phase blocks (pam-launch:execute / :terminal_connection / :webrtc-tunnel /
+        # :cli_session) nest inside and log their own totals — no double-counting.
+        _total_tc = PamConnectTiming('pam-launch:total')
+
+        # Pre-phase timer: covers all work done in execute() before the terminal
+        # connection handoff. Summary fires at pre_terminal_connection below.
+        _exec_tc = PamConnectTiming('pam-launch:execute')
+        _exec_tc.checkpoint('execute_start')
+
         # Save original root logger level and set to ERROR if not in DEBUG mode
         root_logger = logging.getLogger()
         original_level = root_logger.level
@@ -554,6 +614,7 @@ class PAMLaunchCommand(Command):
             if not self._is_valid_pam_record(params, record_uid):
                 record_type = getattr(record, 'record_type', type(record).__name__)
                 raise CommandError('pam launch',f'Record {record_uid} of type "{record_type}" is not a machine record type (pamMachine, pamDirectory, pamDatabase)')
+            _exec_tc.checkpoint('record_loaded')
 
             # Only terminal protocols are supported (SSH, Telnet, Kubernetes, databases).
             protocol = detect_protocol(params, record_uid)
@@ -564,9 +625,31 @@ class PAMLaunchCommand(Command):
                     protocol,
                 )
                 return
+            _exec_tc.checkpoint('protocol_detected_top')
 
-            # Get DAG-linked credential UID early (needed for comparison and validation)
-            dag_linked_uid = _get_launch_credential_uid(params, record_uid)
+            # Build the TunnelDAG once for the entire launch. Previously three separate
+            # call sites (here + two inside extract_terminal_settings) each built a fresh
+            # TunnelDAG and paid 2–3 HTTP roundtrips for it. The resolved tdag is threaded
+            # through _get_launch_credential_uid / find_gateway / launch_terminal_connection
+            # so every downstream consumer reuses the same graph.
+            try:
+                _enc_session_token, _enc_transmission_key, _transmission_key = get_keeper_tokens(params)
+                _launch_tdag = TunnelDAG(
+                    params,
+                    _enc_session_token,
+                    _enc_transmission_key,
+                    record_uid,
+                    transmission_key=_transmission_key,
+                )
+            except Exception as _e:
+                logging.debug('Failed to build TunnelDAG up front: %s — falling back to per-call lookups', _e)
+                _launch_tdag = None
+            _exec_tc.checkpoint('dag_built')
+
+            # Get DAG-linked credential UID early (needed for comparison and validation).
+            # Reuse _launch_tdag so we don't rebuild the DAG.
+            dag_linked_uid = _get_launch_credential_uid(params, record_uid, tdag=_launch_tdag)
+            _exec_tc.checkpoint('dag_linked_uid_resolved')
             if not dag_linked_uid:
                 # Fallback: first entry in pamSettings.connection.userRecords
                 _psf = record.get_typed_field('pamSettings')
@@ -805,14 +888,15 @@ class PAMLaunchCommand(Command):
                             f'No credentials configured for record {record_uid}. '
                             'Configure a linked credential or enable allowSupplyUser/allowSupplyHost.')
 
-            # Find the gateway for this record
-            gateway_info = self.find_gateway(params, record_uid)
+            # Find the gateway for this record (reuse tdag to skip another get_leafs roundtrip)
+            gateway_info = self.find_gateway(params, record_uid, tdag=_launch_tdag)
 
             if not gateway_info:
                 raise CommandError('pam launch', f'No gateway found for record {record_uid}')
 
             logging.debug(f"Found gateway: {gateway_info['gateway_name']} ({gateway_info['gateway_uid']})")
             logging.debug(f"Configuration: {gateway_info['config_uid']}")
+            _exec_tc.checkpoint('find_gateway_ok')
 
             # Optionally check if Gateway appears online; if not, log warning and try anyway.
             try:
@@ -833,6 +917,7 @@ class PAMLaunchCommand(Command):
                     logging.error('Gateway seems offline - trying to connect anyway.')
             except Exception as e:
                 logging.debug('Could not verify gateway status: %s. Continuing...', e)
+            _exec_tc.checkpoint('gateway_online_verified')
 
             if pam_connection_font_size is not None and str(pam_connection_font_size).strip() != '':
                 fs_int = _pam_connection_font_size_int(pam_connection_font_size)
@@ -859,6 +944,14 @@ class PAMLaunchCommand(Command):
                 print(f'Launching connection to {_banner_name_connect}...', flush=True)
                 pre_connect_spinner = PamLaunchSpinner('[ Establishing secure session… ]')
                 pre_connect_spinner.start()
+
+            # Pass the resolved DAG UID through so extract_terminal_settings does not
+            # rebuild the DAG. kwargs carries both the ConnectAs-relevant
+            # launch_credential_uid (possibly CLI-overridden) and the authoritative
+            # dag_linked_uid used only for DAG-comparison logic.
+            kwargs['dag_linked_uid'] = dag_linked_uid
+            _exec_tc.checkpoint('pre_terminal_connection')
+            _exec_tc.summary('execute_pre_interactive')
 
             # Launch terminal connection
             try:
@@ -914,6 +1007,7 @@ class PAMLaunchCommand(Command):
                         connect_banner_title=_banner_title,
                         pre_connect_spinner=pre_connect_spinner,
                         preserve_crlf=not bool(kwargs.get('normalize_crlf')),
+                        pam_total_tc=_total_tc,
                     )
                 except BaseException:
                     if pre_connect_spinner is not None and getattr(
@@ -940,6 +1034,7 @@ class PAMLaunchCommand(Command):
         connect_banner_title: Optional[str] = None,
         pre_connect_spinner: Optional[PamLaunchSpinner] = None,
         preserve_crlf: bool = True,
+        pam_total_tc: Optional[PamConnectTiming] = None,
     ):
         """
         Start CLI session using PythonHandler protocol mode.
@@ -1049,8 +1144,11 @@ class PAMLaunchCommand(Command):
                 _connect_spinner = PamLaunchSpinner('[ Establishing secure session… ]')
                 _connect_spinner.start()
             try:
+                _cli_tc = PamConnectTiming('pam-launch:cli_session')
+                _cli_tc.checkpoint('cli_session_try_enter')
                 # Start the Python handler
                 python_handler.start()
+                _cli_tc.checkpoint('python_handler_start_done')
 
                 # Wait for WebRTC connection to be established
                 logging.debug("Waiting for WebRTC connection...")
@@ -1071,6 +1169,7 @@ class PAMLaunchCommand(Command):
 
                 if not connected:
                     raise CommandError('pam launch', "WebRTC connection not established within timeout")
+                _cli_tc.checkpoint('webrtc_data_plane_connected')
 
                 # Wait for DataChannel to be ready and Gateway to wire the session.
                 # connection state "connected" can precede DataChannel readiness; Gateway also needs
@@ -1078,6 +1177,7 @@ class PAMLaunchCommand(Command):
                 # Configurable via PAM_OPEN_CONNECTION_DELAY (default 0.2s; use 2.0 if handshake never starts).
                 open_conn_delay = float(os.environ.get('PAM_OPEN_CONNECTION_DELAY', '0.2'))
                 time.sleep(open_conn_delay)
+                _cli_tc.checkpoint('open_connection_delay_done')
 
                 # Send OpenConnection to Gateway to initiate guacd session
                 # This is critical - without it, Gateway doesn't start guacd and no Guacamole traffic flows
@@ -1142,6 +1242,7 @@ class PAMLaunchCommand(Command):
                             conversation_id, 1, connect_as_payload
                         )
                         logging.debug("✓ OpenConnection sent successfully")
+                        _cli_tc.checkpoint('open_connection_sent_ok')
                         break
                     except Exception as e:
                         last_error = e
@@ -1183,6 +1284,10 @@ class PAMLaunchCommand(Command):
             guac_ready_timeout = 10.0  # Reduced from 30s - sync triggers readiness quickly
 
             guac_ready_result = python_handler.wait_for_ready(guac_ready_timeout)
+            _cli_tc.checkpoint(
+                'guacamole_wait_for_ready_ok' if guac_ready_result else 'guacamole_wait_for_ready_timeout'
+            )
+            _cli_tc.summary('cli_session_pre_interactive')
             if guac_ready_result:
                 logging.debug("* Guacamole connection ready!")
                 logging.debug(
@@ -1296,6 +1401,13 @@ class PAMLaunchCommand(Command):
                     disable_paste=disable_paste,
                 )
                 logging.debug('Input mode: key-event (InputHandler, default)')
+
+            # Grand-total stop point: we're about to hand control to input_handler.start()
+            # and enter the interactive loop. Everything after this is session runtime,
+            # not launch time. Fires after check_stdout_pipe_support + coordinator setup so
+            # the total reflects the *user-visible* time-to-prompt, not just guac-ready.
+            if pam_total_tc is not None:
+                pam_total_tc.summary('ready_for_prompt')
 
             # Main event loop with input handler
             try:

--- a/keepercommander/commands/pam_launch/terminal_connection.py
+++ b/keepercommander/commands/pam_launch/terminal_connection.py
@@ -75,6 +75,11 @@ if TYPE_CHECKING:
     from ...params import KeeperParams
 
 from ..pam_import.base import ConnectionProtocol
+from .connect_timing import PamConnectTiming
+
+# Sentinel for "dag_linked_uid not resolved yet" — ``None`` is a valid resolved
+# result (no DAG-linked launch credential), so we need a distinct marker.
+_DAG_UID_UNSET = object()
 
 # Protocol sets and defaults (ConnectionProtocol from pam_import.base)
 GRAPHICAL = {ConnectionProtocol.RDP.value, ConnectionProtocol.VNC.value}  # not supported by CLI
@@ -362,6 +367,7 @@ def extract_terminal_settings(
     launch_credential_uid: Optional[str] = None,
     custom_host: Optional[str] = None,
     custom_port: Optional[int] = None,
+    dag_linked_uid: Any = _DAG_UID_UNSET,
 ) -> Dict[str, Any]:
     """
     Extract terminal connection settings from a PAM record.
@@ -392,6 +398,13 @@ def extract_terminal_settings(
     record = vault.KeeperRecord.load(params, record_uid)
     if not isinstance(record, vault.TypedRecord):
         raise CommandError('pam launch', f'Record {record_uid} is not a TypedRecord')
+
+    # Resolve DAG-linked launch credential UID once; the pamSettings block and the
+    # later CLI-override comparison both need the same value. Pam launch passes
+    # a pre-resolved value via the kwarg so the 2–3 HTTP round-trips that build
+    # a TunnelDAG only happen once per command instead of per call site.
+    if dag_linked_uid is _DAG_UID_UNSET:
+        dag_linked_uid = _get_launch_credential_uid(params, record_uid)
 
     settings = {
         'hostname': None,
@@ -476,10 +489,10 @@ def extract_terminal_settings(
                 settings['allowSupplyUser'] = connection.get('allowSupplyUser', False)
 
                 # Extract linked pamUser record UID from pamSettings (may be overridden by CLI later)
-                # When both admin and launch credentials exist, we must use launch credential
-                dag_launch_uid = _get_launch_credential_uid(params, record_uid)
-                if dag_launch_uid:
-                    settings['userRecordUid'] = dag_launch_uid
+                # When both admin and launch credentials exist, we must use launch credential.
+                # dag_linked_uid was resolved once at the top of the function.
+                if dag_linked_uid:
+                    settings['userRecordUid'] = dag_linked_uid
                     logging.debug(f"Using launch credential from DAG: {settings['userRecordUid']}")
                 elif not launch_credential_uid:
                     # No DAG-linked credential and no -cr given.
@@ -529,10 +542,9 @@ def extract_terminal_settings(
         settings['port'] = DEFAULT_PORTS.get(protocol, 22)
 
     # CLI overrides: check if --credential provides a DIFFERENT user than DAG-linked.
-    # Always query the DAG directly - settings['userRecordUid'] may have been set from the
+    # dag_linked_uid is the once-resolved DAG value from the top of the function —
+    # distinct from settings['userRecordUid'] which may have been set from the
     # userRecords[0] fallback (not DAG-linked) and must not be used for this comparison.
-    dag_linked_uid = _get_launch_credential_uid(params, record_uid)
-
     if launch_credential_uid:
         if launch_credential_uid == dag_linked_uid:
             # CLI --credential matches DAG-linked credential - treat as if no --credential was provided
@@ -673,7 +685,11 @@ def create_connection_context(params: KeeperParams,
     return context
 
 
-def _get_launch_credential_uid(params: 'KeeperParams', record_uid: str) -> Optional[str]:
+def _get_launch_credential_uid(
+    params: 'KeeperParams',
+    record_uid: str,
+    tdag: Optional['TunnelDAG'] = None,
+) -> Optional[str]:
     """
     Find the launch credential UID for a PAM record using the DAG.
 
@@ -684,14 +700,19 @@ def _get_launch_credential_uid(params: 'KeeperParams', record_uid: str) -> Optio
     Args:
         params: KeeperParams instance
         record_uid: UID of the pamMachine record
+        tdag: Optional pre-built TunnelDAG to reuse. When provided, skips the
+            expensive ``TunnelDAG(...)`` construction (which issues 2–3 HTTP
+            round-trips). Used by ``pam launch`` to avoid resolving the same
+            DAG three times per command invocation.
 
     Returns:
         UID of the launch credential pamUser record, or None if not found
     """
     try:
-        encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
-        tdag = TunnelDAG(params, encrypted_session_token, encrypted_transmission_key, record_uid,
-                         transmission_key=transmission_key)
+        if tdag is None:
+            encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
+            tdag = TunnelDAG(params, encrypted_session_token, encrypted_transmission_key, record_uid,
+                             transmission_key=transmission_key)
 
         if not tdag.linking_dag.has_graph:
             logging.debug(f"No DAG graph loaded for record {record_uid}")
@@ -1224,6 +1245,8 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
     screen_info = DEFAULT_SCREEN_INFO
 
     try:
+        _pam_tc = PamConnectTiming('pam-launch:webrtc-tunnel')
+        _pam_tc.checkpoint('enter')
         router_token = None
 
         # Get encryption seed from record
@@ -1282,6 +1305,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
         response = router_get_relay_access_creds(params=params, expire_sec=60000000)
         if response is None:
             return {"success": False, "error": "Failed to get relay access credentials"}
+        _pam_tc.checkpoint('relay_creds_ok')
 
         # Create WebRTC settings for terminal (no local socket needed)
         webrtc_settings = {
@@ -1483,6 +1507,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
         logging.debug(f"Created tube with ID: {commander_tube_id}")
         logging.debug(f"Conversation ID for this tube: {conversation_id_original}")
         logging.debug(f"Data channel will be named: {conversation_id}")
+        _pam_tc.checkpoint('create_tube_ok')
 
         # Update signal handler and tunnel session with real tube ID
         signal_handler.tube_id = commander_tube_id
@@ -1502,6 +1527,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
             router_tokens=router_tokens,
             cookie_header=cookie_header
         )
+        _pam_tc.checkpoint('websocket_listener_started')
 
         # Wait for WebSocket to be ready before sending offer (same as pam tunnel start).
         # Use event.wait() when available so we proceed as soon as ready; fallback to short sleep.
@@ -1519,9 +1545,11 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
             logging.debug("Dedicated WebSocket connection established and ready for streaming")
             logging.debug(f"Waiting {backend_delay}s for backend to register conversation...")
             time.sleep(backend_delay)
+            _pam_tc.checkpoint('websocket_ready_backend_delay_done')
         else:
             logging.warning("No WebSocket ready event for tunnel, using backend delay %.1fs", backend_delay)
             time.sleep(backend_delay)
+            _pam_tc.checkpoint('websocket_no_event_backend_delay_done')
 
         # Send offer to gateway via HTTP POST
         logging.debug(f"{bcolors.OKBLUE}Sending {protocol} connection offer to gateway...{bcolors.ENDC}")
@@ -1684,7 +1712,9 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
         else:
             logging.debug(f"No linked pamUser for record {record_uid} - using pamMachine credentials directly")
 
+        _pam_tc.checkpoint('pre_offer_sleep_start')
         time.sleep(1)  # Allow time for WebSocket listener to start
+        _pam_tc.checkpoint('pre_offer_sleep_done')
 
         # Send offer via HTTP POST - two paths: streaming vs non-streaming
         try:
@@ -1734,6 +1764,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                     }
                 if http_session is not None:
                     offer_kwargs["http_session"] = http_session
+                _pam_tc.checkpoint('gateway_offer_http_attempt_1')
                 router_response = router_send_action_to_gateway(
                     params=params,
                     destination_gateway_uid_str=gateway_uid,
@@ -1747,6 +1778,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                     gateway_timeout=30000,
                     **offer_kwargs
                 )
+                _pam_tc.checkpoint('gateway_offer_http_done')
 
                 logging.debug(f"{bcolors.OKGREEN}Offer sent to gateway (streaming mode){bcolors.ENDC}")
 
@@ -1764,6 +1796,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                 logging.debug(f"{bcolors.OKGREEN}Terminal connection established for {protocol.upper()}{bcolors.ENDC}")
                 logging.debug(f"{bcolors.OKBLUE}Connection state: {bcolors.ENDC}gathering candidates...")
 
+                _pam_tc.summary('webrtc_tunnel_open_ok_streaming')
                 return {
                     "success": True,
                     "tube_id": commander_tube_id,
@@ -1780,6 +1813,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                 }
             else:
                 # Non-streaming path: Handle response immediately
+                _pam_tc.checkpoint('gateway_offer_http_attempt_1')
                 router_response = router_send_action_to_gateway(
                     params=params,
                     destination_gateway_uid_str=gateway_uid,
@@ -1792,6 +1826,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                     is_streaming=False,  # Response comes immediately in HTTP response
                     gateway_timeout=30000
                 )
+                _pam_tc.checkpoint('gateway_offer_http_done')
 
                 logging.debug(f"{bcolors.OKGREEN}Offer sent to gateway (non-streaming mode){bcolors.ENDC}")
                 logging.debug(f"Router response: {router_response}")
@@ -1885,6 +1920,7 @@ def _open_terminal_webrtc_tunnel(params: KeeperParams,
                 logging.debug(f"{bcolors.OKGREEN}Terminal connection established for {protocol.upper()}{bcolors.ENDC}")
                 logging.debug(f"{bcolors.OKBLUE}Connection state: {bcolors.ENDC}established (non-streaming mode)...")
 
+                _pam_tc.summary('webrtc_tunnel_open_ok_non_streaming')
                 return {
                     "success": True,
                     "tube_id": commander_tube_id,
@@ -1959,6 +1995,8 @@ def launch_terminal_connection(params: KeeperParams,
         CommandError: If connection cannot be established
     """
     try:
+        _launch_tc = PamConnectTiming('pam-launch:terminal_connection')
+        _launch_tc.checkpoint('enter')
         # Step 1: Detect protocol
         protocol = detect_protocol(params, record_uid)
         if not protocol or protocol not in ALL_TERMINAL:
@@ -1969,8 +2007,12 @@ def launch_terminal_connection(params: KeeperParams,
             )
 
         logging.debug(f"Detected protocol: {protocol}")
+        _launch_tc.checkpoint('protocol_detected')
 
-        # Step 2: Extract settings (with optional CLI overrides)
+        # Step 2: Extract settings (with optional CLI overrides).
+        # Forward the pre-resolved DAG launch credential UID when the caller supplied it
+        # (pam launch does, to collapse three DAG loads into one); otherwise
+        # extract_terminal_settings falls back to resolving it internally.
         settings = extract_terminal_settings(
             params,
             record_uid,
@@ -1978,19 +2020,22 @@ def launch_terminal_connection(params: KeeperParams,
             launch_credential_uid=kwargs.get('launch_credential_uid'),
             custom_host=kwargs.get('custom_host'),
             custom_port=kwargs.get('custom_port'),
+            dag_linked_uid=kwargs.get('dag_linked_uid', _DAG_UID_UNSET),
         )
         logging.debug(f"Extracted settings: hostname={settings['hostname']}, port={settings['port']}")
+        _launch_tc.checkpoint('settings_extracted')
 
         # Step 3: Build connection context
         context = create_connection_context(
-            params, 
-            record_uid, 
-            gateway_info['gateway_uid'], 
-            protocol, 
+            params,
+            record_uid,
+            gateway_info['gateway_uid'],
+            protocol,
             settings,
             connect_as
         )
         logging.debug(f"Built connection context for {protocol}")
+        _launch_tc.checkpoint('context_built')
 
         # Step 4: Open WebRTC tunnel
         tunnel_result = _open_terminal_webrtc_tunnel(
@@ -2006,11 +2051,13 @@ def launch_terminal_connection(params: KeeperParams,
         if not tunnel_result.get('success'):
             error_msg = tunnel_result.get('error', 'Unknown error')
             raise CommandError('pam launch', f'Failed to open WebRTC tunnel: {error_msg}')
+        _launch_tc.checkpoint('webrtc_tunnel_opened')
 
         logging.debug(f"Terminal connection established for {protocol}")
         logging.debug(f"Target: {settings['hostname']}:{settings['port']}")
         logging.debug(f"Gateway: {gateway_info['gateway_name']} ({gateway_info['gateway_uid']})")
 
+        _launch_tc.summary('terminal_connection_ok')
         return {
             'success': True,
             'protocol': protocol,


### PR DESCRIPTION
Previously ``_get_launch_credential_uid`` was called three times per launch — once in ``launch.execute`` and twice inside ``extract_terminal_settings`` — and each call built a fresh ``TunnelDAG`` (2-3 HTTP round-trips each). ``find_gateway`` also re-resolved the config UID via ``get_config_uid_from_record``.

Build the TunnelDAG once in ``execute()`` and thread it through:

- ``_get_launch_credential_uid(params, record_uid, tdag=...)`` reuses the caller's DAG when provided.
- ``find_gateway(params, record_uid, tdag=...)`` reads ``config_uid`` from ``tdag.record.record_uid`` and uses the new ``_gateway_uid_from_config`` helper to skip the redundant ``get_leafs`` roundtrip.
- ``extract_terminal_settings(..., dag_linked_uid=...)`` takes a pre-resolved value via a ``_DAG_UID_UNSET`` sentinel (``None`` is a valid resolved result) and drops both inline DAG lookups.

Add a ``PamConnectTiming`` framework (new ``connect_timing.py``) gated by ``PAM_CONNECT_TIMING=1`` and instrument the full launch:

- ``pam-launch:execute`` — pre-phase checkpoints through gateway resolution (previously invisible).
- ``pam-launch:terminal_connection`` / ``pam-launch:webrtc-tunnel`` — existing phase boundaries around tunnel open.
- ``pam-launch:cli_session`` — checkpoints through guac ready.
- ``pam-launch:total`` — grand-total wall clock from command entry to ``input_handler.start()``.

Verified against QA: grand total ``ready_for_prompt`` drops from ~17.0s to ~12.4s (~4.6s saved). A single ``Found launch credential via DAG`` log line per launch (was three).