### PR TITLE
KC-1261, KC-1267 & KC-1291: Fix: consistent folder JSON response across get, ls, and nsf-get commands

### DIFF
--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -264,15 +264,17 @@ class FolderListCommand(Command, RecordMixin):
                     
                     if len(folders) > 0:
                         for f in folders:
+                            # Check if folder is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_folders') and f.uid in params.nested_share_folders
-                            folder_type = 'nested_share_folder' if is_nested_share else f.type
-                            row = ['folder', f.uid, f.name, f'Flags: {folder_flags(f)}, Parent: {f.parent_uid or "/"}', folder_type]
+                            source = 'nested_share_folder' if is_nested_share else 'classic_folder'
+                            row = ['folder', f.uid, f.name, f'Flags: {folder_flags(f)}, Parent: {f.parent_uid or "/"}', source]
                             combined_table.append(row)
                     
                     if len(records) > 0:
                         for record in records:
+                            # Check if record is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_records') and record.record_uid in params.nested_share_records
-                            source = 'nested_share_folder' if is_nested_share else 'legacy'
+                            source = 'nested_share_folder' if is_nested_share else 'classic'
                             row = ['record', record.record_uid, record.title, 
                                    f'Type: {record.record_type}, Description: {vault_extensions.get_record_description(record)}', source]
                             combined_table.append(row)
@@ -288,9 +290,10 @@ class FolderListCommand(Command, RecordMixin):
                         for f in folders:
                             if f.color:
                                 colors[f.name] = f.color
+                            # Check if folder is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_folders') and f.uid in params.nested_share_folders
-                            folder_type = 'nested_share_folder' if is_nested_share else f.type
-                            row = [f.uid, f.name, folder_flags(f), f.parent_uid or '/', folder_type]
+                            source = 'nested_share_folder' if is_nested_share else 'classic_folder'
+                            row = [f.uid, f.name, folder_flags(f), f.parent_uid or '/', source]
                             table.append(row)
                         table.sort(key=lambda x: (x[1] or '').lower())
                         # Only apply colorization if not JSON format
@@ -305,8 +308,9 @@ class FolderListCommand(Command, RecordMixin):
                         table = []
                         headers = ['record_uid', 'type', 'title', 'description', 'source']
                         for record in records:
+                            # Check if record is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_records') and record.record_uid in params.nested_share_records
-                            source = 'nested_share_folder' if is_nested_share else 'legacy'
+                            source = 'nested_share_folder' if is_nested_share else 'classic'
                             row = [record.record_uid, record.record_type, record.title, vault_extensions.get_record_description(record), source]
                             table.append(row)
                         table.sort(key=lambda x: (x[2] or '').lower())

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -252,7 +252,7 @@ class FolderListCommand(Command, RecordMixin):
             if show_detail:
                 # Helper function to get folder flags
                 def folder_flags(f):
-                    if f.type == 'shared_folder':
+                    if f.type == BaseFolderNode.SharedFolderType:
                         flags = 'S'
                     else:
                         flags = ''
@@ -1269,7 +1269,7 @@ class ArrangeFolderCommand(Command):
         for f_uid in params.root_folder.subfolders:
             if folder_uid:
                 f = params.folder_cache[folder_uid]
-                if f.type != 'user_folder':
+                if f.type != BaseFolderNode.UserFolderType:
                     raise CommandError(self.get_parser().prog, f'\"{f.name}\" cannot be shared folder')
                 break
             if f_uid == folder:

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -264,17 +264,15 @@ class FolderListCommand(Command, RecordMixin):
                     
                     if len(folders) > 0:
                         for f in folders:
-                            # Check if folder is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_folders') and f.uid in params.nested_share_folders
-                            source = 'Nested Share Folder' if is_nested_share else 'Legacy'
-                            row = ['folder', f.uid, f.name, f'Flags: {folder_flags(f)}, Parent: {f.parent_uid or "/"}', source]
+                            folder_type = 'nested_share_folder' if is_nested_share else f.type
+                            row = ['folder', f.uid, f.name, f'Flags: {folder_flags(f)}, Parent: {f.parent_uid or "/"}', folder_type]
                             combined_table.append(row)
                     
                     if len(records) > 0:
                         for record in records:
-                            # Check if record is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_records') and record.record_uid in params.nested_share_records
-                            source = 'Nested' if is_nested_share else 'Legacy'
+                            source = 'nested_share_folder' if is_nested_share else 'legacy'
                             row = ['record', record.record_uid, record.title, 
                                    f'Type: {record.record_type}, Description: {vault_extensions.get_record_description(record)}', source]
                             combined_table.append(row)
@@ -290,10 +288,9 @@ class FolderListCommand(Command, RecordMixin):
                         for f in folders:
                             if f.color:
                                 colors[f.name] = f.color
-                            # Check if folder is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_folders') and f.uid in params.nested_share_folders
-                            source = 'Nested Share Folder' if is_nested_share else 'Legacy'
-                            row = [f.uid, f.name, folder_flags(f), f.parent_uid or '/', source]
+                            folder_type = 'nested_share_folder' if is_nested_share else f.type
+                            row = [f.uid, f.name, folder_flags(f), f.parent_uid or '/', folder_type]
                             table.append(row)
                         table.sort(key=lambda x: (x[1] or '').lower())
                         # Only apply colorization if not JSON format
@@ -308,9 +305,8 @@ class FolderListCommand(Command, RecordMixin):
                         table = []
                         headers = ['record_uid', 'type', 'title', 'description', 'source']
                         for record in records:
-                            # Check if record is from Nested Share Folder
                             is_nested_share = hasattr(params, 'nested_share_records') and record.record_uid in params.nested_share_records
-                            source = 'Nested' if is_nested_share else 'Legacy'
+                            source = 'nested_share_folder' if is_nested_share else 'legacy'
                             row = [record.record_uid, record.record_type, record.title, vault_extensions.get_record_description(record), source]
                             table.append(row)
                         table.sort(key=lambda x: (x[2] or '').lower())

--- a/keepercommander/commands/nested_share_folder/display_commands.py
+++ b/keepercommander/commands/nested_share_folder/display_commands.py
@@ -20,8 +20,10 @@ import json
 import logging
 
 from ..base import Command
+from ..record import RecordGetUidCommand
 from ...error import CommandError
 from ... import nested_share_folder as _nsf
