### PR TITLE
Fix: import --update duplicates Login records instead of updating

### DIFF
--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -205,7 +205,12 @@ def convert_keeper_record(record, has_attachments=False):
                 rec.login = field_value
             elif field_type == 'password' and not rec.password and isinstance(field_value, str):
                 rec.password = field_value
-            elif field_type == 'url' and not field.get('label') and not rec.login_url and isinstance(field_value, str):
+            elif field_type == 'url' and not rec.login_url and isinstance(field_value, str) and \
+                    (not field.get('label') or field.get('label') == field_type):
+                # Treat label='url' as canonical (KC-1163 stamps the type name as a
+                # default label on standard fields). Without this, the URL stored on
+                # imported login records is left out of rec.login_url, the partial
+                # hash diverges, and import --update creates duplicates.
                 rec.login_url = field_value
             elif field_type.endswith('Ref'):
                 ref_type = field_type[:-3]


### PR DESCRIPTION
## Summary

Customer report: importing a CSV with `--update` after changing the password creates a duplicate record instead of updating the existing one — but **only for the default `login` record type**. Records with an explicit `$type,pamUser` (or any non-login type) update correctly.

## Root cause

`prepare_record_add_or_update` builds a partial-key hash (`type` + `title` + `login` + `url`) for every vault record and every CSV row, and uses hash equality to decide "this is the same record, update it" vs. "this is new, add it".

For login type records the two sides of the comparison computed different `$url` tokens:

| Side | Token |
|---|---|
| Vault record (post-import) | `$url:` (empty) |
| Fresh CSV import | `$url:https://test.com` |

Different tokens → different hashes → no match → duplicate inserted.

The divergence comes from `convert_keeper_record` at `imp_exp.py:208`. It refused to promote a typed `url` field to `rec.login_url` when the field had any label:

```python
elif field_type == 'url' and not field.get('label') and not rec.login_url and isinstance(field_value, str):
    rec.login_url = field_value
```

But KC-1163 (`prepare_record_add_or_update` schema-build at `imp_exp.py:2163`) deliberately stamps the field's `$ref` as a default label on every standard schema field so that KSM can resolve them by name:

```python
f.label = field.get('label') or field['$ref']
```

So every Commander-imported login record persists with `label='url'` on the URL field. `convert_keeper_record` then refuses to promote that URL to `rec.login_url` on the next round-trip, the partial-hash `$url` token becomes empty, and the hash diverges from the CSV side.

Non-login record types weren't affected because for them, `tokenize_record_key` walks `rec.fields` (after the `$type/$title/$login/$url` prefix). The URL ends up there on both sides with the same `label='url'`, so the hashes match.

## Fix

Relax the URL-promotion guard in `convert_keeper_record` to accept the schema-default label (`label == field_type`) as canonical, while still rejecting genuinely-custom labels (e.g. `"Backup URL"`) so they stay as separate typed fields:

```python
elif field_type == 'url' and not rec.login_url and isinstance(field_value, str) and \
        (not field.get('label') or field.get('label') == field_type):
    rec.login_url = field_value
```

Single-line change. No effect on write path, no effect on KSM-visible labels (KC-1163 invariants preserved).

## Reproduction (before/after)

Standalone repro with the exact stored shape (`label='url'` on the URL field):

| | Before | After |
|---|---|---|
| Partial-hash tokens (vault) | `$type:login`, `$title:T`, `$login:u`, `$url:` | `$type:login`, `$title:T`, `$login:u`, `$url:https://test.com` |
| Partial-hash tokens (CSV) | `$type:login`, `$title:T`, `$login:u`, `$url:https://test.com` | `$type:login`, `$title:T`, `$login:u`, `$url:https://test.com` |
| `--update` result | duplicate record | record updated ✓ |

## Test plan

- [x] Repro from the customer report (login type, same title/login/url, changed password) now hashes equal on both sides
- [x] URL with no label → still promoted (regression check)
- [x] URL with `label='url'` (schema default) → now promoted (the fix)
- [x] URL with custom label (`'Backup URL'`) → NOT promoted, kept as typed field (regression check)
- [x] Mixed record with both a default-labeled and a custom-labeled URL → only the default is promoted
- [x] All 23 existing tests in `tests/test_kc1163_record_field_labels.py` + `unit-tests/test_command_record.py` still pass
- [x] All 285 tests in the importer suites (`unit-tests/test_importer.py`, `test_cloud_import.py`, `pam/test_kcm_import.py`, `pam/test_pam_import_dedup.py`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)