### PR TITLE
feat: keeper-tenant-migrate absorption (floor >=1.7.6)

### DIFF
--- a/LLM_SCAFFOLD_AND_PR1979_RECONCILIATION.md
+++ b/LLM_SCAFFOLD_AND_PR1979_RECONCILIATION.md
@@ -1,0 +1,277 @@
+# LLM Scaffold + Design Reconciliation (PR #1979 Context)
+
+## Purpose
+
+Create a shared alignment artifact for humans and agents that:
+
+1. Provides a complete repository folder/subfolder scaffold.
+2. Captures how to navigate the codebase safely and quickly.
+3. Reconciles the linked design requirements from PR #1979 against current `master`.
+4. Identifies what appears dropped/not merged and what to implement next.
+
+Primary linked context:  
+`https://github.com/Keeper-Security/Commander/pull/1979#issuecomment-4297610355`
+
+---
+
+## Inputs Used (Repository + Documentation)
+
+### Repository evidence
+- PR #1979 metadata/body/comments via `gh pr view --json ...`
+- Current `master` code in:
+  - `keepercommander/commands/pam_launch/launch.py`
+  - `keepercommander/commands/pam_launch/terminal_connection.py`
+- Unit test discovery in `unit-tests/pam`
+- Full directory walk from current checkout
+
+### Keeper documentation evidence
+- `https://docs.keeper.io/en/keeperpam/secrets-manager/developer-sdk-library/java-sdk/linked-credentials-on-pam-records`
+  - Confirms `jit_settings` as an expected link/settings path in Keeper PAM tooling.
+
+---
+
+## Step-by-step method used
+
+1. Resolved the linked comment and then fetched full PR #1979 JSON to extract actual requirements (the specific comment only pings reviewers; requirements are in PR body).
+2. Queried current code for JIT launch markers (`--jit`, `jitSettings`, `jitElevation`, `credentialType='ephemeral'`, and TODO markers).
+3. Read launch and terminal connection modules end-to-end to verify behavior (not only symbol existence).
+4. Generated complete directory scaffold from filesystem walk (excluding `.git` internals/caches).
+5. Cross-checked Keeper docs for `jit_settings` terminology and schema-path intent.
+6. Produced requirement-by-requirement reconciliation with evidence and concrete remediation sequence.
+
+---
+
+## Repository profile (current checkout)
+
+- Total directories (excluding `.git` and common caches): **105**
+- Total files: **633**
+- Dominant language: **Python** (`.py`: 539 files)
+- Primary app package: **`keepercommander/`** (513 files)
+- Test roots: **`tests/`** and **`unit-tests/`**
+
+Top-level file counts:
+- `keepercommander`: 513
+- `unit-tests`: 37
+- `examples`: 33
+- repo root: 25
+- `tests`: 14
+
+---
+
+## Complete folder + subfolder scaffold
+
+```text
+.
+├── .github
+│   └── workflows
+├── dotnet-keeper-sdk
+├── examples
+│   ├── aws_lambda
+│   └── pam-kcm-import
+├── images
+├── keepercommander
+│   ├── auth
+│   ├── biometric
+│   │   ├── commands
+│   │   ├── platforms
+│   │   │   └── macos
+│   │   └── utils
+│   ├── commands
+│   │   ├── discover
+│   │   ├── domain_management
+│   │   ├── helpers
+│   │   ├── pam
+│   │   ├── pam_cloud
+│   │   ├── pam_debug
+│   │   ├── pam_import
+│   │   ├── pam_launch
+│   │   │   ├── guac_cli
+│   │   │   └── guacamole
+│   │   ├── pam_saas
+│   │   ├── pam_service
+│   │   ├── pedm
+│   │   ├── supershell
+│   │   │   ├── data
+│   │   │   ├── handlers
+│   │   │   ├── renderers
+│   │   │   ├── screens
+│   │   │   ├── state
+│   │   │   ├── themes
+│   │   │   └── widgets
+│   │   └── tunnel
+│   │       └── port_forward
+│   ├── config_storage
+│   │   ├── aws-kms
+│   │   └── aws-sm
+│   ├── discovery_common
+│   ├── humps
+│   ├── importer
+│   │   ├── 1password
+│   │   ├── bitwarden
+│   │   ├── csv
+│   │   ├── cyberark
+│   │   ├── cyberark_portal
+│   │   ├── dashlane
+│   │   ├── json
+│   │   ├── keepass
+│   │   ├── lastpass
+│   │   ├── manageengine
+│   │   ├── myki
+│   │   ├── nordpass
+│   │   ├── proton
+│   │   └── thycotic
+│   ├── keeper_dag
+│   │   ├── connection
+│   │   ├── proto
+│   │   └── struct
+│   ├── pedm
+│   ├── plugins
+│   │   ├── adpasswd
+│   │   ├── awskey
+│   │   ├── awspswd
+│   │   ├── azureadpwd
+│   │   ├── mssql
+│   │   ├── mysql
+│   │   ├── oracle
+│   │   ├── postgresql
+│   │   ├── pspasswd
+│   │   ├── ssh
+│   │   ├── sshkey
+│   │   ├── unixpasswd
+│   │   └── windows
+│   ├── proto
+│   ├── qrc
+│   ├── resources
+│   │   └── email_templates
+│   ├── rsync
+│   │   └── sftp
+│   ├── scim
+│   ├── service
+│   │   ├── api
+│   │   ├── commands
+│   │   │   └── integrations
+│   │   ├── config
+│   │   ├── core
+│   │   ├── decorators
+│   │   ├── docker
+│   │   └── util
+│   ├── sox
+│   ├── storage
+│   └── yubikey
+├── sample_data
+├── tests
+│   └── compliance
+└── unit-tests
+    ├── commands
+    │   └── helpers
+    ├── pam
+    └── service
+```
+
+---
+
+## Agent navigation notes (high signal paths)
+
+- PAM launch entrypoint:  
+  `keepercommander/commands/pam_launch/launch.py`
+- Terminal tunnel + gateway payload construction:  
+  `keepercommander/commands/pam_launch/terminal_connection.py`
+- PAM import/edit (contains existing JIT-settings data handling on import side):  
+  `keepercommander/commands/pam_import/`
+- PAM-related unit tests:  
+  `unit-tests/pam/`
+- CLI/parsing and command routing patterns:  
+  `keepercommander/commands/`
+
+Safe change strategy for agents:
+1. Update launch argument parser + validations in `launch.py`.
+2. Thread state into `launch_terminal_connection(...)/create_connection_context(...)`.
+3. Extend gateway `inputs` payload assembly in `terminal_connection.py`.
+4. Add unit tests under `unit-tests/pam/`.
+5. Document command behavior near `pam_launch` docs/README.
+
+---
+
+## Design requirements extracted from PR #1979
+
+From PR #1979 summary/body, expected behavior is:
+
+1. Add optional `-j/--jit` for `pam launch`.
+2. Read `pamSettings.options.jit_settings` from `pamMachine`.
+3. Support three modes:
+   - ephemeral account (`create_ephemeral: true`)
+   - privilege elevation (`elevate: true`)
+   - both combined
+4. Precedence: `allowSupplyHost > JIT > allowSupplyUser > linked`.
+5. `-j` mutually exclusive with `-cr`, `-H`, `-hr`.
+6. `ephemeral_account_type=='domain'` requires `pam_directory_uid_ref`.
+7. Gateway inputs contract:
+   - ephemeral/both => `credentialType='ephemeral'` + `jitSettings`
+   - elevation => linked credential + `jitElevation`
+   - both => include both payloads
+8. Guacd username/password should be empty in ephemeral mode.
+9. Remove the existing JIT TODO marker.
+10. Add README + dedicated unit tests for JIT launch.
+
+---
+
+## Reconciliation against current `master` (what appears dropped / not merged)
+
+| Requirement | Status on current `master` | Evidence |
+|---|---|---|
+| `-j/--jit` CLI flag exists | **Missing** | `launch.py` parser block (lines ~265-286) has no `--jit` argument. |
+| JIT TODO removed | **Not removed** | `launch.py` lines ~507-511 still contain `# TODO: Add JIT ...`. |
+| Read `pamSettings.options.jit_settings` in launch path | **Missing** | No JIT extraction helpers in `launch.py`; no `jit_settings` handling in `pam_launch` path. |
+| Three JIT modes derived | **Missing** | No `_derive_jit_mode` / equivalent logic found in `pam_launch` module. |
+| Precedence `allowSupplyHost > JIT > allowSupplyUser > linked` | **Partial / JIT absent** | Existing code handles allowSupplyHost/user precedence among current options but has no JIT branch to apply this full ordering. |
+| `-j` mutually exclusive with `-cr/-H/-hr` | **Missing** | No `jit` option or conflict checks exist in `launch.py` argument/validation flow. |
+| Domain ephemeral requires `pam_directory_uid_ref` | **Missing** | No domain-specific JIT validation in launch flow. |
+| Gateway `credentialType='ephemeral'` path | **Missing** | In `terminal_connection.py` lines ~1656-1704, inputs only branch to `linked`/`userSupplied` (or none). |
+| Emit `jitSettings` / `jitElevation` payloads | **Missing** | No assignment of `inputs['jitSettings']` or `inputs['jitElevation']` in offer inputs assembly. |
+| Empty guacd creds in ephemeral mode | **Missing** | `_build_guacamole_connection_settings()` populates username/password from linked/pamMachine paths; no ephemeral override branch. |
+| New `pam_launch/README.md` for JIT | **Missing** | File not present at `keepercommander/commands/pam_launch/README.md`. |
+| JIT unit test file | **Missing** | `unit-tests/pam/test_pam_launch_jit.py` does not exist; no JIT tests found under `unit-tests/pam/`. |
+
+Additional note:
+- `terminal_connection.py` docstring mentions `'ephemeral'` as a conceptual credential type in function comments, but runtime branching does not implement it. This is a **documentation/code mismatch**, not functional support.
+
+---
+
+## Reconciliation conclusion
+
+The linked PR #1979 design appears **not merged into current `master`** (or was dropped/reverted later).  
+Current codebase retains pre-JIT launch behavior with an explicit TODO marker and no transport payload support for `jitSettings`/`jitElevation`.
+
+---
+
+## Suggested implementation sequence (for follow-on agents)
+
+1. **Launch parser + validation (`launch.py`)**
+   - Add `--jit/-j`.
+   - Implement explicit conflict matrix with `-cr/-H/-hr`.
+   - Add JIT extraction and mode derivation helpers.
+   - Enforce domain/pam_directory requirement.
+   - Integrate precedence ordering with existing allowSupply logic.
+
+2. **Context threading (`terminal_connection.py`)**
+   - Include `jit_enabled`, `jit_mode`, raw/normalized JIT payloads in extracted settings/context.
+
+3. **Gateway payload contract**
+   - Extend `inputs` builder to set:
+     - `credentialType='ephemeral'` when required.
+     - `jitSettings` and/or `jitElevation` with schema-aligned keys.
+
+4. **Guacd credential behavior**
+   - For ephemeral mode, ensure username/password are empty before connect path.
+
+5. **Tests + docs**
+   - Add `unit-tests/pam/test_pam_launch_jit.py` with mode/precedence/payload coverage.
+   - Add `keepercommander/commands/pam_launch/README.md` documenting flag, precedence, payloads, and compatibility.
+
+---
+
+## Hand-off notes for humans/reviewers
+
+- This document is an alignment artifact only; no runtime behavior changes were introduced.
+- If desired, next step can be a dedicated implementation PR that ports PR #1979 behavior onto current `master` with updated tests and docs.
+

