### PR TITLE
feat(pam project): add pam project export subcommand

### DIFF
--- a/keepercommander/commands/pam_import/commands.py
+++ b/keepercommander/commands/pam_import/commands.py
@@ -10,6 +10,7 @@
 #
 
 from .edit import PAMProjectImportCommand
+from .export import PAMProjectExportCommand
 from .extend import PAMProjectExtendCommand
 from ..base import GroupCommand
 
@@ -17,4 +18,5 @@ class PAMProjectCommand(GroupCommand):
     def __init__(self):
         super(PAMProjectCommand, self).__init__()
         self.register_command("import", PAMProjectImportCommand(), "Import PAM Project", "i")
+        self.register_command("export", PAMProjectExportCommand(), "Export PAM project to JSON for re-import", "x")
         self.register_command("extend", PAMProjectExtendCommand(), "Extend PAM Project by importing additional data", "e")

--- a/keepercommander/commands/pam_import/export.py
+++ b/keepercommander/commands/pam_import/export.py
@@ -1,0 +1,267 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2025 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+from __future__ import annotations
+import argparse
+import json
+import logging
+
+from .base import (
+    PAM_RESOURCES_RECORD_TYPES,
+    PAM_CONFIG_TYPES,
+    PAM_ENVIRONMENT_TYPES,
+)
+from ..base import Command
+from ..pam.config_facades import PamConfigurationRecordFacade
+from ... import vault
+from ...display import bcolors
+
+
+# Maps v6 record_type -> environment name used by pam project import
+_RECORD_TYPE_TO_ENV = {
+    "pamNetworkConfiguration": "local",
+    "pamAwsConfiguration": "aws",
+    "pamAzureConfiguration": "azure",
+    "pamDomainConfiguration": "domain",
+    "pamGcpConfiguration": "gcp",
+    "pamOciConfiguration": "oci",
+}
+
+# Maps DAG allowedSettings keys -> JSON keys used in PROJECT_IMPORT_JSON_TEMPLATE
+_DAG_KEY_TO_JSON = {
+    "connections":          "connections",
+    "portForwards":         "tunneling",
+    "rotation":             "rotation",
+    "remoteBrowserIsolation": "remote_browser_isolation",
+    "sessionRecording":     "graphical_session_recording",
+    "typescriptRecording":  "text_session_recording",
+    "aiEnabled":            "ai_threat_detection",
+    "aiSessionTerminate":   "ai_terminate_session_on_detection",
+}
+
+
+class PAMProjectExportCommand(Command):
+    """Export a PAM project to a JSON document that can be re-imported via pam project import."""
+
+    parser = argparse.ArgumentParser(prog="pam project export")
+    parser.add_argument(
+        "--project-uid", "-p",
+        required=True, dest="project_uid", action="store",
+        help="PAM configuration record UID to export.",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        required=False, dest="output", action="store",
+        help="File path to write JSON output (default: print to stdout).",
+    )
+
+    def get_parser(self):
+        return PAMProjectExportCommand.parser
+
+    # ------------------------------------------------------------------
+    # Public execute
+    # ------------------------------------------------------------------
+
+    def execute(self, params, **kwargs):
+        project_uid = (kwargs.get("project_uid") or "").strip()
+        output_file = (kwargs.get("output") or "").strip()
+
+        if not project_uid:
+            logging.warning(f"{bcolors.FAIL}--project-uid is required{bcolors.ENDC}")
+            return
+
+        # 1. Load PAM configuration record (v6)
+        config_record = vault.KeeperRecord.load(params, project_uid)
+        if not config_record:
+            logging.warning(
+                f"{bcolors.FAIL}PAM configuration '{project_uid}' not found in vault{bcolors.ENDC}"
+            )
+            return
+        if config_record.version != 6:
+            logging.warning(
+                f"{bcolors.FAIL}Record '{project_uid}' (version {config_record.version}) "
+                f"is not a PAM configuration — version 6 required{bcolors.ENDC}"
+            )
+            return
+        if not isinstance(config_record, vault.TypedRecord):
+            logging.warning(
+                f"{bcolors.FAIL}Record '{project_uid}' is not a TypedRecord{bcolors.ENDC}"
+            )
+            return
+
+        # 2. Determine environment
+        environment = _RECORD_TYPE_TO_ENV.get(config_record.record_type, "local")
+
+        # 3. Get resource UIDs from pamResources.resourceRef
+        facade = PamConfigurationRecordFacade()
+        facade.record = config_record
+        resource_uids = list(facade.resource_ref or [])
+
+        # 4. Try to read connection/rotation/tunneling settings from DAG (best-effort)
+        allowed_settings = self._get_allowed_settings(params, project_uid)
+
+        # 5. Walk resources and gather users
+        resources_list, top_level_users = self._build_resources_and_users(params, resource_uids)
+
+        # 6. Assemble result dict
+        result = {
+            "tool_version": "commander-export-1.0",
+            "project": config_record.title,
+            "shared_folder_users": {},
+            "shared_folder_resources": {},
+            "pam_configuration": {
+                "environment": environment,
+                "title": config_record.title,
+                "connections":                      allowed_settings.get("connections",                      "on"),
+                "rotation":                         allowed_settings.get("rotation",                         "on"),
+                "tunneling":                        allowed_settings.get("tunneling",                        "on"),
+                "remote_browser_isolation":         allowed_settings.get("remote_browser_isolation",         "on"),
+                "graphical_session_recording":      allowed_settings.get("graphical_session_recording",      "off"),
+                "text_session_recording":           allowed_settings.get("text_session_recording",           "off"),
+                "ai_threat_detection":              allowed_settings.get("ai_threat_detection",              "off"),
+                "ai_terminate_session_on_detection": allowed_settings.get("ai_terminate_session_on_detection", "off"),
+            },
+            "pam_data": {
+                "resources": resources_list,
+                "users": top_level_users,
+            },
+        }
+
+        output_json = json.dumps(result, indent=2, sort_keys=True)
+
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as fh:
+                fh.write(output_json)
+            print(f"{bcolors.OKGREEN}PAM project exported to: {output_file}{bcolors.ENDC}")
+            return
+
+        return output_json
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_allowed_settings(self, params, config_uid):
+        """Return on/off dict for tunneling config, falling back to safe defaults."""
+        defaults = {
+            "connections": "on",
+            "rotation": "on",
+            "tunneling": "on",
+            "remote_browser_isolation": "on",
+            "graphical_session_recording": "off",
+            "text_session_recording": "off",
+            "ai_threat_detection": "off",
+            "ai_terminate_session_on_detection": "off",
+        }
+        try:
+            from ..tunnel.port_forward.tunnel_helpers import get_keeper_tokens
+            from ..tunnel.port_forward.TunnelGraph import TunnelDAG, get_vertex_content
+
+            encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
+            tmp_dag = TunnelDAG(
+                params, encrypted_session_token, encrypted_transmission_key,
+                config_uid, is_config=True, transmission_key=transmission_key,
+            )
+            tmp_dag.linking_dag.load()
+            vertex = tmp_dag.linking_dag.get_vertex(config_uid)
+            content = get_vertex_content(vertex) if vertex else None
+            dag_allowed = (content or {}).get("allowedSettings") or {}
+            for dag_key, json_key in _DAG_KEY_TO_JSON.items():
+                if dag_key in dag_allowed:
+                    defaults[json_key] = "on" if dag_allowed[dag_key] else "off"
+        except Exception as exc:
+            logging.debug("PAMProjectExportCommand: could not load DAG allowed settings: %s", exc)
+        return defaults
+
+    def _build_resources_and_users(self, params, resource_uids):
+        """Walk resource UIDs and collect resources + deduplicated top-level users."""
+        resources_list = []
+        top_level_users = []
+        seen_user_uids = set()
+
+        for res_uid in resource_uids:
+            res_record = vault.KeeperRecord.load(params, res_uid)
+            if not res_record or not isinstance(res_record, vault.TypedRecord):
+                logging.debug("Export: skipping resource UID %s (not found or not TypedRecord)", res_uid)
+                continue
+            if res_record.record_type not in PAM_RESOURCES_RECORD_TYPES:
+                logging.debug(
+                    "Export: skipping record %s with type '%s' (not a PAM resource type)",
+                    res_uid, res_record.record_type,
+                )
+                continue
+
+            # Extract raw pamSettings payload (keep as-is for round-trip fidelity)
+            pam_settings_dict = {}
+            pam_settings_field = res_record.get_typed_field("pamSettings")
+            if (
+                pam_settings_field
+                and isinstance(pam_settings_field.value, list)
+                and pam_settings_field.value
+                and isinstance(pam_settings_field.value[0], dict)
+            ):
+                pam_settings_dict = dict(pam_settings_field.value[0])
+
+            # Gather user UIDs referenced by this resource
+            resource_user_entries = []
+            user_uids_for_resource = self._extract_user_uids(pam_settings_dict)
+
+            for usr_uid in user_uids_for_resource:
+                user_obj = self._load_user_obj(params, usr_uid)
+                if user_obj is None:
+                    continue
+                resource_user_entries.append({"uid": usr_uid, "type": user_obj["type"], "title": user_obj["title"], "login": user_obj["login"]})
+                if usr_uid not in seen_user_uids:
+                    seen_user_uids.add(usr_uid)
+                    top_level_users.append(user_obj)
+
+            resources_list.append({
+                "uid": res_uid,
+                "type": res_record.record_type,
+                "title": res_record.title,
+                "pam_settings": pam_settings_dict,
+                "users": resource_user_entries,
+            })
+
+        return resources_list, top_level_users
+
+    def _extract_user_uids(self, pam_settings_dict):
+        """Return all user record UIDs referenced inside a pamSettings dict."""
+        user_uids = []
+        conn = pam_settings_dict.get("connection") or {}
+        if isinstance(conn, dict):
+            for uid in (conn.get("userRecords") or []):
+                if uid and uid not in user_uids:
+                    user_uids.append(uid)
+        # Some record types also reference admin via adminRef / adminCredentialRef at top level
+        for key in ("adminRef", "adminCredentialRef"):
+            uid = pam_settings_dict.get(key)
+            if uid and uid not in user_uids:
+                user_uids.append(uid)
+        return user_uids
+
+    def _load_user_obj(self, params, usr_uid):
+        """Load a pamUser/login record and return a plain dict, or None on failure."""
+        usr_record = vault.KeeperRecord.load(params, usr_uid)
+        if not usr_record or not isinstance(usr_record, vault.TypedRecord):
+            logging.debug("Export: user UID %s not found or not TypedRecord", usr_uid)
+            return None
+        login_field = usr_record.get_typed_field("login")
+        login = ""
+        if login_field:
+            raw = login_field.get_default_value()
+            login = str(raw) if raw is not None else ""
+        return {
+            "uid": usr_uid,
+            "type": usr_record.record_type,
+            "title": usr_record.title,
+            "login": login,
+        }

