### PR TITLE
Extend custom-label fix to login, url, and oneTimeCode fields

### DIFF
--- a/keepercommander/commands/supershell/app.py
+++ b/keepercommander/commands/supershell/app.py
@@ -595,6 +595,8 @@ class SuperShellApp(App):
                                         record_dict['login'] = field_value[0]
                                     elif isinstance(field_value, str):
                                         record_dict['login'] = field_value
+                                    if field_label:
+                                        record_dict['login_label'] = field_label
 
                                 # Extract URL from typed field if not already set
                                 if field_type == 'url' and field_value and not record_dict.get('login_url'):
@@ -602,6 +604,8 @@ class SuperShellApp(App):
                                         record_dict['login_url'] = field_value[0]
                                     elif isinstance(field_value, str):
                                         record_dict['login_url'] = field_value
+                                    if field_label:
+                                        record_dict['login_url_label'] = field_label
 
                                 # Extract TOTP URL from oneTimeCode field
                                 if field_type == 'oneTimeCode' and field_value and not record_dict.get('totp_url'):
@@ -2089,8 +2093,9 @@ class SuperShellApp(App):
                         display_value = '******' if actual_password else value
                     copy_value = actual_password if actual_password else None
                     mount_line(f"[{t['text_dim']}]{key}:[/{t['text_dim']}] [{t['primary']}]{rich_escape(str(display_value))}[/{t['primary']}]", copy_value, is_password=True)
-                elif key == 'URL':
-                    # Display URL, then TOTP if present
+                elif key == 'URL' or (record_data.get('login_url_label') and key == record_data['login_url_label']):
+                    # Display URL, then TOTP if present. Matches both the canonical "URL" label
+                    # and any custom label set on a type=url field.
                     mount_line(f"[{t['text_dim']}]{key}:[/{t['text_dim']}] [{t['primary']}]{rich_escape(str(value))}[/{t['primary']}]", value)
                     display_totp()  # Add TOTP section right after URL (before Notes)
                 elif key == 'Notes':

--- a/keepercommander/record.py
+++ b/keepercommander/record.py
@@ -87,6 +87,9 @@ class Record:
         self.totp = None
         self.version = 2
         self.password_label = ''  # custom label on the v3 password field (e.g. "Passphrase")
+        self.login_label = ''     # custom label on the v3 login field
+        self.url_label = ''       # custom label on the v3 url field
+        self.totp_label = ''      # custom label on the v3 oneTimeCode field
 
     def load(self, data, **kwargs):
         self.version = kwargs.get('version', 2)
@@ -127,6 +130,7 @@ class Record:
                     if isinstance(field_value, str):
                         if field_type == 'login' and not self.login:
                             self.login = field_value
+                            self.login_label = field_label
                             continue
                         if field_type == 'password' and not self.password:
                             self.password = field_value
@@ -134,9 +138,11 @@ class Record:
                             continue
                         if field_type == 'url' and not self.login_url:
                             self.login_url = field_value
+                            self.url_label = field_label
                             continue
                         if field_type == 'oneTimeCode' and not self.totp:
                             self.totp = field_value
+                            self.totp_label = field_label
                             continue
 
                     if field_type:
@@ -224,12 +230,16 @@ class Record:
         print('{0:>20s}: {1:<20s}'.format('UID', self.record_uid))
         print('{0:>20s}: {1:<20s}'.format('Type', self.record_type if self.record_type else ''))
         if self.title: print('{0:>20s}: {1:<20s}'.format('Title', self.title))
-        if self.login: print('{0:>20s}: {1:<20s}'.format('Login', self.login))
+        if self.login:
+            login_label = self.login_label or 'Login'
+            print('{0:>20s}: {1:<20s}'.format(login_label, self.login))
         if self.password:
             display_password = (self.unmasked_password or self.password) if unmask else '********'
             password_label = self.password_label or 'Password'
             print('{0:>20s}: {1:<20s}'.format(password_label, display_password))
-        if self.login_url: print('{0:>20s}: {1:<20s}'.format('URL', self.login_url))
+        if self.login_url:
+            url_label = self.url_label or 'URL'
+            print('{0:>20s}: {1:<20s}'.format(url_label, self.login_url))
         # print('{0:>20s}: https://keepersecurity.com/vault#detail/{1}'.format('Link',self.record_uid))
 
         if len(self.custom_fields) > 0:
@@ -311,7 +321,8 @@ class Record:
                     'Attachments:' if i == 0 else '', atta.get('title') or atta.get('name'), sz, scale, 'ID', atta.get('id')))
 
         if self.totp:
-            print('{0:>20s}: {1}'.format('TOTP URL', self.totp if unmask else '********'))
+            totp_label = self.totp_label or 'TOTP URL'
+            print('{0:>20s}: {1}'.format(totp_label, self.totp if unmask else '********'))
             code, remain, _ = get_totp_code(self.totp)
             if code:
                 print('{0:>20s}: {1:<20s} valid for {2} sec'.format('Two Factor Code', code, remain))


### PR DESCRIPTION
## Summary

Follow-up to #2078. The password-label fix preserved the custom `label` on `type=password` fields. The same one-line discard pattern exists in `Record.load()` for `login`, `url`, and `oneTimeCode` — extend the same treatment to those types.

Stacked on top of #2078; merge that first. Base will redirect to `release` once #2078 lands.

## Evidence customer records already use these labels

Importers actively create labeled fields of all three types:

- `keepercommander/importer/thycotic/thycotic.py:526` — `RecordField(type='login', label=field_label, value=username)`
- `keepercommander/importer/thycotic/thycotic.py:636` — `RecordField(type='url', label=field_label, value=url)`
- `keepercommander/importer/thycotic/thycotic.py:680` — `RecordField(type='oneTimeCode', label=field_label, value=field_value)`
- `keepercommander/importer/1password/one_password.py:154` — `RecordField(type='url', label=label, value=url)`
- `keepercommander/importer/1password/one_password.py:288` — `RecordField(type='login', label=f'{account_type} Username', value=username)`

Any customer who imported a vault from Thycotic or 1Password has records with custom labels on `login` / `url` / `oneTimeCode` — and these labels were silently dropped on display.

## Fix

`record.py`:
- New `self.login_label`, `self.url_label`, `self.totp_label` attributes.
- Captured in `Record.load()` v3 branch at the existing `login` / `url` / `oneTimeCode` discriminators.
- Used in `Record.display()` for the Login, URL, and TOTP URL lines, falling back to the canonical labels.

`commands/supershell/app.py`:
- Capture `login_label` and `login_url_label` into `record_dict` alongside the values, parallel to `password_label` from #2078.
- Extend the `key == 'URL'` matcher so the post-URL `display_totp()` call still fires when the URL has a custom label.
- `Login` has no special-case branch in the supershell text parser (it falls through to the generic field renderer), so only the label capture is needed there.

## Test plan

- [x] V3 record with all four custom labels (`Account ID`, `Master Passcode`, `Admin Portal`, `Backup TOTP`) renders with those exact labels; none of the hardcoded `Login:` / `Password:` / `URL:` / `TOTP URL:` strings appear in the output
- [x] V3 record with no labels still renders with the canonical defaults
- [x] V2 legacy record (`secret1` / `secret2` / `link`) still renders with the canonical defaults
- [x] Mixed record (some labeled, some not) renders each field independently
- [x] All 23 tests in `tests/test_kc1163_record_field_labels.py` and `unit-tests/test_command_record.py` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)