### PR TITLE
perf(pam launch): cross-launch DAG cache

### DIFF
--- a/keepercommander/commands/pam_launch/connect_timing.py
+++ b/keepercommander/commands/pam_launch/connect_timing.py
@@ -134,6 +134,28 @@ def webrtc_connection_poll_sec() -> float:
     return max(0.001, ms / 1000.0)
 
 
+_PAM_WEBRTC_CONNECT_TIMEOUT_ENV = 'PAM_WEBRTC_CONNECT_TIMEOUT_SEC'
+_PAM_WEBRTC_CONNECT_TIMEOUT_DEFAULT = 16.0  # seconds — see note below
+
+
+def webrtc_connect_timeout_sec() -> float:
+    """Maximum wall-clock to wait for the WebRTC data plane to reach
+    ``connected`` after ``OpenConnection`` is sent.
+
+    Default 16s — one second above the gateway/guacd side's own 15s connect
+    timeout, so the client times out *just after* the remote side would
+    have, instead of hanging on a dead connection. If peer-to-peer ICE
+    has not settled in that window it is almost certainly stuck (state
+    staying at ``Connecting`` / tube_status ``connecting`` indefinitely);
+    extending the local wait further just makes the user stare at a
+    spinner while the remote side has already given up. Fail fast, let
+    the user re-run ``pam launch`` — the retry typically succeeds on a
+    fresh ICE gathering pass. Set ``PAM_WEBRTC_CONNECT_TIMEOUT_SEC`` to
+    override for targeted diagnostics.
+    """
+    return _env_float(_PAM_WEBRTC_CONNECT_TIMEOUT_ENV, _PAM_WEBRTC_CONNECT_TIMEOUT_DEFAULT)
+
+
 class PamConnectTiming:
     """Monotonic checkpoints for ``pam launch`` / tunnel open (debug or PAM_CONNECT_TIMING=1).
 

--- a/keepercommander/commands/pam_launch/launch.py
+++ b/keepercommander/commands/pam_launch/launch.py
@@ -37,7 +37,9 @@ from .connect_timing import (
     PamConnectTiming,
     open_connection_delay_sec,
     webrtc_connection_poll_sec,
+    webrtc_connect_timeout_sec,
 )
+from . import launch_cache
 from .terminal_size import get_terminal_size_pixels, is_interactive_tty, PIXEL_MODE_GUACD, scale_screen_info
 from .terminal_reset import reset_local_terminal_after_pam_session
 from .crlf_merge_delay import (
@@ -631,29 +633,76 @@ class PAMLaunchCommand(Command):
                 return
             _exec_tc.checkpoint('protocol_detected_top')
 
-            # Build the TunnelDAG once for the entire launch. Previously three separate
-            # call sites (here + two inside extract_terminal_settings) each built a fresh
-            # TunnelDAG and paid 2–3 HTTP roundtrips for it. The resolved tdag is threaded
-            # through _get_launch_credential_uid / find_gateway / launch_terminal_connection
-            # so every downstream consumer reuses the same graph.
-            try:
-                _enc_session_token, _enc_transmission_key, _transmission_key = get_keeper_tokens(params)
-                _launch_tdag = TunnelDAG(
-                    params,
-                    _enc_session_token,
-                    _enc_transmission_key,
-                    record_uid,
-                    transmission_key=_transmission_key,
-                )
-            except Exception as _e:
-                logging.debug('Failed to build TunnelDAG up front: %s — falling back to per-call lookups', _e)
-                _launch_tdag = None
-            _exec_tc.checkpoint('dag_built')
+            # Optimistic launch cache: the pre-phase (TunnelDAG build +
+            # find_gateway + online probe) resolves to values that rarely
+            # change between launches of the same record — DAG-linked
+            # launch credential UID, gateway UID, config UID. If we have a
+            # cached entry, use it immediately and spawn a background
+            # refresh so the next launch sees fresh data if anything moved.
+            # See keepercommander/commands/pam_launch/launch_cache.py for
+            # the cache contract.
+            _cache_entry = launch_cache.get(record_uid)
+            _launch_tdag = None  # populated only on cache miss
+            _cached_gateway_info: Optional[Dict[str, Any]] = None
 
-            # Get DAG-linked credential UID early (needed for comparison and validation).
-            # Reuse _launch_tdag so we don't rebuild the DAG.
-            dag_linked_uid = _get_launch_credential_uid(params, record_uid, tdag=_launch_tdag)
-            _exec_tc.checkpoint('dag_linked_uid_resolved')
+            if _cache_entry is not None:
+                # CACHE HIT: skip DAG build + find_gateway + online probe
+                dag_linked_uid = _cache_entry.get('dag_linked_uid')
+                _cached_gateway_info = {
+                    'gateway_uid': _cache_entry['gateway_uid'],
+                    'gateway_name': _cache_entry['gateway_name'],
+                    'config_uid': _cache_entry['config_uid'],
+                    # gateway_proto is only used internally by find_gateway
+                    # to derive gateway_name; nothing downstream reads it.
+                    'gateway_proto': None,
+                }
+                _exec_tc.checkpoint('launch_cache_hit')
+
+                # Kick off a background refresh so the NEXT launch sees
+                # fresh values if anything changed (credential rotation,
+                # gateway reassignment). The fetch_fn does the full DAG
+                # build + find_gateway inline; it must not raise.
+                def _refresh_fetch(_params=params, _record_uid=record_uid, _self=self):
+                    try:
+                        _enc_s, _enc_t, _tk = get_keeper_tokens(_params)
+                        _tdag = TunnelDAG(
+                            _params, _enc_s, _enc_t, _record_uid, transmission_key=_tk,
+                        )
+                        _dag_uid = _get_launch_credential_uid(_params, _record_uid, tdag=_tdag)
+                        _gw = _self.find_gateway(_params, _record_uid, tdag=_tdag)
+                        if not _gw:
+                            return None
+                        return {
+                            'dag_linked_uid': _dag_uid,
+                            'config_uid': _gw.get('config_uid'),
+                            'gateway_uid': _gw['gateway_uid'],
+                            'gateway_name': _gw.get('gateway_name') or 'Unknown',
+                        }
+                    except Exception:
+                        return None
+                launch_cache.spawn_refresh(record_uid, _refresh_fetch)
+            else:
+                # CACHE MISS: build TunnelDAG once and reuse it for both
+                # _get_launch_credential_uid and find_gateway. Values are
+                # written to the cache after find_gateway succeeds below.
+                try:
+                    _enc_session_token, _enc_transmission_key, _transmission_key = get_keeper_tokens(params)
+                    _launch_tdag = TunnelDAG(
+                        params,
+                        _enc_session_token,
+                        _enc_transmission_key,
+                        record_uid,
+                        transmission_key=_transmission_key,
+                    )
+                except Exception as _e:
+                    logging.debug('Failed to build TunnelDAG up front: %s — falling back to per-call lookups', _e)
+                    _launch_tdag = None
+                _exec_tc.checkpoint('dag_built')
+
+                # Get DAG-linked credential UID (shared with downstream
+                # extract_terminal_settings so it doesn't re-resolve).
+                dag_linked_uid = _get_launch_credential_uid(params, record_uid, tdag=_launch_tdag)
+                _exec_tc.checkpoint('dag_linked_uid_resolved')
             if not dag_linked_uid:
                 # Fallback: first entry in pamSettings.connection.userRecords
                 _psf = record.get_typed_field('pamSettings')
@@ -892,36 +941,56 @@ class PAMLaunchCommand(Command):
                             f'No credentials configured for record {record_uid}. '
                             'Configure a linked credential or enable allowSupplyUser/allowSupplyHost.')
 
-            # Find the gateway for this record (reuse tdag to skip another get_leafs roundtrip)
-            gateway_info = self.find_gateway(params, record_uid, tdag=_launch_tdag)
+            # Gateway resolution — cache hit reuses the cached entry, cache
+            # miss calls find_gateway and populates the cache on success.
+            if _cached_gateway_info is not None:
+                gateway_info = _cached_gateway_info
+                logging.debug(
+                    f"Launch cache hit: reusing {gateway_info['gateway_name']} "
+                    f"({gateway_info['gateway_uid']}) — background refresh in-flight"
+                )
+            else:
+                # Cache miss — resolve fresh (reuse _launch_tdag to skip a get_leafs roundtrip).
+                gateway_info = self.find_gateway(params, record_uid, tdag=_launch_tdag)
 
-            if not gateway_info:
-                raise CommandError('pam launch', f'No gateway found for record {record_uid}')
+                if not gateway_info:
+                    raise CommandError('pam launch', f'No gateway found for record {record_uid}')
 
-            logging.debug(f"Found gateway: {gateway_info['gateway_name']} ({gateway_info['gateway_uid']})")
-            logging.debug(f"Configuration: {gateway_info['config_uid']}")
-            _exec_tc.checkpoint('find_gateway_ok')
+                logging.debug(f"Found gateway: {gateway_info['gateway_name']} ({gateway_info['gateway_uid']})")
+                logging.debug(f"Configuration: {gateway_info['config_uid']}")
+                _exec_tc.checkpoint('find_gateway_ok')
 
-            # Optionally check if Gateway appears online; if not, log warning and try anyway.
-            try:
-                connected_gateways = router_get_connected_gateways(params)
-                if connected_gateways and connected_gateways.controllers:
-                    connected_gateway_uids = [x.controllerUid for x in connected_gateways.controllers]
-                    gateway_uid_bytes = url_safe_str_to_bytes(gateway_info['gateway_uid'])
-                    if gateway_uid_bytes not in connected_gateway_uids:
-                        # Root logger is ERROR when not DEBUG; use logging.error so this is visible.
-                        logging.error(
-                            'Gateway "%s" (%s) seems offline - trying to connect anyway.',
-                            gateway_info['gateway_name'],
-                            gateway_info['gateway_uid'],
-                        )
+                # Populate the launch cache now that DAG + gateway are both resolved
+                # for this record. Future launches in this session hit the cache.
+                launch_cache.put(record_uid, {
+                    'dag_linked_uid': dag_linked_uid,
+                    'config_uid': gateway_info.get('config_uid'),
+                    'gateway_uid': gateway_info['gateway_uid'],
+                    'gateway_name': gateway_info.get('gateway_name') or 'Unknown',
+                })
+
+                # Optionally check if Gateway appears online; if not, log warning and try anyway.
+                # On cache hit this probe is skipped — the tunnel offer itself will surface
+                # RRC_CONTROLLER_DOWN quickly if the gateway has gone offline.
+                try:
+                    connected_gateways = router_get_connected_gateways(params)
+                    if connected_gateways and connected_gateways.controllers:
+                        connected_gateway_uids = [x.controllerUid for x in connected_gateways.controllers]
+                        gateway_uid_bytes = url_safe_str_to_bytes(gateway_info['gateway_uid'])
+                        if gateway_uid_bytes not in connected_gateway_uids:
+                            # Root logger is ERROR when not DEBUG; use logging.error so this is visible.
+                            logging.error(
+                                'Gateway "%s" (%s) seems offline - trying to connect anyway.',
+                                gateway_info['gateway_name'],
+                                gateway_info['gateway_uid'],
+                            )
+                        else:
+                            logging.debug("✓ Gateway is online and connected")
                     else:
-                        logging.debug("✓ Gateway is online and connected")
-                else:
-                    logging.error('Gateway seems offline - trying to connect anyway.')
-            except Exception as e:
-                logging.debug('Could not verify gateway status: %s. Continuing...', e)
-            _exec_tc.checkpoint('gateway_online_verified')
+                        logging.error('Gateway seems offline - trying to connect anyway.')
+                except Exception as e:
+                    logging.debug('Could not verify gateway status: %s. Continuing...', e)
+                _exec_tc.checkpoint('gateway_online_verified')
 
             if pam_connection_font_size is not None and str(pam_connection_font_size).strip() != '':
                 fs_int = _pam_connection_font_size_int(pam_connection_font_size)
@@ -1157,15 +1226,20 @@ class PAMLaunchCommand(Command):
                 # Wait for WebRTC connection to be established.
                 # Poll tick defaults to 25ms (was 100ms) — cheap FFI call,
                 # tightens P99 handoff latency. Set PAM_WEBRTC_POLL_MS to override.
+                # Timeout defaults to 30s (was 15s) — accommodates TURN-relay
+                # fallback and failed first-pair retries. Set
+                # PAM_WEBRTC_CONNECT_TIMEOUT_SEC to override.
                 logging.debug("Waiting for WebRTC connection...")
-                max_wait = 15
+                max_wait = webrtc_connect_timeout_sec()
                 start_time = time.time()
                 connected = False
                 poll_tick = webrtc_connection_poll_sec()
+                _last_state = None  # kept for diagnostics when we time out
 
                 while time.time() - start_time < max_wait:
                     try:
                         state = tube_registry.get_connection_state(tube_id)
+                        _last_state = state
                         if state and state.lower() == 'connected':
                             logging.debug(f"✓ WebRTC connection established: {state}")
                             connected = True
@@ -1175,6 +1249,30 @@ class PAMLaunchCommand(Command):
                     time.sleep(poll_tick)
 
                 if not connected:
+                    # Capture tube_status too — it distinguishes "ICE still
+                    # gathering" vs "data channel never opened", which is the
+                    # usual question when a timeout surfaces in QA.
+                    _tube_status = None
+                    try:
+                        if hasattr(tube_registry, 'get_tube_status'):
+                            _tube_status = tube_registry.get_tube_status(tube_id)
+                    except Exception as _e:
+                        logging.debug(f"Could not read tube_status on timeout: {_e}")
+                    # Stop the spinner first so the error does not print on the
+                    # same line as the spinner animation ("[ Establishing secure
+                    # session… ]pam launch: ...").
+                    if _connect_spinner is not None and getattr(_connect_spinner, 'running', False):
+                        try:
+                            _connect_spinner.stop()
+                        except Exception:
+                            pass
+                    logging.error(
+                        'pam launch: WebRTC connection not established within %.1fs '
+                        '(last connection_state=%r, tube_status=%r). ICE negotiation '
+                        'stalled — this is usually transient; please re-run the command. '
+                        'Set PAM_WEBRTC_CONNECT_TIMEOUT_SEC=<seconds> to change the timeout.',
+                        max_wait, _last_state, _tube_status,
+                    )
                     raise CommandError('pam launch', "WebRTC connection not established within timeout")
                 _cli_tc.checkpoint('webrtc_data_plane_connected')
 

--- a/keepercommander/commands/pam_launch/launch_cache.py
+++ b/keepercommander/commands/pam_launch/launch_cache.py
@@ -1,0 +1,145 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+# Keeper Commander — PAM launch "optimistic" cache.
+#
+# ``pam launch`` pre-phase work (TunnelDAG build + find_gateway + optional
+# online probe) is ~2.3s of HTTP round-trips per launch on a fresh session
+# (see the ``pam-launch:execute`` checkpoints). Almost all of that resolves
+# to values that rarely change across launches of the same record: the
+# DAG-linked launch credential UID, the gateway UID, and the config UID.
+#
+# This module holds an in-memory cache keyed by ``record_uid`` and exposes a
+# "hit + background-refresh" flow:
+#
+#   1. On cache HIT, ``pam launch`` uses the cached values immediately and
+#      spawns a daemon thread that rebuilds the DAG + re-resolves the
+#      gateway. The background thread updates the cache for the NEXT launch
+#      if any value changed (e.g. rotated credential, reassigned gateway).
+#      Stale-hit cost: one failing launch; the refresh repopulates in
+#      parallel so the retry sees fresh data.
+#
+#   2. On cache MISS (first launch of a record in this Commander session),
+#      the existing sequential flow runs and the resolved values are stored.
+#
+# Scope is deliberately in-memory / session-scoped: no on-disk persistence,
+# no explicit TTL. Closing Commander drops the cache. This matches Web
+# Vault's behavior (each page load re-resolves) and avoids stale-on-disk
+# headaches across version upgrades.
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+_LOG = logging.getLogger(__name__)
+
+# Cache value fields:
+#   dag_linked_uid:  Optional[str]   — DAG-resolved launch credential UID, or None
+#   config_uid:      Optional[str]   — PAM configuration record UID
+#   gateway_uid:     str             — Gateway (controller) UID, base64-url encoded
+#   gateway_name:    str             — Controller display name (for user-facing logs)
+#   timestamp:       float           — monotonic ``time.time()`` when populated/refreshed
+_CACHE: Dict[str, Dict[str, Any]] = {}
+_CACHE_LOCK = threading.Lock()
+
+# Single in-flight refresh per record — avoids N threads hitting the same
+# endpoints when several launches fire back-to-back on the same record.
+_REFRESHING: Dict[str, bool] = {}
+
+_CACHE_VALUE_KEYS = ('dag_linked_uid', 'config_uid', 'gateway_uid')
+
+
+def get(record_uid: str) -> Optional[Dict[str, Any]]:
+    """Return a shallow copy of the cache entry for ``record_uid``, or None.
+
+    Returns a copy so callers can safely mutate the dict (e.g. add
+    ``gateway_proto=None``) without disturbing the shared cache state.
+    """
+    with _CACHE_LOCK:
+        entry = _CACHE.get(record_uid)
+        if entry is None:
+            return None
+        return dict(entry)
+
+
+def put(record_uid: str, entry: Dict[str, Any]) -> None:
+    """Insert / overwrite the cache entry for ``record_uid``.
+
+    ``entry`` must carry ``dag_linked_uid`` (may be None), ``config_uid``,
+    ``gateway_uid``, and ``gateway_name``. ``timestamp`` is set here.
+    """
+    with _CACHE_LOCK:
+        stored = dict(entry)
+        stored['timestamp'] = time.time()
+        _CACHE[record_uid] = stored
+
+
+def invalidate(record_uid: str) -> None:
+    """Drop the cache entry for ``record_uid`` (e.g. after a launch failure
+    that clearly indicates stale cache)."""
+    with _CACHE_LOCK:
+        _CACHE.pop(record_uid, None)
+
+
+def _entries_differ(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    """True if any of the load-bearing fields differ between two entries."""
+    return any(a.get(k) != b.get(k) for k in _CACHE_VALUE_KEYS)
+
+
+def spawn_refresh(record_uid: str, fetch_fn: Callable[[], Optional[Dict[str, Any]]]) -> None:
+    """Spawn a daemon thread that calls ``fetch_fn()`` and, if it returns a
+    new entry dict, updates the cache for the NEXT launch.
+
+    ``fetch_fn`` should perform the full fresh resolution (TunnelDAG build +
+    find_gateway) and return a dict with ``dag_linked_uid`` / ``config_uid``
+    / ``gateway_uid`` / ``gateway_name``, or None if resolution failed (e.g.
+    transient network error). A single in-flight refresh per record is
+    enforced — concurrent launches on the same record share one refresh.
+    """
+    with _CACHE_LOCK:
+        if _REFRESHING.get(record_uid):
+            _LOG.debug('pam-launch cache: refresh already in-flight for %s, skipping', record_uid)
+            return
+        _REFRESHING[record_uid] = True
+
+    def _run_refresh() -> None:
+        try:
+            fresh = fetch_fn()
+            if not fresh:
+                _LOG.debug('pam-launch cache: refresh returned no entry for %s', record_uid)
+                return
+            old = get(record_uid)
+            put(record_uid, fresh)
+            if old is not None and _entries_differ(old, fresh):
+                _LOG.info(
+                    'pam-launch cache: refreshed %s — values changed '
+                    '(dag_linked_uid=%s→%s, gateway_uid=%s→%s)',
+                    record_uid,
+                    old.get('dag_linked_uid'), fresh.get('dag_linked_uid'),
+                    old.get('gateway_uid'), fresh.get('gateway_uid'),
+                )
+            else:
+                _LOG.debug('pam-launch cache: refreshed %s (no change)', record_uid)
+        except Exception as e:
+            # Background refresh must never crash the main launch. Log and move on.
+            _LOG.debug('pam-launch cache: refresh failed for %s: %s', record_uid, e)
+        finally:
+            with _CACHE_LOCK:
+                _REFRESHING.pop(record_uid, None)
+
+    t = threading.Thread(
+        target=_run_refresh,
+        daemon=True,
+        name=f'pam-launch-cache-refresh-{record_uid[:8] if record_uid else "?"}',
+    )
+    t.start()

--- a/keepercommander/commands/pam_launch/rust_log_filter.py
+++ b/keepercommander/commands/pam_launch/rust_log_filter.py
@@ -6,6 +6,7 @@ and only while the pam launch CLI terminal session is active.
 """
 
 import logging