--- a/keepercommander/commands/pam_import/export.py
+++ b/keepercommander/commands/pam_import/export.py
@@ -182,10 +182,25 @@ class PAMProjectExportCommand(Command):
         return defaults
 
     def _build_resources_and_users(self, params, resource_uids):
-        """Walk resource UIDs and collect resources + deduplicated top-level users."""
+        """Walk resource UIDs and collect resources + deduplicated top-level users.
+
+        Two linking strategies are supported:
+
+        1. Standard: ``pam_settings.connection.userRecords[]`` and
+           top-level ``adminRef`` / ``adminCredentialRef`` carry user UIDs.
+        2. Title-based (e.g. KCM imports — see PR #1942): the resource
+           record references users by **title** in
+           ``pam_settings.connection.{launch,administrative}_credentials``
+           (e.g. ``"KCM User - prod-db"``) without a userRecords list. We
+           resolve those by scanning the project's vault for pamUser /
+           login records with matching titles.
+        """
         resources_list = []
         top_level_users = []
         seen_user_uids = set()
+
+        # Pre-build a lookup of (record_type, title.lower()) -> uid for fallback resolution
+        title_to_uid = self._build_user_title_index(params)
 
         for res_uid in resource_uids:
             res_record = vault.KeeperRecord.load(params, res_uid)
