### PR TITLE
Fix: honor custom label on type=password fields in record display

### DIFF
--- a/keepercommander/commands/supershell/app.py
+++ b/keepercommander/commands/supershell/app.py
@@ -586,6 +586,8 @@ class SuperShellApp(App):
                                         record_dict['password'] = field_value[0]
                                     elif isinstance(field_value, str):
                                         record_dict['password'] = field_value
+                                    if field_label:
+                                        record_dict['password_label'] = field_label
 
                                 # Extract login from typed field if not already set
                                 if field_type == 'login' and field_value and not record_dict.get('login'):
@@ -2077,9 +2079,10 @@ class SuperShellApp(App):
                     # Show 'app' for app records if type is blank
                     display_type = value if value else 'app' if record_uid in self.app_record_uids else ''
                     mount_line(f"[{t['text_dim']}]{key}:[/{t['text_dim']}] [{t['primary_dim']}]{rich_escape(str(display_type))}[/{t['primary_dim']}]", display_type)
-                elif key == 'Password':
+                elif key == 'Password' or (record_data.get('password_label') and key == record_data['password_label']):
                     # Show masked password but use ClipboardCommand to copy (generates audit event)
-                    # Respect unmask_secrets toggle
+                    # Respect unmask_secrets toggle. Matches both the canonical "Password" label
+                    # and any custom label (e.g. "Passphrase") set on a type=password field.
                     if self.unmask_secrets:
                         display_value = actual_password if actual_password else value
                     else:

--- a/keepercommander/record.py
+++ b/keepercommander/record.py
@@ -86,6 +86,7 @@ class Record:
         self.unmasked_password = None
         self.totp = None
         self.version = 2
+        self.password_label = ''  # custom label on the v3 password field (e.g. "Passphrase")
 
     def load(self, data, **kwargs):
         self.version = kwargs.get('version', 2)
@@ -129,6 +130,7 @@ class Record:
                             continue
                         if field_type == 'password' and not self.password:
                             self.password = field_value
+                            self.password_label = field_label
                             continue
                         if field_type == 'url' and not self.login_url:
                             self.login_url = field_value
@@ -225,7 +227,8 @@ class Record:
         if self.login: print('{0:>20s}: {1:<20s}'.format('Login', self.login))
         if self.password:
             display_password = (self.unmasked_password or self.password) if unmask else '********'
-            print('{0:>20s}: {1:<20s}'.format('Password', display_password))
+            password_label = self.password_label or 'Password'
+            print('{0:>20s}: {1:<20s}'.format(password_label, display_password))
         if self.login_url: print('{0:>20s}: {1:<20s}'.format('URL', self.login_url))
         # print('{0:>20s}: https://keepersecurity.com/vault#detail/{1}'.format('Link',self.record_uid))
 


### PR DESCRIPTION
## Summary

Records with a v3 typed field whose `type` is `"password"` and which has a custom `label` (e.g. `"Passphrase"` on the built-in **"SSH key with strong passphrase"** record type) were rendering as `Password: ******` in both the regular `keeper get <record>` output and the supershell/TUI detail view. The custom label was being silently dropped during the v3-to-legacy field mapping.

Expected: `Passphrase: ******` (or whatever the field's actual label is).

## Root cause

`Record.load()` in `keepercommander/record.py` maps v3 typed fields to legacy `Record` attributes for display. At the existing password branch, it assigned the value but discarded the label:

```python
if field_type == 'password' and not self.password:
    self.password = field_value
    continue   # ← label lost
```

`Record.display()` then printed the hard-coded string `"Password"` as the label.

The supershell (`commands/supershell/app.py`) parses the text output of the get command and special-cases `key == 'Password'` to apply password semantics: masked display, audit-logged clipboard copy via `ClipboardCommand`, and the unmask toggle. So even if we just renamed the label, the supershell would lose those behaviors for any field whose label isn't literally `"Password"`.

## Fix

- `record.py`: capture `field_label` into a new `self.password_label` attribute during `load()`, and use it in `display()` when set (falling back to `"Password"`).
- `supershell/app.py`: capture the label into `record_dict['password_label']` alongside the password value, and extend the supershell's password-field matcher to honor it.

Diff is 9 lines added / 3 lines changed across two files.

## Test plan

Verified locally with a harness exercising `Record.load() → Record.display()` against the customer's record shape and several variants:

- [x] V3 record, `type=password, label="Passphrase"` → renders as `Passphrase: ********`
- [x] Unmask still works → renders as `Passphrase: <secret>`
- [x] V3 record, `type=password` with no label → still renders as `Password: ********` (no regression)
- [x] V2 / legacy record with `secret2` → still renders as `Password: ********` (no regression)
- [x] Explicit `label="Password"` → renders as `Password:` (no functional difference)
- [x] All 23 existing tests in `tests/test_kc1163_record_field_labels.py` and `unit-tests/test_command_record.py` still pass

Supershell side (text-parsing branch in `_display_record_with_clickable_fields`) is updated so the existing masked-copy / unmask-toggle / `ClipboardCommand` audit-logged copy semantics continue to work after the label is renamed.

## Out of scope

The same one-line label-discard pattern exists for `login`, `url`, and `oneTimeCode` fields in `Record.load()` — they share the symptom in theory but aren't reported here, and the customer's case is specifically the password→passphrase rename. Filed as follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)