### PR TITLE
KC-1232: Updated default values for Date/Time/Day filters in EPM policy

### DIFF
--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1432,6 +1432,14 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         if policy_filter:
             policy_data.update(policy_filter)
 
+        if policy_type in ('PrivilegeElevation', 'FileAccess', 'CommandLine'):
+            missing = [name for name, key in (('user', 'UserCheck'), ('machine', 'MachineCheck'), ('application', 'ApplicationCheck'))
+                       if not policy_filter.get(key)]
+            if missing:
+                raise base.CommandError(
+                    f'At least one machine, application, and user collection required to save this policy type. '
+                    f'Missing: {", ".join(missing)}. Use --user-filter, --machine-filter, --app-filter.')
+
         for filter_name in ('UserCheck', 'MachineCheck', 'ApplicationCheck', 'DateCheck', 'TimeCheck', 'DayCheck'):
             f = policy_data.get(filter_name)
             if f is None:

--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1432,14 +1432,6 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
         if policy_filter:
             policy_data.update(policy_filter)
 
-        if policy_type in ('PrivilegeElevation', 'FileAccess', 'CommandLine'):
-            missing = [name for name, key in (('user', 'UserCheck'), ('machine', 'MachineCheck'), ('application', 'ApplicationCheck'))
-                       if not policy_filter.get(key)]
-            if missing:
-                raise base.CommandError(
-                    f'At least one machine, application, and user collection required to save this policy type. '
-                    f'Missing: {", ".join(missing)}. Use --user-filter, --machine-filter, --app-filter.')
-
         for filter_name, default in (('UserCheck', ['*']), ('MachineCheck', ['*']), ('ApplicationCheck', ['*']),
                                       ('DateCheck', []), ('TimeCheck', []), ('DayCheck', [])):
             if policy_data.get(filter_name) is None:

--- a/keepercommander/commands/pedm/pedm_admin.py
+++ b/keepercommander/commands/pedm/pedm_admin.py
@@ -1440,10 +1440,10 @@ class PedmPolicyAddCommand(base.ArgparseCommand, PedmPolicyMixin):
                     f'At least one machine, application, and user collection required to save this policy type. '
                     f'Missing: {", ".join(missing)}. Use --user-filter, --machine-filter, --app-filter.')
 
-        for filter_name in ('UserCheck', 'MachineCheck', 'ApplicationCheck', 'DateCheck', 'TimeCheck', 'DayCheck'):
-            f = policy_data.get(filter_name)
-            if f is None:
-                policy_data[filter_name] = ['*']
+        for filter_name, default in (('UserCheck', ['*']), ('MachineCheck', ['*']), ('ApplicationCheck', ['*']),
+                                      ('DateCheck', []), ('TimeCheck', []), ('DayCheck', [])):
+            if policy_data.get(filter_name) is None:
+                policy_data[filter_name] = default
 
         arg_status = kwargs.get('status')
         if isinstance(arg_status, str):


### PR DESCRIPTION
### Summary
When creating an EPM policy via CLI without specifying Date, Time, or Day filter options, these fields were being stored as ["*"] instead of [], inconsistent with Admin Console behaviour. This fix aligns the CLI defaults with the UI.

### Changes

- DateCheck, TimeCheck, DayCheck now default to [] when not provided, matching the Admin Console
- UserCheck, MachineCheck, ApplicationCheck continue to default to ["*"] (all)