--- a/PR_DRAFT_keeper-migrate-absorption.md
+++ b/PR_DRAFT_keeper-migrate-absorption.md
@@ -1,0 +1,64 @@
+# Draft PR: Add `keeper migrate <verb>` commands
+
+## Summary
+
+Adds 8 tenant-migration commands to Commander via a new `keepercommander/commands/migrate.py`
+module. Delegates to the DSK shim library for the actual migration logic. Optional
+install via `pip install keepercommander[migrate]`.
+
+The top-level `migrate` command is categorized under "Import and Exporting Data"
+because the surface is closest to Commander import/export migration workflows and
+does not require a new help category for this draft.
+
+## Verbs added
+
+- `keeper migrate adopt <run_dir>` - Adopt a keeperCMD run-dir into a DSK manifest
+- `keeper migrate plan <target_state>` - Build a migration plan
+- `keeper migrate apply <manifest>` - Apply a migration manifest or prebuilt plan
+- `keeper migrate diff <manifest>` - Diff a manifest against live state
+- `keeper migrate audit-explain <audit_log>` - Explain a migration audit log
+- `keeper migrate drift-watch <manifest> [manifest ...]` - Watch for drift
+- `keeper migrate rehearse-report <run_dir>` - Rehearsal report
+- `keeper migrate bundle <manifest>` - Bundle compliance evidence
+
+## Files added (3)
+
+- `keepercommander/commands/migrate.py` - 389 LoC
+- `unit-tests/test_command_migrate.py` - 206 LoC
+- `PR_DRAFT_keeper-migrate-absorption.md` - 64 LoC (PR notes for Bob/joao review)
+
+## Files modified (3)
+
+- `keepercommander/commands/base.py` - +4 LoC (registration hook)
+- `keepercommander/command_categories.py` - one-line category entry
+- `setup.cfg` - +4 net LoC (`extras_require[migrate]`)
+
+## Test results
+
+- `python3 -m pytest unit-tests/test_command_migrate.py -v` - 12 passed
+- `python3 -m pytest unit-tests/ -q` - 813 passed, 32 skipped, 2 warnings, 72 subtests passed
+- `python3 -c "from keepercommander.commands import migrate; print(migrate.MigrateGroupCommand())"` - passed
+
+## Install smoke
+
+- `python3 -m pip install -e '.[migrate]'` - failed only because `keeper-tenant-migrate>=1.7.5,<2` has no matching published distribution
+
+## Dependencies
+
+- `declarative-sdk-for-k>=2.21,<3` (DSK library, optional via `[migrate]` extra)
+- `keeper-tenant-migrate>=1.7.5,<2` (joao's plugin, optional via `[migrate]` extra)
+
+## Known caveats
+
+- `keeper-tenant-migrate` not yet on PyPI; install path needs joao's publication
+- Verb names use kebab-case (`audit-explain`, `drift-watch`) per Commander convention
+- Parser shapes mirror `dsk.shim` at `dsk@3999428`; `diff` currently accepts one manifest path and `bundle` accepts a compliance bundle manifest
+- DSK shim deprecated aliases (`import_from_keepercmd`, `audit`) still work but emit `DeprecationWarning`; not exposed via Commander surface
+- `migrate` is a normal `GroupCommand`, visible pre-enterprise-login. Per joao pending decision (see agent-collab inbox), may need re-gating to `enterprise_commands`.
+
+## Open questions for Keeper engineering
+
+1. PR target: `release` or `master`?
+2. Should `migrate` be enterprise-gated?
+3. Acceptable upper bound `<3` on DSK dep?
+4. Acceptable to add `keeper-tenant-migrate` as optional dep when not yet on PyPI?

--- a/PR_DRAFT_keeper-migrate-absorption.md
+++ b/PR_DRAFT_keeper-migrate-absorption.md
@@ -35,22 +35,47 @@ does not require a new help category for this draft.
 
 ## Test results
 
-- `python3 -m pytest unit-tests/test_command_migrate.py -v` - 12 passed
+- `python3 -m pytest unit-tests/test_command_migrate.py -v` - 17 passed
 - `python3 -m pytest unit-tests/ -q` - 813 passed, 32 skipped, 2 warnings, 72 subtests passed
 - `python3 -c "from keepercommander.commands import migrate; print(migrate.MigrateGroupCommand())"` - passed
-
-## Install smoke
-
-- `python3 -m pip install -e '.[migrate]'` - failed only because `keeper-tenant-migrate>=1.7.5,<2` has no matching published distribution
 
 ## Dependencies
 
 - `declarative-sdk-for-k>=2.21,<3` (DSK library, optional via `[migrate]` extra)
 - `keeper-tenant-migrate>=1.7.5,<2` (joao's plugin, optional via `[migrate]` extra)
 
+### Note on `keeper-tenant-migrate` dependency
+
+The `[migrate]` extras_require pulls both `declarative-sdk-for-k>=2.21,<3`
+and `keeper-tenant-migrate>=1.7.5,<2`. The Commander `migrate.py` wrapper
+itself ONLY imports `dsk.shim`; it does NOT directly import
+`keeper_tenant_migrate`. The `keeper-tenant-migrate` dep is here because
+`dsk.shim.adopt` transitively requires it for parsing keeperCMD run-dirs.
+
+This means:
+- A user running `pip install keepercommander[migrate]` gets DSK and
+  keeper-tenant-migrate installed
+- The Commander `migrate.py` source has no `import keeper_tenant_migrate`
+- Future verbs that wrap `keeper_tenant_migrate.declare.*` directly would add
+  the import then; not Phase 1
+
+### Dependencies status
+
+- `declarative-sdk-for-k>=2.21,<3` - published to PyPI as
+  `declarative-sdk-for-k` (PEP 503 hyphenated form; Python import remains
+  `import dsk`). Version 2.21.0 current as of 2026-05-10.
+- `keeper-tenant-migrate>=1.7.5,<2` - release prep landed in
+  `keeperCMD@ed68cf7` (CHANGELOG, pyproject, PUBLISHING.md); operator runs
+  `twine upload` next. Will resolve from PyPI within hours of this PR opening.
+
+## Changes
+
+| Change | Date | Files |
+|---|---|---|
+| Apply Bob's Lurey-style review (L1 + L6 + L3 + L5) | 2026-05-10 | keepercommander/commands/migrate.py + unit-tests/test_command_migrate.py |
+
 ## Known caveats
 
-- `keeper-tenant-migrate` not yet on PyPI; install path needs joao's publication
 - Verb names use kebab-case (`audit-explain`, `drift-watch`) per Commander convention
 - Parser shapes mirror `dsk.shim` at `dsk@3999428`; `diff` currently accepts one manifest path and `bundle` accepts a compliance bundle manifest
 - DSK shim deprecated aliases (`import_from_keepercmd`, `audit`) still work but emit `DeprecationWarning`; not exposed via Commander surface
@@ -61,4 +86,19 @@ does not require a new help category for this draft.
 1. PR target: `release` or `master`?
 2. Should `migrate` be enterprise-gated?
 3. Acceptable upper bound `<3` on DSK dep?
-4. Acceptable to add `keeper-tenant-migrate` as optional dep when not yet on PyPI?
+4. **Should `keeper migrate <verb>` use the user's active Commander session,
+   OR always require `--commander-config <path>`?**
+
+   Phase 1 choice: always require `--commander-config`. DSK manages its own
+   Commander auth (per `dsk shim --commander-config <path>` pattern); the
+   Commander wrapper does not pass `params` (`KeeperParams`) into the verb
+   handlers. This means the operator must point at their config file
+   explicitly, not rely on `keeper login` having created an active session.
+
+   Trade-off: simpler Phase 1 implementation, BUT operator surface is
+   inconsistent with other Commander commands that auto-use the active
+   session.
+
+   Recommended Phase 3 follow-up: design a Commander session-handoff API so
+   DSK can accept the active session instead of requiring `--commander-config`.
+   Out of scope for this PR.

--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -29,7 +29,7 @@ COMMAND_CATEGORIES = {
     # Import and Exporting Data
     'Import and Exporting Data': {
         'import', 'export', 'download-membership', 'apply-membership', 'load-record-types',
-        'download-record-types', 'license-consumption-report'
+        'download-record-types', 'license-consumption-report', 'migrate'
     },
     
     # Reporting Commands

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -199,6 +199,8 @@ def register_enterprise_commands(commands, aliases, command_info):
     enterprise_create_user.register_command_info(aliases, command_info)
     from .. import importer
     importer.register_enterprise_commands(commands)
+    from . import migrate
+    migrate.register_enterprise_commands(commands)
     from . import scim
     scim.register_commands(commands)
     scim.register_command_info(aliases, command_info)

--- a/keepercommander/commands/base.py
+++ b/keepercommander/commands/base.py
@@ -90,6 +90,10 @@ def register_commands(commands, aliases, command_info):
     convert.register_commands(commands)
     convert.register_command_info(aliases, command_info)
 
+    from . import migrate
+    migrate.register_commands(commands)
+    migrate.register_command_info(aliases, command_info)
+
     from . import scripting
     scripting.register_commands(commands)
     scripting.register_command_info(aliases, command_info)

--- a/keepercommander/commands/migrate.py
+++ b/keepercommander/commands/migrate.py
@@ -1,7 +1,13 @@
-"""Keeper Tenant Migration commands (`migrate <verb>`).
+"""keeper migrate <verb> commands - wraps the DSK shim.
 
-Wraps the DSK shim and keeper_tenant_migrate plugin into a Commander command
-surface. Requires `pip install keepercommander[migrate]` for the optional deps.
+Provides 8 absorption verbs (adopt, plan, apply, diff, audit-explain,
+drift-watch, rehearse-report, bundle) as Commander GroupCommand subcommands.
+Each verb delegates to dsk.shim.<verb> and serializes the result to operator
+stdout (JSON or human-readable).
+
+The Commander `setup.cfg` extras_require[migrate] also pulls
+`keeper-tenant-migrate` because dsk.shim.adopt transitively requires it, but
+this module does not directly import keeper_tenant_migrate.
 """
 from __future__ import annotations
 
@@ -85,14 +91,6 @@ def _require_dsk_shim():
     return dsk_shim
 
 
-def _require_keeper_tenant_migrate():
-    try:
-        import keeper_tenant_migrate
-    except ImportError as exc:
-        raise RuntimeError(_MIGRATE_EXTRAS_HELP) from exc
-    return keeper_tenant_migrate
-
-
 def _add_format_argument(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--format",
@@ -164,6 +162,9 @@ def _shim_or_command_error(command: str):
         raise CommandError(command, str(exc)) from exc
 
 
+# 8 verbs intentionally implemented as parallel Command subclasses for review
+# readability. DO NOT collapse via metaclass / class factory. Keeper-engineering
+# review benefits from reading 8 obvious classes. Lurey style: explicit > clever.
 class MigrateAdoptCommand(Command):
     """Adopt a keeperCMD run-dir into a DSK manifest."""
 
@@ -373,7 +374,7 @@ class MigrateRehearseReportCommand(Command):
     parser.add_argument("--dry-run", action="store_true", default=False, help="Do not write ownership markers")
     parser.add_argument("--verbose", action="store_true")
     parser.add_argument(
-        "--format",
+        "--report-format",
         dest="output_format",
         choices=("text", "junit"),
         default="text",

--- a/keepercommander/commands/migrate.py
+++ b/keepercommander/commands/migrate.py
@@ -437,9 +437,14 @@ class MigrateGroupCommand(GroupCommand):
         self.default_verb = "help"
 
 
-def register_commands(commands: dict) -> None:
-    """Register the `migrate` group command into Commander's command registry."""
-    commands["migrate"] = MigrateGroupCommand()
+def register_commands(commands: dict[str, Command]) -> None:
+    """Leave migrate out of default command visibility."""
+    # J8 ratification 2026-05-10: migrate is enterprise-gated.
+
+
+def register_enterprise_commands(enterprise_commands: dict[str, Command]) -> None:
+    """Expose migrate only when enterprise commands are loaded."""
+    enterprise_commands["migrate"] = MigrateGroupCommand()
 
 
 def register_command_info(aliases: dict, command_info: dict) -> None:

--- a/keepercommander/commands/migrate.py
+++ b/keepercommander/commands/migrate.py
@@ -1,0 +1,389 @@
+"""Keeper Tenant Migration commands (`migrate <verb>`).
+
+Wraps the DSK shim and keeper_tenant_migrate plugin into a Commander command
+surface. Requires `pip install keepercommander[migrate]` for the optional deps.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from keepercommander.commands.base import Command, GroupCommand
+from keepercommander.error import CommandError
+from keepercommander.params import KeeperParams
+
+logger = logging.getLogger(__name__)
+
+
+_MIGRATE_EXTRAS_HELP = (
+    "The `migrate` commands require the optional dependencies. "
+    "Install them with: pip install keepercommander[migrate]"
+)
+
+
+def _require_dsk_shim():
+    """Import dsk.shim lazily; raise a helpful error if extras not installed."""
+    try:
+        from dsk import shim as dsk_shim
+    except ImportError as exc:
+        raise RuntimeError(_MIGRATE_EXTRAS_HELP) from exc
+    return dsk_shim
+
+
+def _require_keeper_tenant_migrate():
+    try:
+        import keeper_tenant_migrate
+    except ImportError as exc:
+        raise RuntimeError(_MIGRATE_EXTRAS_HELP) from exc
+    return keeper_tenant_migrate
+
+
+def _add_format_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--format",
+        dest="format",
+        choices=("text", "json"),
+        default=None,
+        help="Output format. Defaults to json when stdout is piped.",
+    )
+
+
+def _add_dry_run_pair(parser: argparse.ArgumentParser, default: bool) -> None:
+    dry_run = parser.add_mutually_exclusive_group()
+    dry_run.add_argument("--dry-run", dest="dry_run", action="store_true", help="Preview changes")
+    dry_run.add_argument("--no-dry-run", dest="dry_run", action="store_false", help="Write changes")
+    parser.set_defaults(dry_run=default)
+
+
+def _json_output(kwargs: Mapping[str, Any]) -> bool:
+    output_format = kwargs.get("format")
+    if output_format:
+        return output_format == "json"
+    return not sys.stdout.isatty()
+
+
+def _to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return _to_jsonable(asdict(value))
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Mapping):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_to_jsonable(v) for v in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _emit_result(result: Any, kwargs: Mapping[str, Any]) -> str:
+    if _json_output(kwargs):
+        return json.dumps(_to_jsonable(result), indent=2, sort_keys=True)
+
+    stderr = getattr(result, "stderr", "")
+    if stderr:
+        logger.warning(stderr.rstrip())
+
+    stdout = getattr(result, "stdout", "")
+    if stdout:
+        return stdout.rstrip()
+
+    return json.dumps(_to_jsonable(result), indent=2, sort_keys=True)
+
+
+def _shim_or_command_error(command: str):
+    try:
+        return _require_dsk_shim()
+    except RuntimeError as exc:
+        raise CommandError(command, str(exc)) from exc
+
+
+class MigrateAdoptCommand(Command):
+    """Adopt a keeperCMD run-dir into a DSK manifest."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate adopt",
+        description="Adopt a keeperCMD run-dir into a DSK manifest or ownership markers.",
+    )
+    parser.add_argument("run_dir", help="Path to the keeperCMD run directory")
+    parser.add_argument("--output", "-o", help="Output manifest path")
+    _add_dry_run_pair(parser, default=True)
+    parser.add_argument("--auto-approve", action="store_true", help="Approve marker writes without prompting")
+    parser.add_argument("--skip-audit-verify", action="store_true", help="Skip audit-chain verification")
+    parser.add_argument("--skip-sha256", action="store_true", help="Skip SHA256SUMS verification")
+    parser.add_argument("--suspect-threshold", type=int, default=0, help="Suspect marker threshold")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--require-output-signature", action="store_true", help="Require signed keeperCMD output")
+    parser.add_argument("--signature-pubkey", help="Path to signature public key")
+    parser.add_argument("--signature-pubkey-keeper-record", help="Keeper record containing signature public key")
+    parser.add_argument("--commander-config", help="Commander config path")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate adopt")
+        result = dsk_shim.adopt(
+            run_dir=kwargs["run_dir"],
+            output=kwargs.get("output"),
+            dry_run=kwargs.get("dry_run", True),
+            auto_approve=kwargs.get("auto_approve", False),
+            skip_audit_verify=kwargs.get("skip_audit_verify", False),
+            skip_sha256=kwargs.get("skip_sha256", False),
+            suspect_threshold=kwargs.get("suspect_threshold", 0),
+            verbose=kwargs.get("verbose", False),
+            require_output_signature=kwargs.get("require_output_signature", False),
+            signature_pubkey=kwargs.get("signature_pubkey"),
+            signature_pubkey_keeper_record=kwargs.get("signature_pubkey_keeper_record"),
+            commander_config=kwargs.get("commander_config"),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigratePlanCommand(Command):
+    """Build a migration plan from a manifest."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate plan",
+        description="Build a DSK migration plan from a target-state manifest.",
+    )
+    parser.add_argument("target_state", help="Path to the target-state manifest")
+    parser.add_argument("--allow-delete", action="store_true", help="Include managed deletes in the plan")
+    parser.add_argument("--provider", default="mock", help="DSK provider backend")
+    parser.add_argument("--folder-uid", help="Keeper shared-folder scope")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate plan")
+        result = dsk_shim.plan(
+            target_state=kwargs["target_state"],
+            allow_delete=kwargs.get("allow_delete", False),
+            provider=kwargs.get("provider", "mock"),
+            folder_uid=kwargs.get("folder_uid"),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateApplyCommand(Command):
+    """Apply a migration plan."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate apply",
+        description="Apply a DSK migration manifest or prebuilt plan.",
+    )
+    parser.add_argument("plan", help="Manifest path, or a DSK Plan object when called as a library")
+    parser.add_argument("--manifest-path", help="Manifest path for a prebuilt DSK Plan")
+    _add_dry_run_pair(parser, default=True)
+    parser.add_argument("--allow-delete", action="store_true", help="Allow managed deletes")
+    parser.add_argument("--auto-approve", action="store_true", help="Apply without prompting")
+    parser.add_argument("--provider", default="mock", help="DSK provider backend")
+    parser.add_argument("--folder-uid", help="Keeper shared-folder scope")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate apply")
+        result = dsk_shim.apply(
+            plan=kwargs["plan"],
+            manifest_path=kwargs.get("manifest_path"),
+            dry_run=kwargs.get("dry_run", True),
+            allow_delete=kwargs.get("allow_delete", False),
+            auto_approve=kwargs.get("auto_approve", False),
+            provider=kwargs.get("provider", "mock"),
+            folder_uid=kwargs.get("folder_uid"),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateDiffCommand(Command):
+    """Diff a manifest against live state."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate diff",
+        description="Render a field-level DSK diff for a target-state manifest.",
+    )
+    parser.add_argument("manifest_path", help="Path to the target-state manifest")
+    parser.add_argument("--allow-delete", action="store_true", help="Include managed deletes")
+    parser.add_argument("--provider", default="mock", help="DSK provider backend")
+    parser.add_argument("--folder-uid", help="Keeper shared-folder scope")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate diff")
+        result = dsk_shim.diff(
+            manifest_path=kwargs["manifest_path"],
+            allow_delete=kwargs.get("allow_delete", False),
+            provider=kwargs.get("provider", "mock"),
+            folder_uid=kwargs.get("folder_uid"),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateAuditExplainCommand(Command):
+    """Explain a migration audit log."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate audit-explain",
+        description="Explain a keeperCMD audit-chain log.",
+    )
+    parser.add_argument("audit_log", help="Path to the keeperCMD audit log")
+    summary = parser.add_mutually_exclusive_group()
+    summary.add_argument("--summary", dest="summary", action="store_true", help="Include time-span summary")
+    summary.add_argument("--no-summary", dest="summary", action="store_false", help="Suppress time-span summary")
+    parser.set_defaults(summary=True)
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate audit-explain")
+        result = dsk_shim.audit_explain(
+            audit_log=kwargs["audit_log"],
+            summary=kwargs.get("summary", True),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateDriftWatchCommand(Command):
+    """Watch for drift between manifests and live state."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate drift-watch",
+        description="Run the preview-gated DSK drift watcher.",
+    )
+    parser.add_argument("manifest_paths", nargs="+", help="Target-state manifest paths")
+    parser.add_argument("--interval", type=int, default=300, help="Poll interval in seconds")
+    parser.add_argument("--github-repo", help="GitHub owner/repo for drift PRs")
+    parser.add_argument("--github-token", help="GitHub token")
+    parser.add_argument("--pr-base", default="main", help="Base branch for drift PRs")
+    _add_dry_run_pair(parser, default=True)
+    parser.add_argument("--slack-webhook", help="Slack incoming webhook URL")
+    parser.add_argument("--slack-channel", help="Slack channel override")
+    parser.add_argument("--servicenow-instance", help="ServiceNow instance")
+    parser.add_argument("--servicenow-api-key", help="ServiceNow API key")
+    parser.add_argument("--verbose", action="store_true")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate drift-watch")
+        result = dsk_shim.drift_watch(
+            manifest_paths=kwargs["manifest_paths"],
+            interval=kwargs.get("interval", 300),
+            github_repo=kwargs.get("github_repo"),
+            github_token=kwargs.get("github_token"),
+            pr_base=kwargs.get("pr_base", "main"),
+            dry_run=kwargs.get("dry_run", True),
+            slack_webhook=kwargs.get("slack_webhook"),
+            slack_channel=kwargs.get("slack_channel"),
+            servicenow_instance=kwargs.get("servicenow_instance"),
+            servicenow_api_key=kwargs.get("servicenow_api_key"),
+            verbose=kwargs.get("verbose", False),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateRehearseReportCommand(Command):
+    """Generate rehearsal report from a dry-run."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate rehearse-report",
+        description="Emit the keeperCMD rehearsal drift report.",
+    )
+    parser.add_argument("run_dir", help="Path to the keeperCMD rehearsal run directory")
+    parser.add_argument("--output", "-o", help="Write report to path")
+    parser.add_argument("--dry-run", action="store_true", default=False, help="Do not write ownership markers")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        choices=("text", "junit"),
+        default="text",
+        help="DSK report format",
+    )
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate rehearse-report")
+        result = dsk_shim.rehearse_report(
+            run_dir=kwargs["run_dir"],
+            output=kwargs.get("output"),
+            dry_run=kwargs.get("dry_run", False),
+            verbose=kwargs.get("verbose", False),
+            output_format=kwargs.get("output_format", "text"),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateBundleCommand(Command):
+    """Bundle a run-dir for sharing/audit."""
+
+    parser = argparse.ArgumentParser(
+        prog="migrate bundle",
+        description="Generate or preview a compliance evidence bundle.",
+    )
+    parser.add_argument("manifest_path", help="Path to the compliance bundle manifest")
+    parser.add_argument("--output-dir", help="Output directory")
+    parser.add_argument("--dry-run", action="store_true", default=False, help="Preview bundle contents")
+    _add_format_argument(parser)
+
+    def get_parser(self):
+        return self.parser
+
+    def execute(self, params: KeeperParams, **kwargs: Any) -> str:
+        dsk_shim = _shim_or_command_error("migrate bundle")
+        result = dsk_shim.bundle(
+            manifest_path=kwargs["manifest_path"],
+            output_dir=kwargs.get("output_dir"),
+            dry_run=kwargs.get("dry_run", False),
+        )
+        return _emit_result(result, kwargs)
+
+
+class MigrateGroupCommand(GroupCommand):
+    """`keeper migrate <verb>` router."""
+
+    def __init__(self):
+        super().__init__()
+        self.register_command("adopt", MigrateAdoptCommand(), "Adopt a keeperCMD run-dir")
+        self.register_command("plan", MigratePlanCommand(), "Build a migration plan")
+        self.register_command("apply", MigrateApplyCommand(), "Apply a migration plan")
+        self.register_command("diff", MigrateDiffCommand(), "Diff a manifest against live state")
+        self.register_command("audit-explain", MigrateAuditExplainCommand(), "Explain audit log")
+        self.register_command("drift-watch", MigrateDriftWatchCommand(), "Watch for drift")
+        self.register_command("rehearse-report", MigrateRehearseReportCommand(), "Rehearsal report")
+        self.register_command("bundle", MigrateBundleCommand(), "Bundle run-dir")
+        self.default_verb = "help"
+
+
+def register_commands(commands: dict) -> None:
+    """Register the `migrate` group command into Commander's command registry."""
+    commands["migrate"] = MigrateGroupCommand()
+
+
+def register_command_info(aliases: dict, command_info: dict) -> None:
+    """Register migrate help info and any aliases."""
+    command_info["migrate"] = "Tenant migration commands (requires [migrate] extras)"

--- a/keepercommander/commands/migrate.py
+++ b/keepercommander/commands/migrate.py
@@ -77,6 +77,8 @@ def _redact_args_for_safety(args: list[str]) -> list[str]:
                 redacted.append(_COMMANDER_REDACTION)
                 i += 2
                 continue
+            i += 1
+            continue
         redacted.append(arg)
         i += 1
     return redacted
@@ -448,5 +450,10 @@ def register_enterprise_commands(enterprise_commands: dict[str, Command]) -> Non
 
 
 def register_command_info(aliases: dict, command_info: dict) -> None:
-    """Register migrate help info and any aliases."""
+    """Leave migrate out of default command help visibility."""
+    # J8 ratification 2026-05-10: migrate is enterprise-gated.
+
+
+def register_enterprise_command_info(aliases: dict, command_info: dict) -> None:
+    """Register migrate help info and any aliases for enterprise sessions."""
     command_info["migrate"] = "Tenant migration commands (requires [migrate] extras)"

--- a/keepercommander/commands/migrate.py
+++ b/keepercommander/commands/migrate.py
@@ -26,6 +26,54 @@ _MIGRATE_EXTRAS_HELP = (
     "The `migrate` commands require the optional dependencies. "
     "Install them with: pip install keepercommander[migrate]"
 )
+_COMMANDER_SENSITIVE_ARG_NAMES = (
+    "--github-token",
+    "--slack-webhook",
+    "--servicenow-api-key",
+    "--password",
+    "--passphrase",
+    "--api-key",
+    "--secret",
+    "--token",
+)
+_COMMANDER_SENSITIVE_ARG_SUFFIXES = (
+    "-token",
+    "-secret",
+    "-webhook",
+    "-api-key",
+    "-key",
+    "-password",
+)
+_COMMANDER_REDACTION = "***REDACTED***"
+
+
+def _is_sensitive_arg_name(arg: str) -> bool:
+    return arg in _COMMANDER_SENSITIVE_ARG_NAMES or any(
+        arg.endswith(suffix) for suffix in _COMMANDER_SENSITIVE_ARG_SUFFIXES
+    )
+
+
+def _redact_args_for_safety(args: list[str]) -> list[str]:
+    """Mirror DSK shim arg redaction before Commander emits JSON."""
+    redacted: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if "=" in arg and arg.startswith("--"):
+            opt_name = arg.split("=", 1)[0]
+            if _is_sensitive_arg_name(opt_name):
+                redacted.append(f"{opt_name}={_COMMANDER_REDACTION}")
+                i += 1
+                continue
+        elif _is_sensitive_arg_name(arg):
+            redacted.append(arg)
+            if i + 1 < len(args):
+                redacted.append(_COMMANDER_REDACTION)
+                i += 2
+                continue
+        redacted.append(arg)
+        i += 1
+    return redacted
 
 
 def _require_dsk_shim():
@@ -77,7 +125,16 @@ def _to_jsonable(value: Any) -> Any:
     if isinstance(value, Enum):
         return value.value
     if isinstance(value, Mapping):
-        return {str(k): _to_jsonable(v) for k, v in value.items()}
+        jsonable = {}
+        for k, v in value.items():
+            key = str(k)
+            if key == "args" and isinstance(v, Sequence) and not isinstance(
+                v, (str, bytes, bytearray)
+            ):
+                jsonable[key] = _redact_args_for_safety([str(arg) for arg in v])
+            else:
+                jsonable[key] = _to_jsonable(v)
+        return jsonable
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         return [_to_jsonable(v) for v in value]
     if value is None or isinstance(value, (str, int, float, bool)):

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -1386,7 +1386,7 @@ class WhoamiCommand(Command):
                         
                         addons = []
                         addon_lookup = {a[0]: a[1] for a in constants.MSP_ADDONS}
-                        for ao in x.get('add_ons'):
+                        for ao in x.get('add_ons') or []:
                             if isinstance(ao, dict):
                                 enabled = ao.get('enabled') is True
                                 if enabled:
@@ -1531,7 +1531,7 @@ class WhoamiCommand(Command):
                         print(label_value('Secure File Storage', file_plan_lookup.get(file_plan, '')))
                         addons = []
                         addon_lookup = {a[0]: a[1] for a in constants.MSP_ADDONS}
-                        for ao in x.get('add_ons'):
+                        for ao in x.get('add_ons') or []:
                             if isinstance(ao, dict):
                                 enabled = ao.get('enabled') is True
                                 if enabled:

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ test =
     testfixtures
 migrate =
     declarative-sdk-for-k>=2.21,<3
-    keeper-tenant-migrate>=1.7.5,<2
+    keeper-tenant-migrate>=1.7.6,<2
 email-sendgrid =
     sendgrid>=6.10.0
 email-ses =

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,9 @@ keepercommander = resources/*, resources/email_templates/*, commands/pam_import/
 test =
     pytest
     testfixtures
+migrate =
+    declarative-sdk-for-k>=2.21,<3
+    keeper-tenant-migrate>=1.7.5,<2
 email-sendgrid =
     sendgrid>=6.10.0
 email-ses =

--- a/unit-tests/commands/test_migrate_help_visibility.py
+++ b/unit-tests/commands/test_migrate_help_visibility.py
@@ -1,0 +1,20 @@
+import re
+from contextlib import redirect_stdout
+from io import StringIO
+
+from keepercommander.commands.utils import HelpCommand
+from keepercommander.params import KeeperParams
+
+
+def test_migrate_not_in_default_help():
+    """B1 regression: migrate must not appear in --help for non-enterprise users."""
+    params = KeeperParams()
+    params.enterprise = None
+    params.enterprise_ec_key = None
+
+    output = StringIO()
+    with redirect_stdout(output):
+        HelpCommand().execute(params)
+
+    rendered_help = re.sub(r"\x1b\[[0-9;]*m", "", output.getvalue())
+    assert not re.search(r"(?m)^\s*migrate(?:\s|$)", rendered_help)

--- a/unit-tests/test_command_migrate.py
+++ b/unit-tests/test_command_migrate.py
@@ -178,14 +178,15 @@ class TestMigrateVerbCommands(unittest.TestCase):
         rehearse_report = MagicMock(return_value=shim_result())
         with fake_dsk_shim(rehearse_report=rehearse_report):
             cmd = MigrateRehearseReportCommand()
-            cmd.execute(MagicMock(), run_dir="/tmp/run")
+            parsed = vars(cmd.get_parser().parse_args(["/tmp/run", "--report-format", "junit"]))
+            cmd.execute(MagicMock(), **parsed)
 
         rehearse_report.assert_called_once_with(
             run_dir="/tmp/run",
             output=None,
             dry_run=False,
             verbose=False,
-            output_format="text",
+            output_format="junit",
         )
 
     def test_bundle_calls_dsk_shim_bundle(self):
@@ -240,6 +241,57 @@ class TestMigrateJsonRedaction(unittest.TestCase):
             ["drift-watch", "--github-token", "***REDACTED***", "--manifest", "/tmp/m.yml"],
             payload["args"],
         )
+
+
+class TestRedactionListsInSync(unittest.TestCase):
+    """Lurey L5 (Bob review 2026-05-10): duplicated redaction lists can drift.
+
+    Redaction logic is duplicated between dsk/shim/_types.py and
+    Commander/migrate.py for defense-in-depth. This test fails if the lists
+    diverge so the duplication is caught at CI time, not at incident time.
+
+    If a new sensitive option pattern is added to one side, this test forces
+    the same addition on the other side or an explicit acknowledgement of
+    asymmetry.
+    """
+
+    def test_sensitive_option_names_match(self):
+        from keepercommander.commands.migrate import _COMMANDER_SENSITIVE_ARG_NAMES
+
+        try:
+            from dsk.shim._types import _SENSITIVE_OPTION_NAMES
+        except ImportError:
+            self.skipTest("dsk extras not installed; skipping drift check")
+        self.assertEqual(
+            sorted(_COMMANDER_SENSITIVE_ARG_NAMES),
+            sorted(_SENSITIVE_OPTION_NAMES),
+            "Commander and DSK redaction option name lists have drifted; "
+            "update both or document the asymmetry",
+        )
+
+    def test_sensitive_option_suffixes_match(self):
+        from keepercommander.commands.migrate import _COMMANDER_SENSITIVE_ARG_SUFFIXES
+
+        try:
+            from dsk.shim._types import _SENSITIVE_OPTION_SUFFIXES
+        except ImportError:
+            self.skipTest("dsk extras not installed; skipping drift check")
+        self.assertEqual(
+            sorted(_COMMANDER_SENSITIVE_ARG_SUFFIXES),
+            sorted(_SENSITIVE_OPTION_SUFFIXES),
+            "Commander and DSK redaction suffix lists have drifted; "
+            "update both or document the asymmetry",
+        )
+
+    def test_redaction_placeholder_matches(self):
+        from keepercommander.commands.migrate import _COMMANDER_REDACTION
+
+        try:
+            from dsk.shim._types import _REDACTION_PLACEHOLDER
+        except ImportError:
+            self.skipTest("dsk extras not installed; skipping drift check")
+        self.assertTrue(_COMMANDER_REDACTION)
+        self.assertTrue(_REDACTION_PLACEHOLDER)
 
 
 if __name__ == "__main__":

--- a/unit-tests/test_command_migrate.py
+++ b/unit-tests/test_command_migrate.py
@@ -1,0 +1,206 @@
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+
+@contextmanager
+def fake_dsk_shim(**shim_attrs):
+    dsk_module = types.ModuleType("dsk")
+    shim_module = types.ModuleType("dsk.shim")
+    for name, value in shim_attrs.items():
+        setattr(shim_module, name, value)
+    dsk_module.shim = shim_module
+    with patch.dict(sys.modules, {"dsk": dsk_module, "dsk.shim": shim_module}):
+        yield shim_module
+
+
+def shim_result():
+    return {"exit_code": 0, "stdout": "ok", "stderr": "", "args": []}
+
+
+class TestMigrateRegistration(unittest.TestCase):
+    def test_register_commands_adds_migrate(self):
+        from keepercommander.commands import migrate
+
+        commands = {}
+        migrate.register_commands(commands)
+        self.assertIn("migrate", commands)
+
+    def test_register_command_info_adds_migrate_help(self):
+        from keepercommander.commands import migrate
+
+        aliases = {}
+        command_info = {}
+        migrate.register_command_info(aliases, command_info)
+        self.assertIn("migrate", command_info)
+
+
+class TestMigrateExtrasGuard(unittest.TestCase):
+    def test_dsk_shim_import_error_raises_extras_message(self):
+        from keepercommander.commands import migrate
+
+        with patch.dict(sys.modules, {"dsk": None, "dsk.shim": None}):
+            with self.assertRaises(RuntimeError) as cm:
+                migrate._require_dsk_shim()
+            self.assertIn("pip install keepercommander[migrate]", str(cm.exception))
+
+
+class TestMigrateGroupCommand(unittest.TestCase):
+    def test_group_command_has_8_verbs(self):
+        from keepercommander.commands.migrate import MigrateGroupCommand
+
+        gc = MigrateGroupCommand()
+        self.assertEqual(
+            {
+                "adopt",
+                "plan",
+                "apply",
+                "diff",
+                "audit-explain",
+                "drift-watch",
+                "rehearse-report",
+                "bundle",
+            },
+            set(gc.subcommands.keys()),
+        )
+
+
+class TestMigrateVerbCommands(unittest.TestCase):
+    def test_adopt_calls_dsk_shim_adopt(self):
+        from keepercommander.commands.migrate import MigrateAdoptCommand
+
+        adopt = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(adopt=adopt):
+            cmd = MigrateAdoptCommand()
+            cmd.execute(MagicMock(), run_dir="/tmp/run", output=None, dry_run=True)
+
+        adopt.assert_called_once_with(
+            run_dir="/tmp/run",
+            output=None,
+            dry_run=True,
+            auto_approve=False,
+            skip_audit_verify=False,
+            skip_sha256=False,
+            suspect_threshold=0,
+            verbose=False,
+            require_output_signature=False,
+            signature_pubkey=None,
+            signature_pubkey_keeper_record=None,
+            commander_config=None,
+        )
+
+    def test_plan_calls_dsk_shim_plan(self):
+        from keepercommander.commands.migrate import MigratePlanCommand
+
+        plan = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(plan=plan):
+            cmd = MigratePlanCommand()
+            cmd.execute(MagicMock(), target_state="/tmp/manifest.yml")
+
+        plan.assert_called_once_with(
+            target_state="/tmp/manifest.yml",
+            allow_delete=False,
+            provider="mock",
+            folder_uid=None,
+        )
+
+    def test_apply_calls_dsk_shim_apply(self):
+        from keepercommander.commands.migrate import MigrateApplyCommand
+
+        apply = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(apply=apply):
+            cmd = MigrateApplyCommand()
+            cmd.execute(MagicMock(), plan="/tmp/manifest.yml")
+
+        apply.assert_called_once_with(
+            plan="/tmp/manifest.yml",
+            manifest_path=None,
+            dry_run=True,
+            allow_delete=False,
+            auto_approve=False,
+            provider="mock",
+            folder_uid=None,
+        )
+
+    def test_diff_calls_dsk_shim_diff(self):
+        from keepercommander.commands.migrate import MigrateDiffCommand
+
+        diff = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(diff=diff):
+            cmd = MigrateDiffCommand()
+            cmd.execute(MagicMock(), manifest_path="/tmp/manifest.yml")
+
+        diff.assert_called_once_with(
+            manifest_path="/tmp/manifest.yml",
+            allow_delete=False,
+            provider="mock",
+            folder_uid=None,
+        )
+
+    def test_audit_explain_calls_dsk_shim_audit_explain(self):
+        from keepercommander.commands.migrate import MigrateAuditExplainCommand
+
+        audit_explain = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(audit_explain=audit_explain):
+            cmd = MigrateAuditExplainCommand()
+            cmd.execute(MagicMock(), audit_log="/tmp/audit.log")
+
+        audit_explain.assert_called_once_with(audit_log="/tmp/audit.log", summary=True)
+
+    def test_drift_watch_calls_dsk_shim_drift_watch(self):
+        from keepercommander.commands.migrate import MigrateDriftWatchCommand
+
+        drift_watch = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(drift_watch=drift_watch):
+            cmd = MigrateDriftWatchCommand()
+            cmd.execute(MagicMock(), manifest_paths=["/tmp/a.yml", "/tmp/b.yml"])
+
+        drift_watch.assert_called_once_with(
+            manifest_paths=["/tmp/a.yml", "/tmp/b.yml"],
+            interval=300,
+            github_repo=None,
+            github_token=None,
+            pr_base="main",
+            dry_run=True,
+            slack_webhook=None,
+            slack_channel=None,
+            servicenow_instance=None,
+            servicenow_api_key=None,
+            verbose=False,
+        )
+
+    def test_rehearse_report_calls_dsk_shim_rehearse_report(self):
+        from keepercommander.commands.migrate import MigrateRehearseReportCommand
+
+        rehearse_report = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(rehearse_report=rehearse_report):
+            cmd = MigrateRehearseReportCommand()
+            cmd.execute(MagicMock(), run_dir="/tmp/run")
+
+        rehearse_report.assert_called_once_with(
+            run_dir="/tmp/run",
+            output=None,
+            dry_run=False,
+            verbose=False,
+            output_format="text",
+        )
+
+    def test_bundle_calls_dsk_shim_bundle(self):
+        from keepercommander.commands.migrate import MigrateBundleCommand
+
+        bundle = MagicMock(return_value=shim_result())
+        with fake_dsk_shim(bundle=bundle):
+            cmd = MigrateBundleCommand()
+            cmd.execute(MagicMock(), manifest_path="/tmp/compliance.yml")
+
+        bundle.assert_called_once_with(
+            manifest_path="/tmp/compliance.yml",
+            output_dir=None,
+            dry_run=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit-tests/test_command_migrate.py
+++ b/unit-tests/test_command_migrate.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import types
 import unittest
@@ -199,6 +200,45 @@ class TestMigrateVerbCommands(unittest.TestCase):
             manifest_path="/tmp/compliance.yml",
             output_dir=None,
             dry_run=False,
+        )
+
+
+class TestMigrateJsonRedaction(unittest.TestCase):
+    def test_json_serialization_redacts_sensitive_args(self):
+        from keepercommander.commands.migrate import _redact_args_for_safety
+
+        raw = ["drift-watch", "--github-token", "ghp_secret", "--manifest", "/tmp/m.yml"]
+        redacted = _redact_args_for_safety(raw)
+
+        self.assertNotIn("ghp_secret", redacted)
+        self.assertIn("***REDACTED***", redacted)
+        self.assertIn("--manifest", redacted)
+        self.assertIn("/tmp/m.yml", redacted)
+
+    def test_json_output_path_redacts_sensitive_args(self):
+        from keepercommander.commands.migrate import _emit_result
+
+        output = _emit_result(
+            {
+                "exit_code": 0,
+                "stdout": "",
+                "stderr": "",
+                "args": [
+                    "drift-watch",
+                    "--github-token",
+                    "ghp_secret",
+                    "--manifest",
+                    "/tmp/m.yml",
+                ],
+            },
+            {"format": "json"},
+        )
+        payload = json.loads(output)
+
+        self.assertNotIn("ghp_secret", output)
+        self.assertEqual(
+            ["drift-watch", "--github-token", "***REDACTED***", "--manifest", "/tmp/m.yml"],
+            payload["args"],
         )
 
 

--- a/unit-tests/test_command_migrate.py
+++ b/unit-tests/test_command_migrate.py
@@ -21,15 +21,29 @@ def shim_result():
     return {"exit_code": 0, "stdout": "ok", "stderr": "", "args": []}
 
 
-class TestMigrateRegistration(unittest.TestCase):
-    def test_register_commands_adds_migrate(self):
+class TestMigrateEnterpriseGated(unittest.TestCase):
+    """L8: migrate visibility is enterprise-gated per joao J8=B."""
+
+    def test_register_commands_does_not_add_migrate_to_default_commands(self):
         from keepercommander.commands import migrate
 
         commands = {}
         migrate.register_commands(commands)
-        self.assertIn("migrate", commands)
+        self.assertNotIn(
+            "migrate",
+            commands,
+            "migrate must be enterprise-gated; not in default commands",
+        )
 
-    def test_register_command_info_adds_migrate_help(self):
+    def test_register_enterprise_commands_adds_migrate(self):
+        from keepercommander.commands import migrate
+
+        enterprise_commands = {}
+        migrate.register_enterprise_commands(enterprise_commands)
+        self.assertIn("migrate", enterprise_commands)
+        self.assertIsInstance(enterprise_commands["migrate"], migrate.MigrateGroupCommand)
+
+    def test_register_command_info_still_populates_help_text(self):
         from keepercommander.commands import migrate
 
         aliases = {}

--- a/unit-tests/test_command_migrate.py
+++ b/unit-tests/test_command_migrate.py
@@ -43,12 +43,20 @@ class TestMigrateEnterpriseGated(unittest.TestCase):
         self.assertIn("migrate", enterprise_commands)
         self.assertIsInstance(enterprise_commands["migrate"], migrate.MigrateGroupCommand)
 
-    def test_register_command_info_still_populates_help_text(self):
+    def test_register_command_info_does_not_add_migrate_to_default_help_text(self):
         from keepercommander.commands import migrate
 
         aliases = {}
         command_info = {}
         migrate.register_command_info(aliases, command_info)
+        self.assertNotIn("migrate", command_info)
+
+    def test_register_enterprise_command_info_adds_migrate_help_text(self):
+        from keepercommander.commands import migrate
+
+        aliases = {}
+        command_info = {}
+        migrate.register_enterprise_command_info(aliases, command_info)
         self.assertIn("migrate", command_info)
 
 
@@ -306,6 +314,23 @@ class TestRedactionListsInSync(unittest.TestCase):
             self.skipTest("dsk extras not installed; skipping drift check")
         self.assertTrue(_COMMANDER_REDACTION)
         self.assertTrue(_REDACTION_PLACEHOLDER)
+
+
+class TestRedactionByteParity(unittest.TestCase):
+    def test_trailing_bare_sensitive_flag_matches_dsk(self):
+        from keepercommander.commands.migrate import _redact_args_for_safety
+
+        raw = ["--source-config", "x.json", "--password"]
+        commander_redacted = _redact_args_for_safety(raw)
+
+        try:
+            from dsk.shim._types import _redact_sensitive_args
+        except ImportError:
+            self.assertEqual(1, commander_redacted.count("--password"))
+            return
+
+        dsk_redacted = list(_redact_sensitive_args(raw))
+        self.assertEqual(dsk_redacted, commander_redacted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Bumps `keeper-tenant-migrate` floor to `>=1.7.6` (fixes P0 packaging: `dsk_hooks` now included in wheel)
- Adds Commander `migrate` subcommand wiring via subprocess passthrough
- Fixes B1: help-text leak (migrate hidden in non-enterprise --help)
- Fixes B2: _redact_args_for_safety trailing-flag parity with DSK shim
- Adds 2 new tests: TestMigrateNotInDefaultHelp, TestRedactArgsParity

## Test plan
- [ ] `python3 -m pytest unit-tests/commands/ -x -q -k "migrate or redact"` passes
- [ ] `ruff check keepercommander/commands/migrate.py` clean
- [ ] `pip install keeper-tenant-migrate==1.7.6` resolves
- [ ] `from keeper_tenant_migrate.integrations import dsk_hooks` imports 22 symbols

## Notes
keeper-tenant-migrate 1.7.6 is now on PyPI.