### PR TITLE
Add share-folder -roe and list-sf --roe-eligible flags

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -165,6 +165,9 @@ list_parser.add_argument('pattern', nargs='?', type=str, action='store', help='s
 
 
 list_sf_parser = argparse.ArgumentParser(prog='list-sf', description='List all shared folders', parents=[base.report_output_parser])
+list_sf_parser.add_argument('--roe-eligible', dest='roe_eligible', action='store_true',
+                            help='only list shared folders eligible for --rotate-on-expiration '
+                                 '(contain at least one pamUser record with rotation configured)')
 list_sf_parser.add_argument('pattern', nargs='?', type=str, action='store', help='search pattern')
 
 
@@ -1766,6 +1769,9 @@ class RecordListSfCommand(Command):
         fmt = kwargs.get('format', 'table')
         pattern = kwargs['pattern'] if 'pattern' in kwargs else None
         results = api.search_shared_folders(params, pattern or '')
+        if kwargs.get('roe_eligible'):
+            results = [sf for sf in results
+                       if vault_extensions.shared_folder_has_pam_user_with_rotation(params, sf.shared_folder_uid)]
         if any(results):
             table = []
             headers = ['shared_folder_uid', 'name'] if fmt == 'json' else ['Shared Folder UID', 'Name']

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -585,8 +585,10 @@ class ShareFolderCommand(Command):
                         rq.sharedFolderRemoveRecord.append(ro.recordUid)
                 else:
                     if action == 'grant':
-                        ro.canEdit = curr_sf.get('default_can_edit') is True if ce is None else folder_pb2.BOOLEAN_TRUE if ce == 'on' else folder_pb2.BOOLEAN_FALSE
-                        ro.canShare = curr_sf.get('default_can_share') is True if cs is None else folder_pb2.BOOLEAN_TRUE if cs == 'on' else folder_pb2.BOOLEAN_FALSE
+                        default_ce = folder_pb2.BOOLEAN_TRUE if curr_sf.get('default_can_edit') is True else folder_pb2.BOOLEAN_FALSE
+                        default_cs = folder_pb2.BOOLEAN_TRUE if curr_sf.get('default_can_share') is True else folder_pb2.BOOLEAN_FALSE
+                        ro.canEdit = default_ce if ce is None else folder_pb2.BOOLEAN_TRUE if ce == 'on' else folder_pb2.BOOLEAN_FALSE
+                        ro.canShare = default_cs if cs is None else folder_pb2.BOOLEAN_TRUE if cs == 'on' else folder_pb2.BOOLEAN_FALSE
                         sf_key = curr_sf.get('shared_folder_key_unencrypted')
                         if sf_key:
                             rec = params.record_cache[record_uid]

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -32,7 +32,7 @@ from .helpers.record import get_record_uids
 from .helpers.timeout import parse_timeout
 from .record import RecordRemoveCommand
 from .utils import SyncDownCommand
-from .. import api, utils, crypto, constants, rest_api, vault
+from .. import api, utils, crypto, constants, rest_api, vault, vault_extensions
 from ..display import bcolors
 from ..error import KeeperApiError, CommandError, Error
 from ..loginv3 import LoginV3API
@@ -89,8 +89,8 @@ expiration.add_argument('--expire-in', dest='expire_in', action='store',
                         help='share expiration: never or period')
 share_record_parser.add_argument('-roe', '--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
                                  help='rotate the password when the share access expires. '
-                                      'Requires --action=grant, a positive --expire-at/--expire-in '
-                                      '(not "never"), and a pamUser record.')
+                                      'Only valid on grant; requires a positive --expire-at/--expire-in '
+                                      '(not "never") and a pamUser record with rotation configured.')
 share_record_parser.add_argument('record', nargs='?', type=str, action='store', help='record/shared folder path/UID')
 
 share_folder_parser = argparse.ArgumentParser(prog='share-folder', description='Change the permissions of a shared folder')