@@ -212,7 +227,7 @@ class PAMProjectExportCommand(Command):
 
             # Gather user UIDs referenced by this resource
             resource_user_entries = []
-            user_uids_for_resource = self._extract_user_uids(pam_settings_dict)
+            user_uids_for_resource = self._extract_user_uids(pam_settings_dict, title_to_uid)
 
             for usr_uid in user_uids_for_resource:
                 user_obj = self._load_user_obj(params, usr_uid)
@@ -233,14 +248,51 @@ class PAMProjectExportCommand(Command):
 
         return resources_list, top_level_users
 
-    def _extract_user_uids(self, pam_settings_dict):
-        """Return all user record UIDs referenced inside a pamSettings dict."""
+    def _build_user_title_index(self, params):
+        """Index every pamUser / login record by lowercased title for title-based linking."""
+        index = {}
+        record_cache = getattr(params, "record_cache", {}) or {}
+        for uid in record_cache:
+            try:
+                rec = vault.KeeperRecord.load(params, uid)
+            except Exception:
+                continue
+            if not rec or not isinstance(rec, vault.TypedRecord):
+                continue
+            if rec.record_type not in ("pamUser", "login"):
+                continue
+            if rec.title:
+                index.setdefault(rec.title.strip().lower(), uid)
+        return index
+
+    def _extract_user_uids(self, pam_settings_dict, title_to_uid=None):
+        """Return all user record UIDs referenced inside a pamSettings dict.
+
+        Falls back to title-based resolution against ``title_to_uid`` when
+        the record stores a title (e.g. KCM-imported records, PR #1942)
+        instead of a UID in launch_credentials / administrative_credentials.
+        """
         user_uids = []
