### PR TITLE
Implement Enforcement of Record Password and Types policies

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -809,6 +809,10 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                                         role_ids.update(team_roles[team_uid])
                             if column == 'role_count':
                                 row.append(len(role_ids))
+                            elif kwargs.get('format') == 'json':
+                                role_info = [{'role_id': rid, 'role_name': roles[rid]['name']}
+                                             for rid in role_ids if rid in roles]
+                                row.append(role_info)
                             else:
                                 role_names = [roles[role_id]['name'] for role_id in role_ids if role_id in roles]
                                 row.append(role_names)
@@ -987,6 +991,22 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                                     enforcement_type = constants.ENFORCEMENTS.get(k)
                                     if enforcement_type == 'two_factor_duration':
                                         formatted_enforcements[k] = constants.format_two_factor_duration(v)
+                                    elif enforcement_type == 'record_types':
+                                        try:
+                                            rto = v if isinstance(v, dict) else json.loads(v)
+                                            if params.record_type_cache:
+                                                record_types = []
+                                                for record_type_id in itertools.chain(rto.get('std') or [], rto.get('ent') or []):
+                                                    if record_type_id in params.record_type_cache:
+                                                        rtc = json.loads(params.record_type_cache[record_type_id])
+                                                        if '$id' in rtc:
+                                                            record_types.append(rtc['$id'])
+                                                formatted_enforcements[k] = ', '.join(record_types)
+                                            else:
+                                                formatted_enforcements[k] = v
+                                        except (json.JSONDecodeError, TypeError, KeyError, ValueError) as e:
+                                            logging.debug('Failed to format record_types enforcement %s: %s', k, e)
+                                            formatted_enforcements[k] = v
                                     else:
                                         formatted_enforcements[k] = v
                                 row.append(formatted_enforcements)

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -28,6 +28,7 @@ from .helpers.timeout import parse_timeout
 from .. import api, utils, vault, record_types, generator, crypto, attachment, record_facades, record_management
 from ..breachwatch import BreachWatch
 from ..commands import recordv3
+from ..enforcement import PasswordComplexityEnforcer, RecordTypeEnforcer
 from ..error import CommandError
 from ..params import KeeperParams, LAST_RECORD_UID
 from ..subfolder import try_resolve_path, find_folders, get_folder_path
