### PR TITLE
Fix: persistent-login config path differed between shell and systemd

### DIFF
--- a/keepercommander/utils.py
+++ b/keepercommander/utils.py
@@ -38,21 +38,24 @@ def get_logger():
 def get_default_path(override_path=None):
     """
     Get the default path for Commander's data directory.
-    
+
     Precedence order (highest to lowest):
     1. override_path parameter (e.g., from CLI --data-dir) - auto-appends .keeper if needed
     2. KEEPER_DATA_HOME environment variable - auto-appends .keeper if needed
-    3. XDG_DATA_HOME/.keeper (XDG Base Directory Specification)
-    4. HOME/.keeper (legacy default)
-    
+    3. ~/.keeper, if it already holds a non-trivial config.json (legacy backward compatibility)
+    4. $XDG_DATA_HOME/.keeper when XDG_DATA_HOME is set
+    5. ~/.local/share/.keeper (XDG Base Directory Specification default)
+
+    Steps 4 and 5 collapse to the same path on most Linux systems, so the resolved
+    location no longer depends on whether the calling process inherited XDG_DATA_HOME
+    from a shell (relevant for systemd user services, cron, etc.).
+
     Args:
         override_path (str, optional): Override path, typically from CLI argument
-        
+
     Returns:
         Path: The path to use for Commander's data directory
     """
-    import os
-    
     def ensure_keeper_suffix(path_str):
         """Helper to ensure path ends with .keeper suffix"""
         expanded_path = Path(os.path.expanduser(path_str))
@@ -60,7 +63,19 @@ def get_default_path(override_path=None):
             return expanded_path
         else:
             return expanded_path.joinpath('.keeper')
-    
+
+    def legacy_has_state(legacy_dir):
+        """True if legacy ~/.keeper/config.json exists with real content (not empty or '{}')."""
+        try:
+            config_file = legacy_dir.joinpath('config.json')
+            if not config_file.is_file():
+                return False
+            with open(config_file) as f:
+                data = json.load(f)
+            return isinstance(data, dict) and len(data) > 0
+        except Exception:
+            return False
+
     if override_path:
         default_path = ensure_keeper_suffix(override_path)
     else:
@@ -68,12 +83,16 @@ def get_default_path(override_path=None):
         if keeper_data_home:
             default_path = ensure_keeper_suffix(keeper_data_home)
         else:
-            xdg_data_home = os.getenv('XDG_DATA_HOME')
-            if xdg_data_home:
-                default_path = Path(xdg_data_home).joinpath('.keeper')
+            legacy_dir = Path.home().joinpath('.keeper')
+            if legacy_has_state(legacy_dir):
+                default_path = legacy_dir
             else:
-                default_path = Path.home().joinpath('.keeper')
-    
+                xdg_data_home = os.getenv('XDG_DATA_HOME')
+                if xdg_data_home:
+                    default_path = Path(xdg_data_home).joinpath('.keeper')
+                else:
+                    default_path = Path.home().joinpath('.local', 'share', '.keeper')
+
     default_path.mkdir(parents=True, exist_ok=True)
     return default_path
 


### PR DESCRIPTION
## Summary

- `get_default_path()` only honored `\$XDG_DATA_HOME` when the env var was explicitly set; otherwise it fell through to `~/.keeper`. The XDG spec says implementations should treat an unset `XDG_DATA_HOME` as `\$HOME/.local/share` — Commander did not.
- This made the resolved config path environment-dependent: interactive shells on Arch-family distros (CachyOS, etc.) export `XDG_DATA_HOME` and resolve to `~/.local/share/.keeper`, but `systemd --user` services do **not** inherit shell env and fall back to `~/.keeper`.
- Result: persistent-login tokens written by `keeper login` (shell context) were invisible to a systemd-started `keeper ssh-agent start`, which then prompted for the master password on every login session — reported by a customer on CachyOS.

## Fix

New precedence in `keepercommander/utils.py:get_default_path()`:

1. `--data-dir` CLI arg
2. `KEEPER_DATA_HOME` env var
3. `~/.keeper` **if** it already holds a non-trivial `config.json` (legacy back-compat)
4. `\$XDG_DATA_HOME/.keeper` when `XDG_DATA_HOME` is set
5. `~/.local/share/.keeper` (XDG spec default)

Backward compat: a new `legacy_has_state()` helper requires the legacy file to parse as a dict with ≥1 key, so an empty `{}` or invalid JSON does not pin a user to the old path. Existing installs with real content in `~/.keeper/config.json` are untouched.

## Test plan

End-to-end verified inside the project's Docker image (`Dockerfile`, real Linux, non-root `commander` user). 7 scenarios, 13 assertions:

- [x] Fresh install, no env vars → resolves to `~/.local/share/.keeper`
- [x] Shell context (XDG_DATA_HOME set) and systemd context (unset) resolve to the **same path** — the actual bug
- [x] Legacy `~/.keeper` with real content → still wins (back-compat)
- [x] Legacy dir present but `config.json` is `{}` → falls through to XDG
- [x] Legacy dir present, no `config.json` → falls through to XDG (matches what the project's own Dockerfile creates at line 37)
- [x] Legacy `config.json` with invalid JSON → falls through to XDG
- [x] `KEEPER_DATA_HOME` and non-default `XDG_DATA_HOME` overrides still work
- [x] Real `get_params_from_config()` (the function `keeper login` / `keeper ssh-agent start` call) produces the same `config_filename` in both shell and systemd contexts

## Customer reproduction

Reported by customer. CachyOS Linux, systemd user unit `keeper-ssh-agent.service`. Customer's independent investigation already identified the path split.

## Risk

Low. Existing installs with content in `~/.keeper/config.json` see no behavior change. Fresh installs and the customer's broken-systemd case both converge on `~/.local/share/.keeper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)