+        title_to_uid = title_to_uid or {}
         conn = pam_settings_dict.get("connection") or {}
         if isinstance(conn, dict):
             for uid in (conn.get("userRecords") or []):
                 if uid and uid not in user_uids:
                     user_uids.append(uid)
+            # KCM-style title references (PR #1942 schema)
+            for key in ("launch_credentials", "administrative_credentials"):
+                ref = conn.get(key)
+                if not isinstance(ref, str) or not ref:
+                    continue
+                # If it already looks like a UID, accept as-is
+                if len(ref) == 22 and "/" not in ref and " " not in ref:
+                    if ref not in user_uids:
+                        user_uids.append(ref)
+                    continue
+                # Otherwise treat as a title and resolve against the index
+                resolved = title_to_uid.get(ref.strip().lower())
+                if resolved and resolved not in user_uids:
+                    user_uids.append(resolved)
         # Some record types also reference admin via adminRef / adminCredentialRef at top level
         for key in ("adminRef", "adminCredentialRef"):
             uid = pam_settings_dict.get(key)

--- a/unit-tests/pam/test_pam_project_export.py
+++ b/unit-tests/pam/test_pam_project_export.py
@@ -277,6 +277,116 @@ if sys.version_info >= (3, 8):
                              "Top-level keys should be sorted (sort_keys=True)")
 
 
