### PR TITLE
Implement Docker integration changes and add ROE flag to share-record

### DIFF
--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -87,7 +87,7 @@ expiration.add_argument('--expire-at', dest='expire_at', action='store',
 expiration.add_argument('--expire-in', dest='expire_in', action='store',
                         metavar='<NUMBER>[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]',
                         help='share expiration: never or period')
-share_record_parser.add_argument('--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
+share_record_parser.add_argument('-roe', '--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
                                  help='rotate the password when the share access expires. '
                                       'Requires --action=grant, a positive --expire-at/--expire-in '
                                       '(not "never"), and a pamUser record.')
@@ -763,25 +763,15 @@ class ShareRecordCommand(Command):
             raise CommandError('share-record', 'There are no records to share selected')
 
         if rotate_on_expiration:
-            non_pam_user_uids = []
-            for ruid in record_uids:
-                rec_cached = params.record_cache.get(ruid)
-                rec_type = ''
-                if rec_cached:
-                    data_blob = rec_cached.get('data_unencrypted')
-                    if data_blob:
-                        try:
-                            data_str = data_blob.decode() if isinstance(data_blob, (bytes, bytearray)) else data_blob
-                            rec_type = (json.loads(data_str) or {}).get('type', '') or ''
-                        except Exception:
-                            rec_type = ''
-                if rec_type.lower() != 'pamuser':
-                    non_pam_user_uids.append(ruid)
+            non_pam_user_uids = [
+                ruid for ruid in record_uids
+                if getattr(vault.KeeperRecord.load(params, ruid), 'record_type', None) != 'pamUser'
+            ]
             if non_pam_user_uids:
-                raise CommandError('share-record',
-                                   '--rotate-on-expiration is only supported for pamUser records. '
-                                   'The following record(s) are not pamUser records: '
-                                   + ', '.join(non_pam_user_uids))
+                raise CommandError(
+                    'share-record',
+                    '--rotate-on-expiration is only supported for pamUser records. '
+                    'Not pamUser: ' + ', '.join(sorted(non_pam_user_uids)))
 
         if action == 'owner' and len(emails) > 1:
             raise CommandError('share-record', 'You can transfer ownership to a single account only')
@@ -821,6 +811,17 @@ class ShareRecordCommand(Command):
                 record_uid = x.get('record_uid')
                 if record_uid:
                     not_owned_records[record_uid] = x
+
+        def apply_share_expiration(ro):   # type: (record_pb2.SharedRecord) -> None
+            if not isinstance(share_expiration, int):
+                return
+            if share_expiration > 0:
+                ro.expiration = share_expiration * 1000
+                ro.timerNotificationType = record_pb2.NOTIFY_OWNER
+                if rotate_on_expiration:
+                    ro.rotateOnExpiration = True
+            elif share_expiration < 0:
+                ro.expiration = -1
 
         rq = record_pb2.RecordShareUpdateRequest()
         existing_shares = {}
@@ -892,14 +893,7 @@ class ShareRecordCommand(Command):
                         else:
                             ro.editable = can_edit
                             ro.shareable = can_share
-                            if isinstance(share_expiration, int):
-                                if share_expiration > 0:
-                                    ro.expiration = share_expiration * 1000
-                                    ro.timerNotificationType = record_pb2.NOTIFY_OWNER
-                                    if rotate_on_expiration:
-                                        ro.rotateOnExpiration = True
-                                elif share_expiration < 0:
-                                    ro.expiration = -1
+                            apply_share_expiration(ro)
                     elif email in existing_shares:
                         current = existing_shares[email]
                         if action == 'owner':
@@ -908,6 +902,7 @@ class ShareRecordCommand(Command):
                         else:
                             ro.editable = True if can_edit else current.get('editable')
                             ro.shareable = True if can_share else current.get('shareable')
+                            apply_share_expiration(ro)
                     rq.updateSharedRecord.append(ro) if email in existing_shares else rq.addSharedRecord.append(ro)
                 else:
                     if can_share or can_edit:
@@ -946,7 +941,7 @@ class ShareRecordCommand(Command):
                             row.append(str(dt))
                         else:
                             row.append(None)
-                        row.append('Yes' if getattr(obj, 'rotateOnExpiration', False) else None)
+                        row.append('Yes' if obj.rotateOnExpiration else None)
                         table.append(row)
             dump_report_data(table, headers, row_number=True, group_by=0)
         return rq

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -87,6 +87,9 @@ expiration.add_argument('--expire-at', dest='expire_at', action='store',
 expiration.add_argument('--expire-in', dest='expire_in', action='store',
                         metavar='<NUMBER>[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]',
                         help='share expiration: never or period')
+share_record_parser.add_argument('--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
+                                 help='rotate the credential when the share access expires '
+                                      '(only valid with --expire-at/--expire-in and pamUser records)')
 share_record_parser.add_argument('record', nargs='?', type=str, action='store', help='record/shared folder path/UID')
 
 share_folder_parser = argparse.ArgumentParser(prog='share-folder', description='Change the permissions of a shared folder')
@@ -663,6 +666,16 @@ class ShareRecordCommand(Command):
         if action == 'grant':
             share_expiration = get_share_expiration(kwargs.get('expire_at'), kwargs.get('expire_in'))
 
+        rotate_on_expiration = bool(kwargs.get('rotate_on_expiration'))
+        if rotate_on_expiration:
+            if action != 'grant':
+                raise CommandError('share-record',
+                                   '--rotate-on-expiration is only valid with --action=grant')
+            if not isinstance(share_expiration, int) or share_expiration <= 0:
+                raise CommandError('share-record',
+                                   '--rotate-on-expiration requires a positive --expire-at / --expire-in '
+                                   '(cannot be "never").')
+
         record_uid = None
         folder_uid = None
         shared_folder_uid = None
@@ -747,6 +760,27 @@ class ShareRecordCommand(Command):
 
         if len(record_uids) == 0:
             raise CommandError('share-record', 'There are no records to share selected')
+
+        if rotate_on_expiration:
+            non_pam_user_uids = []
+            for ruid in record_uids:
+                rec_cached = params.record_cache.get(ruid)
+                rec_type = ''
+                if rec_cached:
+                    data_blob = rec_cached.get('data_unencrypted')
+                    if data_blob:
+                        try:
+                            data_str = data_blob.decode() if isinstance(data_blob, (bytes, bytearray)) else data_blob
+                            rec_type = (json.loads(data_str) or {}).get('type', '') or ''
+                        except Exception:
+                            rec_type = ''
+                if rec_type.lower() != 'pamuser':
+                    non_pam_user_uids.append(ruid)
+            if non_pam_user_uids:
+                raise CommandError('share-record',
+                                   '--rotate-on-expiration is only supported for pamUser records. '
+                                   'The following record(s) are not pamUser records: '
+                                   + ', '.join(non_pam_user_uids))
 
         if action == 'owner' and len(emails) > 1:
             raise CommandError('share-record', 'You can transfer ownership to a single account only')
@@ -861,6 +895,8 @@ class ShareRecordCommand(Command):
                                 if share_expiration > 0:
                                     ro.expiration = share_expiration * 1000
                                     ro.timerNotificationType = record_pb2.NOTIFY_OWNER
+                                    if rotate_on_expiration:
+                                        ro.rotateOnExpiration = True
                                 elif share_expiration < 0:
                                     ro.expiration = -1
                     elif email in existing_shares:
@@ -882,7 +918,7 @@ class ShareRecordCommand(Command):
                     else:
                         rq.removeSharedRecord.append(ro)
         if dry_run:
-            headers = ['Username', 'Record UID', 'Title', 'Share Action', 'Expiration']
+            headers = ['Username', 'Record UID', 'Title', 'Share Action', 'Expiration', 'Rotate on Expiration']
             table = []
             for attr in ['addSharedRecord', 'updateSharedRecord', 'removeSharedRecord']:
                 if hasattr(rq, attr):
@@ -909,6 +945,7 @@ class ShareRecordCommand(Command):
                             row.append(str(dt))
                         else:
                             row.append(None)
+                        row.append('Yes' if getattr(obj, 'rotateOnExpiration', False) else None)
                         table.append(row)
             dump_report_data(table, headers, row_number=True, group_by=0)
         return rq

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -88,8 +88,9 @@ expiration.add_argument('--expire-in', dest='expire_in', action='store',
                         metavar='<NUMBER>[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]',
                         help='share expiration: never or period')
 share_record_parser.add_argument('--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
-                                 help='rotate the credential when the share access expires '
-                                      '(only valid with --expire-at/--expire-in and pamUser records)')
+                                 help='rotate the password when the share access expires. '
+                                      'Requires --action=grant, a positive --expire-at/--expire-in '
+                                      '(not "never"), and a pamUser record.')
 share_record_parser.add_argument('record', nargs='?', type=str, action='store', help='record/shared folder path/UID')
 
 share_folder_parser = argparse.ArgumentParser(prog='share-folder', description='Change the permissions of a shared folder')

--- a/keepercommander/service/commands/create_service.py
+++ b/keepercommander/service/commands/create_service.py
@@ -76,7 +76,7 @@ class CreateService(Command):
         parser.add_argument('-f', '--fileformat', type=str, help='file format')
         parser.add_argument('-rm', '--run_mode', type=str, help='run mode')
         parser.add_argument('-q', '--queue_enabled', type=str, help='enable request queue (y/n)')
-        parser.add_argument('-ur', '--update-vault-record', dest='update_vault_record', type=str, help='CSMD Config record UID to update with service metadata (Docker mode)')
+        parser.add_argument('-ur', '--update-vault-record', dest='update_vault_record', type=str, help='Commander Service Mode Docker Config record UID to update with service metadata (Docker mode)')
         parser.add_argument('-rl', '--ratelimit', type=str, help='rate limit (e.g., 10/minute, 100/hour)')
         parser.add_argument('-ek', '--encryption_key', type=str, help='encryption key for response encryption (32 alphanumeric characters)')
         parser.add_argument('-te', '--token_expiration', type=str, help='API token expiration (e.g., 30m, 24h, 7d)')
@@ -92,24 +92,30 @@ class CreateService(Command):
             from ..core.globals import init_globals
             init_globals(params)
 
-            config_data = self.service_config.create_default_config()
-
             filtered_kwargs = {k: v for k, v in kwargs.items() if k in ['port', 'allowedip', 'deniedip', 'commands', 'ngrok', 'ngrok_custom_domain', 'cloudflare', 'cloudflare_custom_domain', 'certfile', 'certpassword', 'fileformat', 'run_mode', 'queue_enabled', 'update_vault_record', 'ratelimit', 'encryption', 'encryption_key', 'token_expiration']}
             args = StreamlineArgs(**filtered_kwargs)
+
+            from .integrations.vault_metadata import get_existing_api_key, write_service_metadata
+            existing_api_key = (
+                get_existing_api_key(params, args.update_vault_record)
+                if args.update_vault_record else None
+            )
+
+            config_data = self.service_config.create_default_config()
             self._handle_configuration(config_data, params, args)
-            api_key = self._create_and_save_record(config_data, params, args)
-            
+            api_key = self._create_and_save_record(config_data, params, args, existing_api_key=existing_api_key)
+
             if args.update_vault_record and api_key:
                 actual_service_url = self._get_service_url(config_data)
-                self._update_vault_record_with_metadata(params, args.update_vault_record, actual_service_url, api_key)
-            
+                write_service_metadata(params, args.update_vault_record, actual_service_url, api_key)
+
             self._upload_and_start_service(params)
 
         except ValidationError as e:
             print(f"Validation Error: {str(e)}")
         except Exception as e:
             print(f"Unexpected error: {str(e)}")
-    
+
     @debug_decorator
     def _handle_configuration(self, config_data: Dict[str, Any], params: KeeperParams, args: StreamlineArgs) -> None:       
         if args.port is not None:
@@ -120,11 +126,18 @@ class CreateService(Command):
             self.config_handler.handle_interactive_config(config_data, params)
             self.security_handler.configure_security(config_data)
     
-    def _create_and_save_record(self, config_data: Dict[str, Any], params: KeeperParams, args: StreamlineArgs) -> Optional[str]:
+    def _create_and_save_record(self, config_data: Dict[str, Any], params: KeeperParams, args: StreamlineArgs, existing_api_key: Optional[str] = None) -> Optional[str]:
         if args.port is None:
             self.config_handler._configure_run_mode(config_data)
         
-        record = self.service_config.create_record(config_data["is_advanced_security_enabled"], params, args.commands, args.token_expiration, args.update_vault_record)
+        record = self.service_config.create_record(
+            config_data["is_advanced_security_enabled"],
+            params,
+            args.commands,
+            args.token_expiration,
+            args.update_vault_record,
+            existing_api_key=existing_api_key,
+        )
         config_data["records"] = [record]
         if config_data.get("fileformat"):
             format_type = config_data["fileformat"]
@@ -162,40 +175,3 @@ class CreateService(Command):
             base_url = f"{protocol}://localhost:{port}"
         
         return f"{base_url}{api_path}"
-    
-    def _update_vault_record_with_metadata(self, params: KeeperParams, record_uid: str, service_url: str, api_key: str) -> None:
-        """Update CSMD Config vault record with service URL and API key as custom fields (Docker mode only)"""
-        try:
-            from ... import vault, record_management, api
-            
-            logger.debug(f"Updating vault record {record_uid} with service metadata...")
-            
-            # Load the CSMD Config record
-            record = vault.KeeperRecord.load(params, record_uid)
-            
-            # Add custom fields for service URL and API key
-            # service_url as URL field, api_key as secret field (hidden)
-            custom_fields = [
-                vault.TypedField.new_field('url', service_url, 'service_url'),
-                vault.TypedField.new_field('secret', api_key, 'api_key'),
-            ]
-            
-            # Preserve existing custom fields if any
-            if hasattr(record, 'custom') and record.custom:
-                # Remove old service_url and api_key fields if they exist
-                existing_fields = [f for f in record.custom if f.label not in ['service_url', 'api_key']]
-                record.custom = existing_fields + custom_fields
-            else:
-                record.custom = custom_fields
-            
-            # Update the record
-            record_management.update_record(params, record)
-            params.sync_data = True
-            api.sync_down(params)
-            
-            logger.debug(f"Successfully updated vault record with service metadata")
-            
-        except Exception as e:
-            logger.error(f"Failed to update vault record with service metadata: {e}")
-            # Don't fail the whole service-create if vault update fails
-            logger.warning(f"Could not update vault record with service metadata: {e}")

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -97,7 +97,7 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
         return f'keeper-service-{self.get_integration_name().lower()}'
 
     def get_service_commands(self) -> str:
-        return 'search,share-record,share-folder,share-report,record-add,one-time-share,epm,pedm,device-approve,get,tree,server'
+        return 'search,share-record,kd-share-record,share-folder,kd-share-folder,share-report,record-add,kd-record-add,one-time-share,epm,pedm,device-approve,get,tree,server,sync-down'
 
     # -- Parser (auto-built from name, cached per subclass) ----------
 

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -313,14 +313,14 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
                                record_uid: str, config=None) -> None:
         compose_file = os.path.join(os.getcwd(), 'docker-compose.yml')
         service_name = self.get_docker_service_name()
-
-        if os.path.exists(compose_file):
+        compose_exists = os.path.exists(compose_file)
+        if compose_exists:
             with open(compose_file, 'r') as f:
                 content = f.read()
-
             if f'{service_name}:' in content:
-                DockerSetupPrinter.print_warning(f"{service_name} service already exists in docker-compose.yml")
-                return
+                DockerSetupPrinter.print_warning(
+                    f"{service_name} service already exists in docker-compose.yml; rewriting. Hand edits will be lost."
+                )
 
         try:
             builder = DockerComposeBuilder(
@@ -340,7 +340,9 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
             with open(compose_file, 'w') as f:
                 f.write(yaml_content)
 
-            DockerSetupPrinter.print_success("docker-compose.yml updated successfully")
+            DockerSetupPrinter.print_success(
+                "docker-compose.yml regenerated successfully" if compose_exists else "docker-compose.yml created successfully"
+            )
         except Exception as e:
             raise CommandError(self.get_command_name(), f'Failed to update docker-compose.yml: {str(e)}')
 

--- a/keepercommander/service/commands/integrations/vault_metadata.py
+++ b/keepercommander/service/commands/integrations/vault_metadata.py
@@ -1,0 +1,75 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+from typing import Optional
+
+from ...decorators.logging import logger
+from ....params import KeeperParams
+
+
+SERVICE_URL_FIELD = 'service_url'
+API_KEY_FIELD = 'api_key'
+VAULT_METADATA_MAX_ATTEMPTS = 3
+_STALE_REVISION_HINTS = ('out_of_sync', 'no longer exists')
+
+
+def get_existing_api_key(params: KeeperParams, record_uid: str) -> Optional[str]:
+    try:
+        from .... import vault
+
+        record = vault.KeeperRecord.load(params, record_uid)
+        if not isinstance(record, vault.TypedRecord) or not record.custom:
+            return None
+
+        for field in record.custom:
+            if field.label == API_KEY_FIELD:
+                value = field.get_default_value()
+                if value:
+                    return value
+        return None
+    except Exception as e:
+        logger.debug(f"Could not read vault record {record_uid} to reuse API key: {e}")
+        return None
+
+
+def write_service_metadata(params: KeeperParams, record_uid: str, service_url: str, api_key: str) -> None:
+    from .... import vault, record_management, api
+
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, VAULT_METADATA_MAX_ATTEMPTS + 1):
+        try:
+            params.sync_data = True
+            api.sync_down(params)
+
+            record = vault.KeeperRecord.load(params, record_uid)
+            if not isinstance(record, vault.TypedRecord):
+                raise RuntimeError(f"Vault record {record_uid} is missing or not a typed record")
+
+            preserved = [f for f in (record.custom or []) if f.label not in (SERVICE_URL_FIELD, API_KEY_FIELD)]
+            record.custom = preserved + [
+                vault.TypedField.new_field('url', service_url, SERVICE_URL_FIELD),
+                vault.TypedField.new_field('secret', api_key, API_KEY_FIELD),
+            ]
+
+            record_management.update_record(params, record)
+            params.sync_data = True
+            api.sync_down(params)
+            return
+
+        except Exception as e:
+            last_error = e
+            is_stale = any(hint in str(e).lower() for hint in _STALE_REVISION_HINTS)
+            if not is_stale or attempt == VAULT_METADATA_MAX_ATTEMPTS:
+                break
+            logger.warning(f"Stale revision on vault record {record_uid}; retrying ({attempt}/{VAULT_METADATA_MAX_ATTEMPTS})")
+
+    logger.error(f"Failed to update vault record {record_uid}: {last_error}")

--- a/keepercommander/service/config/record_handler.py
+++ b/keepercommander/service/config/record_handler.py
@@ -11,7 +11,7 @@
 
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any
+from typing import Any, Dict, Optional
 from .cli_handler import CommandHandler
 from .config_validation import ConfigValidator
 from ..decorators.logging import logger, debug_decorator
@@ -41,26 +41,23 @@ class RecordHandler:
         return True
 
     @debug_decorator
-    def create_record(self, is_advanced_security_enabled: str, commands: str, token_expiration: str = None, record_uid: str = None) -> Dict[str, Any]:
+    def create_record(self, is_advanced_security_enabled: str, commands: str, token_expiration: Optional[str] = None, record_uid: Optional[str] = None, existing_api_key: Optional[str] = None) -> Dict[str, Any]:
         """Create a new configuration record."""
-        api_key = generate_api_key()
+        api_key = existing_api_key or generate_api_key()
         record = self._create_base_record(api_key, commands)
-        
-        # Handle token expiration - either from CLI arg (streamlined) or interactive prompt
+
         if token_expiration:
-            # Streamlined mode - use provided expiration
             self._set_expiration_from_string(record, token_expiration)
         elif is_advanced_security_enabled == "y":
-            # Interactive mode - prompt for expiration
             logger.debug("Adding expiration to record (advanced security enabled)")
             self._add_expiration_to_record(record)
-            
-        # Docker mode: redact API key and show vault record UID
+
+        verb = 'Reusing' if existing_api_key else 'Generated'
         if record_uid:
             redacted_key = f"****{api_key[-4:]}" if len(api_key) >= 4 else "****"
-            print(f'Generated API key: {redacted_key} (stored in vault record: {record_uid})')
+            print(f'{verb} API key: {redacted_key} (stored in vault record: {record_uid})')
         else:
-            print(f'Generated API key: {api_key}')
+            print(f'{verb} API key: {api_key}')
         return record
 
     def update_or_add_record(self, params: KeeperParams, title: str, config_path: Path) -> None:

--- a/keepercommander/service/config/service_config.py
+++ b/keepercommander/service/config/service_config.py
@@ -300,10 +300,10 @@ class ServiceConfig:
                 print(f"\nError: {str(e)}")
                 print("\nPlease try again with valid commands.")
 
-    def create_record(self, is_advanced_security_enabled: str, params: KeeperParams, commands: Optional[str] = None, token_expiration: str = None, record_uid: Optional[str] = None) -> Dict[str, Any]:
+    def create_record(self, is_advanced_security_enabled: str, params: KeeperParams, commands: Optional[str] = None, token_expiration: str = None, record_uid: Optional[str] = None, existing_api_key: Optional[str] = None) -> Dict[str, Any]:
         """Create a new configuration record."""
         commands = self.validate_command_list(commands, params) if commands else self._get_validated_commands(params)
-        return self.record_handler.create_record(is_advanced_security_enabled, commands, token_expiration, record_uid)
+        return self.record_handler.create_record(is_advanced_security_enabled, commands, token_expiration, record_uid, existing_api_key=existing_api_key)
 
     def update_or_add_record(self, params: KeeperParams) -> None:
         """Update existing record or add new one."""

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -138,16 +138,20 @@ class DockerSetupBase:
 
         # Create new folder
         try:
-            folder_cmd = FolderMakeCommand()
-            folder_uid = folder_cmd.execute(
-                params,
-                folder=folder_name,
-                shared_folder=True,
-                manage_users=True,
-                manage_records=True,
-                can_edit=True,
-                can_share=True
-            )
+            old_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                folder_uid = FolderMakeCommand().execute(
+                    params,
+                    folder=folder_name,
+                    shared_folder=True,
+                    manage_users=True,
+                    manage_records=True,
+                    can_edit=True,
+                    can_share=True
+                )
+            finally:
+                sys.stdout = old_stdout
             api.sync_down(params)
             DockerSetupPrinter.print_success(f"Shared folder created successfully (UID: {folder_uid})")
             return folder_uid

--- a/unit-tests/service/test_create_service.py
+++ b/unit-tests/service/test_create_service.py
@@ -72,7 +72,8 @@ class TestCreateService(unittest.TestCase):
                 self.params,
                 args.commands,
                 args.token_expiration,
-                None  # record_uid (update_vault_record is None)
+                None,  # record_uid (update_vault_record is None)
+                existing_api_key=None,
             )
             if(args.fileformat):
                 config_data["fileformat"]= args.fileformat