@@ -230,6 +231,7 @@ ParsedFieldValue = collections.namedtuple('ParsedFieldValue', ['section', 'type'
 class RecordEditMixin:
     def __init__(self):
         self.warnings = []
+        self._password_policy = None   # type: Optional[Dict[str, Any]]
 
     def on_warning(self, message):
         if message:
@@ -390,7 +392,7 @@ class RecordEditMixin:
         }
 
     @staticmethod
-    def generate_password(parameters=None):   # type: (Optional[Sequence[str]]) -> str
+    def generate_password(parameters=None, policy=None):   # type: (Optional[Sequence[str]], Optional[dict]) -> str
         if isinstance(parameters, (tuple, list, set)):
             algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto')), 'rand')
             length = next((x for x in parameters if x.isnumeric()), None)
@@ -415,14 +417,17 @@ class RecordEditMixin:
                 length = 5
             gen = generator.DicewarePasswordGenerator(length)
         else:
-            if isinstance(length, int):
-                if length < 4:
-                    length = 4
-                elif length > 200:
-                    length = 200
+            if policy:
+                gen = generator.KeeperPasswordGenerator.create_from_policy(policy, length_override=length)
             else:
-                length = 20
-            gen = generator.KeeperPasswordGenerator(length=length)
+                if isinstance(length, int):
+                    if length < 4:
+                        length = 4
+                    elif length > 200:
+                        length = 200
+                else:
+                    length = 20
+                gen = generator.KeeperPasswordGenerator(length=length)
         return gen.generate()
 
     @staticmethod
@@ -599,7 +604,7 @@ class RecordEditMixin:
                 action_params = []
                 if self.is_generate_value(parsed_field.value, action_params):
                     if record_field.type == 'password':
-                        value = self.generate_password(action_params)
+                        value = self.generate_password(action_params, policy=self._password_policy)
                     elif record_field.type in ('oneTimeCode', 'otp'):
                         value = self.generate_totp_url()
                     elif record_field.type in ('keyPair', 'privateKey'):
@@ -833,6 +838,9 @@ class RecordAddCommand(Command, RecordEditMixin):
         if not record_type:
             raise CommandError('record-add', 'Record type parameter is required.')
 
+        RecordTypeEnforcer.enforce(params, record_type, 'record-add')
+        self._password_policy = PasswordComplexityEnforcer.get_policy(params)
+
         fields = kwargs.get('fields', [])
         # Filter out empty strings that might be introduced by copy-paste or line continuation issues
         fields = [field.strip() for field in fields if field.strip()]
@@ -878,6 +886,12 @@ class RecordAddCommand(Command, RecordEditMixin):
             record.record_uid = record_uid
         record.title = title
         record.notes = self.validate_notes(kwargs.get('notes') or '')
+
+        pw_failures = PasswordComplexityEnforcer.validate_record(params, record)
+        for f in pw_failures:
+            self.on_warning(f)
+        if pw_failures and not kwargs.get('force'):
+            self.on_warning('Use --force to bypass password policy warnings.')
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:
@@ -1243,12 +1257,15 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             else:
                 record_fields.append(parsed_field)
 
+        self._password_policy = PasswordComplexityEnforcer.get_policy(params)
+
         if isinstance(record, vault.PasswordRecord):
             raise CommandError('record-update', 'Legacy record type is not supported. Convert the record to login record type.')
             # self.assign_legacy_fields(record, record_fields)
         elif isinstance(record, vault.TypedRecord):
             record_type = kwargs.get('record_type')
             if record_type:
+                RecordTypeEnforcer.enforce(params, record_type, 'record-update')
                 record.type_name = record_type
                 rt_fields = self.get_record_type_fields(params, record_type)
                 if not rt_fields:
@@ -1257,6 +1274,13 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             self.assign_typed_fields(record, record_fields)
         else:
             raise CommandError('record-update', f'Record \"{record_name}\" can not be edited.')
+
+        if isinstance(record, vault.TypedRecord):
+            pw_failures = PasswordComplexityEnforcer.validate_record(params, record)
+            for f in pw_failures:
+                self.on_warning(f)
+            if pw_failures and not kwargs.get('force'):
+                self.on_warning('Use --force to bypass password policy warnings.')
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -26,6 +26,7 @@ from .base import suppress_exit, raise_parse_exception, dump_report_data, Comman
 from .. import api, crypto, generator
 from .. import recordv3, loginv3
 from ..display import bcolors
+from ..enforcement import PasswordComplexityEnforcer, RecordTypeEnforcer
 from ..error import CommandError
 from ..params import LAST_RECORD_UID
 from ..proto import record_pb2 as records
@@ -116,6 +117,8 @@ command_group = record_type_info_parser.add_mutually_exclusive_group()
 # command_group.add_argument('-lc', '--category', dest='category', action='store', default=None, const = '*', nargs='?', help='list categories or record types in a category')
 command_group.add_argument('-lr', '--list-record', dest='record_name', action='store', default=None, const = '*', nargs='?', help='list record type by name or use * to list all')
 command_group.add_argument('-lf', '--list-field', type=str, dest='field_name', action='store', default=None, help='list field type by name or use * to list all')
+record_type_info_parser.add_argument('-ef', '--effective', dest='effective', action='store_true',
+                                     help='filter -lr results to record types allowed by your enterprise role policy')
 
 
 record_type_parser = argparse.ArgumentParser(prog='record-type', description='Add, modify or delete record type definition')
@@ -222,6 +225,8 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
                 # logging.error(bcolors.FAIL + 'Record type definition not found for type: ' + rt +
                 #     ' - to get list of all available record types use: record-type-info -lr' + bcolors.ENDC)
                 raise CommandError('add', f'Record type definition not found for type: {rt} - to get list of all available record types use: record-type-info -lr')
+
+            RecordTypeEnforcer.enforce(params, rt, 'add')
 
         data_json = str(kwargs['data']).strip() if 'data' in kwargs and kwargs['data'] else None
         data_file = str(kwargs['data_file']).strip() if 'data_file' in kwargs and kwargs['data_file'] else None
@@ -404,6 +409,16 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
             password = get_password_from_rules(kwargs.get('generate_rules'), kwargs.get('generate_length'))
         if password:
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
+
+        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
+        if pw_failures:
+            for f in pw_failures:
+                logging.warning(bcolors.WARNING + f + bcolors.ENDC)
+            if not kwargs.get('force'):
+                raise CommandError(
+                    'add',
+                    'Password does not meet enterprise complexity policy. '
+                    'Pass --force to bypass these warnings.')
 
         record_uid = api.generate_record_uid()
         logging.debug('Generated Record UID: %s', record_uid)
@@ -602,6 +617,9 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
                     ' - to get list of all available record types use: record-type-info -lr' + bcolors.ENDC)
                 return
 
