### PR TITLE
Add prompt before shell command execution in connect/ssh commands

### DIFF
--- a/keepercommander/commands/connect.py
+++ b/keepercommander/commands/connect.py
@@ -24,6 +24,7 @@ import tempfile
 from typing import Optional, Callable, List, Iterable, Tuple, Union
 
 from .base import Command, RecordMixin, dump_report_data, field_to_title, report_output_parser, user_choice
+from .connect_prompts import confirm_argv, confirm_env, confirm_ssh_key
 from .record import find_record, RecordListCommand
 from .ssh_agent import add_ssh_key, try_extract_private_key, SshAgentCommand
 from ..attachment import prepare_attachment_download
@@ -127,23 +128,15 @@ class BaseConnectCommand(Command, RecordMixin):
     def support_extra_parameters(self):
         return True
 
-    # SHELL_SUBSTITUTION = {
-    #     '`': r'\`',
-    #     '$': r'\$',
-    #     '?': r'\?',
-    #     '*': r'\*',
-    #     '^': r'\^',
-    #     '(': r'\(',
-    #     ')': r'\)'
-    # }
-
-    def execute_shell(self):
+    def execute_shell(self, record=None, stage='connect'):
+        # type: (Optional[KeeperRecord], str) -> None
         logging.debug('Executing "%s"', self.command)
         try:
-            # command = self.command.translate(str.maketrans(BaseConnectCommand.SHELL_SUBSTITUTION))
-            command = self.command
-            subprocess.run(shlex.split(command))
-            # os.system(command)
+            argv = shlex.split(self.command)
+            if not confirm_argv(stage, argv, record):
+                logging.info('Skipped %s (user declined).', stage)
+                return
+            subprocess.run(argv)
         finally:
             self.command = ''
             for cb in self.run_at_the_end:
@@ -358,7 +351,7 @@ class ConnectSshCommand(BaseConnectCommand):
         command = ['ssh']
         options = self.get_extra_options(params, record, 'ssh')
         if options:
-            command.append(shlex.split(options.strip(), posix=False))
+            command.extend(shlex.split(options.strip(), posix=False))
         command.append(f'{login}@{host_name}')
         if port:
             command.extend(['-p', port])
@@ -366,9 +359,13 @@ class ConnectSshCommand(BaseConnectCommand):
         pk = try_extract_private_key(params, record)
         if pk:
             private_key, passphrase = pk
-            to_remove = add_ssh_key(private_key, passphrase, record.title)
-            if to_remove:
-                self.run_at_the_end.append(to_remove)
+            if confirm_ssh_key('ssh:record-key', record.title, record,
+                               hint='intrinsic key from record fields'):
+                to_remove = add_ssh_key(private_key, passphrase, record.title)
+                if to_remove:
+                    self.run_at_the_end.append(to_remove)
+            else:
+                logging.info('Skipped ssh:record-key (user declined).')
         else:
             password = BaseConnectCommand.get_record_field(record, 'password')
             if password:
@@ -402,7 +399,7 @@ class ConnectSshCommand(BaseConnectCommand):
 
         self.command = shlex.join(command)
         logging.info('Connecting to "%s" ...', record.title)
-        self.execute_shell()
+        self.execute_shell(record=record, stage='ssh')
 
 
 class ConnectMysqlCommand(BaseConnectCommand):
@@ -452,7 +449,7 @@ class ConnectMysqlCommand(BaseConnectCommand):
 
         self.command = shlex.join(command)
         logging.info('Connecting to "%s" ...', record.title)
-        self.execute_shell()
+        self.execute_shell(record=record, stage='mysql')
 
 
 class ConnectPostgresCommand(BaseConnectCommand):
@@ -503,7 +500,7 @@ class ConnectPostgresCommand(BaseConnectCommand):
 
         self.command = shlex.join(command)
         logging.info('Connecting to "%s" ...', record.title)
-        self.execute_shell()
+        self.execute_shell(record=record, stage='postgresql')
 
 
 class ConnectRdpCommand(BaseConnectCommand):