+from ... import vault
 from .helpers import (
     RECORD_PERM_LABELS, FOLDER_PERM_LABELS,
     get_access_role_label, format_role_display,
@@ -280,8 +282,6 @@ class NestedShareGetCommand(Command):
 
         if include_dag:
             try:
-                from ..record import RecordGetUidCommand
-                from ... import vault
                 r = vault.KeeperRecord.load(params, record_uid)
                 if r:
                     RecordGetUidCommand().include_dag(params, ro, r)
@@ -475,7 +475,6 @@ class NestedShareGetCommand(Command):
             logger.debug('Could not retrieve folder access: %s', e)
 
         try:
-            from ... import vault
             record_uids = collect_records_in_folder(params, folder_uid, recursive=False)
             records_list = []
             for r_uid in record_uids:

--- a/keepercommander/commands/nested_share_folder/display_commands.py
+++ b/keepercommander/commands/nested_share_folder/display_commands.py
@@ -26,7 +26,7 @@ from .helpers import (
     RECORD_PERM_LABELS, FOLDER_PERM_LABELS,
     get_access_role_label, format_role_display,
     format_timestamp, load_record_metadata, command_error_handler,
-    ensure_nested_share_record,
+    ensure_nested_share_record, collect_records_in_folder, ROOT_FOLDER_UID,
 )
 from .parsers import (
     nested_share_record_get_details_parser,
@@ -276,7 +276,7 @@ class NestedShareGetCommand(Command):
             if share_admins:
                 ro['share_admins'] = share_admins
         except Exception as e:
-            logger.debug('Could not retrieve share admins: %s', e)
+            logger.error('Could not retrieve share admins: %s', e)
 
         if include_dag:
             try:
@@ -286,7 +286,7 @@ class NestedShareGetCommand(Command):
                 if r:
                     RecordGetUidCommand().include_dag(params, ro, r)
             except Exception as e:
-                logger.debug('Could not retrieve DAG info for record %s: %s', record_uid, e)
+                logger.error('Could not retrieve DAG info for record %s: %s', record_uid, e)
 
         print(json.dumps(ro, indent=2))
 
@@ -402,12 +402,33 @@ class NestedShareGetCommand(Command):
         owner_username = fobj.get('owner_username')
         owner_account_uid = fobj.get('owner_account_uid')
 
-        parent_uid = fobj.get('parent_uid') or None
+        nsf_folders = getattr(params, 'nested_share_folders', {})
+        raw_parent = fobj.get('parent_uid') or ''
+        # Treat the parent as root if it is absent, a known root sentinel, or not
+        # a real NSF folder entry (some vaults use server-specific root UIDs).
+        is_root_parent = not raw_parent or raw_parent == ROOT_FOLDER_UID or raw_parent not in nsf_folders
+        parent_uid = None if is_root_parent else raw_parent
+
+        def _nsf_folder_path(uid):
+            """Build display path for an NSF folder by walking up the hierarchy."""
+            parts = []
+            cur = uid
+            while cur and cur in nsf_folders:
+                obj = nsf_folders[cur]
+                parts.append(obj.get('name', cur))
+                p = obj.get('parent_uid') or ''
+                cur = None if (not p or p not in nsf_folders) else p
+            return '/'.join(reversed(parts))
+
         fo = {
             'folder_uid': folder_uid,
             'type': 'nested_share_folder',
             'name': name,
-            'parent_uid': parent_uid
+            'parent_uid': parent_uid,
+            'folder': {
+                'uid': parent_uid,
+                'path': _nsf_folder_path(parent_uid) if parent_uid else '/'
+            }
         }
         if owner_username:
             fo['owner'] = owner_username
@@ -452,6 +473,20 @@ class NestedShareGetCommand(Command):
                     fo['share_admins'] = share_admins
         except Exception as e:
             logger.debug('Could not retrieve folder access: %s', e)
+
+        try:
+            from ... import vault
+            record_uids = collect_records_in_folder(params, folder_uid, recursive=False)
+            records_list = []
+            for r_uid in record_uids:
+                entry = {'record_uid': r_uid}
+                rec = vault.KeeperRecord.load(params, r_uid)
+                if rec:
+                    entry['record_name'] = rec.title
+                records_list.append(entry)
+            fo['records'] = records_list
+        except Exception as e:
+            logger.debug('Could not retrieve records for NSF folder %s: %s', folder_uid, e)
 
         print(json.dumps(fo, indent=2))
 

--- a/keepercommander/commands/nested_share_folder/display_commands.py
+++ b/keepercommander/commands/nested_share_folder/display_commands.py
@@ -91,10 +91,11 @@ class NestedShareGetCommand(Command):
         return nested_share_get_parser
 
     def execute(self, params, **kwargs):
-        uid     = (kwargs.get('uid') or '').strip()
-        fmt     = kwargs.get('format') or 'detail'
-        verbose = kwargs.get('verbose', False)
-        unmask  = kwargs.get('unmask', False)
+        uid         = (kwargs.get('uid') or '').strip()
+        fmt         = kwargs.get('format') or 'detail'
+        verbose     = kwargs.get('verbose', False)
+        unmask      = kwargs.get('unmask', False)
+        include_dag = kwargs.get('include_dag', False)
 
         if not uid:
             raise CommandError('nsf-get', 'UID parameter is required')
@@ -116,7 +117,7 @@ class NestedShareGetCommand(Command):
                     resolved,
                 )
             (self._record_json if fmt == 'json' else self._record_detail)(
-                params, resolved, verbose, unmask)
+                params, resolved, verbose, unmask, include_dag=include_dag)
             return
 
         raise CommandError('nsf-get', f'Cannot find any Nested Share Folder object with UID or title: {uid}')
@@ -231,7 +232,7 @@ class NestedShareGetCommand(Command):
                             ', '.join(f'{k}: {v}' for k, v in val.items() if v)
         return ''
 
