### PR TITLE
Add `pam launch` from SuperShell

### DIFF
--- a/keepercommander/commands/pam_launch/launch.py
+++ b/keepercommander/commands/pam_launch/launch.py
@@ -320,11 +320,96 @@ def _print_close_reason_notice(
     return pending_exit_code
 
 
+VALID_PAM_RECORD_TYPES = {'pamDatabase', 'pamDirectory', 'pamMachine'}
+
+
+def is_launchable(params, record_uid):
+    """Return ``(eligible, protocol)`` for a `pam launch` candidate.
+
+    Eligibility: TypedRecord v3, ``record_type`` in :data:`VALID_PAM_RECORD_TYPES`,
+    and detected protocol in :data:`ALL_TERMINAL`. Reads only cached vault data —
+    safe to call from a TUI render path.
+    """
+    try:
+        record = vault.KeeperRecord.load(params, record_uid)
+        if not isinstance(record, vault.TypedRecord):
+            return False, None
+        if record.version != 3:
+            return False, None
+        if record.record_type not in VALID_PAM_RECORD_TYPES:
+            return False, None
+    except Exception as e:
+        logging.debug("is_launchable: cannot load %s: %s", record_uid, e)
+        return False, None
+    try:
+        protocol = detect_protocol(params, record_uid)
+    except Exception as e:
+        logging.debug("is_launchable: detect_protocol failed for %s: %s", record_uid, e)
+        return False, None
+    if protocol not in ALL_TERMINAL:
+        return False, None
+    return True, protocol
+
+
+def get_launch_info(params, record_uid):
+    """Return a summary dict describing how this record will launch, or ``None``.
+
+    Reads only cached vault data — safe to call from a TUI render path.
+
+    Keys:
+        protocol           — terminal protocol (e.g. 'ssh', 'mysql')
+        host               — hostname from pamHostname/host field, or None
+        port               — port (int) from pamHostname/host field, or None
+        allow_supply_host  — bool: user may supply host at launch time
+        allow_supply_user  — bool: user may supply credential at launch time
+        credential_uid     — first userRecords[] entry, or None
+        credential_title   — title of the credential record (if cached), else None
+    """
+    ok, protocol = is_launchable(params, record_uid)
+    if not ok:
+        return None
+    try:
+        record = vault.KeeperRecord.load(params, record_uid)
+    except Exception:
+        return None
+    host, port = _get_host_port_from_record(record)
+    allow_supply_host = False
+    allow_supply_user = False
+    credential_uid = None
+    pam_settings_field = record.get_typed_field('pamSettings')
+    if pam_settings_field:
+        pam_settings_value = pam_settings_field.get_default_value(dict) or {}
+        allow_supply_host = bool(pam_settings_value.get('allowSupplyHost'))
+        connection = pam_settings_value.get('connection') or {}
+        if isinstance(connection, dict):
+            allow_supply_user = bool(connection.get('allowSupplyUser'))
+            user_records = connection.get('userRecords') or []
+            if user_records:
+                credential_uid = user_records[0]
+    credential_title = None
+    if credential_uid:
+        try:
+            cred = vault.KeeperRecord.load(params, credential_uid)
+            if cred is not None:
+                credential_title = getattr(cred, 'title', None)
+        except Exception:
+            credential_title = None
+    return {
+        'protocol': protocol,
+        'host': host,
+        'port': port,
+        'allow_supply_host': allow_supply_host,
+        'allow_supply_user': allow_supply_user,
+        'credential_uid': credential_uid,
+        'credential_title': credential_title,
+    }
+
+
 class PAMLaunchCommand(Command):
     """PAM Launch command to launch a connection to a PAM resource"""
 
-    # Valid PAM record types for launch
-    VALID_PAM_RECORD_TYPES = {'pamDatabase', 'pamDirectory', 'pamMachine'}
+    # Valid PAM record types for launch (kept as class alias for backwards reference)
+    VALID_PAM_RECORD_TYPES = VALID_PAM_RECORD_TYPES
 
     parser = argparse.ArgumentParser(prog='pam launch', description='Launch a connection to a PAM resource')
     parser.add_argument('record', type=str, action='store',
@@ -1180,7 +1265,44 @@ class PAMLaunchCommand(Command):
                 if not has_cli_host:
                     # No CLI host -> must come from the PAM launch record
                     if not hostname_on_record:
-                        if allow_supply_host:
+                        if allow_supply_host and sys.stdin.isatty() and sys.stdout.isatty():
+                            # Interactive prompt instead of erroring out — covers the common
+                            # `pam launch <uid>` case for records with allowSupplyHost and no
+                            # static hostname (e.g. SuperShell launching from the TUI).
+                            prompt_text = (
+                                f'{Fore.CYAN}Enter host for launch '
+                                f'{Fore.WHITE}(format: host:port, e.g. 192.168.1.1:22 or '
+                                f'server.example.com:3306, [::1]:22 for IPv6){Fore.RESET}\n'
+                                f'{Fore.CYAN}Host:port: {Fore.RESET}'
+                            )
+                            custom_host = None
+                            custom_port = None
+                            for _ in range(3):
+                                try:
+                                    user_input = input(prompt_text).strip()
+                                except (EOFError, KeyboardInterrupt):
+                                    logging.info('Canceled')
+                                    return
+                                if not user_input:
+                                    logging.info('Canceled')
+                                    return
+                                try:
+                                    custom_host, custom_port = _parse_host_port(user_input)
+                                    break
+                                except CommandError as e:
+                                    print(f'{Fore.RED}{e}{Fore.RESET}', file=sys.stderr)
+                                    custom_host = None
+                                    custom_port = None
+                            if custom_host is None:
+                                logging.error('Too many invalid host entries; aborting launch.')
+                                return
+                            kwargs['custom_host'] = custom_host
+                            kwargs['custom_port'] = custom_port
+                            has_cli_host = True
+                            logging.info(
+                                'Using interactively supplied host: %s:%s', custom_host, custom_port
+                            )
+                        elif allow_supply_host:
                             raise CommandError('pam launch',
                                 'allowSupplyHost is enabled but no hostname on record. '
                                 'Use --host, --host-record, or --credential with a host:port to specify.')

--- a/keepercommander/commands/supershell/app.py
+++ b/keepercommander/commands/supershell/app.py
@@ -90,6 +90,7 @@ class SuperShellApp(App):
         Binding("m", "toggle_unmask", "Toggle Unmask", show=False),
         Binding("W", "show_user_info", "User Info", show=False),
         Binding("D", "show_device_info", "Device Info", show=False),
+        Binding("L", "launch_pam", "Launch PAM", show=False),
         Binding("?", "show_help", "Help", show=False),
         # Vim-style navigation
         Binding("j", "cursor_down", "Down", show=False),
@@ -1803,6 +1804,33 @@ class SuperShellApp(App):
         except Exception as e:
             logging.debug(f"Error clearing clickable fields: {e}")
 
+    @staticmethod
+    def _strip_pam_internal_fields(output: str) -> str:
+        """Drop noisy PAM fields (pamHostname, pamSettings, trafficEncryptionSeed,
+        checkbox:*) from the legacy ``get`` output, including multi-line dict
+        continuations. The fields stay visible in JSON view; this only affects
+        the Detail view for pamMachine/pamDatabase records.
+        """
+        skip_prefixes = ('pamHostname:', 'pamSettings:', 'trafficEncryptionSeed:', 'checkbox:')
+        kept = []
+        skipping = False
+        brace_depth = 0
+        for raw_line in output.split('\n'):
+            stripped_left = raw_line.lstrip()
+            if skipping:
+                brace_depth += raw_line.count('{') - raw_line.count('}')
+                if brace_depth <= 0:
+                    skipping = False
+                continue
+            if any(stripped_left.startswith(p) for p in skip_prefixes):
+                brace_depth = raw_line.count('{') - raw_line.count('}')
+                if brace_depth > 0:
+                    skipping = True
+                # else: single-line value, just drop this one line
+                continue
+            kept.append(raw_line)
+        return '\n'.join(kept)
+
     def _display_record_with_clickable_fields(self, record_uid: str):
         """Display record details with clickable fields for copy-on-click"""
         t = self.theme_colors
@@ -1815,6 +1843,14 @@ class SuperShellApp(App):
         # Get and parse record output
         output = self._get_record_output(record_uid, format_type='detail')
         output = strip_ansi_codes(output)
+
+        # For launchable PAM records (pamMachine/pamDatabase) hide the
+        # noisy raw fields from Detail view — a parsed Launch section
+        # below replaces them. JSON view stays unchanged.
+        record_data_for_filter = self.records.get(record_uid, {})
+        record_type_for_filter = record_data_for_filter.get('record_type', '')
+        if record_type_for_filter in ('pamMachine', 'pamDatabase'):
+            output = self._strip_pam_internal_fields(output)
 
         if not output or output.strip() == '':
             detail_widget.update("[red]Failed to get record details[/red]")
@@ -1959,6 +1995,68 @@ class SuperShellApp(App):
 
             rotation_displayed = True
 
+        launch_displayed = False
+
+        def display_launch_section():
+            """Render the parsed Launch section for pamMachine/pamDatabase."""
+            nonlocal launch_displayed
+            if launch_displayed:
+                return
+            try:
+                from ..pam_launch.launch import get_launch_info
+                info = get_launch_info(self.params, record_uid)
+            except Exception as e:
+                logging.debug(f"Launch section: get_launch_info failed: {e}")
+                info = None
+            if not info:
+                return
+            protocol = (info.get('protocol') or '').upper() or 'PAM'
+            if info.get('host'):
+                host_str = f"{info['host']}:{info['port']}" if info.get('port') else info['host']
+                if info.get('allow_supply_host'):
+                    host_display = f"{host_str}  (or supplied at launch)"
+                else:
+                    host_display = host_str
+            elif info.get('allow_supply_host'):
+                host_display = "(prompted at launch)"
+            else:
+                host_display = "(not configured)"
+            if info.get('credential_uid'):
+                cred_str = info.get('credential_title') or info['credential_uid']
+                if info.get('allow_supply_user'):
+                    cred_display = f"{cred_str}  (or supplied at launch)"
+                else:
+                    cred_display = cred_str
+            elif info.get('allow_supply_user') or info.get('allow_supply_host'):
+                cred_display = "(prompted at launch)"
+            else:
+                cred_display = "(not configured)"
+            mount_line("", None)
+            mount_line(f"[bold {t['secondary']}]Launch:[/bold {t['secondary']}]", None)
+            mount_line(
+                f"  [{t['text_dim']}]Protocol:[/{t['text_dim']}]    "
+                f"[{t['primary']}]{rich_escape(protocol)}[/{t['primary']}]",
+                protocol,
+            )
+            mount_line(
+                f"  [{t['text_dim']}]Host:[/{t['text_dim']}]        "
+                f"[{t['primary']}]{rich_escape(str(host_display))}[/{t['primary']}]",
+                host_display,
+            )
+            mount_line(
+                f"  [{t['text_dim']}]Credential:[/{t['text_dim']}]  "
+                f"[{t['primary']}]{rich_escape(str(cred_display))}[/{t['primary']}]",
+                cred_display,
+            )
+            mount_line("", None)
+            mount_line(
+                f"  [bold black on {t['primary']}]  >> Press L to Launch {rich_escape(protocol)}  <<  "
+                f"[/bold black on {t['primary']}]",
+                None,
+            )
+            mount_line("", None)
+            launch_displayed = True
+
         for line in output.split('\n'):
             stripped = line.strip()
             if not stripped:
@@ -1973,6 +2071,8 @@ class SuperShellApp(App):
                     mount_line(f"[{t['text_dim']}]{key}:[/{t['text_dim']}] [{t['primary']}]{rich_escape(str(value))}[/{t['primary']}]", value)
                 elif key in ['Title', 'Name'] and not current_section:
                     mount_line(f"[{t['text_dim']}]{key}:[/{t['text_dim']}] [bold {t['primary']}]{rich_escape(str(value))}[/bold {t['primary']}]", value)
+                    if record_type_for_filter in ('pamMachine', 'pamDatabase'):
+                        display_launch_section()
                 elif key == 'Type':
                     # Show 'app' for app records if type is blank
                     display_type = value if value else 'app' if record_uid in self.app_record_uids else ''
@@ -2897,6 +2997,17 @@ class SuperShellApp(App):
             elif record_selected:
                 mode = "JSON" if self.view_mode == 'json' else "Detail"
                 mask_label = "Mask" if self.unmask_secrets else "Unmask"
+                launch_hint = ""
+                if self.selected_record:
+                    try:
+                        from ..pam_launch.launch import is_launchable
+                        ok, protocol = is_launchable(self.params, self.selected_record)
+                        if ok:
+                            launch_hint = (
+                                f"  [{t['text_dim']}]L[/{t['text_dim']}]=Launch {protocol.upper()}"
+                            )
+                    except Exception as e:
+                        logging.debug(f"is_launchable check failed: {e}")
                 shortcuts_bar.update(
                     f"[{t['secondary']}]Mode: {mode}[/{t['secondary']}]  "
                     f"[{t['text_dim']}]t[/{t['text_dim']}]=Toggle  "
@@ -2904,6 +3015,7 @@ class SuperShellApp(App):
                     f"[{t['text_dim']}]u[/{t['text_dim']}]=Username  "
                     f"[{t['text_dim']}]c[/{t['text_dim']}]=Copy All  "
                     f"[{t['text_dim']}]m[/{t['text_dim']}]={mask_label}"
+                    f"{launch_hint}"
                 )
             elif folder_selected:
                 mode = "JSON" if self.view_mode == 'json' else "Detail"
@@ -3679,6 +3791,36 @@ class SuperShellApp(App):
                 self._update_shortcuts_bar(folder_selected=True)
         except Exception as e:
             logging.error(f"Error toggling unmask: {e}", exc_info=True)
+
+    def action_launch_pam(self):
+        """Launch a KeeperPAM connection for the selected record."""
+        if not self.selected_record or self.selected_record not in self.records:
+            self.notify("No record selected", severity="warning")
+            return
+        from ..pam_launch.launch import PAMLaunchCommand, is_launchable
+        from ...error import CommandError
+        ok, protocol = is_launchable(self.params, self.selected_record)
+        if not ok:
+            self.notify("This record is not launchable", severity="warning")
+            return
+        record_uid = self.selected_record
+        with self.suspend():
+            try:
+                PAMLaunchCommand().execute(self.params, record=record_uid)
+            except CommandError as e:
+                # User-visible launch failure — show the message, no traceback.
+                print(f"\nLaunch failed: {e}", file=sys.stderr)
+                try:
+                    input("Press Enter to return to SuperShell...")
+                except (EOFError, KeyboardInterrupt):
+                    pass
+            except Exception as e:
+                logging.error(f"pam launch failed: {e}", exc_info=True)
+                try:
+                    input("Press Enter to return to SuperShell...")
+                except (EOFError, KeyboardInterrupt):
+                    pass
+        self._display_record_detail(record_uid)
 
     def action_copy_password(self):
         """Copy password of selected record to clipboard using clipboard-copy command (generates audit event)"""

--- a/keepercommander/commands/supershell/screens/help.py
+++ b/keepercommander/commands/supershell/screens/help.py
@@ -111,6 +111,7 @@ class HelpScreen(ModalScreen):
   t             Toggle JSON view
   m             Mask/Unmask
   d             Sync vault
+  L             Launch PAM connection
   W             User info
   D             Device info
   P             Preferences

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -1695,7 +1695,8 @@ class LoginCommand(Command):
                     # Check extended server list
                     region = next((k for k, v in KEEPER_SERVERS.items() if v == params.server), params.server)
                 print(f'{Fore.CYAN}Data center: {Fore.WHITE}{region}{Fore.RESET}', file=sys.stderr)
-                print(f'{Fore.CYAN}Use {Fore.GREEN}login --server <region>{Fore.CYAN} to change (US, EU, AU, CA, JP, GOV){Fore.RESET}', file=sys.stderr)
+                hint_cmd = 'keeper login --server <region>' if params.batch_mode else 'login --server <region>'
+                print(f'{Fore.CYAN}Use {Fore.GREEN}{hint_cmd}{Fore.CYAN} to change (US, EU, AU, CA, JP, GOV){Fore.RESET}', file=sys.stderr)
                 print('', file=sys.stderr)
                 user = input(f'{Fore.GREEN}Email: {Fore.RESET}').strip()
             if not user:


### PR DESCRIPTION
## Summary

- Adds a one-key path (`L`) from the SuperShell TUI to a KeeperPAM terminal session for `pamMachine` and `pamDatabase` records, suspending Textual while the session is live.
- Cleans up the Detail view for those record types — hides the noisy raw `pamHostname` / `pamSettings` / `trafficEncryptionSeed` / `checkbox:*` fields and replaces them with a parsed Launch section showing protocol, host, credential, and a visual "Press L to Launch <PROTO>" button. JSON view is unchanged.
- Makes `pam launch` interactive when `allowSupplyHost: True` and the record has no static hostname — prompts for `host:port` instead of erroring out, with retries and the format spelled out in the prompt.
- Drive-by: fixes the misleading `Use login --server <region>` hint that `keeper login` prints in batch mode (it was dispatching to `login(1)` instead of `keeper`).

## Notable design choices

- `is_launchable()` and `get_launch_info()` are now module-level helpers in `pam_launch/launch.py` so the TUI and the CLI share eligibility logic. Both read only cached vault data — safe for SuperShell's render path (no API calls during init/sync).
- SuperShell uses `App.suspend()` to release the terminal during launch, then resumes after the session ends. `CommandError` is caught and shown without a traceback; generic exceptions still log with traceback. Both pause for Enter so the user sees the message before the TUI redraws.
- Multi-line dict values (like `pamSettings`) are stripped from Detail view via brace-counting in `_strip_pam_internal_fields`, so continuation lines don't leak through.
- `L` follows the existing capital-letter action convention (`P`, `W`, `D`); lowercase `l` is taken by vim cursor-right.

## Test plan

- [ ] `keeper supershell` — pamMachine record with static host + userRecords (image #1 in design discussion): Detail panel shows Launch section with resolved host:port and credential title; pressing `L` connects.
- [ ] pamMachine with `allowSupplyHost: True` and no hostname: Launch section shows `Host: (prompted at launch)`; pressing `L` prompts for `host:port` with the format hint, accepts a valid value, and connects. Bad input (e.g. `127.0.0.1` with no port) re-prompts with the validation error in red rather than crashing.
- [ ] pamMachine with `allowSupplyUser: True` plus a static credential: Launch section shows `Credential: <title>  (or supplied at launch)`.
- [ ] Non-launchable record (login type, pamUser): no Launch section, no `L` hint in shortcuts bar; pressing `L` shows "This record is not launchable".
- [ ] JSON view (`t` toggle) on a pamMachine: still shows full `pamSettings` / `pamHostname` raw — only Detail view is filtered.
- [ ] `keeper pam launch <uid>` from `keeper shell` (no SuperShell): existing CLI behavior unchanged for records with static hostnames.
- [ ] `keeper login` from system shell (batch mode): hint reads `keeper login --server <region>`. Inside `keeper shell`: hint reads `login --server <region>`.
- [ ] `?` in SuperShell: Help modal lists the new `L` shortcut under Actions.