+    # ────────────────────────────────────────────────────────────────────
+    # KCM-import compatibility (PR #1942)
+    # ────────────────────────────────────────────────────────────────────
+
+    class TestKCMImportRoundTrip(unittest.TestCase):
+        """KCM-imported records (PR #1942) reference users by *title* in
+        ``pam_settings.connection.launch_credentials`` rather than by UID
+        in ``userRecords[]``. Export must resolve these title references
+        so the exported JSON re-imports with the user link intact.
+        """
+
+        KCM_CFG = "kcm-cfg-1"
+        KCM_RES = "kcm-res-prod-db"
+        KCM_USR = "kcm-usr-prod-db"
+
+        def _make_kcm_records(self):
+            """Build the KCM-shaped vault state (PR #1942 import output)."""
+            cfg = vault.TypedRecord(version=6)
+            cfg.type_name = "pamNetworkConfiguration"
+            cfg.title = "KCM Migration"
+            cfg.record_uid = self.KCM_CFG
+            cfg.fields.append(_make_typed_field("pamResources", [{
+                "controllerUid": "gw-uid",
+                "folderUid": "sf-uid",
+                "resourceRef": [self.KCM_RES],
+            }]))
+
+            res = vault.TypedRecord(version=3)
+            res.type_name = "pamMachine"
+            res.title = "KCM Resource - prod-db"
+            res.record_uid = self.KCM_RES
+            res.fields.append(_make_typed_field("pamSettings", [{
+                "connection": {
+                    "protocol": "ssh",
+                    "port": "22",
+                    "launch_credentials": "KCM User - prod-db",
+                },
+                "options": {"connections": "on", "rotation": "off"},
+            }]))
+
+            usr = vault.TypedRecord(version=3)
+            usr.type_name = "pamUser"
+            usr.title = "KCM User - prod-db"
+            usr.record_uid = self.KCM_USR
+            usr.fields.append(_make_typed_field("login", ["root"]))
+
+            return {self.KCM_CFG: cfg, self.KCM_RES: res, self.KCM_USR: usr}
+
+        def setUp(self):
+            from keepercommander.commands.pam_import.export import PAMProjectExportCommand
+            from unittest.mock import MagicMock
+            self.cmd = PAMProjectExportCommand()
+            self.records = self._make_kcm_records()
+            self.params = MagicMock()
+            self.params.record_cache = {uid: {} for uid in self.records}
+
+        def _execute(self):
+            def _load(_p, uid):
+                return self.records.get(uid)
+            with patch("keepercommander.vault.KeeperRecord.load", side_effect=_load):
+                with patch.object(self.cmd, "_get_allowed_settings",
+                                  return_value=dict(_DEFAULT_ALLOWED)):
+                    return self.cmd.execute(self.params, project_uid=self.KCM_CFG)
+
+        def test_title_based_user_link_resolved(self):
+            """KCM resource → export must include the user via title resolution."""
+            parsed = json.loads(self._execute())
+            resources = parsed["pam_data"]["resources"]
+            self.assertEqual(len(resources), 1, "expected one KCM resource")
+            res = resources[0]
+            self.assertEqual(len(res["users"]), 1,
+                             "KCM resource must export 1 user (resolved by title)")
+            self.assertEqual(res["users"][0]["uid"], self.KCM_USR)
+            self.assertEqual(res["users"][0]["title"], "KCM User - prod-db")
+
+        def test_top_level_users_includes_resolved_user(self):
+            parsed = json.loads(self._execute())
+            top_users = parsed["pam_data"]["users"]
+            self.assertEqual(len(top_users), 1)
+            self.assertEqual(top_users[0]["uid"], self.KCM_USR)
+
+        def test_pam_settings_preserved_for_round_trip(self):
+            """Round-trip safety: KCM-specific pam_settings keys preserved verbatim."""
+            parsed = json.loads(self._execute())
+            res = parsed["pam_data"]["resources"][0]
+            conn = res["pam_settings"]["connection"]
+            self.assertEqual(conn["protocol"], "ssh")
+            self.assertEqual(conn["port"], "22")
+            self.assertEqual(conn["launch_credentials"], "KCM User - prod-db")
+
+        def test_uid_in_launch_credentials_accepted(self):
+            """If launch_credentials already holds a 22-char UID (non-KCM path), keep it as-is."""
+            uid_22 = "AAAAAAAAAAAAAAAAAAAAAA"  # 22 chars, no slash, no space
+            usr = vault.TypedRecord(version=3)
+            usr.type_name = "pamUser"
+            usr.title = "Direct UID User"
+            usr.record_uid = uid_22
+            usr.fields.append(_make_typed_field("login", ["alice"]))
+            self.records[uid_22] = usr
+            self.params.record_cache[uid_22] = {}
+
+            res = self.records[self.KCM_RES]
+            ps = res.get_typed_field("pamSettings").value[0]
+            ps["connection"]["launch_credentials"] = uid_22
+            parsed = json.loads(self._execute())
+            users = parsed["pam_data"]["resources"][0]["users"]
+            self.assertEqual(len(users), 1)
+            self.assertEqual(users[0]["uid"], uid_22)
+
+
 else:
     class TestPAMProjectExportCommand(unittest.TestCase):
         def test_skip(self):

