### PR TITLE
feat(secrets-manager): add token add subcommand

### DIFF
--- a/keepercommander/commands/ksm.py
+++ b/keepercommander/commands/ksm.py
@@ -100,6 +100,19 @@ Commands to configure and manage the Keeper Secrets Manager platform.
   {bcolors.BOLD}Remove Secret from Application:{bcolors.ENDC}
   {bcolors.OKGREEN}secrets-manager share remove --app {bcolors.OKBLUE}[APP NAME OR UID] {bcolors.OKGREEN}--secret {bcolors.OKBLUE}[RECORD OR SHARED FOLDER UID]{bcolors.ENDC}
 
+  {bcolors.BOLD}Add Token to Application:{bcolors.ENDC}
+  {bcolors.OKGREEN}secrets-manager token add {bcolors.OKBLUE}[APP NAME OR UID]{bcolors.ENDC}
+    Options:
+      --count [NUM] : Number of tokens to generate (Default: 1)
+      --unlock-ip : Does not lock IP address to first requesting device
+      --first-access-expires-in-min [MIN] : First time access expiration (Default 60, Max 1440)
+      --access-expire-in-min [MIN] : Client access expiration (Default: no expiration)
+      --name [CLIENT NAME] : Name of the client
+      --config-init [json, b64 or k8s] : Initialize configuration string from a one-time token
+      --return-tokens : Return generated tokens as a comma-separated string
+    Adds one or more one-time access tokens to an existing KSM application.
+    Equivalent to: secrets-manager client add --app [APP NAME OR UID]
+
   -----
   Note: If the UID you are using contains a dash (-) in the beginning, the value should be wrapped 
   in quotes and prepended with an equal sign. For example:
@@ -114,7 +127,7 @@ ksm_parser = argparse.ArgumentParser(prog='secrets-manager', description='Keeper
                                      add_help=False)
 ksm_parser.add_argument('command', type=str, action='store', nargs="*",
                     help='One of: "app list", "app get", "app create", "app update", "app remove", "app share", ' +
-                             '"app unshare", "client add", "client remove", "share add", "share update" or "share remove"')
+                             '"app unshare", "client add", "client remove", "share add", "share update", "share remove" or "token add"')
 ksm_parser.add_argument('--secret', '-s', type=str, action='append', required=False,
                         help='Record UID')
 ksm_parser.add_argument('--app', '-a', type=str, action='store', required=False,
@@ -426,6 +439,32 @@ class KSMCommand(Command):
                     KSMCommand.remove_client(params, app_name_or_uid, client_names_or_ids, force)
 
                 return
+
+        elif ksm_obj in ('token', 'tokens') and ksm_action in ('add', 'create'):
+            if len(ksm_command) < 3:
+                print(
+                    f'{bcolors.WARNING}App UID or name is required.{bcolors.ENDC}\n'
+                    f'\tEx: {bcolors.OKGREEN}secrets-manager token add {bcolors.OKBLUE}MyApp{bcolors.ENDC}'
+                )
+                return
+            app_name_or_uid = ksm_command[2]
+            count = kwargs.get('count', 1)
+            unlock_ip = kwargs.get('unlockIp', False)
+            first_access_expire_on = kwargs.get('firstAccessExpiresIn')
+            access_expire_in_min = kwargs.get('accessExpireInMin')
+            client_name = kwargs.get('name')
+            config_init = kwargs.get('config_init')
+            is_return_tokens = kwargs.get('returnTokens', False)
+            tokens_and_device = KSMCommand.add_client(
+                params, app_name_or_uid, count, unlock_ip,
+                first_access_expire_on, access_expire_in_min,
+                client_name=client_name, config_init=config_init,
+                client_type=enterprise_pb2.GENERAL,
+            )
+            if is_return_tokens and tokens_and_device:
+                tokens_only = [x.get('oneTimeToken', '') for x in tokens_and_device if x.get('oneTimeToken')]
+                return ', '.join(tokens_only) if tokens_only else None
+            return
 
         print(f"{bcolors.WARNING}Unknown combination of KSM commands. " +
               f"Type 'secrets-manager' for more details'{bcolors.ENDC}")

--- a/unit-tests/test_command_ksm.py
+++ b/unit-tests/test_command_ksm.py
@@ -1,0 +1,54 @@
+"""Unit tests for secrets-manager (KSM) CLI commands."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keepercommander.commands.ksm import KSMCommand
+
+
+class TestKSMTokenAdd(unittest.TestCase):
+    """secrets-manager token add <app-uid> → calls add_client."""
+
+    def _make_params(self, record_uid='test-app-uid'):
+        params = MagicMock()
+        params.record_cache = {}
+        return params
+
+    @patch('keepercommander.commands.ksm.KSMCommand.add_client')
+    def test_token_add_calls_add_client(self, mock_add_client):
+        mock_add_client.return_value = [{'oneTimeToken': 'US:abc123', 'deviceToken': 'dt1'}]
+        params = self._make_params()
+        cmd = KSMCommand()
+        result = cmd.execute(params, command=['token', 'add', 'MyApp'],
+                             count=1, unlockIp=False, firstAccessExpiresIn=None,
+                             accessExpireInMin=None, name=None, config_init=None,
+                             returnTokens=False, format='table')
+        mock_add_client.assert_called_once()
+        call_args = mock_add_client.call_args
+        assert call_args[0][1] == 'MyApp', f"Expected 'MyApp', got {call_args[0][1]}"
+
+    @patch('keepercommander.commands.ksm.KSMCommand.add_client')
+    def test_token_add_return_tokens(self, mock_add_client):
+        mock_add_client.return_value = [{'oneTimeToken': 'US:tok1'}, {'oneTimeToken': 'US:tok2'}]
+        params = self._make_params()
+        cmd = KSMCommand()
+        result = cmd.execute(params, command=['token', 'add', 'MyApp'],
+                             count=2, unlockIp=False, firstAccessExpiresIn=None,
+                             accessExpireInMin=None, name=None, config_init=None,
+                             returnTokens=True, format='table')
+        assert result == 'US:tok1, US:tok2', f"Expected 'US:tok1, US:tok2', got {result!r}"
+
+    def test_token_add_missing_app_prints_help(self):
+        params = self._make_params()
+        cmd = KSMCommand()
+        # Should print help and return None without calling add_client
+        with patch('keepercommander.commands.ksm.KSMCommand.add_client') as mock_ac:
+            result = cmd.execute(params, command=['token', 'add'],
+                                 count=1, unlockIp=False, firstAccessExpiresIn=None,
+                                 accessExpireInMin=None, name=None, config_init=None,
+                                 returnTokens=False, format='table')
+            mock_ac.assert_not_called()
+            assert result is None, f"Expected None, got {result!r}"
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `secrets-manager token add <APP_UID_OR_NAME>` as a thin, discoverable wrapper around the existing `client add` flow. Allows operators and automation scripts to add one-time access tokens to an existing KSM application without recreating it.

Equivalent to: `secrets-manager client add --app <APP>`

**Supported flags** (same as `client add`):
`--count`, `--unlock-ip`, `--first-access-expires-in-min`, `--access-expire-in-min`, `--name`, `--config-init`, `--return-tokens`

Implementation delegates entirely to `KSMCommand.add_client()` — no new API surface introduced.

## Test plan
- [x] `pytest unit-tests/test_command_ksm.py` — 3 new tests (happy path, `--return-tokens`, missing-app guard)
- [x] Full suite — 534 passed, 5 skipped
- [x] Live tenant — `secrets-manager token add <app>` generated token with `US:` prefix