### PR TITLE
Add PAM RBI file uploads/downloads and `pam connection edit --scrollb…

### DIFF
--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -834,6 +834,32 @@ def get_config_uid(params, encrypted_session_token, encrypted_transmission_key, 
     return None
 
 
+def get_config_uid_via_pam_link(params, record_uid):
+    """Resolve a resource record's PAM Config UID via KRouter's PAM_LINK graph.
+
+    Returns the config_uid that owns the resource. Used as a fallback when
+    ``get_config_uid`` (legacy ``/api/user/get_leafs`` with graphId=0) returns
+    nothing for resources whose link lives only in the new PAM_LINK stream.
+
+    Returns the config_uid as a base64-url-safe string, or empty string on
+    failure / no link.
+    """
+    try:
+        from ....keeper_dag.proto import GraphSync_pb2 as gs_pb2
+        from ...pam.router_helper import _post_request_to_router
+        record_uid_bytes = url_safe_str_to_bytes(record_uid)
+        rq = gs_pb2.GraphSyncLeafsQuery(vertices=[record_uid_bytes])
+        rs = _post_request_to_router(params, 'graph-sync/pam/get_leafs',
+                                     rq_proto=rq, rs_type=gs_pb2.GraphSyncRefsResult)
+        if rs and rs.refs:
+            for ref in rs.refs:
+                if ref.value:
+                    return utils.base64_url_encode(ref.value)
+    except Exception as e:
+        logging.debug('get_config_uid_via_pam_link: lookup failed for %s: %s', record_uid, e)
+    return ''
+
+
 def get_keeper_tokens(params):
     transmission_key = generate_random_bytes(32)
     server_public_key = rest_api.SERVER_PUBLIC_KEYS[params.rest_context.server_key_id]

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -29,7 +29,8 @@ from keeper_secrets_manager_core.utils import bytes_to_base64, base64_to_bytes, 
 
 from .base import Command, GroupCommand, dump_report_data, RecordMixin
 from .tunnel.port_forward.TunnelGraph import TunnelDAG
-from .tunnel.port_forward.tunnel_helpers import find_open_port, get_config_uid, get_keeper_tokens, \
+from .tunnel.port_forward.tunnel_helpers import find_open_port, get_config_uid, get_config_uid_via_pam_link, \
+    get_keeper_tokens, \
     get_or_create_tube_registry, get_gateway_uid_from_record, resolve_record, resolve_pam_config, resolve_folder, \
     remove_field, start_rust_tunnel, get_tunnel_session, unregister_tunnel_session, CloseConnectionReasons, \
     wait_for_tunnel_connection, create_rust_webrtc_settings, escalate_close, \
@@ -2624,6 +2625,10 @@ class PAMConnectionEditCommand(Command):
                         'the port from the record will be used.')
     parser.add_argument('--key-events', '-k', dest='key_events', choices=choices,
                         help='Toggle Key Events settings')
+    parser.add_argument('--scrollback', '-sb', required=False, dest='scrollback', action='store',
+                        help='Maximum Scrollback Size (terminal history). Integer to set, '
+                             'empty string to remove. Supported only for pamDatabase (any DB protocol) and '
+                             'pamMachine/pamDirectory (ssh/telnet/kubernetes).')
     parser.add_argument('--rotate-on-termination', required=False, dest='rotate_on_termination',
                         choices=['on', 'off'],
                         help='Rotate launch credentials when the PAM session ends (DAG resource meta)')
@@ -2671,6 +2676,51 @@ class PAMConnectionEditCommand(Command):
                                    f"Connections are only supported on pamMachine, pamDatabase, pamDirectory, "
                                    f"pamRemoteBrowser, pamNetworkConfiguration pamAwsConfiguration, and "
                                    f"pamAzureConfiguration records{bcolors.ENDC}")
+
+        # --scrollback: validate record type + effective protocol before any mutation
+        scrollback_arg = kwargs.get('scrollback', None)
+        scrollback_clear = False
+        scrollback_value = None  # parsed int, or None to skip apply
+        if scrollback_arg is not None:
+            db_scrollback_protocols = {'mysql', 'postgresql', 'sql-server', 'mariadb', 'oracle',
+                                       'mongodb', 'redis', 'elasticsearch', 'clickhouse', 'dynamodb'}
+            terminal_scrollback_protocols = {'ssh', 'telnet', 'kubernetes'}
+            if record_type == 'pamDatabase':
+                allowed_protocols = db_scrollback_protocols
+            elif record_type in ('pamMachine', 'pamDirectory'):
+                allowed_protocols = terminal_scrollback_protocols
+            else:
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--scrollback is only supported for pamDatabase, pamMachine, and pamDirectory '
+                    f'records. Record "{record_uid}" is of type "{record_type}".{bcolors.ENDC}')
+
+            existing_ps = record.get_typed_field('pamSettings')
+            existing_protocol = ''
+            if existing_ps and existing_ps.value and isinstance(existing_ps.value[0], dict):
+                existing_protocol = existing_ps.value[0].get('connection', {}).get('protocol') or ''
+            new_protocol_arg = kwargs.get('protocol', None)
+            if kwargs.get('connections') == 'on' and new_protocol_arg is not None:
+                effective_protocol = new_protocol_arg  # may be '' to clear
+            else:
+                effective_protocol = existing_protocol
+            if effective_protocol not in allowed_protocols:
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--scrollback is not supported for protocol "{effective_protocol or "(unset)"}" '
+                    f'on {record_type} records. Allowed protocols: {", ".join(sorted(allowed_protocols))}.{bcolors.ENDC}')
+
+            if scrollback_arg == '':
+                scrollback_clear = True
+            else:
+                try:
+                    scrollback_value = int(scrollback_arg)
+                except (ValueError, TypeError):
+                    raise CommandError('pam connection edit',
+                        f'{bcolors.FAIL}--scrollback must be a non-negative integer or empty string. '
+                        f'Got: "{scrollback_arg}".{bcolors.ENDC}')
+                if scrollback_value < 0:
+                    raise CommandError('pam connection edit',
+                        f'{bcolors.FAIL}--scrollback must be a non-negative integer or empty string. '
+                        f'Got: "{scrollback_arg}".{bcolors.ENDC}')
 
         encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
         if record_type in "pamNetworkConfiguration pamAwsConfiguration pamAzureConfiguration".split():
@@ -2758,6 +2808,24 @@ class PAMConnectionEditCommand(Command):
                 else:
                     logging.debug(f'Unexpected value for --key-events {key_events} (ignored)')
 
+            # --scrollback: apply (validated above; record_type + effective protocol already checked)
+            if scrollback_clear or scrollback_value is not None:
+                psv = pam_settings.value[0] if pam_settings and pam_settings.value else {}
+                vcon = psv.get('connection', {}) if isinstance(psv, dict) else {}
+                current_sb = vcon.get('scrollback') if isinstance(vcon, dict) else None
+                if scrollback_clear:
+                    if current_sb is not None:
+                        pam_settings.value[0]["connection"].pop('scrollback', None)
+                        dirty = True
+                    else:
+                        logging.debug(f'scrollback is already unset on record={record_uid}')
+                else:
+                    if current_sb != scrollback_value:
+                        pam_settings.value[0]["connection"]["scrollback"] = scrollback_value
+                        dirty = True
+                    else:
+                        logging.debug(f'scrollback is already {scrollback_value} on record={record_uid}')
+
             if dirty:
                 record_management.update_record(params, record)
                 api.sync_down(params)
@@ -2768,7 +2836,35 @@ class PAMConnectionEditCommand(Command):
                                        f"Please make sure you have edit rights to record {record_uid} {bcolors.ENDC}")
             dirty = False
 
+            # If only record-level args were passed (e.g. --scrollback, --key-events, --protocol
+            # alone), the record update above is complete — skip the DAG/config lookup, which
+            # would otherwise raise a misleading "No PAM Configuration UID set" error when the
+            # resource isn't linked to a config yet. Mirrors the PAMRbiEditCommand pattern.
+            dag_affecting = (kwargs.get('config') or kwargs.get('admin') or kwargs.get('launch_user')
+                             or kwargs.get('clear_launch_user') or kwargs.get('connections')
+                             or kwargs.get('recording') or kwargs.get('typescriptrecording')
+                             or kwargs.get('rotate_on_termination'))
+            if not dag_affecting:
+                return
+
             existing_config_uid = get_config_uid(params, encrypted_session_token, encrypted_transmission_key, record_uid)
+
+            # When the user did not pass --configuration, fall back to
+            # first the legacy /api/user/get_leafs if that also returned nothing,
+            # then the new /api/user/graph-sync/pam/get_leafs (PAM_LINK stream) 
+            # Without this, `tdag` would be built with config_uid=None, has_graph=False,
+            # and the misleading "No PAM Configuration UID set" error would fire
+            # even though the link is resolvable.
+            if not config_uid:
+                if existing_config_uid:
+                    config_uid = existing_config_uid
+                    logging.debug('pam connection edit: using DAG-resolved config_uid: %s', config_uid)
+                else:
+                    found = get_config_uid_via_pam_link(params, record_uid)
+                    if found:
+                        logging.debug('pam connection edit: resolved config_uid via graph-sync/pam fallback: %s', found)
+                        existing_config_uid = found
+                        config_uid = found
 
             tdag = TunnelDAG(params, encrypted_session_token, encrypted_transmission_key, config_uid,
                              transmission_key=transmission_key)
@@ -3149,6 +3245,10 @@ class PAMRbiEditCommand(Command):
                         help='Allow navigation via direct URL manipulation (on/off/default)')
     parser.add_argument('--ignore-server-cert', '-isc', dest='ignore_server_cert', choices=choices,
                         help='Ignore server certificate errors (on/off/default)')
+    parser.add_argument('--allow-file-uploads', '-fu', dest='allow_file_uploads', choices=choices,
+                        help='Allow file uploads in RBI sessions (on/off/default)')
+    parser.add_argument('--allow-file-downloads', '-fd', dest='allow_file_downloads', choices=choices,
+                        help='Allow file downloads in RBI sessions (on/off/default)')
 
     # URL Filtering
     parser.add_argument('--allowed-urls', '-au', dest='allowed_urls', action='append',
@@ -3197,6 +3297,8 @@ class PAMRbiEditCommand(Command):
         # New RBI settings (Phase 1 - KC-1034)
         allow_url_navigation = kwargs.get('allow_url_navigation')  # on/off/default/None
         ignore_server_cert = kwargs.get('ignore_server_cert')  # on/off/default/None
+        allow_file_uploads = kwargs.get('allow_file_uploads')  # on/off/default/None
+        allow_file_downloads = kwargs.get('allow_file_downloads')  # on/off/default/None
         allowed_urls = kwargs.get('allowed_urls')  # list or None
         allowed_resource_urls = kwargs.get('allowed_resource_urls')  # list or None
         autofill_targets = kwargs.get('autofill_targets')  # list or None
@@ -3214,6 +3316,8 @@ class PAMRbiEditCommand(Command):
         has_new_settings = any([
             allow_url_navigation is not None,
             ignore_server_cert is not None,
+            allow_file_uploads is not None,
+            allow_file_downloads is not None,
             allowed_urls is not None,
             allowed_resource_urls is not None,
             autofill_targets is not None,
@@ -3388,6 +3492,14 @@ class PAMRbiEditCommand(Command):
         # Browser Settings - ignoreInitialSslCert (on/off/default)
         if ignore_server_cert:
             update_connection_toggle('ignoreInitialSslCert', ignore_server_cert)
+
+        # Browser Settings - allowFileUploads (on/off/default)
+        if allow_file_uploads:
+            update_connection_toggle('allowFileUploads', allow_file_uploads)
+
+        # Browser Settings - allowFileDownloads (on/off/default)
+        if allow_file_downloads:
+            update_connection_toggle('allowFileDownloads', allow_file_downloads)
 
         # URL Filtering - allowedUrlPatterns (multi-value, joined with newlines)
         if allowed_urls is not None:

--- a/unit-tests/pam/test_get_config_uid_via_pam_link.py
+++ b/unit-tests/pam/test_get_config_uid_via_pam_link.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for tunnel_helpers.get_config_uid_via_pam_link — the KRouter
+graph-sync/pam/get_leafs fallback used by `pam connection edit` when the
+legacy get_leafs lookup misses. Mirrors the web vault's
+`getMultiLeafsPamLinkDag` call (see vault/js/lib/api/pam/api-dag-pam-link.ts).
+"""
+
+import unittest
+from unittest import mock
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.tunnel.port_forward.tunnel_helpers import get_config_uid_via_pam_link
+    from keepercommander.keeper_dag.proto import GraphSync_pb2 as gs_pb2
+    from keepercommander import utils
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import tunnel_helpers/GraphSync_pb2: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestGetConfigUidViaPamLink(unittest.TestCase):
+    def setUp(self):
+        self.params = mock.MagicMock()
+        self.record_uid = 'AAAAAAAAAAAAAAAAAAAAAA'  # roundtrip-safe base64url for 16 bytes
+        self.config_uid = 'AQEBAQEBAQEBAQEBAQEBAQ'  # roundtrip-safe base64url for 16 bytes
+
+    @mock.patch('keepercommander.commands.pam.router_helper._post_request_to_router')
+    def test_returns_config_uid_on_single_ref(self, mock_post):
+        cfg_bytes = utils.base64_url_decode(self.config_uid)
+        mock_post.return_value = gs_pb2.GraphSyncRefsResult(
+            refs=[gs_pb2.GraphSyncRef(type=gs_pb2.RFT_PAM_NETWORK, value=cfg_bytes, name='')]
+        )
+        result = get_config_uid_via_pam_link(self.params, self.record_uid)
+        self.assertEqual(result, self.config_uid)
+        # Verify endpoint + query shape
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[1], 'graph-sync/pam/get_leafs')
+        rq = kwargs.get('rq_proto') or args[2]
+        self.assertEqual(len(rq.vertices), 1)
+        self.assertEqual(rq.vertices[0], utils.base64_url_decode(self.record_uid))
+
+    @mock.patch('keepercommander.commands.pam.router_helper._post_request_to_router')
+    def test_returns_empty_string_when_no_refs(self, mock_post):
+        mock_post.return_value = gs_pb2.GraphSyncRefsResult(refs=[])
+        self.assertEqual(get_config_uid_via_pam_link(self.params, self.record_uid), '')
+
+    @mock.patch('keepercommander.commands.pam.router_helper._post_request_to_router')
+    def test_returns_empty_string_when_response_is_none(self, mock_post):
+        mock_post.return_value = None
+        self.assertEqual(get_config_uid_via_pam_link(self.params, self.record_uid), '')
+
+    @mock.patch('keepercommander.commands.pam.router_helper._post_request_to_router')
+    def test_skips_refs_with_empty_value(self, mock_post):
+        cfg_bytes = utils.base64_url_decode(self.config_uid)
+        mock_post.return_value = gs_pb2.GraphSyncRefsResult(refs=[
+            gs_pb2.GraphSyncRef(type=gs_pb2.RFT_PAM_NETWORK, value=b'', name=''),
+            gs_pb2.GraphSyncRef(type=gs_pb2.RFT_PAM_NETWORK, value=cfg_bytes, name=''),
+        ])
+        self.assertEqual(get_config_uid_via_pam_link(self.params, self.record_uid), self.config_uid)
+
+    @mock.patch('keepercommander.commands.pam.router_helper._post_request_to_router')
+    def test_swallows_exceptions_and_returns_empty(self, mock_post):
+        mock_post.side_effect = RuntimeError('krouter unreachable')
+        self.assertEqual(get_config_uid_via_pam_link(self.params, self.record_uid), '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_connection_edit_scrollback.py
+++ b/unit-tests/pam/test_pam_connection_edit_scrollback.py
@@ -1,0 +1,309 @@
+"""
+Unit tests for PAM Connection Edit `--scrollback` flag.
+
+Covers argument parsing and the up-front validation that runs before any DAG /
+record mutation: allowed record types (pamDatabase, pamMachine, pamDirectory),
+allowed protocols per type, and value parsing (int / empty string / invalid).
+"""
+
+import unittest
+from unittest import mock
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.tunnel_and_connections import PAMConnectionEditCommand
+    from keepercommander.error import CommandError
+    from keepercommander import vault
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import tunnel_and_connections: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditScrollbackArgs(unittest.TestCase):
+    def setUp(self):
+        self.parser = PAMConnectionEditCommand.parser
+
+    def test_scrollback_int(self):
+        args = self.parser.parse_args(['rec', '--scrollback', '1234'])
+        self.assertEqual(args.scrollback, '1234')
+
+    def test_scrollback_empty_string(self):
+        args = self.parser.parse_args(['rec', '--scrollback', ''])
+        self.assertEqual(args.scrollback, '')
+
+    def test_scrollback_short_alias(self):
+        args = self.parser.parse_args(['rec', '-sb', '5000'])
+        self.assertEqual(args.scrollback, '5000')
+
+    def test_scrollback_not_provided(self):
+        args = self.parser.parse_args(['rec'])
+        self.assertIsNone(args.scrollback)
+
+    def test_help_includes_scrollback(self):
+        help_text = self.parser.format_help()
+        self.assertIn('--scrollback', help_text)
+        self.assertIn('-sb', help_text)
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditScrollbackValidation(unittest.TestCase):
+    """Validation runs before DAG / token operations, so we can drive execute()
+    with mocks that only need to satisfy resolve_single_record + the typed-field
+    accessor for pamSettings."""
+
+    def _mock_record(self, record_type, protocol):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        ps_field = mock.MagicMock()
+        if protocol is None:
+            ps_field.value = []
+        else:
+            ps_field.value = [{'connection': {'protocol': protocol}}]
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else None
+        return rec
+
+    def _execute(self, record, **kwargs):
+        cmd = PAMConnectionEditCommand()
+        params = mock.MagicMock()
+        with mock.patch(
+            'keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record',
+            return_value=record,
+        ):
+            cmd.execute(params, record='rec', **kwargs)
+
+    def test_pam_remote_browser_rejected(self):
+        rec = self._mock_record('pamRemoteBrowser', 'http')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('--scrollback is only supported for pamDatabase, pamMachine, and pamDirectory',
+                      str(ctx.exception))
+
+    def test_pam_user_rejected(self):
+        rec = self._mock_record('pamUser', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        # pamUser fails the outer record-type check before scrollback validation runs
+        self.assertIn("type is not supported for connections", str(ctx.exception))
+
+    def test_pam_network_configuration_rejected(self):
+        rec = self._mock_record('pamNetworkConfiguration', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('--scrollback is only supported for pamDatabase, pamMachine, and pamDirectory',
+                      str(ctx.exception))
+
+    def test_pam_machine_rdp_rejected(self):
+        rec = self._mock_record('pamMachine', 'rdp')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        msg = str(ctx.exception)
+        self.assertIn('not supported for protocol "rdp"', msg)
+        self.assertIn('pamMachine', msg)
+
+    def test_pam_machine_vnc_rejected(self):
+        rec = self._mock_record('pamMachine', 'vnc')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('not supported for protocol "vnc"', str(ctx.exception))
+
+    def test_pam_machine_no_protocol_rejected(self):
+        rec = self._mock_record('pamMachine', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('not supported for protocol "(unset)"', str(ctx.exception))
+
+    def test_pam_directory_http_rejected(self):
+        rec = self._mock_record('pamDirectory', 'http')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('not supported for protocol "http"', str(ctx.exception))
+
+    def test_non_numeric_rejected(self):
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='not-a-number')
+        self.assertIn('--scrollback must be a non-negative integer', str(ctx.exception))
+
+    def test_float_rejected(self):
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='1.5')
+        self.assertIn('--scrollback must be a non-negative integer', str(ctx.exception))
+
+    def test_negative_integer_rejected(self):
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='-100')
+        self.assertIn('--scrollback must be a non-negative integer', str(ctx.exception))
+
+    def test_negative_one_rejected(self):
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='-1')
+        self.assertIn('--scrollback must be a non-negative integer', str(ctx.exception))
+
+    def test_zero_accepted(self):
+        """Zero is a non-negative integer and should pass validation."""
+        rec = self._mock_record('pamMachine', 'ssh')
+        try:
+            self._execute(rec, scrollback='0')
+        except CommandError as e:
+            self.assertNotIn('--scrollback must be', str(e))
+        except Exception:
+            pass  # downstream DAG failure expected; only validation is under test
+
+    def test_protocol_change_in_same_command_validated_against_new(self):
+        """When --connections=on and --protocol=rdp are passed alongside --scrollback,
+        validation uses the new (post-mutation) protocol — rdp -> reject."""
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100', connections='on', protocol='rdp')
+        self.assertIn('not supported for protocol "rdp"', str(ctx.exception))
+
+    def test_protocol_change_without_connections_uses_existing(self):
+        """--protocol is only honored alongside --connections=on; without it,
+        validation uses the existing record protocol."""
+        rec = self._mock_record('pamMachine', 'ssh')
+        # Without --connections=on, the bogus --protocol is ignored, existing
+        # 'ssh' wins. Validation should not raise (it gets past the protocol
+        # check); we expect it to proceed to the DAG layer and fail there.
+        # We just assert the error is NOT the scrollback-protocol error.
+        with self.assertRaises(Exception) as ctx:
+            self._execute(rec, scrollback='100', protocol='rdp')
+        self.assertNotIn('not supported for protocol', str(ctx.exception))
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditScrollbackAllowedCombinations(unittest.TestCase):
+    """For each allowed (record_type, protocol) pair, validation must not raise
+    a scrollback-related error. We don't run the full execute path (which would
+    require mocking the entire DAG layer), only verify validation passes."""
+
+    DB_PROTOCOLS = ['mysql', 'postgresql', 'sql-server', 'mariadb', 'oracle',
+                    'mongodb', 'redis', 'elasticsearch', 'clickhouse', 'dynamodb']
+    TERMINAL_PROTOCOLS = ['ssh', 'telnet', 'kubernetes']
+
+    def _assert_validation_passes(self, record_type, protocol):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        ps_field = mock.MagicMock()
+        ps_field.value = [{'connection': {'protocol': protocol}}]
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else None
+
+        cmd = PAMConnectionEditCommand()
+        params = mock.MagicMock()
+        with mock.patch(
+            'keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record',
+            return_value=rec,
+        ):
+            try:
+                cmd.execute(params, record='rec', scrollback='100')
+            except CommandError as e:
+                self.assertNotIn('--scrollback is only supported', str(e))
+                self.assertNotIn('--scrollback is not supported for protocol', str(e))
+                self.assertNotIn('--scrollback must be an integer', str(e))
+            except Exception:
+                pass  # downstream DAG/token failures are not what we're testing
+
+    def test_pam_database_all_db_protocols(self):
+        for proto in self.DB_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self._assert_validation_passes('pamDatabase', proto)
+
+    def test_pam_machine_terminal_protocols(self):
+        for proto in self.TERMINAL_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self._assert_validation_passes('pamMachine', proto)
+
+    def test_pam_directory_terminal_protocols(self):
+        for proto in self.TERMINAL_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self._assert_validation_passes('pamDirectory', proto)
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditScrollbackEarlyReturn(unittest.TestCase):
+    """When only record-level args (scrollback, key-events, protocol alone) are passed,
+    the command should return after the record update without touching the DAG. Locks in
+    the fix for the misleading 'No PAM Configuration UID set' error when --scrollback is
+    used on a resource that isn't linked to a config."""
+
+    def _mock_record(self, record_type='pamMachine', protocol='ssh'):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        rec.fields = []
+        rec.custom = []
+        ps_field = mock.MagicMock()
+        ps_field.value = [{'connection': {'protocol': protocol}}]
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else (
+            mock.MagicMock(value=['seed']) if name == 'trafficEncryptionSeed' else None
+        )
+        return rec
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_scrollback_alone_skips_dag(self, mock_tdag, mock_get_config_uid,
+                                         mock_tokens, mock_sync, mock_update, mock_resolve):
+        """Running with only --scrollback should NOT invoke get_config_uid or TunnelDAG."""
+        rec = self._mock_record()
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', scrollback='1234')
+        mock_get_config_uid.assert_not_called()
+        mock_tdag.assert_not_called()
+        # The record update IS expected to run (scrollback was written)
+        mock_update.assert_called_once()
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_key_events_alone_skips_dag(self, mock_tdag, mock_get_config_uid,
+                                         mock_tokens, mock_sync, mock_update, mock_resolve):
+        """Same early-return applies to --key-events alone."""
+        rec = self._mock_record()
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', key_events='on')
+        mock_get_config_uid.assert_not_called()
+        mock_tdag.assert_not_called()
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid',
+                return_value=None)
+    def test_scrollback_with_connections_still_runs_dag(self, mock_get_config_uid,
+                                                        mock_tokens, mock_sync, mock_update, mock_resolve):
+        """When --connections is passed alongside --scrollback, the DAG block must still run
+        (and is expected to surface its own errors). We just verify get_config_uid is reached."""
+        rec = self._mock_record()
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        try:
+            cmd.execute(mock.MagicMock(), record='rec', scrollback='1234', connections='on')
+        except Exception:
+            pass  # downstream TunnelDAG instantiation will fail; not under test here
+        mock_get_config_uid.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_rbi_edit.py
+++ b/unit-tests/pam/test_pam_rbi_edit.py
@@ -2,7 +2,7 @@
 Unit tests for PAM RBI Edit command - KC-1034 Feature Parity
 
 Tests the new CLI arguments added to expose RBI settings:
-- Browser Settings: --allow-url-navigation, --ignore-server-cert (on/off/default)
+- Browser Settings: --allow-url-navigation, --ignore-server-cert, --allow-file-uploads, --allow-file-downloads (on/off/default)
 - URL Filtering: --allowed-urls, --allowed-resource-urls (multi-value)
 - Autofill: --autofill-targets (multi-value)
 - Clipboard: --allow-copy, --allow-paste (on/off/default)
@@ -66,6 +66,46 @@ class TestPamRbiEditArguments(unittest.TestCase):
     def test_ignore_server_cert_default(self):
         args = self.parser.parse_args(['--record', 'test-record', '--ignore-server-cert', 'default'])
         self.assertEqual(args.ignore_server_cert, 'default')
+
+    def test_allow_file_uploads_on(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-uploads', 'on'])
+        self.assertEqual(args.allow_file_uploads, 'on')
+
+    def test_allow_file_uploads_off(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-uploads', 'off'])
+        self.assertEqual(args.allow_file_uploads, 'off')
+
+    def test_allow_file_uploads_default(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-uploads', 'default'])
+        self.assertEqual(args.allow_file_uploads, 'default')
+
+    def test_allow_file_uploads_invalid(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['--record', 'test-record', '--allow-file-uploads', 'invalid'])
+
+    def test_allow_file_uploads_not_provided(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--key-events', 'on'])
+        self.assertIsNone(args.allow_file_uploads)
+
+    def test_allow_file_downloads_on(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-downloads', 'on'])
+        self.assertEqual(args.allow_file_downloads, 'on')
+
+    def test_allow_file_downloads_off(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-downloads', 'off'])
+        self.assertEqual(args.allow_file_downloads, 'off')
+
+    def test_allow_file_downloads_default(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--allow-file-downloads', 'default'])
+        self.assertEqual(args.allow_file_downloads, 'default')
+
+    def test_allow_file_downloads_invalid(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['--record', 'test-record', '--allow-file-downloads', 'invalid'])
+
+    def test_allow_file_downloads_not_provided(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--key-events', 'on'])
+        self.assertIsNone(args.allow_file_downloads)
 
     def test_allowed_urls_single(self):
         args = self.parser.parse_args(['--record', 'test-record', '--allowed-urls', '*.example.com'])
@@ -217,6 +257,56 @@ class TestPamRbiEditExecute(unittest.TestCase):
     @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
     @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
     @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_uploads_on_sets_true(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', allow_file_uploads='on')
+        self.assertEqual(self.pam_settings['connection'].get('allowFileUploads'), True)
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_uploads_off_sets_false(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', allow_file_uploads='off')
+        self.assertEqual(self.pam_settings['connection'].get('allowFileUploads'), False)
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_uploads_default_removes_field(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.pam_settings['connection']['allowFileUploads'] = True
+        self.command.execute(self.mock_params, record='test-record', allow_file_uploads='default')
+        self.assertNotIn('allowFileUploads', self.pam_settings['connection'])
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_downloads_on_sets_true(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', allow_file_downloads='on')
+        self.assertEqual(self.pam_settings['connection'].get('allowFileDownloads'), True)
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_downloads_off_sets_false(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', allow_file_downloads='off')
+        self.assertEqual(self.pam_settings['connection'].get('allowFileDownloads'), False)
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_allow_file_downloads_default_removes_field(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.pam_settings['connection']['allowFileDownloads'] = True
+        self.command.execute(self.mock_params, record='test-record', allow_file_downloads='default')
+        self.assertNotIn('allowFileDownloads', self.pam_settings['connection'])
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
     def test_allowed_urls_joins_with_newlines(self, mock_sync, mock_update, mock_resolve):
         mock_resolve.return_value = self.mock_record
         self.command.execute(self.mock_params, record='test-record', allowed_urls=['*.example.com', '*.test.com'])
@@ -356,6 +446,8 @@ class TestPamRbiEditHelp(unittest.TestCase):
         help_text = PAMRbiEditCommand.parser.format_help()
         self.assertIn('--allow-url-navigation', help_text)
         self.assertIn('--ignore-server-cert', help_text)
+        self.assertIn('--allow-file-uploads', help_text)
+        self.assertIn('--allow-file-downloads', help_text)
         self.assertIn('--allowed-urls', help_text)
         self.assertIn('--allowed-resource-urls', help_text)
         self.assertIn('--autofill-targets', help_text)
@@ -385,6 +477,14 @@ class TestPamRbiEditAliases(unittest.TestCase):
     def test_alias_isc(self):
         args = self.parser.parse_args(['--record', 'test-record', '-isc', 'on'])
         self.assertEqual(args.ignore_server_cert, 'on')
+
+    def test_alias_fu(self):
+        args = self.parser.parse_args(['--record', 'test-record', '-fu', 'on'])
+        self.assertEqual(args.allow_file_uploads, 'on')
+
+    def test_alias_fd(self):
+        args = self.parser.parse_args(['--record', 'test-record', '-fd', 'on'])
+        self.assertEqual(args.allow_file_downloads, 'on')
 
     def test_alias_au(self):
         args = self.parser.parse_args(['--record', 'test-record', '-au', '*.example.com'])


### PR DESCRIPTION
- Added **pam rbi edit**: `--allow-file-uploads/-fu and --allow-file-downloads/-fd`
- Added **pam connection edit**: `--scrollback/-sb` (non-negative integer or empty to clear)
- Bugfix: `pam connection edit` no longer errors with "No PAM Configuration UID set" when only record-level args (--scrollback, --key-events) are passed (early-return) or when the config link is resolvable via the new graph-sync /api/user/graph-sync/pam/get_leafs endpoint.