--- a/unit-tests/service/test_vault_metadata.py
+++ b/unit-tests/service/test_vault_metadata.py
@@ -1,0 +1,142 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from keepercommander.params import KeeperParams
+from keepercommander.service.commands.integrations.vault_metadata import (
+    API_KEY_FIELD,
+    SERVICE_URL_FIELD,
+    VAULT_METADATA_MAX_ATTEMPTS,
+    get_existing_api_key,
+    write_service_metadata,
+)
+
+
+def _make_field(label, value):
+    field = Mock()
+    field.label = label
+    field.get_default_value.return_value = value
+    return field
+
+
+def _make_typed_record(custom_fields):
+    from keepercommander import vault
+    record = Mock(spec=vault.TypedRecord)
+    record.custom = list(custom_fields)
+    return record
+
+
+class TestGetExistingApiKey(unittest.TestCase):
+    RECORD_UID = 'abc123uid'
+
+    def setUp(self):
+        self.params = Mock(spec=KeeperParams)
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_api_key_when_present(self, mock_load):
+        mock_load.return_value = _make_typed_record([
+            _make_field(SERVICE_URL_FIELD, 'https://example.com'),
+            _make_field(API_KEY_FIELD, 'prev-key-123'),
+        ])
+        self.assertEqual(get_existing_api_key(self.params, self.RECORD_UID), 'prev-key-123')
+        mock_load.assert_called_once_with(self.params, self.RECORD_UID)
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_none_when_api_key_field_missing(self, mock_load):
+        mock_load.return_value = _make_typed_record([_make_field(SERVICE_URL_FIELD, 'https://example.com')])
+        self.assertIsNone(get_existing_api_key(self.params, self.RECORD_UID))
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_none_when_api_key_value_empty(self, mock_load):
+        mock_load.return_value = _make_typed_record([_make_field(API_KEY_FIELD, '')])
+        self.assertIsNone(get_existing_api_key(self.params, self.RECORD_UID))
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_none_when_custom_is_empty(self, mock_load):
+        mock_load.return_value = _make_typed_record([])
+        self.assertIsNone(get_existing_api_key(self.params, self.RECORD_UID))
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_none_when_record_is_not_typed(self, mock_load):
+        non_typed = Mock()
+        non_typed.custom = [_make_field(API_KEY_FIELD, 'should-not-be-used')]
+        mock_load.return_value = non_typed
+        self.assertIsNone(get_existing_api_key(self.params, self.RECORD_UID))
+
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_returns_none_when_load_raises(self, mock_load):
+        mock_load.side_effect = RuntimeError("boom")
+        self.assertIsNone(get_existing_api_key(self.params, self.RECORD_UID))
+
+
+class TestWriteServiceMetadata(unittest.TestCase):
+    RECORD_UID = 'rec-uid-xyz'
+    SERVICE_URL = 'http://localhost:8900/api/v2'
+    API_KEY = 'fresh-api-key'
+
+    def setUp(self):
+        self.params = Mock(spec=KeeperParams)
+
+    @patch('keepercommander.api.sync_down')
+    @patch('keepercommander.record_management.update_record')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_success_on_first_attempt(self, mock_load, mock_update, mock_sync):
+        existing = Mock()
+        existing.label = 'unrelated'
+        record = _make_typed_record([existing])
+        mock_load.return_value = record
+
+        write_service_metadata(self.params, self.RECORD_UID, self.SERVICE_URL, self.API_KEY)
+
+        mock_update.assert_called_once_with(self.params, record)
+        self.assertEqual(mock_sync.call_count, 2)
+        labels = {f.label for f in record.custom}
+        self.assertIn(SERVICE_URL_FIELD, labels)
+        self.assertIn(API_KEY_FIELD, labels)
+        self.assertIn('unrelated', labels)
+
+    @patch('keepercommander.api.sync_down')
+    @patch('keepercommander.record_management.update_record')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_retries_on_stale_revision_then_succeeds(self, mock_load, mock_update, mock_sync):
+        mock_load.return_value = _make_typed_record([])
+        mock_update.side_effect = [Exception("RS_OUT_OF_SYNC: This object no longer exists."), None]
+
+        write_service_metadata(self.params, self.RECORD_UID, self.SERVICE_URL, self.API_KEY)
+
+        self.assertEqual(mock_update.call_count, 2)
+
+    @patch('keepercommander.api.sync_down')
+    @patch('keepercommander.record_management.update_record')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_does_not_retry_on_non_stale_error(self, mock_load, mock_update, mock_sync):
+        mock_load.return_value = _make_typed_record([])
+        mock_update.side_effect = Exception("Permission denied")
+
+        write_service_metadata(self.params, self.RECORD_UID, self.SERVICE_URL, self.API_KEY)
+
+        self.assertEqual(mock_update.call_count, 1)
+
+    @patch('keepercommander.api.sync_down')
+    @patch('keepercommander.record_management.update_record')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_gives_up_after_max_attempts(self, mock_load, mock_update, mock_sync):
+        mock_load.return_value = _make_typed_record([])
+        mock_update.side_effect = Exception("RS_OUT_OF_SYNC")
+
+        write_service_metadata(self.params, self.RECORD_UID, self.SERVICE_URL, self.API_KEY)
+
+        self.assertEqual(mock_update.call_count, VAULT_METADATA_MAX_ATTEMPTS)
+
+    @patch('keepercommander.api.sync_down')
+    @patch('keepercommander.record_management.update_record')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    def test_does_not_update_when_record_missing(self, mock_load, mock_update, mock_sync):
+        mock_load.return_value = None
+
+        write_service_metadata(self.params, self.RECORD_UID, self.SERVICE_URL, self.API_KEY)
+
+        mock_update.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/test_command_register.py
+++ b/unit-tests/test_command_register.py
@@ -1,7 +1,9 @@
+import json
 from unittest import TestCase, mock
 
 from data_vault import get_synced_params, VaultEnvironment
 from keepercommander.commands import register
