### PR TITLE
Fix KC-1255 and KC-1258

### DIFF
--- a/keepercommander/cli.py
+++ b/keepercommander/cli.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -248,7 +249,15 @@ def command_and_args_from_cmd(command_line):
     return cmd, args
 
 
+_DISALLOWED_COMMAND_CHARS = ('\r', '\n', '\x00')
+
+
 def do_command(params, command_line):
+    # Block control characters to prevent newline-injection at the shell boundary.
+    if isinstance(command_line, str) and any(ch in command_line for ch in _DISALLOWED_COMMAND_CHARS):
+        logging.error('Invalid command: control characters are not allowed in command input.')
+        return
+
     def is_msp(params_local):
         if params_local.enterprise:
             if 'licenses' in params_local.enterprise:
@@ -301,20 +310,43 @@ def do_command(params, command_line):
         return
 
     if command_line.startswith('ksm'):
-        try:
-            subprocess.check_call([OS_WHICH_CMD, 'ksm'], stdout=subprocess.DEVNULL)
-        except subprocess.CalledProcessError:
+        # Exclude cwd from PATH on Windows so a local `ksm.bat` can't hijack
+        # the `ksm` prefix via CreateProcess's implicit cwd search.
+        search_path = os.environ.get('PATH', os.defpath)
+        if sys.platform.startswith('win'):
+            try:
+                cwd_abs = os.path.abspath(os.getcwd())
+            except OSError:
+                cwd_abs = None
+            if cwd_abs:
+                search_path = os.pathsep.join(
+                    p for p in search_path.split(os.pathsep)
+                    if p and os.path.abspath(p) != cwd_abs
+                )
+
+        ksm_path = shutil.which('ksm', path=search_path)
+        if not ksm_path:
             logging.error(
                 'Please install the ksm application to run ksm commands.\n'
                 'See https://docs.keeper.io/secrets-manager/secrets-manager'
                 '/secrets-manager-command-line-interface'
                 '#secrets-manager-cli-installation'
             )
-        else:
-            if sys.platform.startswith('win'):
-                subprocess.check_call(command_line)
-            else:
-                subprocess.check_call(shlex.split(command_line))
+            return
+
+        try:
+            ksm_args = shlex.split(command_line, posix=not sys.platform.startswith('win'))
+        except ValueError as e:
+            logging.error('Invalid ksm command: %s', e)
+            return
+
+        if not ksm_args or ksm_args[0].lower() != 'ksm':
+            logging.error('Invalid ksm command.')
+            return
+
+        # Invoke via argv list with shell=False so arguments aren't re-parsed.
+        ksm_args[0] = ksm_path
+        subprocess.check_call(ksm_args, shell=False)
         return
     elif '-h' in command_line.lower():
         if command_line.lower().startswith('h ') or command_line.lower().startswith('history '):

--- a/keepercommander/service/api/command.py
+++ b/keepercommander/service/api/command.py
@@ -15,8 +15,12 @@ from typing import Tuple, Union
 from ..decorators.unified import unified_api_decorator
 from ..util.command_util import CommandExecutor
 from ..decorators.logging import logger
-from ..core.request_queue import queue_manager
+from ..core.request_queue import queue_manager, derive_owner_key
 from ..util.request_validation import RequestValidator
+
+
+def _caller_owner_key():
+    return derive_owner_key(request.headers.get('api-key'))
 
 
 def _prepare_command_request():
@@ -36,8 +40,11 @@ def _prepare_command_request():
 def _submit_queue_request(processed_command: str, temp_files: list, wait_for_completion: bool):
     """Submit a request to the queue, optionally waiting for the result."""
     request_submitted = False
+    owner_key = _caller_owner_key()
     try:
-        request_id = queue_manager.submit_request(processed_command, temp_files)
+        request_id = queue_manager.submit_request(
+            processed_command, temp_files, owner_key=owner_key
+        )
         request_submitted = True
     except queue.Full:
         RequestValidator.cleanup_temp_files(temp_files)