+            if rt and rt != rt_name:
+                RecordTypeEnforcer.enforce(params, rt, 'edit')
+
         data_json = str(kwargs['data']).strip() if 'data' in kwargs and kwargs['data'] else None
         data_file = str(kwargs['data_file']).strip() if 'data_file' in kwargs and kwargs['data_file'] else None
         data_opts = recordv3.RecordV3.convert_options_to_json(params, record_data, rt_def, kwargs) if rt_def else None
@@ -641,6 +659,16 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
         if password:
             record.password = password
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
+
+        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
+        if pw_failures:
+            for f in pw_failures:
+                logging.warning(bcolors.WARNING + f + bcolors.ENDC)
+            if not kwargs.get('force'):
+                raise CommandError(
+                    'edit',
+                    'Password does not meet enterprise complexity policy. '
+                    'Pass --force to bypass these warnings.')
 
         data_dict = json.loads(data)
         changed = rdata_dict != data_dict
@@ -766,6 +794,17 @@ Column Name       Description
 class RecordTypeInfo(Command):
     def get_parser(self):
         return record_type_info_parser
+
+    @staticmethod
+    def _type_name(params, rtid):
+        entry = params.record_type_cache.get(rtid) if params.record_type_cache else None
+        if not entry:
+            return None
+        try:
+            schema = json.loads(entry) if isinstance(entry, str) else entry
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return schema.get('$id') if isinstance(schema, dict) else None
 
     @staticmethod
     def resolve_record_type(params, record_type_id):
@@ -907,6 +946,11 @@ class RecordTypeInfo(Command):
         # 2021-06-07 if no record_name or field_name specified - list all record types
         has_categories_only = False
         row_data = RecordTypeInfo.resolve_record_types(params, lrid)
+
+        if kwargs.get('effective'):
+            restricted = RecordTypeEnforcer.get_restricted_record_types(params)
+            if restricted:
+                row_data = [r for r in row_data if RecordTypeInfo._type_name(params, r[2]) not in restricted]
 
         rows = []
         for count, cat, rtid, content in row_data:

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -9,18 +9,55 @@
 # Contact: ops@keepersecurity.com
 #
 
+import itertools
 import json
 import logging
 import getpass
 import threading
 from datetime import datetime, timedelta
-from typing import Tuple
+from typing import Tuple, Optional, List, Dict, Any, Set
 
 from . import api, utils, crypto
 from .proto import APIRequest_pb2
 from .display import bcolors
 from .params import KeeperParams
