### PR TITLE
cp-rotation-skip-feat: Optional rotation and bring-your-own-password for credential-provision

### DIFF
--- a/keepercommander/commands/credential_provision.py
+++ b/keepercommander/commands/credential_provision.py
@@ -85,14 +85,16 @@ from keepercommander.commands.pam.router_helper import (
 from keepercommander.proto import pam_pb2
 from keepercommander.commands.pam.config_facades import PamConfigurationRecordFacade
 
+# Default password complexity when no rotation: block or existing_password.
+DEFAULT_COMPLEXITY = "32,5,5,5,5"
+
 # =============================================================================
 # Argument Parser
 # =============================================================================
 
 credential_provision_parser = argparse.ArgumentParser(
     prog='credential-provision',
-    description='Automate PAM User credential provisioning with password rotation '
-                'and email delivery'
+    description='Automate PAM User credential provisioning, with optional password rotation and email delivery.'
 )
 
 # Config input: file path OR base64-encoded content (mutually exclusive)
@@ -389,12 +391,15 @@ class CredentialProvisionCommand(Command):
                         logging.error(error_msg)
                     raise CommandError('credential-provision', error_msg)
 
-                # Generate password
-                password = self._generate_password(config['rotation']['password_complexity'])
+                password, used_existing = self._determine_password(config)
 
-                # Create AD user via Gateway if AD-specific fields are present
+                # AD-create is a push-to-target route — gated when existing_password is set.
                 ad_groups = config['account'].get('ad_groups', [])
                 has_ad_config = config['account'].get('distinguished_name') or ad_groups
+                # ad_ops_allowed tracks whether group-add (which we defer to after PAM
+                # user creation + rotation, to keep rollback semantics clean) can run.
+                ad_ops_allowed = False
+                gateway_uid = None
                 if has_ad_config:
                     # Check Gateway version — AD operations require 1.8.0+
                     gateway_uid = self._get_gateway_uid_for_config(
@@ -408,27 +413,26 @@ class CredentialProvisionCommand(Command):
                                 '    Continuing with PAM User record creation only.'
                             )
                     else:
-                        try:
-                            self._create_ad_user_via_gateway(config, password, params, state)
-                            if output_format == 'text':
-                                logging.info(f'✅ AD user created: {config["account"]["username"]}')
-                        except CommandError as ad_err:
-                            if 'already exists' in str(ad_err).lower():
+                        ad_ops_allowed = True
+                        if self._should_create_ad_user(config):
+                            try:
+                                self._create_ad_user_via_gateway(config, password, params, state)
                                 if output_format == 'text':
-                                    logging.info(f'⚠️  AD user already exists: {config["account"]["username"]} — continuing with PAM User creation')
-                            else:
-                                raise
-
-                        # Add to AD groups
-                        if ad_groups:
-                            succeeded, failed = self._add_ad_user_to_groups_via_gateway(
-                                config, params, state.ad_gateway_uid
+                                    logging.info(f'✅ AD user created: {config["account"]["username"]}')
+                            except CommandError as ad_err:
+                                if 'already exists' in str(ad_err).lower():
+                                    if output_format == 'text':
+                                        logging.info(f'⚠️  AD user already exists: {config["account"]["username"]} — continuing with PAM User creation')
+                                else:
+                                    raise
+                        elif used_existing:
+                            logging.info(
+                                'Skipping AD user creation: existing_password declared; '
+                                'account is assumed to pre-exist.'
                             )
-                            if output_format == 'text':
-                                if succeeded:
-                                    logging.info(f'✅ Added to AD groups: {", ".join(succeeded)}')
-                                if failed:
-                                    logging.warning(f'⚠️  Failed to add to AD groups: {", ".join(failed)}')
+                        # NOTE: group-add deferred to after PAM user creation + rotation
+                        # so a failure in those steps doesn't orphan AD memberships on
+                        # the operator's pre-existing account. See review #8 / PR #2043.
 
                 # Create PAM User record
                 pam_user_uid = self._create_pam_user(config, password, params)
@@ -437,19 +441,49 @@ class CredentialProvisionCommand(Command):
                 if output_format == 'text':
                     logging.info(f'✅ PAM User record created: {pam_user_uid}')
 
+                if used_existing:
+                    self._log_existing_password_use(pam_user_uid)
+
                 # Link to PAM Configuration and configure rotation
                 self._create_dag_link(pam_user_uid, config['account']['pam_config_uid'], params)
                 state.dag_link_created = True
-                self._configure_rotation(pam_user_uid, config, params)
 
-                if output_format == 'text':
-                    logging.info('✅ Rotation configured')
+                rotation_success = False
+                if 'rotation' in config:
+                    # _configure_rotation returns False when it swallowed a gateway-500
+                    # error (rotation NOT actually configured — deferred). Gate the
+                    # success log on the real outcome to avoid contradicting the
+                    # warning lines emitted inside the helper.
+                    rotation_configured = self._configure_rotation(pam_user_uid, config, params)
+                    if rotation_configured and output_format == 'text':
+                        logging.info('✅ Rotation configured')
 
-                # Perform immediate rotation if configured
-                rotation_success = self._rotate_immediately(pam_user_uid, config, params)
+                    if self._should_rotate_on_provision(config):
+                        rotation_success = self._rotate_immediately(pam_user_uid, config, params)
+                        # Only emit the success line when _rotate_immediately actually
+                        # succeeded; failure path already logged a warning + mode-aware hint.
+                        if rotation_success and output_format == 'text':
+                            logging.info('✅ Password rotation submitted')
+                    elif output_format == 'text':
+                        logging.info(
+                            'Skipping immediate rotation (rotate_on_provision: false).'
+                        )
+                elif output_format == 'text':
+                    logging.info('No rotation: block in YAML — rotation will not be configured.')
 
-                if output_format == 'text':
-                    logging.info('✅ Password rotation submitted')
+                # AD group additions — deferred from the AD-create block above so a failure
+                # in _create_pam_user / _create_dag_link / _configure_rotation doesn't orphan
+                # group memberships on the operator's pre-existing AD account. By placing this
+                # AFTER rotation, only graceful (non-rollback) failures remain ahead of it.
+                if has_ad_config and ad_ops_allowed and ad_groups:
+                    succeeded, failed = self._add_ad_user_to_groups_via_gateway(
+                        config, params, gateway_uid
+                    )
+                    if output_format == 'text':
+                        if succeeded:
+                            logging.info(f'✅ Added to AD groups: {", ".join(succeeded)}')
+                        if failed:
+                            logging.warning(f'⚠️  Failed to add to AD groups: {", ".join(failed)}')
 
                 # Delivery: direct share or one-time share URL + email
                 share_url = None
@@ -483,12 +517,21 @@ class CredentialProvisionCommand(Command):
                         logging.info('✅ Record created (no delivery configured)')
 
                 if output_format == 'json':
+                    # rotation_status reflects the chosen execution path per API_CONTRACTS.md.
+                    if 'rotation' not in config:
+                        rotation_status = 'not_configured'
+                    elif rotation_success:
+                        rotation_status = 'synced'
+                    elif config['rotation'].get('on_demand'):
+                        rotation_status = 'on_demand'
+                    else:
+                        rotation_status = 'scheduled'
                     result = {
                         'success': True,
                         'pam_user_uid': pam_user_uid,
                         'username': config['account']['username'],
                         'employee_name': f"{config['user']['first_name']} {config['user']['last_name']}",
-                        'rotation_status': 'synced' if rotation_success else 'scheduled',
+                        'rotation_status': rotation_status,
                         'message': 'Credential provisioning complete'
                     }
                     if has_delivery:
@@ -672,8 +715,19 @@ class CredentialProvisionCommand(Command):
             )
             return errors
 
-        # Validate required top-level sections
-        required_sections = ['user', 'account', 'rotation']
+        # Reject a bare 'rotation:' key with no value. YAML parses `rotation:` to None,
+        # which would crash downstream `.get(...)` calls with an unhelpful AttributeError.
+        # The headline "rotation is optional" invites this typo — fail loudly with guidance.
+        if 'rotation' in config and config['rotation'] is None:
+            errors.append(
+                'rotation: was specified but has no value. Either remove the key entirely\n'
+                '    (Commander will not manage rotation for this record) or provide\n'
+                '    schedule (cron) or on_demand: true, plus password_complexity.'
+            )
+            return errors
+
+        # rotation: block is optional (cp-rotation-skip-feat).
+        required_sections = ['user', 'account']
         for section in required_sections:
             if section not in config:
                 errors.append(f'Missing required section: {section}')
@@ -685,7 +739,9 @@ class CredentialProvisionCommand(Command):
         # Validate each section
         errors.extend(self._validate_user_section(config.get('user', {})))
         errors.extend(self._validate_account_section(config.get('account', {})))
-        errors.extend(self._validate_rotation_section(config.get('rotation', {})))
+        # rotation: optional. Empty 'rotation: {}' still validated (and rejected).
+        if 'rotation' in config:
+            errors.extend(self._validate_rotation_section(config.get('rotation', {})))
 
         # Validate delivery section if present (vault sharing)
         if 'delivery' in config:
@@ -758,8 +814,27 @@ class CredentialProvisionCommand(Command):
         if 'managed_company' in config:
             errors.extend(self._validate_mc_context(params, config['managed_company']))
 
+        # INVARIANT-001: existing_password rejected with provisioning-time
+        # rotation. See TECHNICAL_DECISIONS.md ADR-001 / SECURITY_ARCHITECTURE.md.
+        if config.get('account', {}).get('existing_password'):
+            if 'rotation' in config:
+                rop = config['rotation'].get('rotate_on_provision', True)
+                if rop is not False:
+                    errors.append(
+                        'account.existing_password cannot be combined with a rotation:\n'
+                        '    block unless rotation.rotate_on_provision is explicitly set\n'
+                        '    to false. Either:\n'
+                        '      - Omit the rotation: block (Commander stores the password\n'
+                        '        in the vault but does not manage rotation), or\n'
+                        '      - Set rotation.rotate_on_provision: false (rotation is\n'
+                        '        configured but no immediate rotation fires at provisioning).'
+                    )
+
         # Validate: transfer_ownership/remove_from_service_vault are incompatible with rotation
-        has_rotation = bool(config.get('rotation', {}).get('schedule'))
+        # (any rotation mode — the gateway must own the record to fire rotations whether
+        # cron-driven or on-demand).
+        rot = config.get('rotation', {})
+        has_rotation = bool(rot.get('schedule')) or rot.get('on_demand') is True
         transfer = config.get('delivery', {}).get('transfer_ownership', False)
         remove = config.get('delivery', {}).get('remove_from_service_vault', False)
         if has_rotation and (transfer or remove):
@@ -818,8 +893,8 @@ class CredentialProvisionCommand(Command):
         if not account.get('pam_config_uid'):
             errors.append('account.pam_config_uid is required')
 
-        # CRITICAL: Reject old 'initial_password' field (security issue)
-        # Per blocker resolution, passwords are generated by Commander, not provided in YAML
+        # CRITICAL: reject 'initial_password' (BLOCKER_KC-1007-2). Distinct from
+        # 'existing_password' (stored, never pushed) — see ADR-001.
         if 'initial_password' in account:
             errors.append(
                 'account.initial_password is NOT supported (security).\n'
@@ -827,15 +902,49 @@ class CredentialProvisionCommand(Command):
                 '    Remove this field from your YAML configuration.'
             )
 
+        # existing_password: account's current real password. Stored, never pushed.
+        # Coexistence with rotation gated by INVARIANT-001 in _validate_config.
+        # Whitespace-only strings are rejected by .strip() — bool() of non-empty
+        # strings is True so '   ' would otherwise pass.
+        if 'existing_password' in account:
+            ep = account.get('existing_password')
+            if not isinstance(ep, str) or not ep.strip():
+                errors.append(
+                    'account.existing_password must be a non-empty string if specified.'
+                )
+
         return errors
 
     def _validate_rotation_section(self, rotation: Dict[str, Any]) -> List[str]:
-        """Validate rotation section (schedule and password complexity)."""
+        """Validate rotation section (schedule/on_demand, complexity, flags)."""
         errors = []
 
-        if not rotation.get('schedule'):
-            errors.append('rotation.schedule is required (CRON format)')
+        # Exactly one of schedule (cron) or on_demand: true — mirrors
+        # PAMCreateRecordRotationCommand's mutually-exclusive group.
+        has_schedule = bool(rotation.get('schedule'))
+        on_demand = rotation.get('on_demand')
+
+        if 'on_demand' in rotation and not isinstance(on_demand, bool):
+            errors.append(
+                'rotation.on_demand must be a boolean (true/false) if specified.'
+            )
+            # Treat invalid type as "not set" for mode logic
+            on_demand_truthy = False
         else:
+            on_demand_truthy = on_demand is True
+
+        if has_schedule and on_demand_truthy:
+            errors.append(
+                'rotation must specify exactly one of: schedule (cron expression)\n'
+                '    or on_demand: true. Both are mutually exclusive.'
+            )
+        elif not has_schedule and not on_demand_truthy:
+            errors.append(
+                'rotation must specify exactly one of: schedule (cron expression)\n'
+                '    or on_demand: true.'
+            )
+
+        if has_schedule:
             schedule = rotation['schedule']
             if validate_cron_expression and not validate_cron_expression(schedule, for_rotation=True)[0]:
                 errors.append(
@@ -853,6 +962,14 @@ class CredentialProvisionCommand(Command):
                     f'rotation.password_complexity has invalid format: {complexity}\n'
                     f'    Expected: "length,upper,lower,digit,special"\n'
                     f'    Example: "32,5,5,5,5"'
+                )
+
+        # rotate_on_provision: optional bool, default true. False skips _rotate_immediately.
+        if 'rotate_on_provision' in rotation:
+            rop = rotation['rotate_on_provision']
+            if not isinstance(rop, bool):
+                errors.append(
+                    'rotation.rotate_on_provision must be a boolean (true/false) if specified.'
                 )
 
         return errors
@@ -984,7 +1101,8 @@ class CredentialProvisionCommand(Command):
         """
         Generate dry-run report showing what would be created.
 
-        PII (names, emails) are partially masked for security.
+        PII (names, emails) are partially masked for security. The value of
+        account.existing_password is NEVER included in any output.
 
         Args:
             params: KeeperParams session
@@ -1005,27 +1123,72 @@ class CredentialProvisionCommand(Command):
         redacted_email = self._mask_pii(user.get('personal_email', ''))
         redacted_username = self._mask_pii(username)
 
+        has_rotation = 'rotation' in config
+        uses_existing_password = bool(account.get('existing_password'))
+        if has_rotation:
+            rotation_mode = 'on_demand' if rotation.get('on_demand') else 'scheduled'
+        else:
+            rotation_mode = 'none'
+        will_rotate_immediately = (
+            has_rotation
+            and rotation.get('rotate_on_provision', True) is not False
+        )
+
+        # Build actions list to mirror execute()'s actual call sequence.
+        ad_groups = account.get('ad_groups', [])
+        has_ad_config = bool(account.get('distinguished_name') or ad_groups)
+        delivery_cfg = config.get('delivery', {})
+        has_delivery = bool(delivery_cfg.get('share_to'))
+        email_cfg_name = email_config.get('config_name', '') if email_config else ''
+        has_email = bool(email_cfg_name and email_cfg_name.lower() not in ('none', 'null', ''))
+
+        actions = ['Check for duplicate PAM User']
+        if uses_existing_password:
+            actions.append('Use operator-supplied existing_password (value never echoed)')
+        else:
+            actions.append('Generate secure password (complexity requirements applied)')
+        # AD-create only when AD context AND not declaring an existing account
+        if has_ad_config and not uses_existing_password:
+            actions.append('Create AD user via Gateway')
+        actions.append(f'Create PAM User: {redacted_username}')
+        actions.append(f'Link PAM User to PAM Config: {account.get("pam_config_uid")}')
+        if has_rotation:
+            if rotation_mode == 'on_demand':
+                actions.append('Configure rotation: on-demand (manual triggering only)')
+            else:
+                actions.append(f'Configure rotation: {rotation.get("schedule")}')
+            if will_rotate_immediately:
+                actions.append('Submit immediate rotation')
+        # AD group-add deferred to after PAM user creation + rotation — mirrors the
+        # reorder in execute() (c663a127). Runs whenever ad_groups is set, independent
+        # of AD-create.
+        if ad_groups:
+            actions.append(f'Add to AD groups: {len(ad_groups)} group(s)')
+        # Direct vault share when delivery.share_to is set
+        if has_delivery:
+            actions.append(f'Share directly to: {self._mask_pii(delivery_cfg["share_to"])}')
+        # Share-URL generation + email run only when email is fully configured
+        if has_email:
+            actions.append(
+                f'Generate share URL for PAM User (expiry: {email_config.get("share_url_expiry", "7d")})'
+            )
+            actions.append(f'Send email to: {redacted_email} (config: {email_cfg_name})')
+        else:
+            actions.append(f'Skip welcome email (email.config_name: {email_cfg_name or "(unset)"})')
+
         if output_format == 'json':
             result = {
                 'success': True,
                 'dry_run': True,
                 'employee_name': redacted_name,
-                'actions': [
-                    'Check for duplicate PAM User',
-                    'Generate secure password (complexity requirements applied)',
-                    f'Create PAM User: {redacted_username}',
-                    f'Link PAM User to PAM Config: {account.get("pam_config_uid")}',
-                    f'Configure rotation: {rotation.get("schedule")}',
-                    'Submit immediate rotation',
-                    f'Generate share URL for PAM User (expiry: {email_config.get("share_url_expiry", "7d")})',
-                    f'Send email to: {redacted_email}'
-                ],
+                'actions': actions,
                 'configuration': {
                     'employee': redacted_name,
                     'username': redacted_username,
                     'folder': vault_config.get('folder', 'Shared Folders/PAM/{}'.format(user.get('department', 'Unknown'))),
-                    'rotation_schedule': pam.get('rotation', {}).get('schedule'),
-                    'email_recipient': redacted_email
+                    'rotation_schedule': rotation.get('schedule') if rotation_mode == 'scheduled' else None,
+                    'rotation_mode': rotation_mode,
+                    'email_recipient': redacted_email,
                 }
             }
             print(json.dumps(result, indent=2))
@@ -1036,22 +1199,20 @@ class CredentialProvisionCommand(Command):
             print(f'\nEmployee: {redacted_name}')
             print(f'Username: {redacted_username}')
             print(f'Email: {redacted_email}')
+            if uses_existing_password:
+                print('Password source: operator-supplied existing_password (value not shown)')
+            if has_rotation:
+                if rotation_mode == 'on_demand':
+                    print('Rotation mode: on-demand (manual trigger only)')
+                else:
+                    print(f'Rotation mode: scheduled ({rotation.get("schedule")})')
+                if not will_rotate_immediately:
+                    print('Immediate rotation at provisioning: SKIPPED (rotate_on_provision: false)')
+            else:
+                print('Rotation: not configured (no rotation: block in YAML)')
             print('\nPlanned Actions:')
-            print('  1. Check for duplicate PAM User in folder')
-            print(f'  2. Generate secure password')
-            print(f'     Complexity: requirements applied')
-            print(f'  3. Create PAM User record')
-            default_folder = '/Employees/{}'.format(user.get('department', 'Unknown'))
-            print(f'     Folder: {vault_config.get("folder", default_folder)}')
-            print(f'  4. Link to PAM Config: {account.get("pam_config_uid")[:20]}...')
-            print(f'  5. Configure rotation')
-            print(f'     Schedule: {rotation.get("schedule")}')
-            print(f'  6. Submit immediate rotation')
-            print(f'  7. Generate one-time share URL for PAM User')
-            print(f'     Expiry: {email_config.get("share_url_expiry", "7d")}')
-            print(f'  8. Send welcome email')
-            print(f'     To: {redacted_email}')
-            print(f'     Config: {email_config.get("config_name")}')
+            for idx, action in enumerate(actions, 1):
+                print(f'  {idx}. {action}')
             print('\n' + '='*60)
             print('✓ Validation passed - ready for actual provisioning')
             print('  Run without --dry-run to execute')
@@ -1229,6 +1390,45 @@ class CredentialProvisionCommand(Command):
             pass
 
         return None
+
+    def _determine_password(self, config: Dict[str, Any]) -> Tuple[str, bool]:
+        """Resolve (password, used_existing) per cp-rotation-skip-feat:
+        existing_password → rotation.password_complexity → DEFAULT_COMPLEXITY.
+        """
+        existing = config.get('account', {}).get('existing_password')
+        if existing:
+            return existing, True
+        if 'rotation' in config:
+            complexity = config['rotation']['password_complexity']
+        else:
+            complexity = DEFAULT_COMPLEXITY
+        return self._generate_password(complexity), False
+
+    def _should_rotate_on_provision(self, config: Dict[str, Any]) -> bool:
+        """True when rotation: present and rotate_on_provision is not False."""
+        if 'rotation' not in config:
+            return False
+        return config['rotation'].get('rotate_on_provision', True) is not False
+
+    def _should_create_ad_user(self, config: Dict[str, Any]) -> bool:
+        """True when AD context is set AND existing_password is NOT — gates the
+        rm-create-user push-to-target route. See SECURITY_ARCHITECTURE.md."""
+        account = config.get('account', {})
+        has_ad_config = bool(account.get('distinguished_name') or account.get('ad_groups'))
+        if not has_ad_config:
+            return False
+        if account.get('existing_password'):
+            return False
+        return True
+
+    def _log_existing_password_use(self, pam_user_uid: str) -> None:
+        """Audit log: existing_password was used. Takes only the UID by design;
+        signature is enforced by a structural test to prevent log leakage."""
+        logging.info(
+            'Provisioning with operator-supplied existing_password for '
+            'record %s; rotation immediate skipped, AD-create skipped.',
+            pam_user_uid,
+        )
 
     def _generate_password(self, password_complexity: str) -> str:
         """
@@ -1593,7 +1793,7 @@ class CredentialProvisionCommand(Command):
         pam_user_uid: str,
         config: Dict[str, Any],
         params: KeeperParams
-    ) -> None:
+    ) -> bool:
         """
         Configure automatic password rotation using PAM rotation command.
 
@@ -1618,18 +1818,23 @@ class CredentialProvisionCommand(Command):
             raise CommandError('credential-provision', 'Rotation requires Python 3.8+ (pydantic dependency)')
 
         try:
-            schedule = rotation_config['schedule']
             complexity = rotation_config['password_complexity']
 
             rotation_cmd = PAMCreateRecordRotationCommand()
             directory_uid = config['account'].get('directory_uid')
             kwargs = {
                 'record_name': pam_user_uid,
-                'schedule_cron_data': [schedule],
                 'pwd_complexity': complexity,
                 'enable': True,
                 'force': True,
             }
+
+            # Validator guarantees exactly one of schedule/on_demand is set.
+            if rotation_config.get('on_demand'):
+                kwargs['on_demand'] = True
+            else:
+                kwargs['schedule_cron_data'] = [rotation_config['schedule']]
+
             # Use directory_uid as resource if available, otherwise use pam_config_uid
             # Cannot pass both --resource and --iam-aad-config_uid simultaneously
             if directory_uid:
@@ -1641,11 +1846,16 @@ class CredentialProvisionCommand(Command):
                 # Suppress verbose output from rotation command
                 with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
                     rotation_cmd.execute(params, **kwargs)
+                return True  # Real success — gateway accepted the rotation configuration
             except Exception as rotation_error:
                 error_msg = str(rotation_error)
                 if '500' in error_msg or 'gateway' in error_msg.lower():
+                    # Transient gateway failure — swallow and report False so the
+                    # caller can suppress the misleading success-log. Operator must
+                    # configure rotation manually once the gateway is reachable.
                     logging.warning('Gateway unavailable - rotation configuration deferred')
                     logging.warning('Configure rotation manually when gateway is available')
+                    return False
                 else:
                     raise
 
@@ -1695,10 +1905,17 @@ class CredentialProvisionCommand(Command):
             return True
 
         except Exception as e:
-            # Non-critical failure: PAM User is created and rotation scheduled
-            # The scheduled rotation will eventually sync the password
+            # Non-critical failure: PAM User record is created; rotation is configured.
+            # Remediation hint depends on rotation mode — in on_demand mode there is
+            # no cron tick to wait for, so direct the operator to manual triggering.
             logging.warning(f'⚠️  Immediate rotation failed: {e}')
-            logging.warning(f'   Password will sync on next scheduled rotation')
+            if config.get('rotation', {}).get('on_demand'):
+                logging.warning(
+                    '   Trigger an on-demand rotation manually to sync the password '
+                    '(Rotate Now in the Vault UI, or `pam action rotate <UID>`).'
+                )
+            else:
+                logging.warning('   Password will sync on next scheduled rotation.')
             return False  # Graceful degradation
 
     # =========================================================================
@@ -1889,7 +2106,18 @@ class CredentialProvisionCommand(Command):
 
         Returns:
             Tuple of (succeeded_groups, failed_groups)
+
+        Raises:
+            CommandError: if gateway_uid is None/empty. Pre-PR this fail-fast
+                lived inside _create_ad_user_via_gateway; that path is now skipped
+                when existing_password is set, so we re-assert the precondition here.
         """
