### PR TITLE
Added OS-native keyring storage for Commander config and fixed dependent service commands

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -164,6 +164,8 @@ fail_on_throttle_help = 'Disable default client-side pausing of command executio
 parser.add_argument('--fail-on-throttle', action='store_true', help=fail_on_throttle_help)
 parser.add_argument('--data-dir', dest='data_dir', action='store', help='Directory to use for Commander data (config, cache, etc.). Overrides environment variables.')
 parser.add_argument('--new-login', dest='new_login', action='store_true', help='Force full login flow (bypass persistent login)')
+parser.add_argument('--config-file', dest='config_file', action='store_true',
+                    help='Store credentials in config.json instead of the OS-native keychain')
 parser.add_argument('command', nargs='?', type=str, action='store', help='Command')
 parser.add_argument('options', nargs='*', action='store', help='Options')
 parser.error = usage
@@ -284,17 +286,24 @@ def main(from_package=False):
                     skip_next = False
                     continue
                     
-                # Skip arguments that were handled by main parser
-                main_parser_args = ['--config', '--server', '--user', '--password', '--version', '--debug', 
-                                  '--batch-mode', '--launched-with-shortcut', '--proxy', '--unmask-all', '--fail-on-throttle',
-                                  '--data-dir', '-ks', '-ku', '-kp', '-lwsc']
-                
+                # Skip arguments that were handled by main parser.
+                # Value flags: skip the flag AND the following value argument.
+                # Boolean flags: skip only the flag itself (no value follows).
+                value_main_parser_args = ['--config', '--server', '--user', '--password',
+                                          '--launched-with-shortcut', '--proxy',
+                                          '--data-dir', '-ks', '-ku', '-kp', '-lwsc']
+                bool_main_parser_args = ['--version', '--debug', '--batch-mode',
+                                         '--unmask-all', '--fail-on-throttle',
+                                         '--new-login', '--config-file']
+                main_parser_args = value_main_parser_args + bool_main_parser_args
+
                 is_main_parser_arg = False
                 for main_arg in main_parser_args:
                     if arg.startswith(main_arg + '=') or arg == main_arg:
                         is_main_parser_arg = True
-                        if arg == main_arg:
-                            skip_next = True  # Skip the next argument too (the argument value)
+                        # Only skip the next token for flags that consume a value.
+                        if arg == main_arg and main_arg in value_main_parser_args:
+                            skip_next = True
                         break
                 
                 if is_main_parser_arg:
@@ -418,6 +427,27 @@ def main(from_package=False):
             # Special handling for shell/- when NOT asking for help
             if opts.command == '-':
                 params.batch_mode = True
+            # Pre-queue any sub-command passed after 'shell', or apply session-level
+            # flags when no explicit sub-command is given.
+            if original_args_after_command:
+                sub_cmd = ' '.join([shlex.quote(x) for x in original_args_after_command])
+                first_token = original_args_after_command[0]
+                if first_token == 'login':
+                    # Inject main-parser flags that were stripped from original_args_after_command
+                    login_flags = ''
+                    if opts.new_login:
+                        login_flags += ' --new-login'
+                    if opts.config_file:
+                        login_flags += ' --config-file'
+                    if login_flags:
+                        rest = sub_cmd[len('login'):].strip()
+                        sub_cmd = f'login{login_flags} {rest}'.strip()
+                params.commands.insert(0, sub_cmd)
+            elif opts.config_file:
+                # `keeper shell --config-file` with no sub-command:
+                # set the file sentinel for this session so any subsequent login
+                # uses file-based storage, without forcing a re-login now.
+                params.config[loader.CONFIG_STORAGE_URL] = 'file'
         elif opts.command and os.path.isfile(opts.command):
             with open(opts.command, 'r') as f:
                 lines = f.readlines()
@@ -428,9 +458,11 @@ def main(from_package=False):
             if opts.command:
                 # Use the filtered original argument order to preserve proper flag/value pairing
                 options = ' '.join([shlex.quote(x) for x in original_args_after_command]) if original_args_after_command else ''
-                # Inject --new-login into login command if main parser captured it
+                # Inject --new-login / --config-file into login if main parser captured them
                 if opts.command == 'login' and opts.new_login:
                     options = '--new-login ' + options if options else '--new-login'