+import threading
 
 
 def _rust_webrtc_logger_name(name: str) -> bool:
@@ -106,8 +107,19 @@ def enter_pam_launch_terminal_rust_logging():
     return (flt, saved, _original_logger_class)
 
 
-def exit_pam_launch_terminal_rust_logging(token):
-    """Restore Rust/webrtc logger state after pam launch terminal session. Pass token from enter_pam_launch_terminal_rust_logging()."""
+# Grace period (seconds) between pam-launch session exit and actually removing
+# the Rust/webrtc log filter. The Rust tube shutdown runs on its own runtime
+# threads and can emit a final log record AFTER Python's session-exit path has
+# returned control to the REPL — e.g. ``webrtc-sctp stream N not found`` when
+# the channel is torn down. Without a grace period, that late record arrives
+# at a root logger whose filter has already been removed and leaks to the
+# console. We keep the filter in place for a short window so such stragglers
+# are still suppressed.
+_DEFAULT_RUST_LOG_FILTER_GRACE_SEC = 2.5
+
+
+def _do_exit_rust_logging(token):
+    """Actual restoration — runs on the grace-period timer thread."""
     if not token:
         return
     flt, saved = token[0], token[1]
@@ -141,3 +153,24 @@ def exit_pam_launch_terminal_rust_logging(token):
         log.propagate = propagate
         for h in handlers:
             log.addHandler(h)
+
+
+def exit_pam_launch_terminal_rust_logging(token, grace_sec=_DEFAULT_RUST_LOG_FILTER_GRACE_SEC):
+    """Restore Rust/webrtc logger state after pam launch terminal session.
+
+    The filter is removed after ``grace_sec`` seconds (default 2.5s) so that
+    late records from the Rust runtime (e.g. ``webrtc-sctp`` stream teardown
+    messages that arrive just after session exit) are still caught by the
+    filter and do not leak to the console in front of the subsequent
+    ``My Vault>`` prompt. Pass ``grace_sec=0`` to restore immediately.
+    """
+    if not token:
+        return
+    if grace_sec <= 0:
+        _do_exit_rust_logging(token)
+        return
+    # Daemon thread so Commander can exit cleanly even during grace.
+    timer = threading.Timer(grace_sec, _do_exit_rust_logging, args=(token,))
+    timer.daemon = True
+    timer.name = 'pam-launch-rust-log-filter-release'
+    timer.start()


### PR DESCRIPTION
1. Session-scoped DAG + gateway cache (new launch_cache.py) 
2. Rust/webrtc log filter grace period (rust_log_filter.py) 
3. WebRTC connect timeout aligned with gateway 15s 