@@ -547,7 +544,7 @@ class ConnectRdpCommand(BaseConnectCommand):
         self.command = shlex.join(command)
 
         logging.info('Connecting to "%s" ...', record.title)
-        self.execute_shell()
+        self.execute_shell(record=record, stage='rdp')
 
 
 connect_command_description = '''
@@ -750,9 +747,15 @@ class ConnectCommand(BaseConnectCommand):
         pk = try_extract_private_key(params, record)
         if pk:
             private_key, passphrase = pk
-            to_delete = add_ssh_key(private_key, passphrase if passphrase else None, record.title)
-            if to_delete:
-                yield to_delete
+            stage = f'connect:{endpoint}:record-key'
+            if confirm_ssh_key(stage, record.title, record,
+                               hint='intrinsic key from record fields'):
+                to_delete = add_ssh_key(
+                    private_key, passphrase if passphrase else None, record.title)
+                if to_delete:
+                    yield to_delete
+            else:
+                logging.info('Skipped %s (user declined).', stage)
 
         key_prefix = f'connect:{endpoint}:ssh-key'
         for cf_name, cf_value in ConnectCommand.get_fields_by_patters(record, key_prefix):
@@ -768,13 +771,22 @@ class ConnectCommand(BaseConnectCommand):
                     raise Exception(f'Add ssh-key. Failed to resolve key parameter: {p}')
                 parsed_values.append(val)
                 cf_value = cf_value[m.end():]
-            if len(parsed_values) > 0:
-                cf_value = cf_value.strip()
-                if cf_value:
-                    parsed_values.append(cf_value)
-                to_delete = add_ssh_key(parsed_values[0], parsed_values[1] if len(parsed_values) > 1 else None, key_name)
-                if to_delete:
-                    yield to_delete
+            if not parsed_values:
+                continue
+            cf_value = cf_value.strip()
+            if cf_value:
+                parsed_values.append(cf_value)
+            stage = f'connect:{endpoint}:ssh-key:{key_name}'
+            if not confirm_ssh_key(stage, key_name, record,
+                                   hint=f'from custom field "{cf_name}"'):
+                logging.info('Skipped %s (user declined).', stage)
+                continue
+            to_delete = add_ssh_key(
+                parsed_values[0],
+                parsed_values[1] if len(parsed_values) > 1 else None,
+                key_name)
+            if to_delete:
+                yield to_delete
 
     @staticmethod
     def add_environment_variables(params, endpoint, record, temp_files):
@@ -791,30 +803,30 @@ class ConnectCommand(BaseConnectCommand):
                 p = m.group(1)
                 val = ConnectCommand.get_parameter_value(params, record, p, temp_files)
                 if not val:
-                    raise Exception('Add environment variable. Failed to resolve key parameter: {0}'.format(p))
+                    raise Exception(f'Add environment variable. Failed to resolve key parameter: {p}')
                 cf_value = cf_value[:m.start()] + val + cf_value[m.end():]
-            if cf_value:
-                os.putenv(key_name, cf_value)
+            if not cf_value:
+                continue
+            stage = f'connect:{endpoint}:env:{key_name}'
+            if not confirm_env(stage, key_name, cf_value, record):
+                logging.info('Skipped %s (user declined).', stage)
+                continue
+            os.putenv(key_name, cf_value)
 
-                def clear_env():
-                    os.putenv(key_name, '')
-                yield clear_env
+            def clear_env(name=key_name):
+                os.putenv(name, '')
+            yield clear_env
 
     def connect_endpoint(self, params, endpoint, record, **kwargs):
         # type: (KeeperParams, str, KeeperRecord, ...) -> None
         temp_files = []
         try:
-            command = BaseConnectCommand.get_custom_field(record, f'connect:{endpoint}:pre')
-            if command:
-                command = BaseConnectCommand.get_command_string(params, record, command, temp_files, endpoint=endpoint)
-                if command:
-                    args = shlex.split(command)
-                    subprocess.run(args)
-                    # os.system(command)
+            self._run_record_hook(params, endpoint, record, temp_files, 'pre')
 
             command = ConnectCommand.get_custom_field(record, f'connect:{endpoint}')
             if command:
-                cmd = ConnectCommand.get_command_string(params, record, command, temp_files, endpoint=endpoint)
+                cmd = ConnectCommand.get_command_string(
+                    params, record, command, temp_files, endpoint=endpoint)
                 if cmd:
                     self.run_at_the_end.extend(
                         ConnectCommand.add_ssh_keys(params, endpoint, record, temp_files))
@@ -823,20 +835,31 @@ class ConnectCommand(BaseConnectCommand):
 
                     command = shlex.split(cmd, posix=False)
                     parameters = kwargs.get('parameters')
-                    if isinstance(parameters, list) and len(parameters) > 0:
+                    if isinstance(parameters, list) and parameters:
                         command.extend(parameters)
 
                     self.command = shlex.join(command)
                     logging.info('Connecting to "%s" ...', record.title)
-                    self.execute_shell()
+                    self.execute_shell(record=record, stage=f'connect:{endpoint}')
 
-            command = BaseConnectCommand.get_custom_field(record, f'connect:{endpoint}:post')
-            if command:
-                command = ConnectCommand.get_command_string(params, record, command, temp_files, endpoint=endpoint)
-                if command:
-                    args = shlex.split(command)
-                    subprocess.run(args)
-                    # os.system(command)
+            self._run_record_hook(params, endpoint, record, temp_files, 'post')
         finally:
             for file in temp_files:
                 os.remove(file)
+
+    @staticmethod
+    def _run_record_hook(params, endpoint, record, temp_files, kind):
+        # type: (KeeperParams, str, KeeperRecord, List[str], str) -> None
+        template = BaseConnectCommand.get_custom_field(record, f'connect:{endpoint}:{kind}')
+        if not template:
+            return
+        command = BaseConnectCommand.get_command_string(
+            params, record, template, temp_files, endpoint=endpoint)
+        if not command:
+            return
+        args = shlex.split(command)
+        stage = f'connect:{endpoint}:{kind}'
+        if confirm_argv(stage, args, record):
+            subprocess.run(args)
+        else:
+            logging.info('Skipped %s (user declined).', stage)

--- a/keepercommander/commands/connect_prompts.py
+++ b/keepercommander/commands/connect_prompts.py
@@ -194,9 +194,9 @@ def _emit_record_source(record: Any) -> None:
 def _emit_warning(lines: List[str]) -> None:
     if not lines:
         return
-    sys.stderr.write(f'\n  {_bold_red("  WARNING")}\n')
+    sys.stderr.write(f'\n  {_bold_red("WARNING")}\n')
     for line in lines:
-        sys.stderr.write(f'     {_red(line)}\n')
+        sys.stderr.write(f'    {_red(line)}\n')
 
 
 def _emit_section(label: str, body: List[str]) -> None:
@@ -235,14 +235,20 @@ def confirm_argv(stage: str, argv: List[str], record: Any = None) -> bool:
     """Prompt before running a subprocess. Default-deny."""
     _emit_header(stage)
     _emit_record_source(record)
+    warning_lines = [
+        'Runs an external program with your user privileges.',
+        'Can modify files, settings, or reach the network.',
+    ]
     if argv and _is_interpreter(argv[0]):
-        _emit_warning([
-            'argv[0] is a shell or scripting interpreter.',
-            'This command can run arbitrary code on your machine.',
-        ])
+        warning_lines.append(
+            'argv[0] is a shell/scripting interpreter - it can run any code.'
+        )
+    _emit_warning(warning_lines)
     _emit_section('Command to execute:', _argv_block(argv))
     sys.stderr.write('\n')
-    return read_yes_no()
+    return read_yes_no(
+        f'{_bold("Run this external command? [y/n]")}{_dim(" (default: n): ")}'
+    )
 
 
 def confirm_env(stage: str, name: str, value: str, record: Any = None) -> bool:

--- a/keepercommander/commands/connect_prompts.py
+++ b/keepercommander/commands/connect_prompts.py
@@ -1,0 +1,283 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Confirmation prompts that gate every record-driven side effect in the
+``connect`` / ``ssh`` commands. Defaults are *deny* (EOF, Ctrl-C and any
+non-``y``/``yes`` answer all return False). Record text is stripped of
+control characters before display so a malicious record cannot rewrite the
+prompt with ANSI sequences.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any, List, Optional
+
+
+_BANNER_WIDTH = 72
+_LONG_ARG_THRESHOLD = 80
+
+_SHELL_INTERPRETERS = frozenset({
+    'sh', 'bash', 'zsh', 'ksh', 'dash', 'ash', 'fish', 'tcsh', 'csh',
+})
+
+_OTHER_INTERPRETERS = frozenset({
+    'python', 'python2', 'python3',
+    'perl', 'ruby', 'node', 'nodejs', 'deno',
+    'osascript', 'powershell', 'pwsh', 'cmd',
+    'php', 'lua', 'tclsh', 'awk',
+})
+
+_DANGEROUS_ENV_NAMES = frozenset({
+    'PATH', 'IFS',
+    'LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT',
+    'DYLD_INSERT_LIBRARIES', 'DYLD_LIBRARY_PATH', 'DYLD_FRAMEWORK_PATH',
+    'BASH_ENV', 'ENV', 'PROMPT_COMMAND', 'PS4',
+    'PYTHONSTARTUP', 'PYTHONPATH', 'PYTHONHOME',
+    'PERL5OPT', 'PERL5LIB',
+    'RUBYOPT', 'RUBYLIB',
+    'NODE_OPTIONS', 'NODE_PATH',
+    'JAVA_TOOL_OPTIONS', '_JAVA_OPTIONS',
+    'GIT_SSH', 'GIT_SSH_COMMAND', 'GIT_EXEC_PATH',
+    'SSH_ASKPASS', 'EDITOR', 'VISUAL', 'PAGER',
+})
+
+_DANGEROUS_ENV_PREFIXES = ('LD_', 'DYLD_')
+
+_INTERPRETER_DASH_C_FLAGS = (
+    '-c', '-lc', '-ic', '-Command', '-EncodedCommand',
+    '-e', '-E', '/c', '/C',
+)
+
+_CONTROL_CHAR_RE = re.compile(r'[\x00-\x1f\x7f-\x9f]')
+
+
+def _use_color() -> bool:
+    isatty = getattr(sys.stderr, 'isatty', None)
+    return bool(isatty and isatty()) and os.environ.get('NO_COLOR') is None
+
+
+def _c(code: str, text: str) -> str:
+    return f'\x1b[{code}m{text}\x1b[0m' if _use_color() else text
+
+
+def _bold(s: str) -> str:        return _c('1', s)
+def _dim(s: str) -> str:         return _c('2', s)
+def _red(s: str) -> str:         return _c('31', s)
+def _yellow(s: str) -> str:      return _c('33', s)
+def _cyan(s: str) -> str:        return _c('36', s)
+def _bold_red(s: str) -> str:    return _c('1;31', s)
+def _bold_yellow(s: str) -> str: return _c('1;33', s)
+def _bold_cyan(s: str) -> str:   return _c('1;36', s)
+
+
+def _sanitize(text: Optional[str]) -> str:
+    """Strip C0/C1 control characters (incl. ESC) from attacker-supplied text."""
+    if not isinstance(text, str):
+        return ''
+    return _CONTROL_CHAR_RE.sub('', text)
+
+
+def _is_interpreter(prog: Optional[str]) -> bool:
+    if not prog:
+        return False
+    base = os.path.basename(prog).lower()
+    if base.endswith('.exe'):
+        base = base[:-4]
+    return base in _SHELL_INTERPRETERS or base in _OTHER_INTERPRETERS
+
+
+def _is_dangerous_env_name(name: Optional[str]) -> bool:
+    upper = (name or '').upper()
+    return upper in _DANGEROUS_ENV_NAMES or upper.startswith(_DANGEROUS_ENV_PREFIXES)
+
+
+def _looks_multi_statement(arg: str) -> bool:
+    return (
+        len(arg) > _LONG_ARG_THRESHOLD
+        or ';' in arg
+        or '\n' in arg
+        or '&&' in arg
+        or '||' in arg
+    )
+
+
+def split_shell_statements(script: Optional[str]) -> List[str]:
+    """Split a shell-script into top-level statements"""
+    if not script:
+        return []
+
+    parts: List[str] = []
+    buf: List[str] = []
+    quote: Optional[str] = None
+    escaped = False
+    i, n = 0, len(script)
+
+    def flush() -> None:
+        stmt = ''.join(buf).strip()
+        if stmt:
+            parts.append(stmt)
+        buf.clear()
+
+    while i < n:
+        c = script[i]
+        if escaped:
+            buf.append(c)
+            escaped = False
+        elif c == '\\' and quote != "'":
+            buf.append(c)
+            escaped = True
+        elif quote is not None:
+            buf.append(c)
+            if c == quote:
+                quote = None
+        elif c in ('"', "'"):
+            quote = c
+            buf.append(c)
+        elif c in ('\n', ';'):
+            flush()
+        elif c in ('&', '|') and i + 1 < n and script[i + 1] == c:
+            flush()
+            parts.append(c * 2)
+            i += 1
+        else:
+            buf.append(c)
+        i += 1
+
+    flush()
+    return parts
+
+
+def read_yes_no(prompt: Optional[str] = None) -> bool:
+    """Default-deny y/n reader."""
+    if prompt is None:
+        prompt = f'{_bold("Proceed? [y/n]")}{_dim(" (default: n): ")}'
+    try:
+        return input(prompt).strip().lower() in ('y', 'yes')
+    except (EOFError, KeyboardInterrupt):
+        sys.stderr.write(_dim('\n(aborted - treated as "no")\n'))
+        return False
+
+
+def _hr() -> str:
+    return _dim('─' * _BANNER_WIDTH)
+
+
+def _emit_header(stage: str) -> None:
+    sys.stderr.write(f'\n{_hr()}\n')
+    sys.stderr.write(
+        f'  {_bold_cyan("Confirmation required")}  {_dim("·")}  '
+        f'{_cyan(_sanitize(stage))}\n'
+    )
+    sys.stderr.write(f'{_hr()}\n')
+
+
+def _emit_record_source(record: Any) -> None:
+    if record is None:
+        return
+    title = _sanitize(getattr(record, 'title', '')) or '<untitled>'
+    uid = _sanitize(getattr(record, 'record_uid', '')) or '<no-uid>'
+    sys.stderr.write(f'\n  {_bold("Source record")}: "{title}"\n')
+    sys.stderr.write(f'  {_bold("UID")}:           {uid}\n')
+
+
+def _emit_warning(lines: List[str]) -> None:
+    if not lines:
+        return
+    sys.stderr.write(f'\n  {_bold_red("  WARNING")}\n')
+    for line in lines:
+        sys.stderr.write(f'     {_red(line)}\n')
+
+
+def _emit_section(label: str, body: List[str]) -> None:
+    sys.stderr.write(f'\n  {_bold_yellow(label)}\n')
+    for line in body:
+        sys.stderr.write(line + '\n')
+
+
+def _argv_block(argv: List[str]) -> List[str]:
+    if not argv:
+        return [f'    {_dim("(empty argv)")}']
+
+    is_dash_c = (
+        len(argv) >= 3
+        and _is_interpreter(argv[0])
+        and argv[1] in _INTERPRETER_DASH_C_FLAGS
+    )
+
+    lines: List[str] = []
+    for i, raw in enumerate(argv):
+        label = _dim(f'argv[{i}]')
+        if is_dash_c and i == 2 and _looks_multi_statement(raw):
+            stmts = split_shell_statements(raw)
+            real = [s for s in stmts if s not in ('&&', '||')]
+            if len(real) > 1:
+                lines.append(f'    {label}  {len(real)} statements ({len(raw)} chars):')
+                bar = _yellow('┃')
+                for s in stmts:
+                    lines.append(f'             {bar} {_sanitize(s)}')
+                continue
+        lines.append(f'    {label}  {_sanitize(raw)}')
+    return lines
+
+
+def confirm_argv(stage: str, argv: List[str], record: Any = None) -> bool:
+    """Prompt before running a subprocess. Default-deny."""
+    _emit_header(stage)
+    _emit_record_source(record)
+    if argv and _is_interpreter(argv[0]):
+        _emit_warning([
+            'argv[0] is a shell or scripting interpreter.',
+            'This command can run arbitrary code on your machine.',
+        ])
+    _emit_section('Command to execute:', _argv_block(argv))
+    sys.stderr.write('\n')
+    return read_yes_no()
+
+
+def confirm_env(stage: str, name: str, value: str, record: Any = None) -> bool:
+    """Prompt before setting an environment variable. Default-deny."""
+    _emit_header(stage)
+    _emit_record_source(record)
+    if _is_dangerous_env_name(name):
+        _emit_warning([
+            f'{_sanitize(name)} can alter how subsequent programs load',
+            'or execute code (loader hijack, init hook, runtime option).',
+        ])
+    _emit_section('Environment variable to set:', [
+        f'    {_bold(_sanitize(name))} {_dim("=")} {_sanitize(value)}',
+    ])
+    sys.stderr.write('\n')
+    return read_yes_no(
+        f'{_bold("Set this variable? [y/n]")}{_dim(" (default: n): ")}'
+    )
+
+
+def confirm_ssh_key(stage: str, key_name: str, record: Any = None,
+                    hint: Optional[str] = None) -> bool:
+    """Prompt before loading a private key into the local ssh-agent. Default-deny."""
+    _emit_header(stage)
+    _emit_record_source(record)
+    _emit_warning([
+        'An SSH private key will be added to your local ssh-agent.',
+        'Once loaded it can authenticate as you to any host that',
+        'trusts it (including via forwarded agent: ssh -A).',
+    ])
+    details = [f'    {_dim("Name:")}  {_sanitize(key_name) or "<unnamed>"}']
+    if hint:
+        details.append(f'    {_dim("Hint:")}  {_sanitize(hint)}')
+    _emit_section('Key details:', details)
+    sys.stderr.write('\n')
+    return read_yes_no(
+        f'{_bold("Add this key to your agent? [y/n]")}{_dim(" (default: n): ")}'
+    )

--- a/unit-tests/test_connect_security.py
+++ b/unit-tests/test_connect_security.py
@@ -1,0 +1,114 @@
+"""Minimal security regression tests for `connect` / `ssh`."""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from keepercommander.commands import connect, connect_prompts as cp
+
+
+def _record():
+    return SimpleNamespace(record_uid='rec-1', title='Shared SSH', custom=[])
+
+
+class TestGatesBlockOnDenial(unittest.TestCase):
+    def test_execute_shell_does_not_run_subprocess_on_denial(self):
+        inst = connect.BaseConnectCommand.__new__(connect.BaseConnectCommand)
+        inst.command = 'bash -c "rm -rf /"'
+        inst.run_at_the_end = []
+        with mock.patch.object(connect.subprocess, 'run') as run, \
+                mock.patch('builtins.input', return_value='n'):
+            inst.execute_shell(record=_record(), stage='test')
+        run.assert_not_called()
+
+    def test_pre_and_post_do_not_run_subprocess_on_denial(self):
+        cmd = connect.ConnectCommand.__new__(connect.ConnectCommand)
+        cmd.command = ''
+        cmd.run_at_the_end = []
+        fields = {
+            'connect:ssh:pre':  'bash -c "evil-pre"',
+            'connect:ssh:post': 'bash -c "evil-post"',
+        }
+        with mock.patch.object(
+                connect.BaseConnectCommand, 'get_custom_field',
+                side_effect=lambda r, n: fields.get(n)), \
+                mock.patch.object(
+                connect.ConnectCommand, 'get_custom_field',
+                side_effect=lambda r, n: fields.get(n)), \
+                mock.patch.object(
+                connect.BaseConnectCommand, 'get_command_string',
+                side_effect=lambda p, r, t, tf, **kw: t), \
+                mock.patch.object(
+                connect.ConnectCommand, 'add_ssh_keys',
+                side_effect=lambda *a, **kw: iter(())), \
+                mock.patch.object(
+                connect.ConnectCommand, 'add_environment_variables',
+                side_effect=lambda *a, **kw: iter(())), \
+                mock.patch.object(connect.subprocess, 'run') as run, \
+                mock.patch('builtins.input', return_value='n'):
+            cmd.connect_endpoint(SimpleNamespace(), 'ssh', _record())
+        run.assert_not_called()
+
+    def test_env_does_not_putenv_on_denial(self):
+        with mock.patch.object(
+                connect.ConnectCommand, 'get_fields_by_patters',
+                return_value=[('connect:ssh:env:LD_PRELOAD', '/tmp/evil.so')]), \
+                mock.patch.object(connect.os, 'putenv') as pe, \
+                mock.patch('builtins.input', return_value='n'):
+            list(connect.ConnectCommand.add_environment_variables(
+                SimpleNamespace(), 'ssh', _record(), []))
+        pe.assert_not_called()
+
+    def test_ssh_keys_do_not_load_on_denial(self):
+        with mock.patch.object(
+                connect, 'try_extract_private_key',
+                return_value=('PEMDATA', '')), \
+                mock.patch.object(
+                connect.ConnectCommand, 'get_fields_by_patters',
+                return_value=[]), \
+                mock.patch.object(connect, 'add_ssh_key') as ask, \
+                mock.patch('builtins.input', return_value='n'):
+            list(connect.ConnectCommand.add_ssh_keys(
+                SimpleNamespace(), 'ssh', _record(), []))
+        ask.assert_not_called()
+
+
+class TestDefaultDeny(unittest.TestCase):
+    def test_empty_input_is_no(self):
+        with mock.patch('builtins.input', return_value=''):
+            self.assertFalse(cp.read_yes_no())
+
+    def test_eof_is_no(self):
+        with mock.patch('builtins.input', side_effect=EOFError):
+            self.assertFalse(cp.read_yes_no())
+
+    def test_unrecognised_answer_is_no(self):
+        for resp in ('n', 'N', 'no', 'maybe', '1', 'true', 'Y E S'):
+            with mock.patch('builtins.input', return_value=resp):
+                self.assertFalse(cp.read_yes_no(), resp)
+
+    def test_yes_variants_are_yes(self):
+        for resp in ('y', 'Y', 'yes', 'YES', '  y  '):
+            with mock.patch('builtins.input', return_value=resp):
+                self.assertTrue(cp.read_yes_no(), resp)
+
+
+class TestSplitterDoesNotHidePayloads(unittest.TestCase):
+    def test_quoted_semicolons_are_not_separators(self):
+        self.assertEqual(
+            cp.split_shell_statements('echo "a; b"; rm -rf /'),
+            ['echo "a; b"', 'rm -rf /'],
+        )
+
+
+class TestRecordTextIsSanitized(unittest.TestCase):
+    def test_ansi_escape_in_record_title_is_stripped(self):
+        evil = 'Connect\x1b[2J\x1b[H<fake prompt>'
+        self.assertEqual(cp._sanitize(evil), 'Connect[2J[H<fake prompt>')
+
+    def test_other_controls_are_stripped(self):
+        self.assertEqual(cp._sanitize('a\x00b\x07c\x7fd'), 'abcd')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a y/n confirmation before every record-driven side effect in `connect` and `ssh`: subprocess execution, environment-variable sets, and SSH-agent key loads.
- Closes the RCE where a shared record's custom fields (`:pre`, `:post`, `:env:*`, `:ssh-key:*`, `ssh:option`) could silently run code on the operator's machine.
- Fixes a pre-existing `TypeError` in `ConnectSshCommand` when `ssh:option` is set, so the new gate on that vector is reachable.
- Defaults are deny; EOF, Ctrl-C and non-interactive stdin all decline, so scripted / CI runs skip every gated step.