@@ -118,6 +118,11 @@ expiration.add_argument('--expire-at', dest='expire_at', action='store', metavar
                         help='share expiration: never or ISO datetime (yyyy-MM-dd[ hh:mm:ss])')
 expiration.add_argument('--expire-in', dest='expire_in', action='store', metavar='PERIOD',
                         help='share expiration: never or period (<NUMBER>[(y)ears|(mo)nths|(d)ays|(h)ours(mi)nutes]')
+share_folder_parser.add_argument('-roe', '--rotate-on-expiration', dest='rotate_on_expiration', action='store_true',
+                                 help='rotate the password when the share access expires. '
+                                      'Only valid on grant; requires a positive --expire-at/--expire-in '
+                                      '(not "never") and at least one pamUser record with rotation '
+                                      'configured in the folder.')
 share_folder_parser.add_argument('folder', nargs='+', type=str, action='store', help='shared folder path or UID')
 
 share_report_parser = argparse.ArgumentParser(prog='share-report', description='Generates a report of shared records',
@@ -307,6 +312,25 @@ class ShareFolderCommand(Command):
         if action == 'grant':
             share_expiration = get_share_expiration(kwargs.get('expire_at'), kwargs.get('expire_in'))
 
+        rotate_on_expiration = bool(kwargs.get('rotate_on_expiration'))
+        if rotate_on_expiration:
+            if action != 'grant':
+                raise CommandError('share-folder',
+                                   '--rotate-on-expiration is only valid when granting access')
+            if not isinstance(share_expiration, int) or share_expiration <= 0:
+                raise CommandError('share-folder',
+                                   '--rotate-on-expiration requires a positive --expire-at / --expire-in '
+                                   '(cannot be "never").')
+            ineligible_folders = [
+                uid for uid in shared_folder_uids
+                if not vault_extensions.shared_folder_has_pam_user_with_rotation(params, uid)
+            ]
+            if ineligible_folders:
+                raise CommandError(
+                    'share-folder',
+                    '--rotate-on-expiration requires the folder to contain at least one pamUser record '
+                    'with rotation configured. Ineligible folder(s): ' + ', '.join(sorted(ineligible_folders)))
+
         as_users = set()
         as_teams = set()
 
@@ -368,7 +392,8 @@ class ShareFolderCommand(Command):
 
         def prep_rq(recs, users, curr_sf):
             return self.prepare_request(params, kwargs, curr_sf, users, sf_teams, recs, default_record=default_record,
-                                        default_account=default_account, share_expiration=share_expiration)
+                                        default_account=default_account, share_expiration=share_expiration,
+                                        rotate_on_expiration=rotate_on_expiration)
 
         for sf_uid in shared_folder_uids:
             sf_users = as_users.copy()
@@ -419,7 +444,7 @@ class ShareFolderCommand(Command):
     @staticmethod
     def prepare_request(params, kwargs, curr_sf, users, teams, rec_uids, *,
                         default_record=False, default_account=False,
-                        share_expiration=None):
+                        share_expiration=None, rotate_on_expiration=False):
         rq = folder_pb2.SharedFolderUpdateV3Request()
         rq.sharedFolderUid = utils.base64_url_decode(curr_sf['shared_folder_uid'])
         if 'revision' in curr_sf:
@@ -429,6 +454,19 @@ class ShareFolderCommand(Command):
         action = kwargs.get('action') or 'grant'
         mr = kwargs.get('manage_records')
         mu = kwargs.get('manage_users')
+
+        def apply_share_expiration(target):
+            """Set expiration / timer / rotateOnExpiration on a User/Team/Record update proto."""
+            if not isinstance(share_expiration, int):
+                return
+            if share_expiration > 0:
+                target.expiration = share_expiration * 1000
+                target.timerNotificationType = record_pb2.NOTIFY_OWNER
+                if rotate_on_expiration:
+                    target.rotateOnExpiration = True
+            elif share_expiration < 0:
+                target.expiration = -1
+
         if default_account and action == 'grant':
             if mr is not None:
                 rq.defaultManageRecords = folder_pb2.BOOLEAN_TRUE if mr == 'on' else folder_pb2.BOOLEAN_FALSE
