### PR TITLE
feat: declare keeper-tenant-migrate>=1.7.6 as a Commander dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ install_requires =
     tabulate
     websockets
     keeper_pam_webrtc_rs>=2.1.17
+    keeper-tenant-migrate>=1.7.6
     pydantic>=2.6.4
     fpdf2>=2.8.3
     tzlocal>=5.0


### PR DESCRIPTION
# feat: declare `keeper-tenant-migrate>=1.7.6` as a Commander dependency

## Summary

Adds the `keeper-tenant-migrate` plugin as an install-time dependency
of `keepercommander`. Commander's existing plugin-loader machinery
auto-discovers the package on install and registers the `tenant-migrate`
subcommand — no Commander-side wrapper code added.

This is the minimal absorption shape: cmd remains its own product at
`jlima8900/keeperCMD` with its own release cadence and SemVer contract.
Commander declares the dependency so operators get cmd shipped
alongside Commander rather than via a separate `keeper-migrate`
console-script install.

## Change

```diff
# setup.cfg
     keeper_pam_webrtc_rs>=2.1.17
+    keeper-tenant-migrate>=1.7.6
     pydantic>=2.6.4
```

One line. No other Commander-side code change.

## What's in `keeper-tenant-migrate` v1.7.6

The cmd v1.7.6 release captures a multi-phase pre-PR validation series
documented in [`jlima8900/keeperCMD`](https://github.com/jlima8900/keeperCMD)
at `keeper_tenant_migrate/.context/`. Highlights:

### Audit-chain integrity
- **All 14 destructive verbs** emit tamper-evident chain entries at
  the canonical `<run_dir>/audit.log` location (Phase 2 audit-emission
  verification + audit-emission-followup-2026-05-11).
- HMAC-chained `prev_hash` ensures any post-hoc edit invalidates the
  chain from that point forward.
- Chain entries record subcommand name, inputs (paths + flags), outputs
  (counts + hashes), and timestamps. Safe for SIEM forwarding (no
  plaintext field values).

### File-permission hardening
- `0o600` enforced on all plaintext-bearing bundles: records-export
  per-record JSONs, chunked records-import per-chunk bundles, take-
  ownership backups, converter output (single + split-by-type).

### Fail-CLOSED safeguards
- `auto-migrate --expected-source-tenant` / `--expected-target-tenant`
  raise `ValueError` pre-stage-dispatch on mismatch (no warn-and-
  continue path).
- `undo --mc` threading: MC-scoped reversals stay scoped via MCContext;
  chain entries record `inputs.mc` for downstream correlation.

### Stable Python API for declarative-SDK consumers
- `keeper_tenant_migrate.integrations.dsk_hooks` ships 14 callable
  hooks + 8 type symbols, R6.1 SemVer-versioned. Tier 1-3 surface:
  - Tier 1 (I1-I8 absorption verbs): `discover_run_dir`,
    `verify_run_dir_integrity`, `get_audit_chain_tail`,
    `get_users_transition_table`, `get_transition_baseline`,
    `validate_run_dir_for_adopt`
  - Tier 2 (I9 + I15 + I17 + I18): `get_enterprise_state`,
    `get_vault_sharing_state`, `get_compliance_evidence`,
    `run_static_health_checks`
  - Tier 3 (I16 + I18-streaming + I20): `get_msp_context_state`,
    `stream_compliance_evidence_for_siem`,
    `list_keeper_product_dependencies`

### Wheel packaging
- v1.7.5 wheel omitted the `integrations` subpackage. v1.7.6 ships it
  correctly — `from keeper_tenant_migrate.integrations import dsk_hooks`
  resolves from clean pip install.

## Validation

- **2432 plugin tests pass** on `jlima8900/keeperCMD` master
- **7 phase audit docs** under `keeper_tenant_migrate/.context/`:
  - subcommand-surface-catalogue (41 verbs, argparse introspection)
  - phase2-audit-emission-report (5 cross-cutting audits)
  - phase3-coverage-gap-audit (every uncovered line categorized)
  - phase4-per-subcommand-deep-audit (38/41 PASS on 3-leg audit)
  - phase5-documentation-audit (3 inline doc patches)
  - phase6-live-validation-gap-matrix (35/41 verbs rehearsal-anchored)
  - phase7-pr-readiness-master-checklist (synthesis)
- **CI green** on every keeperCMD master commit since Phase 1 (15+ commits)
- **Rehearsal-17 live-confirmation procedure** documented at
  `keeper_tenant_migrate/.context/rehearsal-17-quickref-2026-05-11.md`

## Test plan

cmd v1.7.6 is fully built + tagged + installable. Reviewers can run:

```bash
# Clean venv install from git tag (works today, no PyPI dependency)
python3 -m venv /tmp/review-venv
/tmp/review-venv/bin/pip install \
    git+https://github.com/jlima8900/keeperCMD.git@v1.7.6#subdirectory=keeper_tenant_migrate

# Verify the integrations subpackage ships
/tmp/review-venv/bin/python -c "
from keeper_tenant_migrate.integrations import dsk_hooks
expected = {
    'discover_run_dir', 'verify_run_dir_integrity', 'get_audit_chain_tail',
    'get_users_transition_table', 'get_transition_baseline',
    'validate_run_dir_for_adopt', 'get_enterprise_state',
    'get_vault_sharing_state', 'get_compliance_evidence',
    'run_static_health_checks', 'UnsafeArtifactError',
    'get_msp_context_state', 'stream_compliance_evidence_for_siem',
    'list_keeper_product_dependencies',
}
missing = expected - set(dir(dsk_hooks))
assert not missing, f'Missing: {missing}'
import keeper_tenant_migrate
print(f'OK — keeper_tenant_migrate {keeper_tenant_migrate.__version__}')
"
# Expected: OK — keeper_tenant_migrate 1.7.6

# Plugin self-test
/tmp/review-venv/bin/keeper-migrate self-test
```

- [ ] Clean-venv install from git tag completes
- [ ] dsk_hooks 14-symbol contract verifies
- [ ] `keeper-migrate self-test` exits 0
- [ ] Existing Commander test suite passes (no regressions expected — no
      Commander-side code touched)
- [ ] Rehearsal-17 live-confirmation pass on cmd-side
      (`keeper_tenant_migrate/.context/rehearsal-17-quickref-2026-05-11.md`)

## Coordination notes

- **PyPI publish of v1.7.6 is a packaging-step formality**, not a gate
  for review. The code is on GitHub at the `v1.7.6` tag and pip-
  installable from the git URL above. PyPI publish has been parked in
  the cmd repo pending Keeper engineering's preference on package-
  index strategy — easy to flip on or normalize the `setup.cfg`
  line to a git URL once Keeper engineering has weighed in.
- **DSK absorption** (declarative SDK at `msawczynk/dsk`) is a separate
  cross-product concern documented in `keeperCMD/DSK_INTEGRATION_ANALYSIS.md`.
  This PR does NOT take a position on DSK absorption; cmd's dsk_hooks
  surface is consumer-facing only.
- **Out-of-scope for this PR**: native Commander-side subcommand wrapper
  (cmd is loaded via existing plugin discovery), KSM/PAM-deep coverage
  (out of cmd's lane per `cmd-keeper-product-boundaries-2026-05-10.md`),
  changes to `keepercommander/commands/migrate.py` (file not added).

## References

- cmd repo: https://github.com/jlima8900/keeperCMD
- cmd v1.7.6 tag: https://github.com/jlima8900/keeperCMD/releases/tag/v1.7.6
- Phase 7 master checklist: `keeper_tenant_migrate/.context/phase7-pr-readiness-master-checklist-2026-05-11.md` in cmd repo
- Boundary doc (cmd vs Keeper-product domains): `keeper_tenant_migrate/.context/cmd-keeper-product-boundaries-2026-05-10.md` in cmd repo