+        if not gateway_uid:
+            raise CommandError(
+                'credential-provision',
+                'No connected Gateway found for PAM Configuration — cannot add AD groups. '
+                'Ensure the Gateway associated with the PAM Configuration is online.'
+            )
         username = config['account']['username']
         pam_config_uid = config['account']['pam_config_uid']
         resource_uid = config['account'].get('directory_uid')

--- a/tests/test_credential_provision_dryrun.py
+++ b/tests/test_credential_provision_dryrun.py
@@ -1,0 +1,471 @@
+"""
+cp-rotation-skip-feat — Story 4 dry-run rewrite tests
+
+Covers the rewrite of _dry_run_report:
+  - Reflects the chosen execution path (rotation present/absent, on_demand/
+    schedule, rotate_on_provision, existing_password)
+  - Absorbs commit 97dc8893: line 1027's NameError (pam undefined) fix
+  - Adds rotation_mode field to JSON output
+  - Extends rotation_status values
+
+Critical regression: `cp --output json --dry-run` must NOT raise NameError
+for any behavior-matrix cell.
+"""
+
+import io
+import json
+import pytest
+from contextlib import redirect_stdout
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from keepercommander.commands.credential_provision import CredentialProvisionCommand
+
+
+def make_params():
+    p = MagicMock()
+    p.key_cache = {}
+    return p
+
+
+def base_config(**overrides):
+    """Minimal valid config; overrides merge top-level keys."""
+    config = {
+        'user': {'first_name': 'A', 'last_name': 'B', 'personal_email': 'a@b.com', 'department': 'Eng'},
+        'account': {'username': 'svc-test', 'pam_config_uid': 'cfg-uid'},
+        'email': {'config_name': 'none', 'send_to': 'a@b.com'},
+    }
+    config.update(overrides)
+    return config
+
+
+# =============================================================================
+# NameError absorption — every behavior-matrix cell, JSON mode
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDryRunJsonNoNameError(TestCase):
+    """Regression for commit 97dc8893: line 1027 referenced an undefined `pam`.
+    Every behavior-matrix cell must complete in JSON mode without NameError.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _run_json_dry_run(self, config):
+        """Capture stdout from a JSON-mode dry-run; return parsed JSON."""
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, config, 'json')
+        out = buf.getvalue()
+        return json.loads(out)
+
+    def test_cell_1_no_rotation_no_existing_password(self):
+        result = self._run_json_dry_run(base_config())
+        self.assertTrue(result['success'])
+        self.assertTrue(result['dry_run'])
+
+    def test_cell_2_no_rotation_with_existing_password(self):
+        cfg = base_config()
+        cfg['account']['existing_password'] = 'KnownPass!'
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_3_schedule_default_rop(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_4_schedule_rop_false(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_5_on_demand_default_rop(self):
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_6_on_demand_rop_false(self):
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_7_schedule_rop_false_existing_password(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        cfg['account']['existing_password'] = 'KnownPass!'
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+    def test_cell_8_on_demand_rop_false_existing_password_tandem(self):
+        """Tandem's exact use case — must not crash dry-run."""
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        cfg['account']['existing_password'] = 'KnownPass!'
+        result = self._run_json_dry_run(cfg)
+        self.assertTrue(result['success'])
+
+
+# =============================================================================
+# rotation_mode reporting (new JSON field)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRotationModeJsonField(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _run(self, config):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, config, 'json')
+        return json.loads(buf.getvalue())
+
+    def test_no_rotation_block_mode_is_none(self):
+        result = self._run(base_config())
+        self.assertEqual(result['configuration'].get('rotation_mode'), 'none')
+
+    def test_schedule_mode_reported(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run(cfg)
+        self.assertEqual(result['configuration'].get('rotation_mode'), 'scheduled')
+
+    def test_on_demand_mode_reported(self):
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run(cfg)
+        self.assertEqual(result['configuration'].get('rotation_mode'), 'on_demand')
+
+    def test_rotation_schedule_field_uses_local_binding(self):
+        """The actual fix from commit 97dc8893 — reads from `rotation` local,
+        not the undefined `pam` symbol."""
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run(cfg)
+        self.assertEqual(result['configuration'].get('rotation_schedule'), '0 0 3 * * ?')
+
+    def test_rotation_schedule_null_when_on_demand(self):
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        })
+        result = self._run(cfg)
+        # No cron => no schedule string in the JSON
+        self.assertIsNone(result['configuration'].get('rotation_schedule'))
+
+
+# =============================================================================
+# Actions list reflects chosen path
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestActionsListReflectsPath(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _actions(self, config):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, config, 'json')
+        return json.loads(buf.getvalue())['actions']
+
+    def test_no_rotation_no_configure_rotation_action(self):
+        actions = self._actions(base_config())
+        joined = '\n'.join(actions)
+        self.assertNotIn('Configure rotation', joined)
+        self.assertNotIn('immediate rotation', joined.lower())
+
+    def test_rotation_present_includes_configure_action(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        actions = self._actions(cfg)
+        self.assertTrue(any('Configure rotation' in a for a in actions))
+        self.assertTrue(any('immediate rotation' in a.lower() for a in actions))
+
+    def test_rop_false_omits_immediate_action(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        actions = self._actions(cfg)
+        self.assertTrue(any('Configure rotation' in a for a in actions))
+        self.assertFalse(any('immediate rotation' in a.lower() for a in actions),
+                         f"Expected no immediate-rotation action; got: {actions}")
+
+    def test_existing_password_omits_generate_action(self):
+        cfg = base_config()
+        cfg['account']['existing_password'] = 'KnownPass!'
+        actions = self._actions(cfg)
+        self.assertFalse(any('Generate secure password' in a for a in actions),
+                         f"Expected no password-generation action; got: {actions}")
+        self.assertTrue(any('existing' in a.lower() and 'password' in a.lower() for a in actions),
+                        f"Expected existing-password mention; got: {actions}")
+
+
+# =============================================================================
+# Dry-run actions list must mirror execute() — regression for review finding #3
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDryRunActionsMirrorExecute(TestCase):
+    """The actions list must reflect what execute() will actually do.
+    Pre-fix divergences:
+      - 'Add to AD groups' was never emitted even though execute() always runs
+        group-add when ad_groups is set
+      - 'Generate share URL' was emitted unconditionally even though execute()
+        gates it on has_email
+      - Direct-share was never represented
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _actions(self, config):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, config, 'json')
+        return json.loads(buf.getvalue())['actions']
+
+    def test_ad_groups_emits_group_add_action_independent_of_create(self):
+        # BYO password + ad_groups: CREATE skipped, but group-add still runs.
+        cfg = base_config()
+        cfg['account']['existing_password'] = 'KnownPass!'
+        cfg['account']['distinguished_name'] = 'CN=svc,OU=...,DC=corp,DC=local'
+        cfg['account']['ad_groups'] = ['CN=Engineers,OU=Groups,DC=corp,DC=local']
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        # CREATE must NOT appear (existing_password gate)
+        self.assertNotIn('Create AD user', joined,
+            f"AD-create should be skipped; got: {actions}")
+        # Group-add MUST appear
+        self.assertTrue(any('AD groups' in a for a in actions),
+            f"Expected AD groups action; got: {actions}")
+
+    def test_ad_groups_emits_action_when_create_also_runs(self):
+        # No existing_password + ad_groups: CREATE runs, group-add ALSO runs.
+        cfg = base_config()
+        cfg['account']['distinguished_name'] = 'CN=svc,OU=...,DC=corp,DC=local'
+        cfg['account']['ad_groups'] = ['CN=A,DC=corp', 'CN=B,DC=corp']
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        self.assertIn('Create AD user', joined,
+            f"Expected AD-create action; got: {actions}")
+        self.assertTrue(any('AD groups: 2' in a for a in actions),
+            f"Expected AD groups count=2 action; got: {actions}")
+
+    def test_share_url_only_when_email_configured(self):
+        # email.config_name: none — share-URL action must NOT appear.
+        cfg = base_config()  # email.config_name = 'none'
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        self.assertNotIn('Generate share URL', joined,
+            f"Share-URL action should be skipped when no email; got: {actions}")
+        # And the skip-email line should appear
+        self.assertTrue(any('Skip welcome email' in a for a in actions),
+            f"Expected skip-welcome-email action; got: {actions}")
+
+    def test_share_url_appears_when_email_configured(self):
+        cfg = base_config()
+        cfg['email']['config_name'] = 'SMTP-Gmail'
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        self.assertIn('Generate share URL', joined,
+            f"Expected share-URL action with real email config; got: {actions}")
+        self.assertTrue(any('Send email to' in a and 'config: SMTP-Gmail' in a for a in actions),
+            f"Expected send-email action with config name; got: {actions}")
+
+    def test_direct_share_action_when_delivery_configured(self):
+        cfg = base_config()
+        cfg['delivery'] = {'share_to': 'alice@example.com'}
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        self.assertTrue(any('Share directly to' in a for a in actions),
+            f"Expected direct-share action; got: {actions}")
+        # The recipient should be PII-redacted in dry-run output
+        self.assertNotIn('alice@example.com', joined,
+            f"Recipient email should be redacted in dry-run; got: {actions}")
+
+    def test_group_add_action_appears_after_create_pam_user_action(self):
+        """Regression for review #B (round 3): dry-run actions list must mirror
+        execute()'s call order — `Add to AD groups` must appear AFTER `Create PAM User`,
+        same invariant as the structural test on execute() itself.
+        """
+        cfg = base_config()
+        cfg['account']['distinguished_name'] = 'CN=svc,OU=...,DC=corp,DC=local'
+        cfg['account']['ad_groups'] = ['CN=Engineers,DC=corp']
+        actions = self._actions(cfg)
+        group_idx = next((i for i, a in enumerate(actions) if 'AD groups' in a), None)
+        create_idx = next((i for i, a in enumerate(actions) if 'Create PAM User' in a), None)
+        self.assertIsNotNone(group_idx, f'Expected AD-groups action; got: {actions}')
+        self.assertIsNotNone(create_idx, f'Expected Create PAM User action; got: {actions}')
+        self.assertGreater(
+            group_idx, create_idx,
+            f'Add-to-AD-groups must come AFTER Create-PAM-User in dry-run order '
+            f'(mirrors execute() reorder in c663a127). Got order: {actions}',
+        )
+
+    def test_no_direct_share_action_when_no_delivery(self):
+        cfg = base_config()  # no delivery section
+        actions = self._actions(cfg)
+        joined = '\n'.join(actions)
+        self.assertNotIn('Share directly to', joined,
+            f"Direct-share action should not appear without delivery section; got: {actions}")
+
+
+# =============================================================================
+# Existing-password value NEVER in dry-run output
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDryRunNeverExposesExistingPassword(TestCase):
+    """The actual password value must not appear in any dry-run output."""
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    SECRET = 'TandemS3cretP@ssw0rd-DoNotEcho'
+
+    def _run(self, output_format):
+        cfg = base_config(rotation={
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+            'rotate_on_provision': False,
+        })
+        cfg['account']['existing_password'] = self.SECRET
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, cfg, output_format)
+        return buf.getvalue()
+
+    def test_json_output_never_contains_secret(self):
+        out = self._run('json')
+        self.assertNotIn(self.SECRET, out,
+                         "existing_password value MUST NOT appear in JSON dry-run output")
+
+    def test_text_output_never_contains_secret(self):
+        out = self._run('text')
+        self.assertNotIn(self.SECRET, out,
+                         "existing_password value MUST NOT appear in text dry-run output")
+
+
+# =============================================================================
+# Success-path JSON rotation_status (regression for E2E bug found 2026-05-12)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSuccessPathRotationStatus(TestCase):
+    """The success-path JSON (in execute(), not _dry_run_report) must produce
+    the same 4-value rotation_status as the dry-run JSON. E2E run on
+    2026-05-12 caught a bug where cells 1, 2 (no rotation block) and cell 8
+    (on_demand + rop:false) all incorrectly reported 'scheduled'.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+
+    def _compute(self, config, rotation_success: bool) -> str:
+        # Mirrors the logic at execute() line 508; this test isolates it.
+        if 'rotation' not in config:
+            return 'not_configured'
+        if rotation_success:
+            return 'synced'
+        if config['rotation'].get('on_demand'):
+            return 'on_demand'
+        return 'scheduled'
+
+    def test_no_rotation_block_reports_not_configured(self):
+        config = {'account': {}}
+        self.assertEqual(self._compute(config, rotation_success=False), 'not_configured')
+
+    def test_schedule_with_immediate_fired_reports_synced(self):
+        config = {'rotation': {'schedule': '0 0 3 * * ?'}}
+        self.assertEqual(self._compute(config, rotation_success=True), 'synced')
+
+    def test_schedule_without_immediate_reports_scheduled(self):
+        config = {'rotation': {'schedule': '0 0 3 * * ?'}}
+        self.assertEqual(self._compute(config, rotation_success=False), 'scheduled')
+
+    def test_on_demand_with_immediate_fired_reports_synced(self):
+        config = {'rotation': {'on_demand': True}}
+        self.assertEqual(self._compute(config, rotation_success=True), 'synced')
+
+    def test_on_demand_without_immediate_reports_on_demand(self):
+        config = {'rotation': {'on_demand': True}}
+        self.assertEqual(self._compute(config, rotation_success=False), 'on_demand')
+
+
+# =============================================================================
+# Text mode still works (regression for existing demo YAMLs)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDryRunTextMode(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_text_mode_emits_header(self):
+        cfg = base_config(rotation={
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, cfg, 'text')
+        out = buf.getvalue()
+        self.assertIn('DRY RUN MODE', out)
+        self.assertIn('NO CHANGES WILL BE MADE', out)
+
+    def test_text_mode_mentions_existing_password_use(self):
+        cfg = base_config()
+        cfg['account']['existing_password'] = 'KnownPass!'
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.cmd._dry_run_report(self.params, cfg, 'text')
+        out = buf.getvalue()
+        # mentions the fact, not the value
+        self.assertTrue('existing' in out.lower() and 'password' in out.lower())
+        self.assertNotIn('KnownPass!', out)

--- a/tests/test_credential_provision_execute.py
+++ b/tests/test_credential_provision_execute.py
@@ -1,0 +1,476 @@
+"""
+cp-rotation-skip-feat — Story 2/3 execution-flow tests
+
+Story 2 — Password source decision & _configure_rotation branching:
+  - Password source: existing_password → rotation.password_complexity → DEFAULT_COMPLEXITY
+  - _configure_rotation: on_demand mode vs schedule mode
+  - _configure_rotation is skipped when 'rotation' not in config
+
+Story 3 — Push-to-target guards:
+  - _rotate_immediately gated on rotate_on_provision (default True)
+  - _create_ad_user_via_gateway gated on not existing_password
+  - _add_ad_user_to_groups_via_gateway still runs when ad_groups set
+  - logging.info line when existing_password is used (no value in log)
+"""
+
+import logging
+import pytest
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, call
+
+from keepercommander.commands.credential_provision import (
+    CredentialProvisionCommand,
+    DEFAULT_COMPLEXITY,
+)
+
+
+# =============================================================================
+# Story 2 — _determine_password helper
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeterminePassword(TestCase):
+    """
+    The password-source decision is extracted into _determine_password for
+    testability. It returns (password, used_existing).
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+
+    def test_existing_password_takes_precedence(self):
+        config = {
+            'account': {'existing_password': 'KnownPass123!'},
+            'rotation': {'password_complexity': '16,2,2,2,2'},  # should be ignored
+        }
+        with patch.object(self.cmd, '_generate_password') as gen:
+            password, used_existing = self.cmd._determine_password(config)
+        self.assertEqual(password, 'KnownPass123!')
+        self.assertTrue(used_existing)
+        gen.assert_not_called()
+
+    def test_rotation_complexity_used_when_no_existing_password(self):
+        config = {
+            'account': {},
+            'rotation': {'password_complexity': '24,3,3,3,3'},
+        }
+        with patch.object(self.cmd, '_generate_password', return_value='GENERATED') as gen:
+            password, used_existing = self.cmd._determine_password(config)
+        self.assertEqual(password, 'GENERATED')
+        self.assertFalse(used_existing)
+        gen.assert_called_once_with('24,3,3,3,3')
+
+    def test_default_complexity_used_when_no_rotation_and_no_existing(self):
+        config = {'account': {}}
+        with patch.object(self.cmd, '_generate_password', return_value='GENERATED') as gen:
+            password, used_existing = self.cmd._determine_password(config)
+        self.assertEqual(password, 'GENERATED')
+        self.assertFalse(used_existing)
+        gen.assert_called_once_with(DEFAULT_COMPLEXITY)
+
+    def test_empty_existing_password_falls_through_to_generation(self):
+        # An empty string is rejected by the validator (Story 1), but if it
+        # somehow reaches _determine_password, treat as not-supplied.
+        config = {
+            'account': {'existing_password': ''},
+            'rotation': {'password_complexity': '24,3,3,3,3'},
+        }
+        with patch.object(self.cmd, '_generate_password', return_value='GENERATED') as gen:
+            password, used_existing = self.cmd._determine_password(config)
+        self.assertFalse(used_existing)
+        gen.assert_called_once_with('24,3,3,3,3')
+
+
+# =============================================================================
+# Story 2 — _configure_rotation branching on schedule vs on_demand
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestConfigureRotationBranching(TestCase):
+    """
+    _configure_rotation must pass either schedule_cron_data (cron mode) or
+    on_demand=True (manual-trigger mode) to PAMCreateRecordRotationCommand,
+    but never both.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = MagicMock()
+
+    def _call_configure(self, rotation_config):
+        config = {
+            'account': {'pam_config_uid': 'cfg-uid'},
+            'rotation': rotation_config,
+        }
+        # PAMCreateRecordRotationCommand is imported at module level in
+        # credential_provision.py — patch where it's used.
+        with patch(
+            'keepercommander.commands.credential_provision.PAMCreateRecordRotationCommand'
+        ) as cmd_class:
+            instance = cmd_class.return_value
+            self.cmd._configure_rotation('pam-uid', config, self.params)
+        return cmd_class, instance
+
+    def test_schedule_mode_passes_schedule_cron_data(self):
+        rotation = {
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        }
+        _, instance = self._call_configure(rotation)
+        instance.execute.assert_called_once()
+        kwargs = instance.execute.call_args.kwargs
+        self.assertEqual(kwargs.get('schedule_cron_data'), ['0 0 3 * * ?'])
+        self.assertNotIn('on_demand', kwargs)
+
+    def test_on_demand_mode_passes_on_demand_true(self):
+        rotation = {
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        }
+        _, instance = self._call_configure(rotation)
+        instance.execute.assert_called_once()
+        kwargs = instance.execute.call_args.kwargs
+        self.assertEqual(kwargs.get('on_demand'), True)
+        self.assertNotIn('schedule_cron_data', kwargs)
+
+    def test_complexity_always_forwarded(self):
+        for rotation in (
+            {'schedule': '0 0 3 * * ?', 'password_complexity': '32,5,5,5,5'},
+            {'on_demand': True, 'password_complexity': '32,5,5,5,5'},
+        ):
+            _, instance = self._call_configure(rotation)
+            kwargs = instance.execute.call_args.kwargs
+            self.assertEqual(kwargs.get('pwd_complexity'), '32,5,5,5,5')
+
+    def test_enable_force_flags_unchanged(self):
+        rotation = {'on_demand': True, 'password_complexity': '32,5,5,5,5'}
+        _, instance = self._call_configure(rotation)
+        kwargs = instance.execute.call_args.kwargs
+        self.assertEqual(kwargs.get('enable'), True)
+        self.assertEqual(kwargs.get('force'), True)
+
+
+# =============================================================================
+# Story 3 — _rotate_immediately gated on rotate_on_provision
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRotateOnProvisionGate(TestCase):
+    """
+    _rotate_immediately at provisioning time fires only when rotate_on_provision
+    is True (the default). When false, the immediate rotation must be skipped.
+
+    Since _rotate_immediately is called from execute(), this test validates the
+    GATE LOGIC by exercising a small helper that mirrors the gate's predicate.
+    The full integration is verified in TestExecuteFlow below.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+
+    def test_should_rotate_default_true(self):
+        config = {'rotation': {'schedule': '0 0 3 * * ?'}}
+        self.assertTrue(self.cmd._should_rotate_on_provision(config))
+
+    def test_should_rotate_explicit_true(self):
+        config = {'rotation': {'rotate_on_provision': True}}
+        self.assertTrue(self.cmd._should_rotate_on_provision(config))
+
+    def test_should_rotate_explicit_false(self):
+        config = {'rotation': {'rotate_on_provision': False}}
+        self.assertFalse(self.cmd._should_rotate_on_provision(config))
+
+    def test_should_rotate_no_rotation_block(self):
+        # No rotation block at all => no rotation work, including no immediate
+        config = {}
+        self.assertFalse(self.cmd._should_rotate_on_provision(config))
+
+
+# =============================================================================
+# Story 3 — _create_ad_user_via_gateway gated on not existing_password
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestADCreateGate(TestCase):
+    """
+    The AD-create path pushes the password to the target via rm-create-user.
+    When existing_password is set, the operator has declared the account
+    pre-exists; AD-create must be skipped to prevent push-to-target.
+
+    The gate is enforced in execute(); this test validates the predicate.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+
+    def test_ad_create_allowed_without_existing_password(self):
+        config = {'account': {'distinguished_name': 'CN=...'}}
+        self.assertTrue(self.cmd._should_create_ad_user(config))
+
+    def test_ad_create_skipped_with_existing_password(self):
+        config = {
+            'account': {
+                'distinguished_name': 'CN=...',
+                'existing_password': 'KnownPass!',
+            }
+        }
+        self.assertFalse(self.cmd._should_create_ad_user(config))
+
+    def test_ad_create_allowed_no_ad_fields_no_existing_pw(self):
+        # No AD fields => has_ad_config is False; gate returns False but for
+        # a different reason. The predicate intentionally returns False here
+        # because there's nothing to create.
+        config = {'account': {}}
+        self.assertFalse(self.cmd._should_create_ad_user(config))
+
+    def test_ad_create_with_ad_groups_only(self):
+        config = {'account': {'ad_groups': ['CN=Group1']}}
+        self.assertTrue(self.cmd._should_create_ad_user(config))
+
+
+# =============================================================================
+# Story 3 — logging.info when existing_password is used (NO VALUE)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExistingPasswordLogging(TestCase):
+    """
+    When existing_password is used, exactly one logging.info line records the
+    fact (with record UID, no value). This is the on-the-CLI audit trail.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+
+    def test_log_line_contains_no_password_value(self):
+        record_uid = "rec-uid-123"
+        with self.assertLogs(level='INFO') as captured:
+            self.cmd._log_existing_password_use(record_uid)
+        joined = '\n'.join(captured.output)
+        self.assertIn(record_uid, joined,
+                      "log line should reference the record UID")
+        self.assertIn('existing_password', joined,
+                      "log line should reference the field name")
+
+    def test_rotate_immediately_failure_warning_branches_on_mode(self):
+        """Regression for review #A (round 3): when _rotate_immediately fails,
+        the remediation hint must reflect the rotation mode. on_demand mode
+        has no schedule — the operator must trigger manually, not wait for cron.
+        """
+        cmd = CredentialProvisionCommand()
+        params = MagicMock()
+
+        # Force the inner rotate command to raise
+        with patch(
+            'keepercommander.commands.credential_provision.PAMGatewayActionRotateCommand'
+        ) as rotate_class:
+            instance = rotate_class.return_value
+            instance.execute.side_effect = RuntimeError('simulated gateway failure')
+
+            # on_demand mode → hint must reference manual trigger
+            with self.assertLogs(level='WARNING') as captured:
+                result = cmd._rotate_immediately(
+                    'pam-uid',
+                    {'rotation': {'on_demand': True}},
+                    params,
+                )
+            self.assertFalse(result)
+            joined = '\n'.join(captured.output)
+            self.assertIn('manually', joined.lower(),
+                f'Expected manual-trigger hint for on_demand mode; got: {captured.output}')
+            self.assertNotIn('scheduled rotation', joined,
+                f'Should NOT reference "scheduled rotation" in on_demand mode; got: {captured.output}')
+
+        # schedule mode → hint must reference the next scheduled rotation
+        with patch(
+            'keepercommander.commands.credential_provision.PAMGatewayActionRotateCommand'
+        ) as rotate_class:
+            instance = rotate_class.return_value
+            instance.execute.side_effect = RuntimeError('simulated gateway failure')
+
+            with self.assertLogs(level='WARNING') as captured:
+                cmd._rotate_immediately(
+                    'pam-uid',
+                    {'rotation': {'schedule': '0 0 3 * * ?'}},
+                    params,
+                )
+            joined = '\n'.join(captured.output)
+            self.assertIn('scheduled rotation', joined,
+                f'Expected scheduled-rotation hint in schedule mode; got: {captured.output}')
+
+    def test_log_function_does_not_accept_password_value(self):
+        """The function signature accepts ONLY the record UID — by design,
+        the password value is never passed to it, so there is no way for a
+        future maintainer to accidentally log the secret."""
+        import inspect
+        sig = inspect.signature(self.cmd._log_existing_password_use)
+        params = list(sig.parameters.keys())
+        self.assertEqual(params, ['pam_user_uid'],
+                         "Signature must accept only the record UID")
+
+
+# =============================================================================
+# Story 3 — full-source structural regression guard
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSourceCodeRegressionGuard(TestCase):
+    """
+    Structural test: the source file must not contain any logging statement
+    that interpolates the value of existing_password. This catches future
+    maintainers who accidentally add a log call with the secret value.
+
+    Failure of this test does NOT mean we're leaking — it means the source
+    pattern is suspicious and a human must verify.
+    """
+
+    SOURCE_FILE = (
+        'keepercommander/commands/credential_provision.py'
+    )
+
+    def test_add_ad_user_to_groups_raises_when_gateway_uid_is_none(self):
+        """Regression for review #7 (offline gateway + existing_password + ad_groups):
+        the helper must fail fast with CommandError, not silently per-group.
+        Pre-PR this fail-fast lived inside _create_ad_user_via_gateway; that path
+        is now skipped when existing_password is set, so we re-assert it here.
+        """
+        from keepercommander.error import CommandError
+        cmd = CredentialProvisionCommand()
+        params = MagicMock()
+        config = {'account': {'pam_config_uid': 'cfg-uid', 'username': 'svc'}}
+        with self.assertRaises(CommandError) as ctx:
+            cmd._add_ad_user_to_groups_via_gateway(config, params, gateway_uid=None)
+        self.assertIn('Gateway', str(ctx.exception))
+
+    def test_group_add_call_site_appears_after_create_pam_user(self):
+        """Regression for review #8 (rollback gap when group-add precedes pam-user-create):
+        the group-add call site must appear in the source AFTER _create_pam_user so a
+        failure during the critical record-creation steps doesn't orphan AD memberships.
+        """
+        import os, re
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        src_path = os.path.join(repo_root, self.SOURCE_FILE)
+        with open(src_path, 'r') as f:
+            source = f.read()
+
+        # Find the line number of the execute()-level _create_pam_user call.
+        create_pam_match = re.search(
+            r'pam_user_uid\s*=\s*self\._create_pam_user\(',
+            source,
+        )
+        self.assertIsNotNone(create_pam_match, "Could not find _create_pam_user assignment")
+        create_pam_pos = create_pam_match.start()
+
+        # Find the line number of the execute()-level _add_ad_user_to_groups_via_gateway call.
+        group_add_match = re.search(
+            r'self\._add_ad_user_to_groups_via_gateway\(',
+            source,
+        )
+        self.assertIsNotNone(group_add_match, "Could not find group-add call site")
+        group_add_pos = group_add_match.start()
+
+        self.assertGreater(
+            group_add_pos, create_pam_pos,
+            "_add_ad_user_to_groups_via_gateway must be called AFTER _create_pam_user "
+            "to avoid orphaning AD group memberships if record creation fails. "
+            "See PR #2043 review #8."
+        )
+
+    def test_add_ad_user_to_groups_uses_local_gateway_uid(self):
+        """Regression guard for review finding #2: the call to
+        _add_ad_user_to_groups_via_gateway must pass the local `gateway_uid`
+        (resolved at line ~401), NOT `state.ad_gateway_uid` (which is only set
+        as a side effect inside _create_ad_user_via_gateway and stays None when
+        the AD-create gate skips the create call for existing_password YAMLs).
+        """
+        import os, re
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        src_path = os.path.join(repo_root, self.SOURCE_FILE)
+        with open(src_path, 'r') as f:
+            source = f.read()
+        # Find any call to _add_ad_user_to_groups_via_gateway
+        pattern = re.compile(
+            r'self\._add_ad_user_to_groups_via_gateway\s*\(([^)]*)\)',
+            re.MULTILINE | re.DOTALL,
+        )
+        calls = pattern.findall(source)
+        self.assertGreater(len(calls), 0,
+            "Expected to find at least one call site for _add_ad_user_to_groups_via_gateway")
+        for args in calls:
+            self.assertNotIn('state.ad_gateway_uid', args,
+                "_add_ad_user_to_groups_via_gateway must not be called with "
+                "state.ad_gateway_uid — that's None when AD-create is skipped. "
+                "Use the local `gateway_uid` instead.")
+            # And it should explicitly pass gateway_uid
+            self.assertIn('gateway_uid', args,
+                f"Call site should pass gateway_uid; got args: {args!r}")
+
+    def test_rotation_configured_log_gated_on_real_success(self):
+        """Regression for round-5 review finding: the '✅ Rotation configured'
+        log line must only fire when _configure_rotation actually configured
+        rotation (returns True), not after a swallowed gateway-500 deferral
+        (returns False). Sibling pattern to the rotation_success gate.
+        """
+        import os
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        src_path = os.path.join(repo_root, self.SOURCE_FILE)
+        with open(src_path, 'r') as f:
+            source = f.read()
+        idx = source.find("'✅ Rotation configured'")
+        self.assertGreater(idx, 0, "Could not locate the rotation-configured log line")
+        context = source[max(0, idx - 300):idx]
+        # Must be gated on something more than just output_format — the actual
+        # return value of _configure_rotation needs to be checked.
+        self.assertIn('rotation_configured', context,
+            "The '✅ Rotation configured' log must be gated on _configure_rotation's "
+            "real return value, not just output_format. Otherwise a swallowed "
+            "gateway-500 deferral produces 'rotation deferred' warning + checkmark "
+            "contradiction. See PR #2043 round-5 review.")
+
+    def test_rotation_success_log_gated_on_rotation_success(self):
+        """Regression for review #E (round 4): the '✅ Password rotation submitted'
+        log line must only fire when _rotate_immediately actually succeeded
+        (returns True), not unconditionally after the call. Otherwise a failing
+        rotation produces contradictory output (warning + success checkmark)
+        in the same provisioning run.
+        """
+        import os
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        src_path = os.path.join(repo_root, self.SOURCE_FILE)
+        with open(src_path, 'r') as f:
+            source = f.read()
+        idx = source.find("'✅ Password rotation submitted'")
+        self.assertGreater(idx, 0, "Could not locate the success-log line")
+        context = source[max(0, idx - 200):idx]
+        self.assertIn('rotation_success', context,
+            "The '✅ Password rotation submitted' log must be gated on rotation_success. "
+            "Otherwise a False return from _rotate_immediately produces a misleading "
+            "success line in the same provisioning run. See PR #2043 review #E.")
+
+    def test_no_log_statement_references_existing_password_value(self):
+        import os
+        import re
+        # Resolve path from the worktree root
+        repo_root = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '..'))
+        src_path = os.path.join(repo_root, self.SOURCE_FILE)
+        with open(src_path, 'r') as f:
+            source = f.read()
+        # Look for patterns like logging.X(f"... {existing_password} ...")
+        # where existing_password is the VALUE, not the field name.
+        # We forbid: logging.<level>(...{...existing_password...}...) where
+        # the f-string is referring to the variable.
+        pattern = re.compile(
+            r'logging\.(debug|info|warning|error|critical)\s*\([^)]*\{[^}]*existing_password[^}]*\}',
+            re.MULTILINE | re.DOTALL,
+        )
+        matches = pattern.findall(source)
+        self.assertEqual(matches, [],
+            "Found logging statement that may include existing_password VALUE — "
+            "review for potential credential leak.")

--- a/tests/test_credential_provision_validation.py
+++ b/tests/test_credential_provision_validation.py
@@ -1,0 +1,642 @@
+"""
+cp-rotation-skip-feat — Story 1 validator tests
+
+Tests for the schema-validator changes that gate the rest of the feature:
+  - rotation: block becomes optional
+  - rotation.on_demand (boolean, mutually exclusive with rotation.schedule)
+  - rotation.rotate_on_provision (boolean, default true)
+  - account.existing_password (non-empty string)
+  - INVARIANT-001 cross-section invariant
+  - DEFAULT_COMPLEXITY module-level constant
+  - empty-dict rotation: {} edge case
+  - regression: account.initial_password still rejected (KC-1007-2 unchanged)
+  - regression: deprecated pam.rotation: shape still emits migration error
+"""
+
+import pytest
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from keepercommander.commands.credential_provision import (
+    CredentialProvisionCommand,
+    DEFAULT_COMPLEXITY,
+)
+
+
+# =============================================================================
+# Shared fixtures / helpers
+# =============================================================================
+
+
+def make_valid_user():
+    return {
+        'first_name': 'Test',
+        'last_name': 'User',
+        'personal_email': 'test@example.com',
+    }
+
+
+def make_valid_account(extra=None):
+    base = {
+        'username': 'svc-test',
+        'pam_config_uid': 'abc123',
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def make_valid_rotation(extra=None):
+    base = {
+        'schedule': '0 0 3 * * ?',
+        'password_complexity': '32,5,5,5,5',
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def make_params():
+    """Minimal KeeperParams mock — these validator tests must not trigger
+    vault/api lookups, so the configs avoid directory_uid / delivery.share_to."""
+    p = MagicMock()
+    p.key_cache = {}
+    return p
+
+
+# =============================================================================
+# DEFAULT_COMPLEXITY module constant
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDefaultComplexityConstant(TestCase):
+    def test_default_complexity_is_defined(self):
+        self.assertIsNotNone(DEFAULT_COMPLEXITY)
+
+    def test_default_complexity_is_a_valid_complexity_string(self):
+        # Format: "length,upper,lower,digit,special"
+        parts = DEFAULT_COMPLEXITY.split(',')
+        self.assertEqual(len(parts), 5)
+        for p in parts:
+            int(p)  # would raise if not numeric
+
+    def test_default_complexity_meets_minimum_strength(self):
+        # Sanity: length >= 16, each class >= 2 (these are the architect's stated defaults).
+        parts = [int(p) for p in DEFAULT_COMPLEXITY.split(',')]
+        self.assertGreaterEqual(parts[0], 16, "default length must be at least 16")
+        for cls_count in parts[1:]:
+            self.assertGreaterEqual(cls_count, 2, "each character class count must be at least 2")
+
+
+# =============================================================================
+# rotation: block is now optional
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRotationBlockOptional(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_validate_succeeds_without_rotation_block(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [], f"Expected no errors, got: {errors}")
+
+    def test_validate_succeeds_with_full_rotation_block_unchanged(self):
+        # Regression: existing YAMLs (with rotation block) must keep validating
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': make_valid_rotation(),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [], f"Expected no errors, got: {errors}")
+
+
+# =============================================================================
+# Empty-dict rotation: {} edge case
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestEmptyRotationDict(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_null_rotation_value_rejected_with_helpful_error(self):
+        """Regression for review #C: `rotation:` with no value parses to None
+        in YAML and would crash downstream .get() calls. Validator must reject
+        with a clear message before any None-attribute access."""
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': None,  # <-- bare `rotation:` key, no value
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(
+            any('rotation' in e and 'no value' in e for e in errors),
+            f'Expected helpful "rotation: was specified but has no value" error; got: {errors}',
+        )
+
+    def test_empty_rotation_dict_does_not_silently_pass(self):
+        # rotation: {} — present but empty — must be rejected
+        # (either as "missing schedule/on_demand" or with a structural error)
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': {},
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(len(errors) > 0, "Empty rotation: {} dict must produce a validation error")
+
+
+# =============================================================================
+# schedule / on_demand mutual exclusivity (ROT-001)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestScheduleOnDemandMutex(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _base_config(self, rotation):
+        return {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': rotation,
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+
+    def test_only_schedule_validates(self):
+        cfg = self._base_config({
+            'schedule': '0 0 3 * * ?',
+            'password_complexity': '32,5,5,5,5',
+        })
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertEqual(errors, [], f"Expected no errors, got: {errors}")
+
+    def test_only_on_demand_validates(self):
+        cfg = self._base_config({
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        })
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertEqual(errors, [], f"Expected no errors, got: {errors}")
+
+    def test_both_schedule_and_on_demand_rejected(self):
+        cfg = self._base_config({
+            'schedule': '0 0 3 * * ?',
+            'on_demand': True,
+            'password_complexity': '32,5,5,5,5',
+        })
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('schedule' in e and 'on_demand' in e for e in errors),
+            f"Expected mutual-exclusivity error, got: {errors}",
+        )
+
+    def test_neither_schedule_nor_on_demand_rejected(self):
+        cfg = self._base_config({
+            'password_complexity': '32,5,5,5,5',
+        })
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(len(errors) > 0,
+            "Rotation block missing both schedule and on_demand must be rejected")
+
+
+# =============================================================================
+# on_demand type check (ROT-002)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestOnDemandTypeCheck(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _config_with_on_demand(self, value):
+        return {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': {
+                'on_demand': value,
+                'password_complexity': '32,5,5,5,5',
+            },
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+
+    def test_on_demand_true_validates(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_on_demand(True))
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_on_demand_string_rejected(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_on_demand("true"))
+        self.assertTrue(any('on_demand' in e and 'boolean' in e.lower() for e in errors),
+                        f"Expected on_demand boolean type error, got: {errors}")
+
+    def test_on_demand_int_rejected(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_on_demand(1))
+        self.assertTrue(any('on_demand' in e and 'boolean' in e.lower() for e in errors),
+                        f"Expected on_demand boolean type error, got: {errors}")
+
+
+# =============================================================================
+# rotate_on_provision type check (ROT-003)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRotateOnProvisionTypeCheck(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _config_with_rop(self, value):
+        return {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': {
+                'schedule': '0 0 3 * * ?',
+                'password_complexity': '32,5,5,5,5',
+                'rotate_on_provision': value,
+            },
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+
+    def test_rotate_on_provision_true_validates(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_rop(True))
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_rotate_on_provision_false_validates(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_rop(False))
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_rotate_on_provision_string_rejected(self):
+        errors = self.cmd._validate_config(self.params, self._config_with_rop("false"))
+        self.assertTrue(
+            any('rotate_on_provision' in e and 'boolean' in e.lower() for e in errors),
+            f"Got: {errors}",
+        )
+
+
+# =============================================================================
+# account.existing_password (ACC-001)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestExistingPasswordValidation(TestCase):
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_existing_password_non_empty_string_validates_without_rotation(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'existing_password': 'KnownPass123!'}),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_existing_password_empty_string_rejected(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'existing_password': ''}),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(
+            any('existing_password' in e for e in errors),
+            f"Got: {errors}",
+        )
+
+    def test_existing_password_whitespace_only_rejected(self):
+        """Regression for review #D (round 4): whitespace-only strings like
+        '   ' or '\\t' are non-empty but meaningless. Validator must reject
+        per its stated 'non-empty string' contract."""
+        for value in ['   ', '\t', '\n', '  \t\n  ']:
+            config = {
+                'user': make_valid_user(),
+                'account': make_valid_account({'existing_password': value}),
+                'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+            }
+            errors = self.cmd._validate_config(self.params, config)
+            self.assertTrue(
+                any('existing_password' in e for e in errors),
+                f'Expected rejection for whitespace-only value {value!r}; got: {errors}',
+            )
+
+    def test_existing_password_preserves_internal_whitespace(self):
+        """Passwords legitimately containing internal whitespace must NOT be
+        rejected — only purely-whitespace strings are rejected."""
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'existing_password': 'pass with spaces'}),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [],
+            f'Internal whitespace in passwords must be preserved; got: {errors}')
+
+    def test_existing_password_non_string_rejected(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'existing_password': 12345}),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(
+            any('existing_password' in e for e in errors),
+            f"Got: {errors}",
+        )
+
+
+# =============================================================================
+# INVARIANT-001 cross-section invariant
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestInvariant001(TestCase):
+    """
+    INVARIANT-001: existing_password is rejected if a rotation: block is
+    present AND rotate_on_provision is not explicitly false.
+
+    This is the load-bearing security check that prevents the customer-supplied
+    password from being pushed to the target system at provisioning time.
+    """
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _config(self, rotation, existing_password=None):
+        account = make_valid_account()
+        if existing_password is not None:
+            account['existing_password'] = existing_password
+        return {
+            'user': make_valid_user(),
+            'account': account,
+            'rotation': rotation,
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+
+    def test_existing_password_with_schedule_and_default_rop_rejected(self):
+        # No rotate_on_provision => defaults to true => rejection
+        cfg = self._config(
+            rotation={'schedule': '0 0 3 * * ?', 'password_complexity': '32,5,5,5,5'},
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('existing_password' in e for e in errors),
+            f"INVARIANT-001 must reject, got: {errors}",
+        )
+
+    def test_existing_password_with_schedule_and_explicit_rop_true_rejected(self):
+        cfg = self._config(
+            rotation={
+                'schedule': '0 0 3 * * ?',
+                'password_complexity': '32,5,5,5,5',
+                'rotate_on_provision': True,
+            },
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('existing_password' in e for e in errors),
+            f"INVARIANT-001 must reject, got: {errors}",
+        )
+
+    def test_existing_password_with_on_demand_and_default_rop_rejected(self):
+        # on_demand + default rop=true => still fires _rotate_immediately => rejected
+        cfg = self._config(
+            rotation={'on_demand': True, 'password_complexity': '32,5,5,5,5'},
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('existing_password' in e for e in errors),
+            f"INVARIANT-001 must reject, got: {errors}",
+        )
+
+    def test_existing_password_with_rop_false_validates(self):
+        # Cell 7 of behavior matrix: schedule + rop=false + existing_password => allowed
+        cfg = self._config(
+            rotation={
+                'schedule': '0 0 3 * * ?',
+                'password_complexity': '32,5,5,5,5',
+                'rotate_on_provision': False,
+            },
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_existing_password_with_on_demand_and_rop_false_validates(self):
+        # Cell 8 of behavior matrix (Tandem's case)
+        cfg = self._config(
+            rotation={
+                'on_demand': True,
+                'password_complexity': '32,5,5,5,5',
+                'rotate_on_provision': False,
+            },
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_existing_password_with_no_rotation_block_validates(self):
+        # Cell 2 of behavior matrix
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'existing_password': 'KnownPass123!'}),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [], f"Got: {errors}")
+
+    def test_invariant_error_message_mentions_remediation(self):
+        # Error message must guide the operator to a fix
+        cfg = self._config(
+            rotation={'schedule': '0 0 3 * * ?', 'password_complexity': '32,5,5,5,5'},
+            existing_password='KnownPass123!',
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        joined = '\n'.join(errors)
+        self.assertIn('rotate_on_provision', joined,
+                      "Error message should mention rotate_on_provision as a remediation option")
+
+
+# =============================================================================
+# Regression: delivery.transfer_ownership / remove_from_service_vault must be
+# rejected when ANY rotation is configured (schedule OR on_demand).
+# Catches the bug where the has_rotation predicate only checked schedule.
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRotationDeliveryInvariant(TestCase):
+    """The existing transfer_ownership/remove_from_service_vault incompatibility
+    with rotation must apply to BOTH schedule and on_demand modes. Pre-fix,
+    has_rotation = bool(rotation.schedule) missed the on_demand case."""
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def _config(self, rotation, delivery):
+        return {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'rotation': rotation,
+            'delivery': delivery,
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+
+    def test_on_demand_with_transfer_ownership_rejected(self):
+        cfg = self._config(
+            rotation={'on_demand': True, 'password_complexity': '32,5,5,5,5'},
+            delivery={'share_to': 'someone@example.com', 'transfer_ownership': True},
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('transfer_ownership' in e and 'rotation' in e for e in errors),
+            f"Expected transfer_ownership-rotation incompatibility error; got: {errors}",
+        )
+
+    def test_on_demand_with_remove_from_service_vault_rejected(self):
+        cfg = self._config(
+            rotation={'on_demand': True, 'password_complexity': '32,5,5,5,5'},
+            delivery={'share_to': 'someone@example.com', 'remove_from_service_vault': True},
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('remove_from_service_vault' in e and 'rotation' in e for e in errors),
+            f"Expected remove_from_service_vault-rotation incompatibility error; got: {errors}",
+        )
+
+    def test_schedule_with_transfer_ownership_still_rejected(self):
+        # Regression: pre-existing behavior for schedule mode must still fire.
+        cfg = self._config(
+            rotation={'schedule': '0 0 3 * * ?', 'password_complexity': '32,5,5,5,5'},
+            delivery={'share_to': 'someone@example.com', 'transfer_ownership': True},
+        )
+        errors = self.cmd._validate_config(self.params, cfg)
+        self.assertTrue(
+            any('transfer_ownership' in e for e in errors),
+            f"Expected rejection; got: {errors}",
+        )
+
+
+# =============================================================================
+# Regression: account.initial_password still rejected (KC-1007-2)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestInitialPasswordStillRejected(TestCase):
+    """initial_password rejection from KC-1007-2 must remain unchanged."""
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_initial_password_still_rejected(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account({'initial_password': 'whatever'}),
+            'rotation': make_valid_rotation(),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(any('initial_password' in e for e in errors),
+                        f"Got: {errors}")
+
+
+# =============================================================================
+# Regression: deprecated pam.rotation: shape still emits migration error
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeprecatedPamRotationMigrationError(TestCase):
+    """The pre-existing deprecation migration error must be unchanged."""
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_deprecated_pam_rotation_emits_migration_error(self):
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'pam': {
+                'rotation': {
+                    'schedule': '0 0 3 * * ?',
+                    'password_complexity': '32,5,5,5,5',
+                }
+            },
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(
+            any('deprecated' in e.lower() for e in errors),
+            f"Expected deprecation migration error, got: {errors}",
+        )
+
+
+# =============================================================================
+# Regression: existing required-field errors still fire
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestRequiredSectionsRegression(TestCase):
+    """user and account remain required; rotation no longer is."""
+
+    def setUp(self):
+        self.cmd = CredentialProvisionCommand()
+        self.params = make_params()
+
+    def test_missing_user_section_rejected(self):
+        config = {
+            'account': make_valid_account(),
+            'rotation': make_valid_rotation(),
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(any('user' in e for e in errors), f"Got: {errors}")
+
+    def test_missing_account_section_rejected(self):
+        config = {
+            'user': make_valid_user(),
+            'rotation': make_valid_rotation(),
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertTrue(any('account' in e for e in errors), f"Got: {errors}")
+
+    def test_missing_rotation_section_no_longer_rejected(self):
+        # Critical regression target: pre-feature this would have failed.
+        config = {
+            'user': make_valid_user(),
+            'account': make_valid_account(),
+            'email': {'config_name': 'none', 'send_to': 'test@example.com'},
+        }
+        errors = self.cmd._validate_config(self.params, config)
+        self.assertEqual(errors, [],
+            f"rotation: should be optional now; got: {errors}")

--- a/unit-tests/test_credential_provision.py
+++ b/unit-tests/test_credential_provision.py
@@ -582,16 +582,20 @@ class TestComprehensiveValidation(unittest.TestCase):
         self.assertEqual(len(errors), 0, 'Valid config should have no errors')
 
     def test_missing_required_sections(self):
-        """Test detection of missing required sections."""
+        """Test detection of missing required sections.
+
+        Note: rotation is OPTIONAL as of cp-rotation-skip-feat (omitting it means
+        Commander will not manage rotation for the record). Only user and account
+        are required top-level sections.
+        """
         config = {
             'user': {'first_name': 'John'},
-            # Missing account, rotation sections
+            # Missing account section
         }
         errors = self.cmd._validate_config(self.mock_params, config)
         self.assertGreater(len(errors), 0, 'Should detect missing sections')
         error_text = ' '.join(errors)
         self.assertIn('account', error_text)
-        self.assertIn('rotation', error_text)
 
     def test_multiple_validation_errors(self):
         """Test that multiple errors are collected (not fail-fast)."""


### PR DESCRIPTION
## Summary

Extends `credential-provision` (alias `cp`) to support onboarding **existing** PAM accounts whose passwords must not be rotated at provisioning time. Three new YAML capabilities plus an absorbed bug fix.

**Customer driver:** Tandem.

## Tracking

No JIRA ticket — internal tracking via `cp-rotation-skip-feat`. Full design docs in `.claude-context/Commander/development/cp-rotation-skip-feat/`.

## Changes

### YAML schema (all additions are opt-in; existing YAMLs unchanged)

| Field | Section | Type | Purpose |
|---|---|---|---|
| (existing) `rotation:` | top-level | object | Now **optional** (was required). Omit to indicate Commander will not manage rotation for the new record. |
| `rotation.on_demand` | inside `rotation:` | bool | `true` configures rotation for manual triggering only (no cron). Mutually exclusive with `rotation.schedule`. |
| `rotation.rotate_on_provision` | inside `rotation:` | bool (default `true`) | `false` defers the provisioning-time immediate rotation. Default preserves today's behavior. |
| `account.existing_password` | inside `account:` | non-empty string | Onboard an existing account using its current real password. **Never** pushed to the target. |

### Behavior matrix (8 supported cells)

See `ARCHITECTURE_AND_DESIGN.md` § Behavior Matrix. The validator rejects the single combination that would push a customer-supplied password to a target (INVARIANT-001).

### Code touch points

- `credential_provision.py`:
  - New module-level `DEFAULT_COMPLEXITY = "32,5,5,5,5"` constant
  - New `_determine_password`, `_should_rotate_on_provision`, `_should_create_ad_user`, `_log_existing_password_use` helpers
  - `_validate_config` — `rotation:` removed from `required_sections`; INVARIANT-001 cross-section check added
  - `_validate_rotation_section` — schedule/on_demand mutex + on_demand + rotate_on_provision type checks
  - `_validate_account_section` — accepts `existing_password`; keeps `initial_password` rejection
  - `_configure_rotation` — branches on `on_demand` vs `schedule`
  - `_dry_run_report` — full rewrite; **absorbs commit `97dc8893` (orphan `credential-provision-fixes` branch)** which fixed the JSON-mode NameError at line 1027
  - `execute()` — gate `_create_ad_user_via_gateway` on `not existing_password`; gate `_rotate_immediately` on `rotate_on_provision`; emit one `logging.info` line for `existing_password` use
  - Argparse `description` text updated
- Three new test files: `test_credential_provision_validation.py`, `test_credential_provision_execute.py`, `test_credential_provision_dryrun.py` — 71 new tests

## Breaking Changes

**None.** Schema relaxation is strict (rotation: becomes optional; new fields are opt-in). Every previously-valid YAML continues to validate and execute identically.

## Migration Guide

Not required. The deprecated `pam.rotation:` migration error (introduced in a prior commit) is unchanged.

## Rollback Instructions

Pure code revert (`git revert <merge-commit>`). No data migrations, no DB changes, no infrastructure changes. Users with YAMLs that opt into the new fields would see them become invalid validator inputs again — pre-feature behavior.

## Testing Performed

- ✅ 71 new unit tests (Phase 4 TDD + signature guard)
- ✅ 36 pre-existing `test_credential_provision_kc1035.py` tests pass (regression)
- ✅ `cp --output json --dry-run` smoke-tested for all 8 behavior-matrix cells (closes the absorbed NameError fix)
- ✅ Structural regression guards (source-code grep for log-leak patterns; signature constraint on `_log_existing_password_use`)
- ✅ All 4 demo YAMLs validate (2 new + 2 existing — modulo offline limitations on `directory_uid` resolution)
- ⏸️ 3 pre-existing e2e tests skipped (require live Keeper session + Gateway infrastructure)

## Security Notes

This PR introduces a narrow carve-out from `BLOCKER_KC-1007-2_Password-Generation-Flow_2025-11-17`. The previous decision (reject `account.initial_password` because it would let YAML dictate the password Commander pushes to a target) is **preserved unchanged**. The new `account.existing_password` field has deliberately distinct semantics: it represents *the password that already exists* on the account, and is **never pushed** to any target.

Three enforcement layers:
1. Validator INVARIANT-001 rejects YAML combinations that would fire an immediate rotation with `existing_password` set.
2. Helper `_should_create_ad_user` skips `_create_ad_user_via_gateway` (the other push-to-target route) when `existing_password` is set.
3. Source-code structural guard test rejects any future log statement that interpolates the `existing_password` value.

See `TECHNICAL_DECISIONS.md` ADR-001 and `SECURITY_ARCHITECTURE.md` for the full rationale + threat model.

## Reviewer Guidance

Focus on:
1. **Security review** — confirm INVARIANT-001 is reachable from every combination in the behavior matrix that ought to be rejected. Test file: `tests/test_credential_provision_validation.py` § `TestInvariant001`.
2. **Backwards compatibility** — confirm the schema relaxation (removing `'rotation'` from `required_sections`) doesn't accidentally accept malformed YAMLs. Test file: `TestEmptyRotationDict`, `TestRequiredSectionsRegression`.
3. **Dry-run output format** — the text-mode dry-run format changed (uses an actions array instead of hardcoded numbered prints). Output now includes `(config: <name>)` for the email step. Mention this to anyone tooling against the text format.
4. **The absorbed bug fix** — commit `97dc8893` from the orphan `credential-provision-fixes` branch is folded into Story 4 here. The customer's reported `cp --output json --dry-run` NameError is closed.

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Documentation updated (inline + design docs)
- [x] No security vulnerabilities (KC-1007-2 invariant preserved; new field gated by INVARIANT-001)
- [x] Performance acceptable (no perf-sensitive code touched)
- [x] Backwards compatibility verified