@@ -444,12 +482,7 @@ class ShareFolderCommand(Command):
             for email in users:
                 uo = folder_pb2.SharedFolderUpdateUser()
                 uo.username = email
-                if isinstance(share_expiration, int):
-                    if share_expiration > 0:
-                        uo.expiration = share_expiration * 1000
-                        uo.timerNotificationType = record_pb2.NOTIFY_OWNER
-                    elif share_expiration < 0:
-                        uo.expiration = -1
+                apply_share_expiration(uo)
                 if email in existing_users:
                     if action == 'grant':
                         uo.manageRecords = folder_pb2.BOOLEAN_NO_CHANGE if mr is None else folder_pb2.BOOLEAN_TRUE if mr == 'on' else folder_pb2.BOOLEAN_FALSE
@@ -489,12 +522,7 @@ class ShareFolderCommand(Command):
             for team_uid in teams:
                 to = folder_pb2.SharedFolderUpdateTeam()
                 to.teamUid = utils.base64_url_decode(team_uid)
-                if isinstance(share_expiration, int):
-                    if share_expiration > 0:
-                        to.expiration = share_expiration * 1000
-                        to.timerNotificationType = record_pb2.NOTIFY_OWNER
-                    elif share_expiration < 0:
-                        to.expiration = -1
+                apply_share_expiration(to)
                 if team_uid in existing_teams:
                     team = existing_teams[team_uid]
                     if action == 'grant':
@@ -546,12 +574,7 @@ class ShareFolderCommand(Command):
             for record_uid in rec_uids:
                 ro = folder_pb2.SharedFolderUpdateRecord()
                 ro.recordUid = utils.base64_url_decode(record_uid)
-                if isinstance(share_expiration, int):
-                    if share_expiration > 0:
-                        ro.expiration = share_expiration * 1000
-                        ro.timerNotificationType = record_pb2.NOTIFY_OWNER
-                    elif share_expiration < 0:
-                        ro.expiration = -1
+                apply_share_expiration(ro)
 
                 if record_uid in existing_records:
                     if action == 'grant':
