### PR TITLE
Correct the secret template character-limit in Thycotic import

### DIFF
--- a/keepercommander/importer/thycotic/thycotic.py
+++ b/keepercommander/importer/thycotic/thycotic.py
@@ -371,7 +371,7 @@ class ThycoticImporter(BaseImporter, ThycoticMixin):
                     record.folders.append(record_folder)
 
             template_name = secret.get('secretTemplateName', '')
-            template_name = template_name[:30]
+            template_name = template_name[:32]
             if template_name in loaded_record_types:
                 record.type = template_name
             elif template_name in ('Pin', 'Security Alarm Code'):


### PR DESCRIPTION
When importing secrets from Thycotic/Delinea, we may map Delinea-secret-templates to Keeper-custom-record-types:  
- We make a list of all available record types
- We check the secret's template name and if it's a match with any record type, we import it as that record type.

However, since custom record type names have a character limit in Keeper, we have an additional logic:  
1. Consider template name "This string is 33 characters long"
2. We truncate the name to its first 30 characters: "This string is 33 characters l", then compare with available custom record type names

The problem with this logic is that custom record types have a 32-character limit in Keeper, not 30. As such the truncate in (2) is incorrect. Changed truncate action to 32 characters to match true custom record type limit.