--- a/unit-tests/pam/test_pam_project_export.py
+++ b/unit-tests/pam/test_pam_project_export.py
@@ -1,0 +1,287 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2025 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+"""
+Unit tests for PAMProjectExportCommand.
+
+Uses real vault.TypedRecord / vault.TypedField objects (no network access)
+so isinstance() checks in the production code pass correctly.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from keepercommander import vault
+
+# ── record builders ────────────────────────────────────────────────────────
+
+def _make_typed_field(field_type, value, label=None):
+    """Create a real vault.TypedField."""
+    tf = vault.TypedField.new_field(field_type, value, field_label=label)
+    return tf
+
+
+def _make_config_record(uid, title="Test Project", record_type="pamNetworkConfiguration",
+                        resource_uids=None):
+    """Real vault.TypedRecord v6 for a PAM configuration."""
+    resource_uids = resource_uids or ["res-machine-1", "res-db-1"]
+
+    rec = vault.TypedRecord(version=6)
+    rec.type_name = record_type
+    rec.title = title
+    rec.record_uid = uid
+
+    pam_res_value = [{
+        "controllerUid": "gw-uid-abc",
+        "folderUid": "sf-uid-abc",
+        "resourceRef": list(resource_uids),
+    }]
+    rec.fields.append(_make_typed_field("pamResources", pam_res_value))
+    return rec
+
+
+def _make_resource_record(uid, title, record_type, user_uids=None):
+    """Real vault.TypedRecord v3 for a PAM resource."""
+    user_uids = user_uids or []
+    rec = vault.TypedRecord(version=3)
+    rec.type_name = record_type
+    rec.title = title
+    rec.record_uid = uid
+
+    pam_settings_value = [{
+        "connection": {"userRecords": list(user_uids), "protocol": "ssh"},
+    }]
+    rec.fields.append(_make_typed_field("pamSettings", pam_settings_value))
+    return rec
+
+
+def _make_user_record(uid, title, login):
+    """Real vault.TypedRecord v3 for a pamUser."""
+    rec = vault.TypedRecord(version=3)
+    rec.type_name = "pamUser"
+    rec.title = title
+    rec.record_uid = uid
+    rec.fields.append(_make_typed_field("login", [login]))
+    return rec
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+CONFIG_UID = "cfg-uid-001"
+MACHINE_UID = "res-machine-1"
+DB_UID = "res-db-1"
+USER1_UID = "usr-uid-001"
+USER2_UID = "usr-uid-002"
+
+_RECORDS = {
+    CONFIG_UID: _make_config_record(CONFIG_UID, "Test Project",
+                                    resource_uids=[MACHINE_UID, DB_UID]),
+    MACHINE_UID: _make_resource_record(MACHINE_UID, "Linux Server", "pamMachine",
+                                       user_uids=[USER1_UID]),
+    DB_UID: _make_resource_record(DB_UID, "Postgres DB", "pamDatabase",
+                                  user_uids=[USER1_UID, USER2_UID]),
+    USER1_UID: _make_user_record(USER1_UID, "Admin User", "root"),
+    USER2_UID: _make_user_record(USER2_UID, "DB User", "dbuser"),
+}
+
+
+def _fake_load(_params, uid):
+    """Replacement for vault.KeeperRecord.load in tests."""
+    return _RECORDS.get(uid)
+
+
+_DEFAULT_ALLOWED = {
+    "connections": "on", "rotation": "on", "tunneling": "on",
+    "remote_browser_isolation": "on", "graphical_session_recording": "off",
+    "text_session_recording": "off", "ai_threat_detection": "off",
+    "ai_terminate_session_on_detection": "off",
+}
+
+# ── tests ──────────────────────────────────────────────────────────────────
+
+if sys.version_info >= (3, 8):
+
+    from unittest.mock import MagicMock
+
+    class TestPAMProjectExportCommand(unittest.TestCase):
+
+        def setUp(self):
+            from keepercommander.commands.pam_import.export import PAMProjectExportCommand
+            self.cmd = PAMProjectExportCommand()
+            self.params = MagicMock()
+            self.params.record_cache = {uid: {} for uid in _RECORDS}
+
+        def _execute(self, project_uid=CONFIG_UID, output=None):
+            """Run execute() with vault.KeeperRecord.load mocked."""
+            with patch("keepercommander.vault.KeeperRecord.load", side_effect=_fake_load):
+                with patch.object(self.cmd, "_get_allowed_settings",
+                                  return_value=dict(_DEFAULT_ALLOWED)):
+                    kwargs = {"project_uid": project_uid}
+                    if output:
+                        kwargs["output"] = output
+                    return self.cmd.execute(self.params, **kwargs)
+
+        # ── basic output ──────────────────────────────────────────────
+
+        def test_returns_string(self):
+            result = self._execute()
+            self.assertIsInstance(result, str,
+                                  "execute() should return a JSON string when --output is not set")
+
+        def test_valid_json(self):
+            parsed = json.loads(self._execute())
+            self.assertIsInstance(parsed, dict)
+
+        # ── required top-level keys ───────────────────────────────────
+
+        def test_has_project_key(self):
+            parsed = json.loads(self._execute())
+            self.assertIn("project", parsed)
+            self.assertEqual(parsed["project"], "Test Project")
+
+        def test_has_pam_configuration_key(self):
+            parsed = json.loads(self._execute())
+            self.assertIn("pam_configuration", parsed)
+
+        def test_has_pam_data_key(self):
+            parsed = json.loads(self._execute())
+            self.assertIn("pam_data", parsed)
+            self.assertIn("resources", parsed["pam_data"])
+            self.assertIn("users", parsed["pam_data"])
+
+        def test_has_tool_version(self):
+            parsed = json.loads(self._execute())
+            self.assertIn("tool_version", parsed)
+            self.assertEqual(parsed["tool_version"], "commander-export-1.0")
+
+        # ── pam_configuration fields ──────────────────────────────────
+
+        def test_pam_configuration_environment(self):
+            parsed = json.loads(self._execute())
+            self.assertEqual(parsed["pam_configuration"]["environment"], "local")
+
+        def test_pam_configuration_on_off_values(self):
+            parsed = json.loads(self._execute())
+            cfg = parsed["pam_configuration"]
+            for key in ("connections", "rotation", "tunneling", "remote_browser_isolation"):
+                self.assertIn(cfg[key], ("on", "off"), f"{key} must be 'on' or 'off'")
+
+        # ── resources ────────────────────────────────────────────────
+
+        def test_resources_count(self):
+            parsed = json.loads(self._execute())
+            self.assertEqual(len(parsed["pam_data"]["resources"]), 2)
+
+        def test_resource_has_required_keys(self):
+            parsed = json.loads(self._execute())
+            for res in parsed["pam_data"]["resources"]:
+                for key in ("uid", "type", "title", "users"):
+                    self.assertIn(key, res, f"resource missing key: {key}")
+
+        def test_resource_uids_are_unique(self):
+            parsed = json.loads(self._execute())
+            uids = [r["uid"] for r in parsed["pam_data"]["resources"]]
+            self.assertEqual(len(uids), len(set(uids)), "resource UIDs must be unique")
+
+        def test_resource_types(self):
+            parsed = json.loads(self._execute())
+            types = {r["type"] for r in parsed["pam_data"]["resources"]}
+            self.assertIn("pamMachine", types)
+            self.assertIn("pamDatabase", types)
+
+        # ── users ────────────────────────────────────────────────────
+
+        def test_top_level_users_deduplication(self):
+            # USER1 appears in both machine and database resources;
+            # must only appear once in pam_data.users
+            parsed = json.loads(self._execute())
+            top_uids = [u["uid"] for u in parsed["pam_data"]["users"]]
+            self.assertEqual(len(top_uids), len(set(top_uids)),
+                             "top-level user UIDs must be unique (de-duplicated)")
+
+        def test_top_level_users_count(self):
+            # USER1 shared across both resources, USER2 only in DB → 2 unique users
+            parsed = json.loads(self._execute())
+            self.assertEqual(len(parsed["pam_data"]["users"]), 2)
+
+        def test_user_has_required_keys(self):
+            parsed = json.loads(self._execute())
+            for usr in parsed["pam_data"]["users"]:
+                for key in ("uid", "type", "title", "login"):
+                    self.assertIn(key, usr, f"user missing key: {key}")
+
+        # ── --output flag ────────────────────────────────────────────
+
+        def test_output_flag_writes_file(self):
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+                tmp_path = tmp.name
+            try:
+                result = self._execute(output=tmp_path)
+                # When --output is set, execute() should return None
+                self.assertIsNone(result)
+                self.assertTrue(os.path.exists(tmp_path))
+                with open(tmp_path, encoding="utf-8") as fh:
+                    content = fh.read()
+                parsed = json.loads(content)
+                self.assertIn("project", parsed)
+                self.assertIn("tool_version", parsed)
+            finally:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        # ── error handling ───────────────────────────────────────────
+
+        def test_missing_project_uid_returns_none(self):
+            with patch("keepercommander.vault.KeeperRecord.load", side_effect=_fake_load):
+                result = self.cmd.execute(self.params, project_uid="", output=None)
+            self.assertIsNone(result)
+
+        def test_unknown_uid_returns_none(self):
+            with patch("keepercommander.vault.KeeperRecord.load", return_value=None):
+                result = self.cmd.execute(self.params, project_uid="unknown-uid", output=None)
+            self.assertIsNone(result)
+
+        def test_non_v6_record_returns_none(self):
+            v3_rec = vault.TypedRecord(version=3)
+            v3_rec.type_name = "pamMachine"
+            v3_rec.title = "some"
+            v3_rec.record_uid = "some-uid"
+            with patch("keepercommander.vault.KeeperRecord.load", return_value=v3_rec):
+                result = self.cmd.execute(self.params, project_uid="some-uid", output=None)
+            self.assertIsNone(result)
+
+        # ── round-trip / determinism ─────────────────────────────────
+
+        def test_sort_keys_determinism(self):
+            result1 = self._execute()
+            result2 = self._execute()
+            self.assertEqual(result1, result2, "Output must be deterministic across calls")
+
+        def test_output_is_sorted(self):
+            result = self._execute()
+            parsed = json.loads(result)
+            keys = list(parsed.keys())
+            self.assertEqual(keys, sorted(keys),
+                             "Top-level keys should be sorted (sort_keys=True)")
+
+
+else:
+    class TestPAMProjectExportCommand(unittest.TestCase):
+        def test_skip(self):
+            self.skipTest("Requires Python 3.8+")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements `PAMProjectExportCommand` which walks the vault graph for a given PAM project configuration UID and emits a JSON document directly re-importable via `pam project import`.

Registered as `pam project export` (shortcut `x`). Closes the UX gap where the help text read "PAM Project Import/Export" but only import was implemented.

**Output schema** matches `PROJECT_IMPORT_JSON_TEMPLATE` exactly:
`project`, `shared_folder_users`, `shared_folder_resources`, `pam_configuration`, `pam_data.{resources, users}`

**Design decisions:**
- Resource UIDs derived from Keeper record UIDs — stable, deterministic, idempotent re-import across tenants
- `sort_keys=True` — deterministic output suitable for git diffs and drift detection
- `tool_version: "commander-export-1.0"` — activates the tool_version branch in import for future generator-aware behaviour
- `--output FILE` writes JSON to disk; omitting prints to stdout
- Users shared across multiple resources are de-duplicated in `pam_data.users`

## Test plan
- [x] `pytest unit-tests/pam/test_pam_project_export.py` — 21/21 tests (valid JSON, key presence, UID uniqueness, user dedup, --output file, error cases, sort determinism)
- [x] Full suite — 558 passed
- [x] Live tenant — `pam project export -p <uid>` returned valid JSON with `project`, `pam_configuration`, `pam_data`, `tool_version`