### PR TITLE
Disable SO_REUSEADDR on tunnel start

### DIFF
--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -786,8 +786,6 @@ def find_open_port(tried_ports: list, start_port=49152, end_port=65535, preferre
 def is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         try:
-            # Enable SO_REUSEADDR to allow binding to ports in TIME_WAIT state
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             s.bind((host, port))
             return True
         except OSError:


### PR DESCRIPTION
When starting tunnels from Windows, Keeper reuses the same port (49152). This is because of SO_REUSEADDR and Windows behavior, and is resolved when disabling it.