-from .error import KeeperApiError
+from .error import KeeperApiError, CommandError
+
+
+def _find_enforcement_value(enforcements, key):
+    # type: (Any, str) -> Any
+    """Return raw enforcement value for `key` across known layouts, or None."""
+    if not isinstance(enforcements, dict):
+        return None
+    for bucket in ('jsons', 'strings'):
+        items = enforcements.get(bucket)
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict) and item.get('key') == key:
+                    return item.get('value')
+    return enforcements.get(key) if key in enforcements else None
+
+
+def _coerce_int(value):
+    # type: (Any) -> Optional[int]
+    """Coerce enforcement values to int.
+
+    Server-side enforcement payloads sometimes serialize numeric fields as
+    strings. Returns None if the value cannot be safely interpreted as int.
+    `bool` is intentionally rejected (it's a subclass of int).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if s.lstrip('-').isdigit():
+            try:
+                return int(s)
+            except ValueError:
+                return None
+    return None
 
 
 class MasterPasswordReentryEnforcer:
@@ -354,3 +391,167 @@ class MasterPasswordReentryEnforcer:
         # If no authentication methods are available, policy does not apply
         logging.info("Master Password Re-authentication skipped: Master Password or alternate SSO Master Password not available - policy does not apply")
         return True
+
+
+class PasswordComplexityEnforcer:
+    """Enforces GENERATED_PASSWORD_COMPLEXITY policy on record passwords."""
+
+    _POLICY_KEY = 'generated_password_complexity'
+
+    _CHAR_CLASSES = (
+        ('lower-use', 'lower-min', 'lowercase', str.islower),
+        ('upper-use', 'upper-min', 'uppercase', str.isupper),
+        ('digit-use', 'digit-min', 'digit',     str.isdigit),
+    )
+
+    @classmethod
+    def get_policy(cls, params):   # type: (KeeperParams) -> Optional[Dict[str, Any]]
+        if not params or not params.enforcements:
+            return None
+        raw = _find_enforcement_value(params.enforcements, cls._POLICY_KEY)
+        if raw is None:
+            return None
+        try:
+            rules = json.loads(raw) if isinstance(raw, str) else raw
+        except (json.JSONDecodeError, TypeError):
+            logging.debug('Failed to parse %s enforcement', cls._POLICY_KEY)
+            return None
+        if isinstance(rules, list) and rules and isinstance(rules[0], dict):
+            return rules[0]
+        if isinstance(rules, dict):
+            return rules
+        return None
+
+    @classmethod
+    def validate_password(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
+        failures = []   # type: List[str]
+        if not policy or not isinstance(password, str) or not password:
+            return failures
+
+        min_length = _coerce_int(policy.get('length'))
+        if min_length is not None and min_length > 0 and len(password) < min_length:
+            failures.append(
+                f'Password must be at least {min_length} characters (got {len(password)}).')
+
+        for use_key, min_key, label, predicate in cls._CHAR_CLASSES:
+            if not policy.get(use_key):
+                continue
+            required = _coerce_int(policy.get(min_key, 1))
+            if required is None or required <= 0:
+                continue
+            count = sum(1 for c in password if predicate(c))
+            if count < required:
+                failures.append(
+                    f'Password must contain at least {required} {label} character(s) (got {count}).')
+
+        if policy.get('special-use'):
+            required = _coerce_int(policy.get('special-min', 1))
+            if required is not None and required > 0:
+                allowed = policy.get('special') or ''
+                count = (sum(1 for c in password if c in allowed) if allowed
+                         else sum(1 for c in password if not c.isalnum()))
+                if count < required:
+                    failures.append(
+                        f'Password must contain at least {required} special character(s) (got {count}).')
+
+        return failures
+
+    @classmethod
+    def validate_record(cls, params, source):   # type: (KeeperParams, Any) -> List[str]
+        """Return policy violations across all password fields in `source`.
+
+        `source` may be a vault.TypedRecord, a v3 record-data dict, or a JSON
+        string of that dict. Returns [] when no policy applies or no password
+        fields are present.
+        """
+        policy = cls.get_policy(params)
+        if not policy:
+            return []
+        failures = []   # type: List[str]
+        for pw in cls._extract_passwords(source):
+            failures.extend(cls.validate_password(pw, policy))
+        return failures
+
+    @staticmethod
+    def _extract_passwords(source):   # type: (Any) -> List[str]
+        if source is None:
+            return []
+        passwords = []   # type: List[str]
+        if hasattr(source, 'fields') and hasattr(source, 'custom'):
+            for fld in itertools.chain(source.fields or [], source.custom or []):
+                if getattr(fld, 'type', None) == 'password':
+                    val = getattr(fld, 'value', None)
+                    if isinstance(val, list):
+                        passwords.extend(v for v in val if isinstance(v, str) and v)
+            return passwords
+
+        data = source
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except (json.JSONDecodeError, TypeError):
+                return []
+        if not isinstance(data, dict):
+            return []
+        for fld in data.get('fields') or []:
+            if isinstance(fld, dict) and fld.get('type') == 'password':
+                val = fld.get('value')
+                if isinstance(val, list):
+                    passwords.extend(v for v in val if isinstance(v, str) and v)
+        return passwords
+
+
+class RecordTypeEnforcer:
+    """Enforces RESTRICT_RECORD_TYPES policy on record creation/update.
+
+    Stored value is a JSON object {"std": [<id>, ...], "ent": [<id>, ...]} of
+    record-type IDs the user is *blocked* from creating. IDs are resolved to
+    type names via `params.record_type_cache`.
+    """
+
+    _POLICY_KEY = 'restrict_record_types'
+
+    @classmethod
+    def get_restricted_record_types(cls, params):   # type: (KeeperParams) -> Optional[Set[str]]
+        if not params or not params.enforcements:
+            return None
+        raw = _find_enforcement_value(params.enforcements, cls._POLICY_KEY)
+        if raw is None:
+            return None
+        try:
+            policy = raw if isinstance(raw, dict) else json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            logging.debug('Failed to parse %s enforcement', cls._POLICY_KEY)
+            return None
+        if not isinstance(policy, dict):
+            return None
+
+        cache = getattr(params, 'record_type_cache', None) or {}
+        restricted = set()   # type: Set[str]
+        for rt_id in list(policy.get('std') or []) + list(policy.get('ent') or []):
+            entry = cache.get(rt_id)
+            if not entry:
+                continue
+            try:
+                schema = json.loads(entry) if isinstance(entry, str) else entry
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if isinstance(schema, dict):
+                name = schema.get('$id')
+                if name:
+                    restricted.add(name)
+        return restricted
+
+    @classmethod
+    def enforce(cls, params, record_type, command):
+        # type: (KeeperParams, Optional[str], str) -> None
+        """Raise CommandError when `record_type` is blocked by policy."""
+        if not record_type:
+            return
+        restricted = cls.get_restricted_record_types(params)
+        if not restricted or record_type not in restricted:
+            return
+        raise CommandError(
+            command,
+            f'Record type "{record_type}" is restricted by your enterprise role policy '
+            f'and cannot be created.')

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -132,6 +132,26 @@ class KeeperPasswordGenerator(PasswordGenerator):
         length = sum(rule_list) if length is None else length
         return cls(length=length, caps=upper, lower=lower, digits=digits, symbols=symbols, special_characters=special_characters)
 
+    @classmethod
+    def create_from_policy(cls, policy, length_override=None):
+        # type: (dict, Optional[int]) -> KeeperPasswordGenerator
+        """Create a generator that satisfies the given password complexity enforcement policy."""
+        pw_length = length_override or policy.get('length') or DEFAULT_PASSWORD_LENGTH
+        lower_min = policy.get('lower-min', 0) if policy.get('lower-use') else None
+        upper_min = policy.get('upper-min', 0) if policy.get('upper-use') else None
+        digit_min = policy.get('digit-min', 0) if policy.get('digit-use') else None
+        special_min = policy.get('special-min', 0) if policy.get('special-use') else None
+        special_chars = policy.get('special', PW_SPECIAL_CHARACTERS) or PW_SPECIAL_CHARACTERS
+
+        return cls(
+            length=pw_length,
+            lower=lower_min,
+            caps=upper_min,
+            digits=digit_min,
+            symbols=special_min,
+            special_characters=special_chars
+        )
+
 
 class DicewarePasswordGenerator(PasswordGenerator):
     def __init__(self, number_of_rolls, word_list_file=None, delimiter=' '):   # type: (int, Optional[str], str) -> None


### PR DESCRIPTION
## Summary

Implements two enterprise enforcement policies for record commands:

- **`generated_password_complexity`** — `record-add` / `record-update` now validate every password field against the policy and warn on violations. `--force` bypasses the warnings.
- **`restrict_record_types`** — blocks `record-add` / `record-update` from creating or converting to record types disallowed by the user's role policy.

Also surfaces the resolved record-type names in `enterprise-info --format json` for visibility.

### Changes Tested

- `record-add` / `record-update` with a violating password → warnings shown, `--force` bypasses.
- `record-add -t pamUser` (or any restricted type) → `CommandError`, no record created.
- `record-update --record-type X` to a restricted type → blocked.
- Auto-generated passwords (`$GEN`) satisfy the active complexity policy.
- `enterprise-info --format json` shows resolved record-type names for the restricted policy.