+                if opts.command == 'login' and opts.config_file:
+                    options = '--config-file ' + options if options else '--config-file'
                 command = ' '.join([opts.command or '', options]).strip()
                 params.commands.append(command)
             params.commands.append('q')

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -296,6 +296,10 @@ login_parser = argparse.ArgumentParser(prog='login', description='Start a login 
 login_parser.add_argument('-p', '--pass', dest='password', action='store', help='master password')
 login_parser.add_argument('--new-login', dest='new_login', action='store_true', help='Force full login flow')
 login_parser.add_argument('--server', dest='server', action='store', help='Data center region (US, EU, AU, CA, JP, GOV, etc.)')
+login_parser.add_argument('--config-file', dest='config_file', action='store_true',
+                          help='Store config in config.json instead of the OS-native keychain '
+                               '(use for headless servers, Docker, or CI/CD environments). '
+                               'Equivalent to setting KEEPER_CONFIG_STORAGE=file.')
 login_parser.add_argument('email', nargs='?', type=str, help='account email')
 login_parser.error = raise_parse_exception
 login_parser.exit = suppress_exit
@@ -1714,6 +1718,53 @@ class LoginCommand(Command):
         params.password = password
         new_login = kwargs.get('new_login') is True
         skip_sync = kwargs.get('skip_sync') is True
+
+        # Apply storage backend choice before login so that store_config_properties
+        # (called inside api.login) honours the user's explicit preference.
+        # Mirrors KSM CLI's use_config_file / use_keyring logic in Profile.init().
+        import platform as _platform
+        from ..config_storage.loader import (
+            CONFIG_STORAGE_URL, OS_KEYCHAIN_URL, is_os_keychain_available, _is_os_keychain_url
+        )
+
+        use_config_file = (
+            kwargs.get('config_file') is True
+            or os.environ.get('KEEPER_CONFIG_STORAGE', '').lower() == 'file'
+            # Also respect a sentinel set programmatically before login
+            # (e.g. `keeper shell --config-file` sets it in __main__.py).
+            or params.config.get(CONFIG_STORAGE_URL) == 'file'
+        )
+
+        if not isinstance(params.config, dict):
+            params.config = {}
+
+        if use_config_file:
+            # User explicitly chose file storage (--config-file flag or env var).
+            # Set the sentinel so store_config_properties skips keychain auto-detection
+            # and preserves this choice in config.json for future runs.
+            params.config[CONFIG_STORAGE_URL] = 'file'
+        else:
+            # User wants default behaviour (keychain when available).
+            # Clear any lingering 'file' sentinel written by a previous
+            # `keeper login --config-file` so keychain auto-detection can run.
+            if params.config.get(CONFIG_STORAGE_URL) == 'file':
+                del params.config[CONFIG_STORAGE_URL]
+
+            # Warn if keychain is unavailable (headless/CI environments),
+            # mirroring KSM CLI's fallback warning in Profile.init().
+            # Also fires when a previously stored keychain URL is in config.json
+            # but the keychain is no longer reachable (e.g. SSH into a desktop box).
+            current_backend = params.config.get(CONFIG_STORAGE_URL)
+            keychain_was_or_would_be_selected = (
+                not current_backend or _is_os_keychain_url(current_backend)
+            )
+            if keychain_was_or_would_be_selected and not is_os_keychain_available():
+                logging.warning(
+                    '%sWarning: OS keychain not available. Config will be stored in config.json '
+                    '(use --config-file to suppress this message).%s',
+                    Fore.YELLOW, Fore.RESET
+                )
+
         try:
             api.login(params, new_login=new_login)
         except Exception as exc:
@@ -1739,6 +1790,22 @@ class LoginCommand(Command):
                 loginv3.LoginV3API.register_encrypted_data_key_for_device(params)
             except Exception as e:
                 logging.debug(f'Device registration: {e}')
+
+            # Print config storage confirmation, mirroring KSM CLI's post-init messages.
+            stored_backend = (params.config or {}).get(CONFIG_STORAGE_URL, '')
+            if stored_backend and stored_backend != 'file':
+                _os = _platform.system()
+                if _os == 'Darwin':
+                    _storage_label = 'macOS Keychain'
+                elif _os == 'Windows':
+                    _storage_label = 'Windows Credential Manager'
+                else:
+                    _storage_label = 'system keyring (Secret Service)'
+                logging.info('%sConfig stored in %s.%s', Fore.GREEN, _storage_label, Fore.RESET)
+            else:
+                logging.info('%sConfig stored in %s.%s', Fore.GREEN,
+                             os.path.abspath(params.config_filename) if params.config_filename else 'config.json',
+                             Fore.RESET)
 
             # Show post-login message (only for explicit login command, not auto-login)
             show_help = kwargs.get('show_help', True)

--- a/keepercommander/config_storage/loader.py
+++ b/keepercommander/config_storage/loader.py
@@ -39,12 +39,7 @@ OS_KEYCHAIN_URL = 'os-keychain://default'
 
 
 def _make_os_keychain_url(config_filename=None):  # type: (Optional[str]) -> str
-    """Return a config-file-specific os-keychain URL.
-
-    The netloc is an 8-character SHA-256 prefix of the absolute config path,
-    so each Commander config file maps to a distinct keychain account and
-    multiple profiles can coexist without overwriting each other.
-    """
+    """Return an os-keychain URL with the netloc derived from a SHA-256 hash of the config path."""
     if config_filename:
         path_hash = hashlib.sha256(
             os.path.abspath(config_filename).encode()
@@ -63,10 +58,7 @@ def _is_os_keychain_url(url):  # type: (Optional[str]) -> bool
 def is_os_keychain_available():  # type: () -> bool
     """Return True if a real OS-native keychain is available and usable.
 
-    Uses the same detection logic as KeyringConfigStorage.is_available() in the
-    Keeper Secrets Manager CLI (KSM-800): checks whether the keyring backend
-    module name contains 'fail', which is the indicator used by the keyring
-    library when no real OS backend is found (e.g. headless Linux).
+
 
     Returns False when:
     - keyring is not installed
@@ -149,13 +141,7 @@ _KEYCHAIN_SERVICE = 'KeeperCommander'
 
 
 def _keychain_account_from_url(url):  # type: (Optional[str]) -> str
-    """Return the keyring account key for *url*.
-
-    Uses the netloc of the URL (e.g. the path hash written by
-    _make_os_keychain_url) so that each config file maps to its own
-    keychain account.  Falls back to 'config' for legacy entries that
-    were written with the old hardcoded key.
-    """
+    """Return the keyring account key from the URL netloc; falls back to 'config' for legacy entries."""
     if url:
         netloc = urlparse(url).netloc
         if netloc:
@@ -164,13 +150,7 @@ def _keychain_account_from_url(url):  # type: (Optional[str]) -> str
 
 
 def _clear_os_keychain_if_present(url=None):  # type: (Optional[str]) -> None
-    """Delete Commander's keychain entry for *url* if it exists.
-
-    Called after a successful file write when switching to file-based
-    storage, so that stale credentials are not left orphaned in the OS
-    keychain.  Silently ignored if keyring is not installed or the entry
-    does not exist.
-    """
+    """Delete the keychain entry for *url* if it exists. Called after switching to file storage."""
     account_key = _keychain_account_from_url(url)
     try:
         import keyring
@@ -206,26 +186,11 @@ def store_config_properties(params):
 
     config_json = params.config.copy()
 
-    # ------------------------------------------------------------------ #
-    # Storage backend selection — mirrors KSM CLI's Profile.init() logic  #
-    # ------------------------------------------------------------------ #
-    # Sentinel value written by `keeper login --config-file` (or the
-    # KEEPER_CONFIG_STORAGE=file env var) to explicitly opt into file-based
-    # storage.  We strip it from config_json before writing so the JSON file
-    # stays clean, but keep it in params.config so it persists for the
-    # lifetime of this process (the next startup reads it from the file,
-    # which won't have the sentinel — that is intentional: if the user runs
-    # `keeper login` next time without --config-file, auto-detection runs
-    # again).  Persisting across restarts requires the file sentinel to stay
-    # in config.json, so we leave it in config_json as-is below.
-
     explicitly_use_file = (
         config_json.get(CONFIG_STORAGE_URL) == 'file'
         or os.getenv('KEEPER_CONFIG_STORAGE', '').lower() == 'file'
     )
 
-    # Capture the previously stored keychain URL before it is overwritten,
-    # so we can delete the right keychain account after a successful file write.
     previous_keychain_url = (
         config_json.get(CONFIG_STORAGE_URL)
         if _is_os_keychain_url(config_json.get(CONFIG_STORAGE_URL))
@@ -233,20 +198,12 @@ def store_config_properties(params):
     )
 
     if explicitly_use_file:
-        # User opted into file storage.  Remove any existing keychain URL so
-        # the plugin dispatch block below is skipped entirely, and keep the
-        # 'file' sentinel in the written JSON so the choice survives restarts.
         logging.debug('File-based config storage selected (--config-file or KEEPER_CONFIG_STORAGE=file).')
         config_json[CONFIG_STORAGE_URL] = 'file'
 
     elif CONFIG_STORAGE_URL not in config_json:
-        # No explicit choice and no previously persisted backend.
-        # Auto-activate the OS-native keychain, matching KSM CLI's default
-        # behaviour of using the keychain whenever it is available.
-        # Skipped when running in headless/CI environments (keychain unavailable).
-        # Pre-keychain installs are handled in load_config_properties, which sets
-        # the 'file' sentinel before login populates params.config with credentials,
-        # so this branch is only reached on a genuinely fresh login (no prior config).
+        # Auto-select keychain on fresh login; pre-keychain installs are handled
+        # in load_config_properties before this runs.
         if is_os_keychain_available():
             logging.debug('Auto-selecting OS keychain backend for config storage.')
             keychain_url = _make_os_keychain_url(params.config_filename)
@@ -279,19 +236,8 @@ def store_config_properties(params):
 
         except SecureStorageException as sse:
             if not _is_os_keychain_url(url):
-                # For explicitly configured non-OS backends (e.g. aws-kms://, aws-sm://),
-                # a store failure must not silently downgrade secrets to a plaintext
-                # config.json — that would expose credentials without the user's knowledge.
-                raise
-            # OS keychain failed (e.g. permission denied, no daemon) — fall back to
-            # file-based storage.  config_json is still unmodified here so all fields
-            # are preserved for the file write below.
-            logging.warning(
-                'OS keychain store failed (%s). '
-                'Falling back to file-based config storage.', sse
-            )
-            # Undo the auto-selected backend so the file write includes the
-            # protected fields in plaintext (with chmod 600 as before).
+                raise  # Non-OS backends must not silently downgrade to plaintext.
+            logging.warning('OS keychain store failed (%s). Falling back to file-based config storage.', sse)
             del config_json[CONFIG_STORAGE_URL]
             params.config.pop(CONFIG_STORAGE_URL, None)
 
@@ -301,10 +247,6 @@ def store_config_properties(params):
                 json.dump(config_json, fd, ensure_ascii=False, indent=2)
             # Set secure file permissions (600) for configuration files containing sensitive data
             utils.set_file_permissions(params.config_filename)
-            # File write succeeded — now safe to remove any stale keychain entry.
-            # Doing this after the write mirrors the commit-after-success pattern
-            # used for the keychain store above, ensuring credentials are never
-            # lost from both backends simultaneously.
             if explicitly_use_file and previous_keychain_url:
                 _clear_os_keychain_if_present(previous_keychain_url)
         except Exception as error:
@@ -326,9 +268,7 @@ def load_config_properties(params):
 
     if CONFIG_STORAGE_URL in params.config:
         url = params.config[CONFIG_STORAGE_URL]
-        # 'file' is the sentinel written by `keeper login --config-file`.
-        # All protected fields are already in the JSON, so no plugin needed.
-        if url != 'file':
+        if url != 'file':  # 'file' sentinel means credentials are in the JSON already
             storage = _get_plugin(url)
             encrypted_data = None
             if ENCRYPTED_DATA in params.config:
@@ -339,17 +279,11 @@ def load_config_properties(params):
             if isinstance(conf, dict):
                 params.config.update(conf)
     else:
-        # No storage backend recorded. If the config already contains credentials
-        # (device_token or private_key), this is a pre-keychain Commander install.
-        # Mark it as file-based storage NOW — before login has a chance to add more
-        # credentials to params.config — so store_config_properties does not
-        # silently migrate the user to the OS keychain on next save.
+        # No backend recorded. If credentials already exist in the file, this is a
+        # pre-keychain install — mark as file mode to prevent silent migration.
         if params.config.get('device_token') or params.config.get('private_key'):
             params.config[CONFIG_STORAGE_URL] = 'file'
-            logging.debug(
-                'Detected pre-keychain config.json — marking storage as file-based '
-                'to prevent silent migration to OS keychain.'
-            )
+            logging.debug('Detected pre-keychain config.json — keeping file-based storage.')
 
     for name in PROTECTED_PROPERTIES + PROTECTED_CONNECTED_PROPERTIES + PROTECTED_READONLY_PROPERTIES:
         config_name, params_name = split_name(name)

--- a/keepercommander/config_storage/loader.py
+++ b/keepercommander/config_storage/loader.py
@@ -10,9 +10,11 @@
 #
 
 import abc
+import hashlib
 import importlib
 import json
 import logging
+import os
 import pkgutil
 from typing import Tuple, Union, List, Optional
 
@@ -28,6 +30,71 @@ EDITABLE_PROPERTIES = ['proxy']
 BOOL_PROPERTIES = ['debug', 'batch_mode', 'unmask_all']
 INT_PROPERTIES = ['timedelay', 'logout_timer']
 ENCRYPTED_DATA = 'encrypted_data'
+
+# Scheme used for the OS-native keychain backend.
+_OS_KEYCHAIN_SCHEME = 'os-keychain'
+
+# Fallback URL used when no config filename is available.
+OS_KEYCHAIN_URL = 'os-keychain://default'
+
+
+def _make_os_keychain_url(config_filename=None):  # type: (Optional[str]) -> str
+    """Return a config-file-specific os-keychain URL.
+
+    The netloc is an 8-character SHA-256 prefix of the absolute config path,
+    so each Commander config file maps to a distinct keychain account and
+    multiple profiles can coexist without overwriting each other.
+    """
+    if config_filename:
+        path_hash = hashlib.sha256(
+            os.path.abspath(config_filename).encode()
+        ).hexdigest()[:8]
+        return f'{_OS_KEYCHAIN_SCHEME}://{path_hash}'
+    return OS_KEYCHAIN_URL
+
+
+def _is_os_keychain_url(url):  # type: (Optional[str]) -> bool
+    """Return True if *url* refers to the OS-native keychain backend."""
+    if not url:
+        return False
+    return urlparse(url).scheme == _OS_KEYCHAIN_SCHEME
+
+
+def is_os_keychain_available():  # type: () -> bool
+    """Return True if a real OS-native keychain is available and usable.
+
+    Uses the same detection logic as KeyringConfigStorage.is_available() in the
+    Keeper Secrets Manager CLI (KSM-800): checks whether the keyring backend
+    module name contains 'fail', which is the indicator used by the keyring
+    library when no real OS backend is found (e.g. headless Linux).
+
+    Returns False when:
+    - keyring is not installed
+    - the runtime is headless Linux with no SecretService daemon
+    - keyring fell back to a plaintext or fail backend
+    - any other error prevents keychain access
+    """
+    try:
+        import keyring
+        backend = keyring.get_keyring()
+        if 'fail' in backend.__class__.__module__.lower():
+            logging.debug(
+                'OS keychain not available (backend module: %s). '
+                'Falling back to file-based config storage.',
+                backend.__class__.__module__
+            )
+            return False
+        logging.debug(
+            'OS keychain available via backend: %s.%s',
+            backend.__class__.__module__, backend.__class__.__name__
+        )
+        return True
+    except ImportError:
+        logging.debug('OS keychain not available: keyring package is not installed.')
+        return False
+    except Exception as e:
+        logging.debug('OS keychain probe failed: %s', e)
+        return False
 
 
 class SecureStorageException(Exception):
@@ -78,6 +145,46 @@ def split_name(name):   # type: (Union[str, Tuple[str, str]]) -> Tuple[str, str]
     return name, name
 
 
+_KEYCHAIN_SERVICE = 'KeeperCommander'
+
+
+def _keychain_account_from_url(url):  # type: (Optional[str]) -> str
+    """Return the keyring account key for *url*.
+
+    Uses the netloc of the URL (e.g. the path hash written by
+    _make_os_keychain_url) so that each config file maps to its own
+    keychain account.  Falls back to 'config' for legacy entries that
+    were written with the old hardcoded key.
+    """
+    if url:
+        netloc = urlparse(url).netloc
+        if netloc:
+            return netloc
+    return 'config'
+
+
+def _clear_os_keychain_if_present(url=None):  # type: (Optional[str]) -> None
+    """Delete Commander's keychain entry for *url* if it exists.
+
+    Called after a successful file write when switching to file-based
+    storage, so that stale credentials are not left orphaned in the OS
+    keychain.  Silently ignored if keyring is not installed or the entry
+    does not exist.
+    """
+    account_key = _keychain_account_from_url(url)
+    try:
+        import keyring
+        try:
+            if keyring.get_password(_KEYCHAIN_SERVICE, account_key) is not None:
+                keyring.delete_password(_KEYCHAIN_SERVICE, account_key)
+                logging.debug('Deleted keychain entry: service=%s account=%s',
+                              _KEYCHAIN_SERVICE, account_key)
+        except keyring.errors.PasswordDeleteError:
+            pass  # Entry didn't exist — nothing to do.
+    except Exception as exc:
+        logging.debug('Could not clear OS keychain entries: %s', exc)
+
+
 def store_config_properties(params):
     if not isinstance(params, KeeperParams):
         return
@@ -99,21 +206,94 @@ def store_config_properties(params):
 
     config_json = params.config.copy()
 
-    if CONFIG_STORAGE_URL in config_json:
-        url = config_json[CONFIG_STORAGE_URL]
-        storage = _get_plugin(url)
-        conf_protected = {}
-        for name in protected_properties + PROTECTED_READONLY_PROPERTIES:
-            config_name, _ = split_name(name)
-            if config_name in config_json:
-                value = config_json[config_name] or ''
-                if value:
-                    conf_protected[config_name] = value
-                del config_json[config_name]
+    # ------------------------------------------------------------------ #
+    # Storage backend selection — mirrors KSM CLI's Profile.init() logic  #
+    # ------------------------------------------------------------------ #
+    # Sentinel value written by `keeper login --config-file` (or the
+    # KEEPER_CONFIG_STORAGE=file env var) to explicitly opt into file-based
+    # storage.  We strip it from config_json before writing so the JSON file
+    # stays clean, but keep it in params.config so it persists for the
+    # lifetime of this process (the next startup reads it from the file,
+    # which won't have the sentinel — that is intentional: if the user runs
+    # `keeper login` next time without --config-file, auto-detection runs
+    # again).  Persisting across restarts requires the file sentinel to stay
+    # in config.json, so we leave it in config_json as-is below.
 
-        encrypted_data = storage.store_configuration(url, conf_protected)
-        if isinstance(encrypted_data, bytes):
-            config_json[ENCRYPTED_DATA] = utils.base64_url_encode(encrypted_data)
+    explicitly_use_file = (
+        config_json.get(CONFIG_STORAGE_URL) == 'file'
+        or os.getenv('KEEPER_CONFIG_STORAGE', '').lower() == 'file'
+    )
+
+    # Capture the previously stored keychain URL before it is overwritten,
+    # so we can delete the right keychain account after a successful file write.
+    previous_keychain_url = (
+        config_json.get(CONFIG_STORAGE_URL)
+        if _is_os_keychain_url(config_json.get(CONFIG_STORAGE_URL))
+        else None
+    )
+
+    if explicitly_use_file:
+        # User opted into file storage.  Remove any existing keychain URL so
+        # the plugin dispatch block below is skipped entirely, and keep the
+        # 'file' sentinel in the written JSON so the choice survives restarts.
+        logging.debug('File-based config storage selected (--config-file or KEEPER_CONFIG_STORAGE=file).')
+        config_json[CONFIG_STORAGE_URL] = 'file'
+
+    elif CONFIG_STORAGE_URL not in config_json:
+        # No explicit choice and no previously persisted backend.
+        # Auto-activate the OS-native keychain, matching KSM CLI's default
+        # behaviour of using the keychain whenever it is available.
+        # Skipped when running in headless/CI environments (keychain unavailable).
+        # Pre-keychain installs are handled in load_config_properties, which sets
+        # the 'file' sentinel before login populates params.config with credentials,
+        # so this branch is only reached on a genuinely fresh login (no prior config).
+        if is_os_keychain_available():
+            logging.debug('Auto-selecting OS keychain backend for config storage.')
+            keychain_url = _make_os_keychain_url(params.config_filename)
+            params.config[CONFIG_STORAGE_URL] = keychain_url
+            config_json[CONFIG_STORAGE_URL] = keychain_url
+
+    if CONFIG_STORAGE_URL in config_json and config_json[CONFIG_STORAGE_URL] != 'file':
+        url = config_json[CONFIG_STORAGE_URL]
+        try:
+            storage = _get_plugin(url)
+
+            # Build the protected payload and a candidate config_json that has
+            # those fields removed. We only commit the removal once the store
+            # succeeds — this prevents data loss if the keychain call fails.
+            conf_protected = {}
+            config_json_committed = config_json.copy()
+            for name in protected_properties + PROTECTED_READONLY_PROPERTIES:
+                config_name, _ = split_name(name)
+                if config_name in config_json:
+                    value = config_json[config_name] or ''
+                    if value:
+                        conf_protected[config_name] = value
+                    config_json_committed.pop(config_name, None)
+
+            encrypted_data = storage.store_configuration(url, conf_protected)
+            # Store succeeded — commit the cleaned config_json.
+            config_json = config_json_committed
+            if isinstance(encrypted_data, bytes):
+                config_json[ENCRYPTED_DATA] = utils.base64_url_encode(encrypted_data)
+
+        except SecureStorageException as sse:
+            if not _is_os_keychain_url(url):
+                # For explicitly configured non-OS backends (e.g. aws-kms://, aws-sm://),
+                # a store failure must not silently downgrade secrets to a plaintext
+                # config.json — that would expose credentials without the user's knowledge.
+                raise
+            # OS keychain failed (e.g. permission denied, no daemon) — fall back to
+            # file-based storage.  config_json is still unmodified here so all fields
+            # are preserved for the file write below.
+            logging.warning(
+                'OS keychain store failed (%s). '
+                'Falling back to file-based config storage.', sse
+            )
+            # Undo the auto-selected backend so the file write includes the
+            # protected fields in plaintext (with chmod 600 as before).
+            del config_json[CONFIG_STORAGE_URL]
+            params.config.pop(CONFIG_STORAGE_URL, None)
 
     if params.config_filename:
         try:
@@ -121,6 +301,12 @@ def store_config_properties(params):
                 json.dump(config_json, fd, ensure_ascii=False, indent=2)
             # Set secure file permissions (600) for configuration files containing sensitive data
             utils.set_file_permissions(params.config_filename)
+            # File write succeeded — now safe to remove any stale keychain entry.
+            # Doing this after the write mirrors the commit-after-success pattern
+            # used for the keychain store above, ensuring credentials are never
+            # lost from both backends simultaneously.
+            if explicitly_use_file and previous_keychain_url:
+                _clear_os_keychain_if_present(previous_keychain_url)
         except Exception as error:
             logging.debug(error, exc_info=True)
             logging.error(f'Failed to write configuration to {params.config_filename}. '
@@ -140,15 +326,30 @@ def load_config_properties(params):
 
     if CONFIG_STORAGE_URL in params.config:
         url = params.config[CONFIG_STORAGE_URL]
-        storage = _get_plugin(url)
-        encrypted_data = None
-        if ENCRYPTED_DATA in params.config:
-            ed = params.config[ENCRYPTED_DATA]
-            if isinstance(ed, str):
-                encrypted_data = utils.base64_url_decode(ed)
-        conf = storage.load_configuration(url, encrypted_data)
-        if isinstance(conf, dict):
-            params.config.update(conf)
+        # 'file' is the sentinel written by `keeper login --config-file`.
+        # All protected fields are already in the JSON, so no plugin needed.
+        if url != 'file':
+            storage = _get_plugin(url)
+            encrypted_data = None
+            if ENCRYPTED_DATA in params.config:
+                ed = params.config[ENCRYPTED_DATA]
+                if isinstance(ed, str):
+                    encrypted_data = utils.base64_url_decode(ed)
+            conf = storage.load_configuration(url, encrypted_data)
+            if isinstance(conf, dict):
+                params.config.update(conf)
+    else:
+        # No storage backend recorded. If the config already contains credentials
+        # (device_token or private_key), this is a pre-keychain Commander install.
+        # Mark it as file-based storage NOW — before login has a chance to add more
+        # credentials to params.config — so store_config_properties does not
+        # silently migrate the user to the OS keychain on next save.
+        if params.config.get('device_token') or params.config.get('private_key'):
+            params.config[CONFIG_STORAGE_URL] = 'file'
+            logging.debug(
+                'Detected pre-keychain config.json — marking storage as file-based '
+                'to prevent silent migration to OS keychain.'
+            )
 
     for name in PROTECTED_PROPERTIES + PROTECTED_CONNECTED_PROPERTIES + PROTECTED_READONLY_PROPERTIES:
         config_name, params_name = split_name(name)

--- a/keepercommander/config_storage/os-keychain/__init__.py
+++ b/keepercommander/config_storage/os-keychain/__init__.py
@@ -1,0 +1,3 @@
+from .os_keychain_storage import SecureStorage
+
+__all__ = ['SecureStorage']

--- a/keepercommander/config_storage/os-keychain/os_keychain_storage.py
+++ b/keepercommander/config_storage/os-keychain/os_keychain_storage.py
@@ -9,25 +9,7 @@
 # Contact: ops@keepersecurity.com
 #
 
-"""
-OS-native keychain storage backend for Keeper Commander.
-
-Protected config fields are stored as a single JSON blob in one keyring entry.
-The OS keychain (macOS Keychain / Windows Credential Manager / Linux Secret Service)
-handles encryption and integrity natively, so no separate integrity hash is needed.
-Backend availability is detected by inspecting the keyring backend module name,
-consistent with KeyringConfigStorage.is_available() in the KSM CLI.
-
-Storage layout in the OS keychain:
-  service / application : KeeperCommander
-  account / key         : <url netloc>  →  JSON blob of all protected fields
-
-The account key is derived from the netloc of the storage URL (e.g. the 8-char
-SHA-256 prefix of the config file path written by _make_os_keychain_url).  This
-allows multiple Commander config files on the same OS user to coexist without
-overwriting each other's keychain entry.  Legacy entries written with the old
-hardcoded key 'config' are handled by _keychain_account_from_url in loader.py.
-"""
+"""OS-native keychain storage backend for Keeper Commander (macOS Keychain, Windows Credential Manager, Linux Secret Service)."""
 
 import json
 import logging
@@ -42,30 +24,14 @@ KEYRING_SERVICE = 'KeeperCommander'
 
 
 class SecureStorage(SecureStorageBase):
-    """OS-native keychain storage backend for Commander configuration.
-
-    Delegates to the appropriate OS facility via the Python ``keyring`` library:
-      - macOS   → Keychain (Security framework)
-      - Windows → Credential Manager (DPAPI-backed)
-      - Linux desktop → SecretService API (GNOME Keyring / KWallet)
-
-    The entire set of protected configuration fields is serialised to a single
-    JSON blob and stored under one keyring entry.  The OS keychain provides
-    encryption and access control natively.
-
-    No sensitive data is written back to config.json; the file only retains the
-    ``config_storage`` key that points to this backend.
+    """Stores protected config fields as a JSON blob in the OS keychain via the keyring library.
+    Supports macOS Keychain, Windows Credential Manager, and Linux SecretService.
+    config.json retains only the config_storage pointer — no credentials on disk.
     """
 
     @staticmethod
     def _account_key(url: str) -> str:
-        """Derive the keyring account key from the storage URL netloc.
-
-        Each config file gets a unique netloc (an 8-char path hash) via
-        _make_os_keychain_url in loader.py, so multiple profiles on the
-        same OS user do not overwrite each other.  Falls back to 'config'
-        for legacy entries written before per-profile keys were introduced.
-        """
+        """Return keyring account key from URL netloc; falls back to 'config' for legacy entries."""
         netloc = urlparse(url).netloc if url else ''
         return netloc if netloc else 'config'
 

--- a/keepercommander/config_storage/os-keychain/os_keychain_storage.py
+++ b/keepercommander/config_storage/os-keychain/os_keychain_storage.py
@@ -1,0 +1,139 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2024 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+"""
+OS-native keychain storage backend for Keeper Commander.
+
+Protected config fields are stored as a single JSON blob in one keyring entry.
+The OS keychain (macOS Keychain / Windows Credential Manager / Linux Secret Service)
+handles encryption and integrity natively, so no separate integrity hash is needed.
+Backend availability is detected by inspecting the keyring backend module name,
+consistent with KeyringConfigStorage.is_available() in the KSM CLI.
+
+Storage layout in the OS keychain:
+  service / application : KeeperCommander
+  account / key         : <url netloc>  →  JSON blob of all protected fields
+
+The account key is derived from the netloc of the storage URL (e.g. the 8-char
+SHA-256 prefix of the config file path written by _make_os_keychain_url).  This
+allows multiple Commander config files on the same OS user to coexist without
+overwriting each other's keychain entry.  Legacy entries written with the old
+hardcoded key 'config' are handled by _keychain_account_from_url in loader.py.
+"""
+
+import json
+import logging
+from urllib.parse import urlparse
+from typing import Optional
+
+from ..loader import SecureStorageBase, SecureStorageException
+
+# Top-level service / application name visible in the OS keychain UI.
+# On macOS this appears in Keychain Access; on Windows in Credential Manager.
+KEYRING_SERVICE = 'KeeperCommander'
+
+
+class SecureStorage(SecureStorageBase):
+    """OS-native keychain storage backend for Commander configuration.
+
+    Delegates to the appropriate OS facility via the Python ``keyring`` library:
+      - macOS   → Keychain (Security framework)
+      - Windows → Credential Manager (DPAPI-backed)
+      - Linux desktop → SecretService API (GNOME Keyring / KWallet)
+
+    The entire set of protected configuration fields is serialised to a single
+    JSON blob and stored under one keyring entry.  The OS keychain provides
+    encryption and access control natively.
+
+    No sensitive data is written back to config.json; the file only retains the
+    ``config_storage`` key that points to this backend.
+    """
+
+    @staticmethod
+    def _account_key(url: str) -> str:
+        """Derive the keyring account key from the storage URL netloc.
+
+        Each config file gets a unique netloc (an 8-char path hash) via
+        _make_os_keychain_url in loader.py, so multiple profiles on the
+        same OS user do not overwrite each other.  Falls back to 'config'
+        for legacy entries written before per-profile keys were introduced.
+        """
+        netloc = urlparse(url).netloc if url else ''
+        return netloc if netloc else 'config'
+
+    def load_configuration(self, url: str, encrypted_data: Optional[bytes] = None) -> dict:
+        """Retrieve protected fields from the OS keychain.
+
+        ``encrypted_data`` is unused — the OS keychain handles encryption
+        internally and returns plaintext to authorised callers.
+        """
+        try:
+            import keyring
+        except ImportError:
+            raise SecureStorageException(
+                'keyring package is not installed.\nRun: pip install keyring'
+            )
+
+        try:
+            account_key = self._account_key(url)
+            raw = keyring.get_password(KEYRING_SERVICE, account_key)
+            if not raw:
+                return {}
+
+            config = json.loads(raw)
+            if not isinstance(config, dict):
+                raise SecureStorageException(
+                    'Keychain entry is not a valid JSON object.'
+                )
+
+            logging.debug(
+                'Loaded %d field(s) from OS keychain (%s / %s).',
+                len(config), KEYRING_SERVICE, account_key
+            )
+            return config
+
+        except SecureStorageException:
+            raise
+        except Exception as e:
+            raise SecureStorageException(
+                f'Failed to load configuration from OS keychain: {e}'
+            )
+
+    def store_configuration(self, url: str, configuration: dict) -> Optional[bytes]:
+        """Store protected fields in the OS keychain as a single JSON blob.
+
+        Returns ``None`` because no encrypted blob needs to be embedded in
+        config.json — the keychain manages encryption internally.
+        """
+        try:
+            import keyring
+        except ImportError:
+            raise SecureStorageException(
+                'keyring package is not installed.\nRun: pip install keyring'
+            )
+
+        try:
+            account_key = self._account_key(url)
+            config_json = json.dumps(configuration, indent=4, sort_keys=True)
+            keyring.set_password(KEYRING_SERVICE, account_key, config_json)
+
+            logging.debug(
+                'Stored %d field(s) in OS keychain (%s / %s).',
+                len(configuration), KEYRING_SERVICE, account_key
+            )
+            return None
+
+        except SecureStorageException:
+            raise
+        except Exception as e:
+            raise SecureStorageException(
+                f'Failed to store configuration in OS keychain: {e}'
+            )

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -156,6 +156,7 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
 
     def execute(self, params, **kwargs):
         name = self.get_integration_name()
+        self._require_file_based_config(params, f'{name.lower()}-app-setup')
 
         # Phase 1 -- Docker service mode setup
         print(f"\n{bcolors.BOLD}Phase 1: Running Docker Service Mode Setup{bcolors.ENDC}")

--- a/keepercommander/service/commands/service_docker_setup.py
+++ b/keepercommander/service/commands/service_docker_setup.py
@@ -69,6 +69,8 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
 
     def execute(self, params, **kwargs):
         """Main execution flow for standalone command"""
+        self._require_file_based_config(params, 'service-docker-setup')
+
         # Parse arguments
         config_path = self._get_config_path(kwargs.get('config_path'))
         

--- a/keepercommander/service/config/file_handler.py
+++ b/keepercommander/service/config/file_handler.py
@@ -173,10 +173,7 @@ class ConfigFormatHandler:
         if private_key:
             return private_key
 
-        # config.json has no private_key — credentials are in the OS keychain.
-        # Avoid get_params_from_config: it calls sys.exit(1) on SecureStorageException
-        # and input() on JSON errors, both of which break daemon/Docker contexts.
-        # Instead load via KeeperParams + load_config_properties directly.
+        # No private_key in file — try loading from secure storage backend.
         try:
             from ...params import KeeperParams
             from ...config_storage.loader import load_config_properties

--- a/keepercommander/service/config/file_handler.py
+++ b/keepercommander/service/config/file_handler.py
@@ -154,29 +154,67 @@ class ConfigFormatHandler:
             raise ValidationError(f"Failed to decrypt configuration file: {str(e)}")
 
     @staticmethod
-    def encrypted_content(plaintext, config_path: Path, config_dir ) -> bytes:
-        """Encrypt the content of the configuration file."""
-        from hashlib import sha256
-        from ...crypto import encrypt_aes_v2
+    def _resolve_private_key(config_dir: Path) -> str:
+        """Return the device private_key regardless of storage backend.
+
+        When OS-native keychain storage is active, ``private_key`` is not
+        present in config.json.  This helper loads it via
+        ``load_config_properties`` so both encrypt and decrypt work
+        transparently in keychain mode.
+        """
         config_json = config_dir / "config.json"
         if not config_json.exists():
             raise FileNotFoundError(f"Config.json file not found: {config_json}")
+
+        with open(config_json, 'r') as json_file:
+            config_json_data = json.load(json_file)
+
+        private_key = config_json_data.get("private_key")
+        if private_key:
+            return private_key
+
+        # config.json has no private_key — credentials are in the OS keychain.
+        # Avoid get_params_from_config: it calls sys.exit(1) on SecureStorageException
+        # and input() on JSON errors, both of which break daemon/Docker contexts.
+        # Instead load via KeeperParams + load_config_properties directly.
+        try:
+            from ...params import KeeperParams
+            from ...config_storage.loader import load_config_properties
+            tmp_params = KeeperParams()
+            tmp_params.config_filename = str(config_json)
+            tmp_params.config = dict(config_json_data)
+            load_config_properties(tmp_params)
+            private_key = getattr(tmp_params, 'device_private_key', None)
+        except Exception:
+            private_key = None
+
+        if not private_key:
+            raise ValidationError(
+                "Field 'private_key' could not be resolved from config. Possible causes: "
+                "the OS keychain is unavailable or access was denied, the configured "
+                "storage backend failed, the config_storage value is invalid, or the "
+                "configuration is corrupted. Enable debug logging for details."
+            )
+        return private_key
+
+    @staticmethod
+    def encrypted_content(plaintext, config_path: Path, config_dir) -> bytes:
+        """Encrypt the content of the configuration file."""
+        from hashlib import sha256
+        from ...crypto import encrypt_aes_v2
         if not config_path.exists():
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
         try:
-            with open(config_json, 'r') as json_file:
-                config_json_data = json.load(json_file)
-            private_key = config_json_data.get("private_key")
-            if not private_key:
-                raise ValidationError("Field 'private_key' not found in the configuration file.")
+            private_key = ConfigFormatHandler._resolve_private_key(config_dir)
             hashed_key = sha256(private_key.encode('utf-8')).digest()
             if isinstance(plaintext, dict):
                 plaintext = json.dumps(plaintext)
-            encrypted_content = encrypt_aes_v2(plaintext.encode('utf-8'), hashed_key)
-            return encrypted_content
+            return encrypt_aes_v2(plaintext.encode('utf-8'), hashed_key)
+        except (FileNotFoundError, ValidationError):
+            raise
         except Exception as e:
             raise ValidationError(f"Failed to encrypt configuration file: {str(e)}")
-            
+
     @staticmethod
     def encrypt_config_file(config_path: Path, config_dir: Path) -> None:
         """Encrypt the content of the configuration file and save it back."""
@@ -184,23 +222,17 @@ class ConfigFormatHandler:
         with open(config_path, 'wb') as encrypted_file:
             encrypted_file.write(encrypted_content)
         logger.debug(f" {config_path} File encryption success. ")
-        
-        
+
     @staticmethod
     def decrypt_config_file(encrypted_content: bytes, config_dir: Path) -> str:
         """Decrypt the content of the configuration file and return it as a string."""
         from hashlib import sha256
         from ...crypto import decrypt_aes_v2
-        config_json = config_dir / "config.json"
-        if not config_json.exists():
-            raise FileNotFoundError(f"Config.json file not found: {config_json}")
         try:
-            with open(config_json, 'r') as json_file:
-                config_json_data = json.load(json_file)
-            private_key = config_json_data.get("private_key")
-            if not private_key:
-                raise ValidationError("Field 'private_key' not found in the configuration file.")
+            private_key = ConfigFormatHandler._resolve_private_key(config_dir)
             hashed_key = sha256(private_key.encode('utf-8')).digest()
             return decrypt_aes_v2(encrypted_content, hashed_key).decode('utf-8')
+        except (FileNotFoundError, ValidationError):
+            raise
         except Exception as e:
             raise ValidationError(f"Failed to decrypt configuration file: {str(e)}")

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -41,16 +41,7 @@ class DockerSetupBase:
 
     @staticmethod
     def _require_file_based_config(params, command_name: str) -> None:
-        """Raise CommandError if credentials are stored in the OS keychain.
-
-        Service setup commands (docker-setup, slack-app-setup, teams-app-setup)
-        need to upload config.json to the Keeper vault.  When keychain mode is
-        active, config.json only contains a storage pointer — not the actual
-        credentials — so the upload would be incomplete or incorrect.
-
-        Users must re-login with --config-file to store credentials locally
-        before running these commands.
-        """
+        """Raise CommandError if credentials are in the OS keychain rather than config.json."""
         from ...config_storage.loader import CONFIG_STORAGE_URL, _is_os_keychain_url
         config_storage = params.config.get(CONFIG_STORAGE_URL, '') if isinstance(params.config, dict) else ''
         if _is_os_keychain_url(config_storage):
@@ -60,7 +51,8 @@ class DockerSetupBase:
                 f'{bcolors.FAIL}This command requires credentials to be stored in config.json, '
                 f'but they are currently stored in the OS keychain.{bcolors.ENDC}\n\n'
                 f'{bcolors.OKBLUE}Please re-login with the --config-file flag first:{bcolors.ENDC}\n\n'
-                f'    {bcolors.OKBLUE}keeper login --config-file{bcolors.ENDC}\n\n'
+                f'    {bcolors.OKGREEN}login --config-file{bcolors.ENDC}    '
+                f'{bcolors.OKGREEN}(or: keeper shell --config-file){bcolors.ENDC}\n\n'
                 f'Then re-run this command.'
             )
 
@@ -210,10 +202,16 @@ class DockerSetupBase:
             raise CommandError('docker-setup', f'Failed to create record: {str(e)}')
 
     def _upload_config_file(self, params, record_uid: str, config_path: str) -> None:
-        """Upload config.json as attachment, or store as custom field if no file storage plan."""
+        """Upload config.json as attachment, or store as custom field if no file storage plan.
+
+        When OS-native keychain storage is active, config.json only contains the
+        ``config_storage`` pointer and no credentials.  In that case the essential
+        auth fields are sourced from ``params`` (which already has them loaded from
+        the keychain) and written to a temporary file for upload.
+        """
         temp_config_path = None
         try:
-            cleaned_config_path = self._clean_config_json(config_path)
+            cleaned_config_path = self._get_uploadable_config(params, config_path)
             if cleaned_config_path != config_path:
                 temp_config_path = cleaned_config_path
 
@@ -231,6 +229,51 @@ class DockerSetupBase:
                     os.unlink(temp_config_path)
                 except OSError:
                     pass
+
+    def _get_uploadable_config(self, params, config_path: str) -> str:
+        """Return a path to a config file with only essential auth keys for vault upload."""
+        try:
+            with open(config_path, 'r') as f:
+                config_data = json.load(f)
+        except Exception:
+            return config_path
+
+        config_storage = config_data.get('config_storage', '')
+        from ...config_storage.loader import _is_os_keychain_url
+        if _is_os_keychain_url(config_storage):
+            # OS-keychain mode: credentials live in the keychain, not in the file.
+            # Build the essential-keys dict from the already-loaded params object.
+            # Other backends (aws-kms://, aws-sm://, etc.) manage their own upload
+            # semantics and should not be rewritten here.
+            essential_config = {}
+            for file_key, params_attr in [
+                ('server', 'server'),
+                ('user', 'user'),
+                ('device_token', 'device_token'),
+                ('private_key', 'device_private_key'),
+                ('clone_code', 'clone_code'),
+            ]:
+                value = getattr(params, params_attr, None)
+                if value:
+                    essential_config[file_key] = value
+
+            if not essential_config:
+                raise CommandError(
+                    'docker-setup',
+                    'No credentials found in params. Please log in before running this command.'
+                )
+
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+                json.dump(essential_config, tmp, indent=2)
+                temp_path = tmp.name
+
+            DockerSetupPrinter.print_success(
+                f'Config sourced from OS keychain ({len(essential_config)} essential keys)'
+            )
+            return temp_path
+
+        # File-based storage: clean the JSON as before.
+        return self._clean_config_json(config_path)
 
     def _upload_config_as_attachment(self, params, record_uid: str, config_path: str) -> None:
         """Upload config.json as a file attachment (requires file storage plan)."""

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -39,6 +39,31 @@ from ..config.record_handler import RecordHandler
 class DockerSetupBase:
     """Base class for Docker setup with reusable core logic"""
 
+    @staticmethod
+    def _require_file_based_config(params, command_name: str) -> None:
+        """Raise CommandError if credentials are stored in the OS keychain.
+
+        Service setup commands (docker-setup, slack-app-setup, teams-app-setup)
+        need to upload config.json to the Keeper vault.  When keychain mode is
+        active, config.json only contains a storage pointer — not the actual
+        credentials — so the upload would be incomplete or incorrect.
+
+        Users must re-login with --config-file to store credentials locally
+        before running these commands.
+        """
+        from ...config_storage.loader import CONFIG_STORAGE_URL, _is_os_keychain_url
+        config_storage = params.config.get(CONFIG_STORAGE_URL, '') if isinstance(params.config, dict) else ''
+        if _is_os_keychain_url(config_storage):
+            raise CommandError(
+                command_name,
+                f'{bcolors.FAIL}{bcolors.BOLD}Error:{bcolors.ENDC} '
+                f'{bcolors.FAIL}This command requires credentials to be stored in config.json, '
+                f'but they are currently stored in the OS keychain.{bcolors.ENDC}\n\n'
+                f'{bcolors.OKBLUE}Please re-login with the --config-file flag first:{bcolors.ENDC}\n\n'
+                f'    {bcolors.OKBLUE}keeper login --config-file{bcolors.ENDC}\n\n'
+                f'Then re-run this command.'
+            )
+
     def run_setup_steps(self, params, folder_name: str, app_name: str, record_name: str,
                        config_path: str, timeout: str, skip_device_setup: bool = False) -> SetupResult:
         """

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -210,16 +210,10 @@ class DockerSetupBase:
             raise CommandError('docker-setup', f'Failed to create record: {str(e)}')
 
     def _upload_config_file(self, params, record_uid: str, config_path: str) -> None:
-        """Upload config.json as attachment, or store as custom field if no file storage plan.
-
-        When OS-native keychain storage is active, config.json only contains the
-        ``config_storage`` pointer and no credentials.  In that case the essential
-        auth fields are sourced from ``params`` (which already has them loaded from
-        the keychain) and written to a temporary file for upload.
-        """
+        """Upload config.json as attachment, or store as custom field if no file storage plan."""
         temp_config_path = None
         try:
-            cleaned_config_path = self._get_uploadable_config(params, config_path)
+            cleaned_config_path = self._clean_config_json(config_path)
             if cleaned_config_path != config_path:
                 temp_config_path = cleaned_config_path
 
@@ -237,57 +231,6 @@ class DockerSetupBase:
                     os.unlink(temp_config_path)
                 except OSError:
                     pass
-
-    def _get_uploadable_config(self, params, config_path: str) -> str:
-        """Return a path to a config file containing only essential auth keys.
-
-        If the active storage backend is the OS keychain (config.json only has
-        the ``config_storage`` pointer), the credentials are read from ``params``
-        and written to a temp file.  Otherwise the existing ``_clean_config_json``
-        logic is used to strip non-essential keys from the file on disk.
-        """
-        try:
-            with open(config_path, 'r') as f:
-                config_data = json.load(f)
-        except Exception:
-            return config_path
-
-        config_storage = config_data.get('config_storage', '')
-        from ...config_storage.loader import _is_os_keychain_url
-        if _is_os_keychain_url(config_storage):
-            # OS-keychain mode: credentials live in the keychain, not in the file.
-            # Build the essential-keys dict from the already-loaded params object.
-            # Other backends (aws-kms://, aws-sm://, etc.) manage their own upload
-            # semantics and should not be rewritten here.
-            essential_config = {}
-            for file_key, params_attr in [
-                ('server', 'server'),
-                ('user', 'user'),
-                ('device_token', 'device_token'),
-                ('private_key', 'device_private_key'),
-                ('clone_code', 'clone_code'),
-            ]:
-                value = getattr(params, params_attr, None)
-                if value:
-                    essential_config[file_key] = value
-
-            if not essential_config:
-                raise CommandError(
-                    'docker-setup',
-                    'No credentials found in params. Please log in before running this command.'
-                )
-
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
-                json.dump(essential_config, tmp, indent=2)
-                temp_path = tmp.name
-
-            DockerSetupPrinter.print_success(
-                f'Config sourced from OS keychain ({len(essential_config)} essential keys)'
-            )
-            return temp_path
-
-        # File-based storage: clean the JSON as before.
-        return self._clean_config_json(config_path)
 
     def _upload_config_as_attachment(self, params, record_uid: str, config_path: str) -> None:
         """Upload config.json as a file attachment (requires file storage plan)."""

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -185,10 +185,16 @@ class DockerSetupBase:
             raise CommandError('docker-setup', f'Failed to create record: {str(e)}')
 
     def _upload_config_file(self, params, record_uid: str, config_path: str) -> None:
-        """Upload config.json as attachment, or store as custom field if no file storage plan."""
+        """Upload config.json as attachment, or store as custom field if no file storage plan.
+
+        When OS-native keychain storage is active, config.json only contains the
+        ``config_storage`` pointer and no credentials.  In that case the essential
+        auth fields are sourced from ``params`` (which already has them loaded from
+        the keychain) and written to a temporary file for upload.
+        """
         temp_config_path = None
         try:
-            cleaned_config_path = self._clean_config_json(config_path)
+            cleaned_config_path = self._get_uploadable_config(params, config_path)
             if cleaned_config_path != config_path:
                 temp_config_path = cleaned_config_path
 
@@ -206,6 +212,57 @@ class DockerSetupBase:
                     os.unlink(temp_config_path)
                 except OSError:
                     pass
+
+    def _get_uploadable_config(self, params, config_path: str) -> str:
+        """Return a path to a config file containing only essential auth keys.
+
+        If the active storage backend is the OS keychain (config.json only has
+        the ``config_storage`` pointer), the credentials are read from ``params``
+        and written to a temp file.  Otherwise the existing ``_clean_config_json``
+        logic is used to strip non-essential keys from the file on disk.
+        """
+        try:
+            with open(config_path, 'r') as f:
+                config_data = json.load(f)
+        except Exception:
+            return config_path
+
+        config_storage = config_data.get('config_storage', '')
+        from ...config_storage.loader import _is_os_keychain_url
+        if _is_os_keychain_url(config_storage):
+            # OS-keychain mode: credentials live in the keychain, not in the file.
+            # Build the essential-keys dict from the already-loaded params object.
+            # Other backends (aws-kms://, aws-sm://, etc.) manage their own upload
+            # semantics and should not be rewritten here.
+            essential_config = {}
+            for file_key, params_attr in [
+                ('server', 'server'),
+                ('user', 'user'),
+                ('device_token', 'device_token'),
+                ('private_key', 'device_private_key'),
+                ('clone_code', 'clone_code'),
+            ]:
+                value = getattr(params, params_attr, None)
+                if value:
+                    essential_config[file_key] = value
+
+            if not essential_config:
+                raise CommandError(
+                    'docker-setup',
+                    'No credentials found in params. Please log in before running this command.'
+                )
+
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+                json.dump(essential_config, tmp, indent=2)
+                temp_path = tmp.name
+
+            DockerSetupPrinter.print_success(
+                f'Config sourced from OS keychain ({len(essential_config)} essential keys)'
+            )
+            return temp_path
+
+        # File-based storage: clean the JSON as before.
+        return self._clean_config_json(config_path)
 
     def _upload_config_as_attachment(self, params, record_uid: str, config_path: str) -> None:
         """Upload config.json as a file attachment (requires file storage plan)."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pyngrok>=7.5.0
 flask-limiter
 psutil
 python-dotenv
+keyring
 fpdf2>=2.8.3
 cbor2; sys_platform == "darwin" and python_version>='3.10'
 pyobjc-framework-LocalAuthentication; sys_platform == "darwin" and python_version>='3.10'

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     pyngrok
     pyperclip
     python-dotenv
+    keyring
     requests>=2.31.0
     tabulate
     websockets


### PR DESCRIPTION
### Summary
Commander CLI config is now stored in the OS-native credential store by default (macOS Keychain, Windows Credential Manager, Linux Secret Service) instead of a world-readable config.json file. Users can opt into file storage explicitly using --config-file or the KEEPER_CONFIG_STORAGE=file environment variable. Service setup commands and config encryption have been updated to work correctly in both storage modes.

### Changes

- New os-keychain plugin stores protected config fields in the OS keychain via the keyring library; account key derived from the config file path hash so multiple profiles don't collide
- Auto-selects keychain on fresh login; existing config.json users and headless environments (CI, SSH) fall back to file automatically
- config.json retains only a storage pointer when keychain is active — no credentials on disk
- keeper login --config-file forces file storage; also works as keeper shell --config-file and keeper shell login --config-file. KEEPER_CONFIG_STORAGE=file as an env var alternative
- service-docker-setup, slack-app-setup, teams-app-setup block early with a clear error if credentials are in the keychain, prompting the user to re-login with --config-file
- SecureStorageException fallback scoped to OS keychain only — other backends re-raise to prevent silent plaintext downgrade
- Service config encrypt/decrypt loads private_key via KeeperParams + load_config_properties when absent from config.json, avoiding sys.exit() in daemon/Docker contexts
- Added keyring to requirements.txt and setup.cfg