### PR TITLE
fix(workflow): poll for WS_STARTED after checkout to break ready_to_start loop

### DIFF
--- a/keepercommander/commands/workflow/mfa.py
+++ b/keepercommander/commands/workflow/mfa.py
@@ -12,6 +12,7 @@
 import datetime
 import getpass
 import logging
+import time
 from typing import NamedTuple, Optional
 
 from ..pam.router_helper import _post_request_to_router
@@ -742,6 +743,31 @@ def check_workflow_for_launch(
             except Exception as e:
                 logging.error("Failed to check out: %s", sanitize_router_error(e))
                 return WorkflowGate(allowed=False)
+
+            # Router propagation delay: the start_workflow call is processed
+            # asynchronously, so a validate() immediately after checkout can
+            # still return WS_READY_TO_START before the router has written the
+            # WS_STARTED transition.  When that happens and handled_ready_to_start
+            # is already True the outer loop falls to the "already-handled" guard
+            # and returns WorkflowGate(allowed=False) — the user sees "Workflow
+            # approved but not yet checked out" again and re-triggers checkout,
+            # producing an infinite prompt loop.
+            #
+            # Fix: poll with exponential back-off (0.5 → 1 → 2 → 2 s, ≤5.5 s
+            # total) until the router confirms WS_STARTED or we exhaust retries.
+            # On success we break out of the outer loop immediately; on failure
+            # we fall through to let the outer loop decide.
+            _poll_delays = (0.5, 1.0, 2.0, 2.0)
+            for _delay in _poll_delays:
+                time.sleep(_delay)
+                _probe = validator.validate(silent_actionable=True)
+                if _probe.get('allowed') or _probe.get('block_reason') != 'ready_to_start':
+                    result = _probe
+                    break
+            else:
+                result = validator.validate(silent_actionable=True)
+            if result.get('allowed'):
+                break
             continue
 
         if block_reason == 'waiting' and not handled_waiting and wait:


### PR DESCRIPTION
## Problem

`pam launch` (and `pam tunnel`) exhibit an infinite prompt loop when the
workflow `ready_to_start` → checkout → re-validate cycle races the router:

1. User or `pam launch --auto-checkout` hits `WS_READY_TO_START` → confirms
   checkout → `start_workflow_for_record` is called.
2. The outer loop in `check_workflow_for_launch` immediately calls
   `validator.validate()` again.
3. Because `start_workflow` is processed **asynchronously** by the router,
   the validate call can still return `WS_READY_TO_START` before
   `WS_STARTED` is visible.
4. `handled_ready_to_start` is already `True`, so the "already-handled"
   guard fires and the function returns `WorkflowGate(allowed=False)`.
5. The user sees **"Workflow approved but not yet checked out"** a second
   time and is prompted to check out again → loop.

## Fix

After a successful `start_workflow_for_record`, poll with exponential
back-off (**0.5 → 1 → 2 → 2 s**, ≤5.5 s total) until the router
confirms `WS_STARTED` or retries are exhausted.

- On success: break out of the outer loop immediately (no extra network
  round-trip in the happy path once the router catches up, typically
  within the first 0.5 s poll).
- On failure: fall through to the outer loop's normal handling (existing
  behaviour, no regression).

## Testing

Verified in a live Keeper lab environment:

- `pam launch <record> --auto-checkout` no longer loops; reaches
  **"Establishing secure session"** without repeating the checkout prompt.
- Manual flow (`pam workflow start` before `pam launch`) is unaffected —
  the router already returns `WS_STARTED` by the time `pam launch` runs.
- `--wait` polling path (`_poll_until_state_change`) is unchanged.

## Files changed

| File | Change |
|------|--------|
| `keepercommander/commands/workflow/mfa.py` | Add `import time`; replace bare `continue` after checkout with back-off poll |


Made with [Cursor](https://cursor.com)