### PR TITLE
Fix `server` and `region_label` vars in Tunnel Diagnose Command

### DIFF
--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -936,7 +936,7 @@ class PAMTunnelDiagnoseCommand(Command):
         output_format = kwargs.get('format', 'table')
         test_filter = kwargs.get('test_filter')
 
-        server = 'keepersecurity.us' if server == 'govcloud.keepersecurity.us' else params.server  # e.g. "keepersecurity.com"
+        server = 'keepersecurity.us' if params.server == 'govcloud.keepersecurity.us' else params.server  # e.g. "keepersecurity.com"
         krelay_server = os.environ.get('KRELAY_URL') or f'krelay.{server}'
         connect_host = f'connect.{server}'
 

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -1029,7 +1029,7 @@ class PAMTunnelDiagnoseCommand(Command):
         print(row.rstrip())
 
         passed_ports = sum(1 for _, ok, _ in port_results if ok)
-        print(f'    {self._check()}  {self._green(str(passed_ports))}/{len(port_results)} sampled ports reachable')
+        print(f'    {self._check()}'+self._green(f'  {str(passed_ports)}/{len(port_results)} sampled ports reachable'))
         print()
 
         # ── section 4: WebRTC connectivity (Rust library) ─────────────────────

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -936,7 +936,7 @@ class PAMTunnelDiagnoseCommand(Command):
         output_format = kwargs.get('format', 'table')
         test_filter = kwargs.get('test_filter')
 
-        server = params.server  # e.g. "keepersecurity.com"
+        server = 'keepersecurity.us' if server == 'govcloud.keepersecurity.us' else params.server  # e.g. "keepersecurity.com"
         krelay_server = os.environ.get('KRELAY_URL') or f'krelay.{server}'
         connect_host = f'connect.{server}'
 
@@ -944,7 +944,7 @@ class PAMTunnelDiagnoseCommand(Command):
         self._print_header()
         print()
         now = datetime.datetime.utcnow()
-        region_label = 'US' if server == 'keepersecurity.com' else server.split('.')[0].upper()
+        region_label = 'US' if server == 'keepersecurity.com' else 'GOVCLOUD' if server == 'keepersecurity.us' else server.split('.')[-1].upper()
         print(self._green(f'  Region  {region_label}  \u00b7  {server}'))
         print(self._green(f'  Date    {now.strftime("%Y-%m-%d  %H:%M")} UTC'))
         if record_name:

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -1325,9 +1325,6 @@ class PAMTunnelDiagnoseCommand(Command):
         print(f'  {self._dsep()}')
         print()
 
-        return 0 if passed_total == total_checks else 1
-
-
 class PAMConnectionEditCommand(Command):
     choices = ['on', 'off', 'default']
     protocols = ['', 'http', 'kubernetes', 'mysql', 'postgresql', 'rdp', 'sql-server', 'ssh', 'telnet', 'vnc']


### PR DESCRIPTION
In GOVCLOUD envs, the `server` variable causes the tested URLs to be:   
`govcloud.keepersecurity.us`
`connect.govcloud.keepersecurity.us`
`krelay.govcloud.keepersecurity.us`
Instead of:
`keepersecurity.us`
`connect.keepersecurity.us`
`krelay.keepersecurity.us`

For servers other than `US` and `GOVCLOUD`, the `region_label` variable resolves as `KEEPERSECURITY`, instead of `EU`, `CA`, `AU` and `JP`

Also:
Edited a print statement to appear entirely in green instead of partially
Removed the int returned when running the command with format=table in the CLI