-    def _record_json(self, params, record_uid, verbose, _unmask=False):
+    def _record_json(self, params, record_uid, verbose, _unmask=False, include_dag=False):
         meta = load_record_metadata(params, record_uid)
         ro = {
             'record_uid': record_uid, 'title': meta['title'],
@@ -276,6 +277,16 @@ class NestedShareGetCommand(Command):
                 ro['share_admins'] = share_admins
         except Exception as e:
             logger.debug('Could not retrieve share admins: %s', e)
+
+        if include_dag:
+            try:
+                from ..record import RecordGetUidCommand
+                from ... import vault
+                r = vault.KeeperRecord.load(params, record_uid)
+                if r:
+                    RecordGetUidCommand().include_dag(params, ro, r)
+            except Exception as e:
+                logger.debug('Could not retrieve DAG info for record %s: %s', record_uid, e)
 
         print(json.dumps(ro, indent=2))
 
@@ -391,7 +402,13 @@ class NestedShareGetCommand(Command):
         owner_username = fobj.get('owner_username')
         owner_account_uid = fobj.get('owner_account_uid')
 
-        fo = {'nested_share_folder_uid': folder_uid, 'name': name}
+        parent_uid = fobj.get('parent_uid') or None
+        fo = {
+            'folder_uid': folder_uid,
+            'type': 'nested_share_folder',
+            'name': name,
+            'parent_uid': parent_uid
+        }
         if owner_username:
             fo['owner'] = owner_username
 

--- a/keepercommander/commands/nested_share_folder/parsers.py
+++ b/keepercommander/commands/nested_share_folder/parsers.py
@@ -349,3 +349,6 @@ nested_share_get_parser.add_argument(
 nested_share_get_parser.add_argument(
     '--unmask', dest='unmask', action='store_true', default=False,
     help='Reveal masked field values (passwords, secrets)')
+nested_share_get_parser.add_argument(
+    '--include-dag', dest='include_dag', action='store_true', default=False,
+    help='Include DAG/GraphSync information in json output (PAM record types only)')

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -305,10 +305,13 @@ class RecordGetUidCommand(Command):
             sf = api.get_shared_folder(params, uid)
             if fmt == 'json':
                 path = get_folder_path(params, sf.shared_folder_uid, delimiter=os.sep) if sf.shared_folder_uid else ''
+                sf_node = params.folder_cache.get(sf.shared_folder_uid) if sf.shared_folder_uid else None
                 sfo = {
-                    "shared_folder_uid": sf.shared_folder_uid,
+                    "folder_uid": sf.shared_folder_uid,
+                    "type": "shared_folder",
                     "name": sf.name,
                     "path": path,
+                    "parent_uid": sf_node.parent_uid if sf_node and sf_node.parent_uid else None,
                     "manage_users": sf.default_manage_users,
                     "manage_records": sf.default_manage_records,
                     "can_edit": sf.default_can_edit,
@@ -365,13 +368,11 @@ class RecordGetUidCommand(Command):
                 fo = {
                     'folder_uid': f.uid,
                     'type': f.type,
-                    'name': f.name
+                    'name': f.name,
+                    'parent_uid': f.parent_uid or None
                 }
-                if isinstance(f, (subfolder.SharedFolderFolderNode, subfolder.SharedFolderNode)):
-                    fo['shared_folder_uid'] = f.shared_folder_uid if isinstance(f, subfolder.SharedFolderFolderNode) \
-                        else f.uid
-                if f.parent_uid:
-                    fo['parent_folder_uid'] = f.parent_uid
+                if isinstance(f, subfolder.SharedFolderFolderNode):
+                    fo['shared_folder_uid'] = f.shared_folder_uid
                 if f.type == BaseFolderNode.UserFolderType:
                     fo['path'] = get_folder_path(params, f.uid)
                     record_uids = params.subfolder_record_cache.get(f.uid, set())

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -306,12 +306,17 @@ class RecordGetUidCommand(Command):
             if fmt == 'json':
                 path = get_folder_path(params, sf.shared_folder_uid, delimiter=os.sep) if sf.shared_folder_uid else ''
                 sf_node = params.folder_cache.get(sf.shared_folder_uid) if sf.shared_folder_uid else None
+                parent_uid = sf_node.parent_uid if sf_node and sf_node.parent_uid else None
                 sfo = {
                     "folder_uid": sf.shared_folder_uid,
-                    "type": "shared_folder",
+                    "type": "classic_folder",
                     "name": sf.name,
                     "path": path,
-                    "parent_uid": sf_node.parent_uid if sf_node and sf_node.parent_uid else None,
+                    "parent_uid": parent_uid,
+                    "folder": {
+                        "uid": parent_uid,
+                        "path": get_folder_path(params, parent_uid) if parent_uid else "/"
+                    },
                     "manage_users": sf.default_manage_users,
                     "manage_records": sf.default_manage_records,
                     "can_edit": sf.default_can_edit,
@@ -365,18 +370,31 @@ class RecordGetUidCommand(Command):
         if uid in params.folder_cache:
             f = params.folder_cache[uid]
             if fmt == 'json':
+                folder_type = 'nested_share_folder' if f.type == BaseFolderNode.NestedShareFolderType else 'classic_folder'
+                parent_uid = f.parent_uid or None
                 fo = {
                     'folder_uid': f.uid,
-                    'type': f.type,
+                    'type': folder_type,
                     'name': f.name,
-                    'parent_uid': f.parent_uid or None
+                    'parent_uid': parent_uid,
+                    'folder': {
+                        'uid': parent_uid,
+                        'path': get_folder_path(params, parent_uid) if parent_uid else '/'
+                    }
                 }
                 if isinstance(f, subfolder.SharedFolderFolderNode):
                     fo['shared_folder_uid'] = f.shared_folder_uid
                 if f.type == BaseFolderNode.UserFolderType:
                     fo['path'] = get_folder_path(params, f.uid)
                     record_uids = params.subfolder_record_cache.get(f.uid, set())
-                    fo['records'] = [{'record_uid': r} for r in record_uids]
+                    records_list = []
+                    for r_uid in record_uids:
+                        entry = {'record_uid': r_uid}
+                        rec = vault.KeeperRecord.load(params, r_uid)
+                        if rec:
+                            entry['record_name'] = rec.title
+                        records_list.append(entry)
+                    fo['records'] = records_list
                 print(json.dumps(fo, indent=2))
             else:
                 f.display()

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -376,6 +376,7 @@ class RecordGetUidCommand(Command):
                     'folder_uid': f.uid,
                     'type': folder_type,
                     'name': f.name,
+                    'path': get_folder_path(params, f.uid),
                     'parent_uid': parent_uid,
                     'folder': {
                         'uid': parent_uid,
@@ -385,7 +386,6 @@ class RecordGetUidCommand(Command):
                 if isinstance(f, subfolder.SharedFolderFolderNode):
                     fo['shared_folder_uid'] = f.shared_folder_uid
                 if f.type == BaseFolderNode.UserFolderType:
-                    fo['path'] = get_folder_path(params, f.uid)
                     record_uids = params.subfolder_record_cache.get(f.uid, set())
                     records_list = []
                     for r_uid in record_uids:

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -465,9 +465,11 @@ class RecordGetUidCommand(Command):
             if r:
                 params.queue_audit_event('open_record', record_uid=uid)
                 if fmt == 'json':
-
+                    is_nsf_record = (hasattr(params, 'nested_share_records')
+                                     and uid in getattr(params, 'nested_share_records', {}))
                     ro = {
                         'record_uid': uid,
+                        'source': 'nested_share_folder' if is_nsf_record else 'classic',
                     }
                     if version < 3 or kwargs.get('legacy') is True:
                         ro['title'] = r.title


### PR DESCRIPTION
### Summary
Folder JSON responses were inconsistent across get, ls, and nsf-get commands — using different field names for the same data, missing parent_uid, and inconsistent type/source values. This fix standardises the response format across all three commands and adds --include-dag support to nsf-get.

### Changes

- get (shared folder) — renamed shared_folder_uid → folder_uid, added "type": "classic_folder" and parent_uid
- get (folder cache) — renamed parent_folder_uid → parent_uid for consistency across all folder types; path field now present for all folder types (was only user_folder before)
- get (all folder types) — added "folder": {"uid", "path"} location block indicating the parent folder's UID and path; root-level folders return "path": "/"
- get (shared_folder_folder) — retains shared_folder_uid alongside folder_uid since it identifies the owning shared folder, which is distinct from the immediate parent
- get (user_folder) — records array now includes record_name alongside record_uid
- get (records) — added "source" field ("classic" or "nested_share_folder") as vault-namespace discriminator, consistent with ls output
- ls --format json — folder source now uses "classic_folder" / "nested_share_folder" instead of "Legacy" / "Nested Share Folder"; record source standardised to "classic" / "nested_share_folder"
- nsf-get --format json — renamed nested_share_folder_uid → folder_uid, added "type": "nested_share_folder" and parent_uid; root-level NSF folders return parent_uid: null instead of raw server-side root sentinel UID
- nsf-get (folder) — added records array with record_uid and record_name for records in the folder
- nsf-get — added --include-dag flag to include DAG/GraphSync data for PAM resource record types (pamMachine, pamDatabase, pamUser, pamDirectory, pamRemoteBrowser)