### PR TITLE
KC-1234: Fix- include path and records in user folder get response

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -347,6 +347,10 @@ class RecordGetUidCommand(Command):
                         else f.uid
                 if f.parent_uid:
                     fo['parent_folder_uid'] = f.parent_uid
+                if f.type == BaseFolderNode.UserFolderType:
+                    fo['path'] = get_folder_path(params, f.uid)
+                    record_uids = params.subfolder_record_cache.get(f.uid, set())
+                    fo['records'] = [{'record_uid': r} for r in record_uids]
                 print(json.dumps(fo, indent=2))
             else:
                 f.display()


### PR DESCRIPTION
### Summary
The get command for user_folder type did not return path or records in the JSON response, preventing the Terraform provider from detecting folder moves and record changes during its Read/refresh cycle. These fields are now included to enable full state reconciliation.

### Changes

- path — added to the user_folder get response, built by walking up the folder tree to produce the full path (e.g. "Parent/My Folder")
- records — added as a list of { record_uid } objects from the folder's record cache, allowing Terraform to detect records added or removed outside of its control