### PR TITLE
Fix action-report returning all active users

### DIFF
--- a/keepercommander/commands/aram.py
+++ b/keepercommander/commands/aram.py
@@ -2421,7 +2421,7 @@ class ActionReportCommand(EnterpriseCommand):
             logging.warning(f'Invalid target_user_status \'{target_status}\': value must be one of {valid_targets}')
             return
 
-        target_users = args[0]
+        target_users = get_no_action_users(*args)
         usernames = {user['username'] for user in target_users}
 
         columns_arg = kwargs.get('columns')


### PR DESCRIPTION
When running command such as `action-report -t no-logon -d 30` or `action-report -t no-update -d 30`, all active users are returned, instead of the expected users. This issue was introduced by this Commit:
https://github.com/Keeper-Security/Commander/pull/1908/changes/01429a5e0f7057a60847f118e3638d83e488d8fc