+from keepercommander.error import CommandError
 from keepercommander.proto import APIRequest_pb2, record_pb2
 from keepercommander import utils
 
@@ -62,6 +64,132 @@ class TestRegister(TestCase):
         TestRegister.expected_commands.extend(['records_share_update'])
         cmd.execute(params, email=['user2@keepersecurity.com'], action='revoke', record=record_uid)
         self.assertEqual(len(TestRegister.expected_commands), 0)
+
+    def _mark_record_as_pam_user(self, params, record_uid):
+        rec = params.record_cache[record_uid]
+        try:
+            existing = rec.get('data_unencrypted')
+            data = json.loads(existing.decode() if isinstance(existing, (bytes, bytearray)) else (existing or '{}'))
+        except Exception:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data['type'] = 'pamUser'
+        rec['data_unencrypted'] = json.dumps(data).encode()
+
+    def test_share_record_rotate_on_expiration_sets_flag(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        self._mark_record_as_pam_user(params, record_uid)
+
+        captured = {}
+
+        def capture_record_share(rq):
+            status = record_pb2.SharedRecordStatus()
+            status.recordUid = rq.recordUid
+            status.status = 'success'
+            status.username = rq.toUsername
+            captured.setdefault('rqs', []).append(rq)
+            return status
+
+        original = TestRegister.record_share_rq_rs
+        TestRegister.record_share_rq_rs = staticmethod(capture_record_share)
+        try:
+            self.record_share_mock = mock.patch('keepercommander.api.get_record_shares').start()
+            self.record_share_mock.side_effect = lambda *_args, **_kw: None
+
+            cmd = register.ShareRecordCommand()
+            TestRegister.expected_commands.extend(['records_share_update'])
+            cmd.execute(params,
+                        email=['user2@keepersecurity.com'],
+                        action='grant',
+                        can_share=False,
+                        can_edit=True,
+                        record=record_uid,
+                        expire_in='1d',
+                        rotate_on_expiration=True)
+            self.assertEqual(len(TestRegister.expected_commands), 0)
+            rqs = captured.get('rqs', [])
+            self.assertTrue(rqs, 'Expected at least one SharedRecord on the wire')
+            # The new add/update entry must carry the rotateOnExpiration bit and a positive expiration.
+            target = next((r for r in rqs if r.toUsername == 'user2@keepersecurity.com'), None)
+            self.assertIsNotNone(target, 'Expected SharedRecord for the target email')
+            self.assertTrue(target.rotateOnExpiration,
+                            'rotateOnExpiration should be set when --rotate-on-expiration is passed')
+            self.assertGreater(target.expiration, 0)
+            self.assertEqual(target.timerNotificationType, record_pb2.NOTIFY_OWNER)
+        finally:
+            TestRegister.record_share_rq_rs = original
+
+    def test_share_record_rotate_on_expiration_requires_expiration(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        self._mark_record_as_pam_user(params, record_uid)
+
+        cmd = register.ShareRecordCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.prep_request(params, dict(
+                email=['user2@keepersecurity.com'],
+                action='grant',
+                can_share=False,
+                can_edit=False,
+                record=record_uid,
+                rotate_on_expiration=True,
+            ))
+        self.assertIn('--rotate-on-expiration', str(ctx.exception))
+
+    def test_share_record_rotate_on_expiration_rejects_never(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        self._mark_record_as_pam_user(params, record_uid)
+
+        cmd = register.ShareRecordCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.prep_request(params, dict(
+                email=['user2@keepersecurity.com'],
+                action='grant',
+                record=record_uid,
+                expire_at='never',
+                rotate_on_expiration=True,
+            ))
+        self.assertIn('--rotate-on-expiration', str(ctx.exception))
+
+    def test_share_record_rotate_on_expiration_rejects_non_pam_user(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        # Intentionally do NOT mark as pamUser; keep the fixture's default type.
+        cmd = register.ShareRecordCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.prep_request(params, dict(
+                email=['user2@keepersecurity.com'],
+                action='grant',
+                record=record_uid,
+                expire_in='1d',
+                rotate_on_expiration=True,
+            ))
+        self.assertIn('pamUser', str(ctx.exception))
+
+    def test_share_record_rotate_on_expiration_rejects_non_grant_action(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        self._mark_record_as_pam_user(params, record_uid)
+
+        cmd = register.ShareRecordCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.prep_request(params, dict(
+                email=['user2@keepersecurity.com'],
+                action='revoke',
+                record=record_uid,
+                expire_in='1d',
+                rotate_on_expiration=True,
+            ))
+        self.assertIn('--rotate-on-expiration', str(ctx.exception))
+
+    def test_share_record_parser_accepts_rotate_on_expiration(self):
+        ns = register.share_record_parser.parse_args(
+            ['-e', 'user2@example.com', '--expire-in', '1d', '--rotate-on-expiration', 'rec-uid'])
+        self.assertTrue(ns.rotate_on_expiration)
+        self.assertEqual(ns.expire_in, '1d')
 
     def test_share_folder(self):
         params = get_synced_params()

--- a/unit-tests/test_command_register.py
+++ b/unit-tests/test_command_register.py
@@ -1,4 +1,3 @@
-import json
 from unittest import TestCase, mock
 
 from data_vault import get_synced_params, VaultEnvironment
@@ -65,38 +64,118 @@ class TestRegister(TestCase):
         cmd.execute(params, email=['user2@keepersecurity.com'], action='revoke', record=record_uid)
         self.assertEqual(len(TestRegister.expected_commands), 0)
 
-    def _mark_record_as_pam_user(self, params, record_uid):
-        rec = params.record_cache[record_uid]
-        try:
-            existing = rec.get('data_unencrypted')
-            data = json.loads(existing.decode() if isinstance(existing, (bytes, bytearray)) else (existing or '{}'))
-        except Exception:
-            data = {}
-        if not isinstance(data, dict):
-            data = {}
-        data['type'] = 'pamUser'
-        rec['data_unencrypted'] = json.dumps(data).encode()
+    def _patch_record_type_as_pam_user(self, target_uid):
+        """Patch vault.KeeperRecord.load so the given record reports record_type='pamUser'."""
+        from keepercommander import vault
+        real_load = vault.KeeperRecord.load
 
-    def test_share_record_rotate_on_expiration_sets_flag(self):
-        params = get_synced_params()
-        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
-        self._mark_record_as_pam_user(params, record_uid)
+        def fake_load(params, record_uid, *args, **kwargs):
+            loaded = real_load(params, record_uid, *args, **kwargs)
+            if record_uid == target_uid and loaded is not None:
+                loaded.get_record_type = lambda: 'pamUser'
+            return loaded
 
-        captured = {}
+        return mock.patch.object(vault.KeeperRecord, 'load', side_effect=fake_load)
 
-        def capture_record_share(rq):
+    def _capture_shared_record_requests(self):
+        """Patch the response-builder so we can assert on outbound SharedRecord protos."""
+        captured = []
+
+        def capture(rq):
             status = record_pb2.SharedRecordStatus()
             status.recordUid = rq.recordUid
             status.status = 'success'
             status.username = rq.toUsername
-            captured.setdefault('rqs', []).append(rq)
+            captured.append(rq)
             return status
 
         original = TestRegister.record_share_rq_rs
-        TestRegister.record_share_rq_rs = staticmethod(capture_record_share)
+        TestRegister.record_share_rq_rs = staticmethod(capture)
+        return captured, original
+
+    @staticmethod
+    def _existing_share_response(target_email, *, editable=False, shareable=False):
+        def _impl(params, record_uids, *_args, **_kw):
+            return [{
+                'record_uid': next(iter(record_uids)),
+                'shares': {
+                    'user_permissions': [
+                        {'username': params.user, 'owner': True},
+                        {'username': target_email, 'owner': False,
+                         'shareable': shareable, 'editable': editable},
+                    ]
+                }
+            }]
+        return _impl
+
+    def test_share_record_rotate_on_expiration_sets_flag(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+
+        captured, original = self._capture_shared_record_requests()
         try:
-            self.record_share_mock = mock.patch('keepercommander.api.get_record_shares').start()
-            self.record_share_mock.side_effect = lambda *_args, **_kw: None
+            mock.patch('keepercommander.api.get_record_shares',
+                       side_effect=lambda *_args, **_kw: None).start()
+
+            cmd = register.ShareRecordCommand()
+            TestRegister.expected_commands.extend(['records_share_update'])
+            with self._patch_record_type_as_pam_user(record_uid):
+                cmd.execute(params,
+                            email=['user2@keepersecurity.com'],
+                            action='grant',
+                            can_share=False,
+                            can_edit=True,
+                            record=record_uid,
+                            expire_in='1d',
+                            rotate_on_expiration=True)
+            self.assertEqual(len(TestRegister.expected_commands), 0)
+            target = next((r for r in captured if r.toUsername == 'user2@keepersecurity.com'), None)
+            self.assertIsNotNone(target)
+            self.assertTrue(target.rotateOnExpiration)
+            self.assertGreater(target.expiration, 0)
+            self.assertEqual(target.timerNotificationType, record_pb2.NOTIFY_OWNER)
+        finally:
+            TestRegister.record_share_rq_rs = original
+
+    def test_share_record_rotate_on_expiration_sets_flag_on_existing_share(self):
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+
+        captured, original = self._capture_shared_record_requests()
+        try:
+            mock.patch('keepercommander.api.get_record_shares',
+                       side_effect=self._existing_share_response('user2@keepersecurity.com')).start()
+
+            cmd = register.ShareRecordCommand()
+            TestRegister.expected_commands.extend(['records_share_update'])
+            with self._patch_record_type_as_pam_user(record_uid):
+                cmd.execute(params,
+                            email=['user2@keepersecurity.com'],
+                            action='grant',
+                            can_share=False,
+                            can_edit=False,
+                            record=record_uid,
+                            expire_in='1d',
+                            rotate_on_expiration=True)
+            self.assertEqual(len(TestRegister.expected_commands), 0)
+            target = next((r for r in captured if r.toUsername == 'user2@keepersecurity.com'), None)
+            self.assertIsNotNone(target)
+            self.assertTrue(target.rotateOnExpiration,
+                            'rotateOnExpiration must travel on update path, not just add path')
+            self.assertGreater(target.expiration, 0)
+            self.assertEqual(target.timerNotificationType, record_pb2.NOTIFY_OWNER)
+        finally:
+            TestRegister.record_share_rq_rs = original
+
+    def test_share_record_update_expiration_without_roe(self):
+        """Existing share must accept --expire-in updates, matching Vault UX."""
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+
+        captured, original = self._capture_shared_record_requests()
+        try:
+            mock.patch('keepercommander.api.get_record_shares',
+                       side_effect=self._existing_share_response('user2@keepersecurity.com', editable=True)).start()
 
             cmd = register.ShareRecordCommand()
             TestRegister.expected_commands.extend(['records_share_update'])
@@ -104,27 +183,46 @@ class TestRegister(TestCase):
                         email=['user2@keepersecurity.com'],
                         action='grant',
                         can_share=False,
-                        can_edit=True,
+                        can_edit=False,
                         record=record_uid,
-                        expire_in='1d',
-                        rotate_on_expiration=True)
-            self.assertEqual(len(TestRegister.expected_commands), 0)
-            rqs = captured.get('rqs', [])
-            self.assertTrue(rqs, 'Expected at least one SharedRecord on the wire')
-            # The new add/update entry must carry the rotateOnExpiration bit and a positive expiration.
-            target = next((r for r in rqs if r.toUsername == 'user2@keepersecurity.com'), None)
-            self.assertIsNotNone(target, 'Expected SharedRecord for the target email')
-            self.assertTrue(target.rotateOnExpiration,
-                            'rotateOnExpiration should be set when --rotate-on-expiration is passed')
+                        expire_in='1d')
+            target = next((r for r in captured if r.toUsername == 'user2@keepersecurity.com'), None)
+            self.assertIsNotNone(target)
             self.assertGreater(target.expiration, 0)
             self.assertEqual(target.timerNotificationType, record_pb2.NOTIFY_OWNER)
+            self.assertFalse(target.rotateOnExpiration)
+        finally:
+            TestRegister.record_share_rq_rs = original
+
+    def test_share_record_update_clears_expiration_with_never(self):
+        """--expire-at never on an existing share must clear the timer (expiration = -1)."""
+        params = get_synced_params()
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+
+        captured, original = self._capture_shared_record_requests()
+        try:
+            mock.patch('keepercommander.api.get_record_shares',
+                       side_effect=self._existing_share_response('user2@keepersecurity.com', editable=True)).start()
+
+            cmd = register.ShareRecordCommand()
+            TestRegister.expected_commands.extend(['records_share_update'])
+            cmd.execute(params,
+                        email=['user2@keepersecurity.com'],
+                        action='grant',
+                        can_share=False,
+                        can_edit=False,
+                        record=record_uid,
+                        expire_at='never')
+            target = next((r for r in captured if r.toUsername == 'user2@keepersecurity.com'), None)
+            self.assertIsNotNone(target)
+            self.assertEqual(target.expiration, -1)
+            self.assertFalse(target.rotateOnExpiration)
         finally:
             TestRegister.record_share_rq_rs = original
 
     def test_share_record_rotate_on_expiration_requires_expiration(self):
         params = get_synced_params()
         record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
-        self._mark_record_as_pam_user(params, record_uid)
 
         cmd = register.ShareRecordCommand()
         with self.assertRaises(CommandError) as ctx:
@@ -141,7 +239,6 @@ class TestRegister(TestCase):
     def test_share_record_rotate_on_expiration_rejects_never(self):
         params = get_synced_params()
         record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
-        self._mark_record_as_pam_user(params, record_uid)
 
         cmd = register.ShareRecordCommand()
         with self.assertRaises(CommandError) as ctx:
@@ -172,7 +269,6 @@ class TestRegister(TestCase):
     def test_share_record_rotate_on_expiration_rejects_non_grant_action(self):
         params = get_synced_params()
         record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
-        self._mark_record_as_pam_user(params, record_uid)
 
         cmd = register.ShareRecordCommand()
         with self.assertRaises(CommandError) as ctx:
@@ -184,12 +280,6 @@ class TestRegister(TestCase):
                 rotate_on_expiration=True,
             ))
         self.assertIn('--rotate-on-expiration', str(ctx.exception))
-
-    def test_share_record_parser_accepts_rotate_on_expiration(self):
-        ns = register.share_record_parser.parse_args(
-            ['-e', 'user2@example.com', '--expire-in', '1d', '--rotate-on-expiration', 'rec-uid'])
-        self.assertTrue(ns.rotate_on_expiration)
-        self.assertEqual(ns.expire_in, '1d')
 
     def test_share_folder(self):
         params = get_synced_params()


### PR DESCRIPTION
## Summary

1. `share-folder --rotate-on-expiration` flag so a share automatically rotates the share key when its expiration is hit.
2. Service-mode (slack-app / teams-app / docker) now preserves its API key across `docker compose down`/`up`, plus a few smaller fixes around the same setup flow.

## Changes

**share-folder**
- Add `--rotate-on-expiration` flag (and help text).
- Tests for the new behavior.

**Service mode — Docker / Slack-App / Teams-App**
- Reuse the API key from the deployment's Docker Config vault record on restart instead of generating a new one. Falls back to a fresh key on first run.
- Extract the read/write helpers for that record into a small `vault_metadata` module with bounded-retry write to defend against a race with the background config monitor.
- `*-app-setup` now regenerates `docker-compose.yml` on re-run so new UIDs and KSM config land (hand edits not preserved; a warning is printed).
- Suppress stray JSON output from the underlying folder-create command during interactive setup.
- Unit tests for the new helpers.