@@ -671,7 +694,7 @@ class ShareRecordCommand(Command):
         if rotate_on_expiration:
             if action != 'grant':
                 raise CommandError('share-record',
-                                   '--rotate-on-expiration is only valid with --action=grant')
+                                   '--rotate-on-expiration is only valid when granting access')
             if not isinstance(share_expiration, int) or share_expiration <= 0:
                 raise CommandError('share-record',
                                    '--rotate-on-expiration requires a positive --expire-at / --expire-in '
@@ -763,15 +786,16 @@ class ShareRecordCommand(Command):
             raise CommandError('share-record', 'There are no records to share selected')
 
         if rotate_on_expiration:
-            non_pam_user_uids = [
+            ineligible_record_uids = [
                 ruid for ruid in record_uids
                 if getattr(vault.KeeperRecord.load(params, ruid), 'record_type', None) != 'pamUser'
+                or not vault_extensions.record_has_rotation_configured(params, ruid)
             ]
-            if non_pam_user_uids:
+            if ineligible_record_uids:
                 raise CommandError(
                     'share-record',
-                    '--rotate-on-expiration is only supported for pamUser records. '
-                    'Not pamUser: ' + ', '.join(sorted(non_pam_user_uids)))
+                    '--rotate-on-expiration requires a pamUser record with rotation configured. '
+                    'Ineligible record(s): ' + ', '.join(sorted(ineligible_record_uids)))
 
         if action == 'owner' and len(emails) > 1:
             raise CommandError('share-record', 'You can transfer ownership to a single account only')

--- a/keepercommander/vault_extensions.py
+++ b/keepercommander/vault_extensions.py
@@ -119,6 +119,31 @@ def matches_record(record, pattern, search_fields=None):    # type: (vault.Keepe
     return False
 
 
+def record_has_rotation_configured(params, record_uid):
+    # type: (KeeperParams, str) -> bool
+    """Return True if the record has a rotation configuration set up."""
+    return record_uid in (params.record_rotation_cache or {})
+
+
+def shared_folder_has_pam_user_with_rotation(params, shared_folder_uid):
+    # type: (KeeperParams, str) -> bool
+    """Return True if the shared folder contains at least one pamUser record with rotation configured.
+
+    Required precondition for the server to accept --rotate-on-expiration on a folder share.
+    """
+    sf = params.shared_folder_cache.get(shared_folder_uid)
+    if not sf:
+        return False
+    for r in sf.get('records', []):
+        record_uid = r['record_uid']
+        record = vault.KeeperRecord.load(params, record_uid)
+        if (record is not None
+                and record.record_type == 'pamUser'
+                and record_has_rotation_configured(params, record_uid)):
+            return True
+    return False
+
+
 def find_records(params,                   # type: KeeperParams
                  search_str=None,          # type: Optional[str]
                  record_type=None,         # type: Union[str, Iterable[str], None]

--- a/unit-tests/test_command_record.py
+++ b/unit-tests/test_command_record.py
@@ -177,6 +177,21 @@ class TestRecord(TestCase):
             cmd.execute(params, pattern='INVALID')
             mock_print.assert_not_called()
 
+    def test_shared_list_filters_by_roe_eligible(self):
+        params = get_synced_params()
+        cmd = record.RecordListSfCommand()
+
+        with mock.patch('builtins.print') as mock_print:
+            cmd.execute(params, roe_eligible=True)
+            mock_print.assert_not_called()
+
+        with mock.patch(
+                'keepercommander.vault_extensions.shared_folder_has_pam_user_with_rotation',
+                return_value=True):
+            with mock.patch('builtins.print') as mock_print:
+                cmd.execute(params, roe_eligible=True)
+                mock_print.assert_called()
+
     def test_team_list_command(self):
         params = get_synced_params()
         cmd = record.RecordListTeamCommand()

--- a/unit-tests/test_command_register.py
+++ b/unit-tests/test_command_register.py
@@ -1,3 +1,5 @@
+import datetime
+from contextlib import contextmanager
 from unittest import TestCase, mock
 
 from data_vault import get_synced_params, VaultEnvironment
@@ -64,18 +66,21 @@ class TestRegister(TestCase):
         cmd.execute(params, email=['user2@keepersecurity.com'], action='revoke', record=record_uid)
         self.assertEqual(len(TestRegister.expected_commands), 0)
 
-    def _patch_record_type_as_pam_user(self, target_uid):
-        """Patch vault.KeeperRecord.load so the given record reports record_type='pamUser'."""
+    @contextmanager
+    def _make_record_rotation_eligible(self, params, target_uid):
+        """Present the record as a pamUser with rotation configured (ROE-eligible)."""
         from keepercommander import vault
+        params.record_rotation_cache[target_uid] = {'record_uid': target_uid, 'revision': 1}
         real_load = vault.KeeperRecord.load
 
-        def fake_load(params, record_uid, *args, **kwargs):
-            loaded = real_load(params, record_uid, *args, **kwargs)
-            if record_uid == target_uid and loaded is not None:
+        def fake_load(p, uid, *args, **kwargs):
+            loaded = real_load(p, uid, *args, **kwargs)
+            if uid == target_uid and loaded is not None:
                 loaded.get_record_type = lambda: 'pamUser'
             return loaded
 
-        return mock.patch.object(vault.KeeperRecord, 'load', side_effect=fake_load)
+        with mock.patch.object(vault.KeeperRecord, 'load', side_effect=fake_load):
+            yield
 
     def _capture_shared_record_requests(self):
         """Patch the response-builder so we can assert on outbound SharedRecord protos."""
@@ -119,7 +124,7 @@ class TestRegister(TestCase):
 
             cmd = register.ShareRecordCommand()
             TestRegister.expected_commands.extend(['records_share_update'])
-            with self._patch_record_type_as_pam_user(record_uid):
+            with self._make_record_rotation_eligible(params, record_uid):
                 cmd.execute(params,
                             email=['user2@keepersecurity.com'],
                             action='grant',
@@ -148,7 +153,7 @@ class TestRegister(TestCase):
 
             cmd = register.ShareRecordCommand()
             TestRegister.expected_commands.extend(['records_share_update'])
-            with self._patch_record_type_as_pam_user(record_uid):
+            with self._make_record_rotation_eligible(params, record_uid):
                 cmd.execute(params,
                             email=['user2@keepersecurity.com'],
                             action='grant',
@@ -293,6 +298,55 @@ class TestRegister(TestCase):
         TestRegister.expected_commands.extend(['shared_folder_update_v3'])
         cmd.execute(params, action='revoke', user=['user2@keepersecurity.com'], folder=shared_folder_uid)
         self.assertEqual(len(TestRegister.expected_commands), 0)
+
+    def test_share_folder_prepare_request_sets_rotate_on_expiration(self):
+        """SharedFolderUpdateUser/Team/Record all carry rotateOnExpiration when -roe is on."""
+        params = get_synced_params()
+        shared_folder_uid = next(iter(params.shared_folder_cache.keys()))
+        record_uid = next(iter([x['record_uid'] for x in params.meta_data_cache.values() if x['can_share']]))
+        team_uid = utils.base64_url_encode(b'a' * 16)
+
+        curr_sf = dict(params.shared_folder_cache[shared_folder_uid])
+        curr_sf.setdefault('users', [])
+        curr_sf['teams'] = [{'team_uid': team_uid, 'manage_records': True, 'manage_users': True}]
+        curr_sf.setdefault('records', [])
+
+        future_ts = int(datetime.datetime.now().timestamp()) + 86_400
+
+        params.key_cache['user2@keepersecurity.com'] = mock.MagicMock(
+            rsa=utils.base64_url_decode(vault_env.encoded_public_key), ec=None)
+
+        rq = register.ShareFolderCommand.prepare_request(
+            params,
+            kwargs={'action': 'grant'},
+            curr_sf=curr_sf,
+            users=['user2@keepersecurity.com'],
+            teams=[team_uid],
+            rec_uids=[record_uid],
+            share_expiration=future_ts,
+            rotate_on_expiration=True,
+        )
+
+        user_msgs = list(rq.sharedFolderAddUser) + list(rq.sharedFolderUpdateUser)
+        team_msgs = list(rq.sharedFolderAddTeam) + list(rq.sharedFolderUpdateTeam)
+        record_msgs = list(rq.sharedFolderAddRecord) + list(rq.sharedFolderUpdateRecord)
+
+        for msgs, label in [(user_msgs, 'user'), (team_msgs, 'team'), (record_msgs, 'record')]:
+            self.assertTrue(msgs, f'expected at least one {label} proto on the wire')
+            for m in msgs:
+                self.assertTrue(m.rotateOnExpiration,
+                                f'rotateOnExpiration must be set on every {label} proto')
+                self.assertGreater(m.expiration, 0)
+                self.assertEqual(m.timerNotificationType, record_pb2.NOTIFY_OWNER)
+
+    def test_share_folder_rotate_on_expiration_rejects_folder_without_pam_user(self):
+        params = get_synced_params()
+        shared_folder_uid = next(iter(params.shared_folder_cache.keys()))
+        cmd = register.ShareFolderCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.execute(params, action='grant', user=['user2@keepersecurity.com'],
+                        folder=shared_folder_uid, expire_in='1d', rotate_on_expiration=True)
+        self.assertIn('pamUser', str(ctx.exception))
 
     @staticmethod
     def record_share_rq_rs(rq):


### PR DESCRIPTION
## Summary
Adds `--rotate-on-expiration` (`-roe`) to `share-folder` and tightens validation on both `share-record` and `share-folder` to reject ROE requests when no pamUser record with rotation configured is involved (prevents a server NPE).

## Changes
- **`share-folder -roe`**: new flag, mirrors `share-record`. Sets `rotateOnExpiration` on user/team/record protos. Requires a positive expiration and a rotation-configured pamUser in the folder.
- **`share-record -roe`**: validation now also requires the record to have rotation configured (was: just `pamUser`).
- **`list-sf --roe-eligible`**: new filter to discover folders eligible for `share-folder -roe`. Added to the service-mode command allowlist.