@@ -47,7 +54,7 @@ def _submit_queue_request(processed_command: str, temp_files: list, wait_for_com
         }), 503), False
 
     if wait_for_completion:
-        result_data = queue_manager.wait_for_result(request_id)
+        result_data = queue_manager.wait_for_result(request_id, owner_key=owner_key)
         if result_data is None:
             return (jsonify({
                 "status": "error",
@@ -136,9 +143,10 @@ def create_command_blueprint():
     @bp.route("/status/<request_id>", methods=["GET"])
     @unified_api_decorator()
     def get_request_status(request_id: str, **kwargs) -> Tuple[Response, int]:
-        """Get the status of a specific request."""
+        """Get status; only the submitting API key can read its own request."""
         try:
-            status_info = queue_manager.get_request_status(request_id)
+            owner_key = _caller_owner_key()
+            status_info = queue_manager.get_request_status(request_id, owner_key=owner_key)
             if status_info is None:
                 return jsonify({
                     "status": "error",
@@ -158,12 +166,12 @@ def create_command_blueprint():
     @bp.route("/result/<request_id>", methods=["GET"])
     @unified_api_decorator()
     def get_request_result(request_id: str, **kwargs) -> Tuple[Union[Response, bytes], int]:
-        """Get the result of a completed request."""
+        """Get result; only the submitting API key can read its own request."""
         try:
-            result_data = queue_manager.get_request_result(request_id)
+            owner_key = _caller_owner_key()
+            result_data = queue_manager.get_request_result(request_id, owner_key=owner_key)
             if result_data is None:
-                # Check if request exists but isn't completed
-                status_info = queue_manager.get_request_status(request_id)
+                status_info = queue_manager.get_request_status(request_id, owner_key=owner_key)
                 if status_info is None:
                     return jsonify({
                         "status": "error",
@@ -186,9 +194,10 @@ def create_command_blueprint():
     @bp.route("/queue/status", methods=["GET"])
     @unified_api_decorator()
     def get_queue_status(**kwargs) -> Tuple[Response, int]:
-        """Get overall queue status information."""
+        """Get queue status, scoped to the caller's API key."""
         try:
-            queue_status = queue_manager.get_queue_status()
+            owner_key = _caller_owner_key()
+            queue_status = queue_manager.get_queue_status(owner_key=owner_key)
             return jsonify({
                 "success": True,
                 **queue_status

--- a/keepercommander/service/core/request_queue.py
+++ b/keepercommander/service/core/request_queue.py
@@ -9,6 +9,8 @@
 # Contact: ops@keepersecurity.com
 #
 
+import hashlib
+import hmac
 import queue
 import threading
 import time
@@ -20,6 +22,13 @@ from dataclasses import dataclass, asdict
 
 from ..util.command_util import CommandExecutor
 from ..decorators.logging import logger, debug_decorator
+
+
+def derive_owner_key(api_key: Optional[str]) -> Optional[str]:
+    """Return a SHA-256 hash of the api-key, or None if none provided."""
+    if not api_key:
+        return None
+    return hashlib.sha256(api_key.strip().encode('utf-8')).hexdigest()
 
 
 # Queue configuration constants
@@ -51,10 +60,13 @@ class QueuedRequest:
     status_code: Optional[int] = None  # HTTP status code from command execution
     error_message: Optional[str] = None
     temp_files: list = None  # List of temporary file paths to clean up
-    
+    # Hashed api-key of the submitter; used to scope queue reads per caller.
+    owner_key: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert request to dictionary for JSON serialization."""
         data = asdict(self)
+        data.pop("owner_key", None)
         # Convert datetime objects to ISO strings and handle bytes objects
         for key, value in data.items():
             if isinstance(value, datetime):
@@ -121,26 +133,17 @@ class RequestQueueManager:
         logger.info("Request queue worker stopped")
     
     @debug_decorator
-    def submit_request(self, command: str, temp_files: list = None) -> str:
-        """Submit a new command request to the queue.
-        
-        Args:
-            command: The command string to execute
-            temp_files: List of temporary file paths to clean up after execution
-            
-        Returns:
-            str: Unique request ID
-            
-        Raises:
-            queue.Full: If the queue is at capacity
-        """
+    def submit_request(self, command: str, temp_files: list = None,
+                       owner_key: Optional[str] = None) -> str:
+        """Submit a request; ``owner_key`` scopes who can read it back."""
         request_id = str(uuid.uuid4())
         request = QueuedRequest(
             request_id=request_id,
             command=command,
             status=RequestStatus.QUEUED,
             created_at=datetime.now(),
-            temp_files=temp_files or []
+            temp_files=temp_files or [],
+            owner_key=owner_key,
         )
         
         try:
@@ -153,71 +156,57 @@ class RequestQueueManager:
             logger.error("Error: Request queue is full")
             raise
     
+    @staticmethod
+    def _is_owner(request: QueuedRequest, owner_key: Optional[str]) -> bool:
+        # Anonymous matches anonymous; otherwise require an exact owner match.
+        if request.owner_key is None and owner_key is None:
+            return True
+        if request.owner_key is None or owner_key is None:
+            return False
+        return hmac.compare_digest(request.owner_key, owner_key)
+
     @debug_decorator
-    def get_request_status(self, request_id: str) -> Optional[Dict[str, Any]]:
-        """Get the status of a specific request.
-        
-        Args:
-            request_id: The unique request identifier
-            
-        Returns:
-            Dict containing request status and metadata, or None if not found
-        """
+    def get_request_status(self, request_id: str,
+                           owner_key: Optional[str] = None) -> Optional[Dict[str, Any]]:
+        """Return status for ``request_id`` only if owned by ``owner_key``."""
         with self.data_lock:
-            # Check active requests
-            if request_id in self.active_requests:
-                return self.active_requests[request_id].to_dict()
-                
-            # Check completed requests
-            if request_id in self.completed_requests:
-                return self.completed_requests[request_id].to_dict()
-                
-            return None
-    
+            request = self.active_requests.get(request_id) \
+                or self.completed_requests.get(request_id)
+            if request is None or not self._is_owner(request, owner_key):
+                return None
+            return request.to_dict()
+
     @debug_decorator
-    def get_request_result(self, request_id: str) -> Optional[Tuple[Any, int]]:
-        """Get the result of a completed request.
-        
-        Args:
-            request_id: The unique request identifier
-            
-        Returns:
-            Tuple of (result, status_code) or None if not found/not completed
-        """
+    def get_request_result(self, request_id: str,
+                           owner_key: Optional[str] = None) -> Optional[Tuple[Any, int]]:
+        """Return result for ``request_id`` only if owned by ``owner_key``."""
         with self.data_lock:
-            if request_id in self.completed_requests:
-                request = self.completed_requests[request_id]
-                if request.status == RequestStatus.COMPLETED:
-                    status_code = request.status_code if request.status_code is not None else 200
-                    return request.result, status_code
-                elif request.status == RequestStatus.FAILED:
-                    return {"error": request.error_message}, 500
-                elif request.status == RequestStatus.EXPIRED:
-                    return {
-                        "error": request.error_message or "Error: Request expired before execution"
-                    }, 504
+            request = self.completed_requests.get(request_id)
+            if request is None or not self._is_owner(request, owner_key):
+                return None
+            if request.status == RequestStatus.COMPLETED:
+                status_code = request.status_code if request.status_code is not None else 200
+                return request.result, status_code
+            elif request.status == RequestStatus.FAILED:
+                return {"error": request.error_message}, 500
+            elif request.status == RequestStatus.EXPIRED:
+                return {
+                    "error": request.error_message or "Error: Request expired before execution"
+                }, 504
             return None
 
     @debug_decorator
-    def wait_for_result(self, request_id: str, timeout: Optional[float] = None) -> Optional[Tuple[Any, int]]:
-        """Wait synchronously for a queued request result.
-
-        Args:
-            request_id: The unique request identifier
-            timeout: Maximum seconds to wait while the request remains queued.
-                Once processing starts, continue waiting for completion.
-
-        Returns:
-            Tuple of (result, status_code), or None if the request vanished unexpectedly.
-        """
+    def wait_for_result(self, request_id: str, timeout: Optional[float] = None,
+                        owner_key: Optional[str] = None) -> Optional[Tuple[Any, int]]:
+        """Block until the request completes; only returns to its owner."""
         deadline = time.monotonic() + (timeout if timeout is not None else self.request_timeout)
 
         while True:
-            result_data = self.get_request_result(request_id)
+            result_data = self.get_request_result(request_id, owner_key=owner_key)
             if result_data is not None:
                 return result_data
 
-            status_info = self.get_request_status(request_id)
+            status_info = self.get_request_status(request_id, owner_key=owner_key)
             if status_info is None:
                 return None
 
@@ -268,18 +257,30 @@ class RequestQueueManager:
         return True
     
     @debug_decorator
-    def get_queue_status(self) -> Dict[str, Any]:
-        """Get overall queue status information.
-        
-        Returns:
-            Dict containing queue statistics
-        """
+    def get_queue_status(self, owner_key: Optional[str] = None) -> Dict[str, Any]:
+        """Return queue status scoped to ``owner_key``."""
         with self.data_lock:
+            active_for_caller = sum(
+                1 for r in self.active_requests.values()
+                if self._is_owner(r, owner_key)
+            )
+            completed_for_caller = sum(
+                1 for r in self.completed_requests.values()
+                if self._is_owner(r, owner_key)
+            )
+
+            current_id = self.current_request_id
+            if current_id is not None:
+                current_request = self.active_requests.get(current_id) \
+                    or self.completed_requests.get(current_id)
+                if current_request is None or not self._is_owner(current_request, owner_key):
+                    current_id = None
+
             return {
                 "queue_size": self.request_queue.qsize(),
-                "active_requests": len(self.active_requests),
-                "completed_requests": len(self.completed_requests),
-                "currently_processing": self.current_request_id,
+                "active_requests": active_for_caller,
+                "completed_requests": completed_for_caller,
+                "currently_processing": current_id,
                 "worker_running": self.is_running and self.worker_thread and self.worker_thread.is_alive()
             }
     

--- a/unit-tests/service/test_api_routes.py
+++ b/unit-tests/service/test_api_routes.py
@@ -55,8 +55,8 @@ class TestServiceApiRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers.get('X-API-Legacy'), 'true')
         self.assertEqual(response.get_json(), {"status": "success", "data": {"command": "ls"}})
-        mock_submit.assert_called_once_with('ls', [])
-        mock_wait.assert_called_once_with('req-1')
+        mock_submit.assert_called_once_with('ls', [], owner_key=None)
+        mock_wait.assert_called_once_with('req-1', owner_key=None)
 
     def test_v1_direct_route_keeps_legacy_execution_path(self):
         app = Flask(__name__)


### PR DESCRIPTION
## Summary
Fixes two issues [KC-1255](https://keeper.atlassian.net/browse/KC-1255) and [KC-1258](https://keeper.atlassian.net/browse/KC-1258):

1. **Cross-API-key data exposure on the async queue.** The queue read endpoints returned data by `request_id` only, with no ownership check, letting any valid API key read another key's queued command and result. `policy_check` also bypassed authorization on GET.
2. **Command injection via line breaks.** `keeper shell` accepted command strings containing `\r`, `\n`, or `\x00`, allowing one logical command to be split into multiple shell lines.

## Changes
- Queue entries are now bound to a hashed identifier of the submitting API key. All queue read endpoints (`/status/<id>`, `/result/<id>`, `/queue/status`) are scoped to the caller; non-owners get 404.
- `keeper shell` rejects commands containing embedded control characters.

[KC-1255]: https://keeper.atlassian.net/browse/KC-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1258]: https://keeper.atlassian.net/browse/KC-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