### PR TITLE
Fix NSF CLI record updates, nested directory creation and Service Mode delete response handling

### DIFF
--- a/keepercommander/commands/nested_share_folder/folder_commands.py
+++ b/keepercommander/commands/nested_share_folder/folder_commands.py
@@ -61,52 +61,122 @@ class NestedShareFolderMkdirCommand(Command):
         if current and current in getattr(params, 'nested_share_folders', {}):
             base_folder_uid = current
 
-        folder_name = self._parse_path(folder_path)
+        segments = self._parse_path(folder_path)
 
-        existing_uid = self._find_existing_child(params, folder_name, base_folder_uid)
-        if existing_uid:
-            logging.warning('nsf-mkdir: Folder "%s" already exists', folder_name)
-            return existing_uid
+        parent_uid = base_folder_uid
+        last_idx = len(segments) - 1
+        created_uid = None
 
-        with command_error_handler('nsf-mkdir'):
-            result = _nsf.create_folder_v3(
-                params=params, folder_name=folder_name,
-                parent_uid=base_folder_uid,
-                color=color,
-                inherit_permissions=inherit_permissions,
-            )
-            check_result(result, 'nsf-mkdir')
+        for idx, segment in enumerate(segments):
+            is_leaf = (idx == last_idx)
+            existing_uid = self._find_existing_child(params, segment, parent_uid)
+            if existing_uid:
+                if is_leaf:
+                    logging.warning('nsf-mkdir: Folder "%s" already exists', segment)
+                    return existing_uid
+                parent_uid = existing_uid
+                continue
+
+            seg_color = color if is_leaf else None
+            seg_inherit = inherit_permissions if is_leaf else True
+
+            with command_error_handler('nsf-mkdir'):
+                result = _nsf.create_folder_v3(
+                    params=params, folder_name=segment,
+                    parent_uid=parent_uid,
+                    color=seg_color,
+                    inherit_permissions=seg_inherit,
+                )
+                check_result(result, 'nsf-mkdir')
+
+            created_uid = result['folder_uid']
+            self._cache_new_folder(
+                params, created_uid, segment, parent_uid,
+                folder_key=result.get('folder_key_unencrypted'))
+
+            if not is_leaf:
+                logging.debug('nsf-mkdir: Created intermediate folder "%s"', segment)
+            parent_uid = created_uid
 
         params.sync_data = True
-        return result['folder_uid']
+        return created_uid
 
     @staticmethod
     def _parse_path(folder_path):
-        # Collapse escaped slashes (//) to a sentinel so we can detect any
-        # stray path separator and refuse it — nsf-mkdir creates a single
-        # folder, not a nested hierarchy.
-        collapsed = folder_path.replace('//', '\x00')
-        if '/' in collapsed:
-            raise CommandError('nsf-mkdir',
-                               'Character "/" is reserved. Use "//" inside folder name')
-        name = collapsed.replace('\x00', '/').strip()
-        if not name:
+        """Split *folder_path* into a list of segment names.
+
+        ``//`` inside a segment is treated as a literal ``/`` in the
+        folder name (same escaping convention as legacy ``mkdir``).
+        A single ``/`` is the path separator.
+
+        Returns a list with at least one non-empty segment.
+        """
+        sentinel = '\x00'
+        collapsed = folder_path.replace('//', sentinel)
+        raw_segments = collapsed.split('/')
+        segments = []
+        for raw in raw_segments:
+            name = raw.replace(sentinel, '/').strip()
+            if name:
+                segments.append(name)
+        if not segments:
             raise CommandError('nsf-mkdir', 'Invalid folder name')
-        return name
+        return segments
+
+    @staticmethod
+    def _cache_new_folder(params, folder_uid, name, parent_uid, folder_key=None):
+        """Insert a just-created folder into the local NSF cache so that
+        subsequent segments in the same path can discover it as a parent
+        without requiring a full sync round-trip.
+
+        ``folder_key`` is the unencrypted folder key returned by the
+        creation API; caching it under ``folder_key_unencrypted`` lets
+        ``get_folder_key`` find it when encrypting the child segment's
+        key, avoiding the "Parent folder key not found" fallback that
+        would otherwise encrypt the child key with the user data key
+        instead of the parent's key.
+        """
+        nsf = getattr(params, 'nested_share_folders', None)
+        if nsf is None:
+            return
+        entry = {
+            'name': name,
+            'parent_uid': parent_uid or '',
+        }
+        if folder_key:
+            entry['folder_key_unencrypted'] = folder_key
+        nsf[folder_uid] = entry
 
     @staticmethod
     def _find_existing_child(params, folder_name, parent_uid):
+        """Find an existing NSF folder named *folder_name* whose parent matches
+        *parent_uid*. ``parent_uid=None`` means "root level".
+
+        A folder is considered at root level when its ``parent_uid`` is empty,
+        is the well-known root sentinel (``ROOT_FOLDER_UID`` / ``'root'``), or
+        points to a UID that is not itself a known NSF folder (the per-account
+        vault-drive container UID — e.g. ``AAAAAAAAAAAAAAAAAUIpTQ`` — which
+        ``normalize_parent_uid`` does not recognise but which behaves as root
+        in every other folder traversal in the codebase).
+        """
         nsf_folders = getattr(params, 'nested_share_folders', {})
         name_lower = folder_name.lower()
-        expected_parent = parent_uid or ''
+        looking_for_root = not parent_uid
         for fuid, fobj in nsf_folders.items():
             if fobj.get('name', '').lower() != name_lower:
                 continue
-            existing_parent = normalize_parent_uid(fobj.get('parent_uid', ''))
-            if existing_parent == 'root':
-                existing_parent = ''
-            if existing_parent == expected_parent:
-                return fuid
+            raw_parent = fobj.get('parent_uid') or ''
+            normalized = normalize_parent_uid(raw_parent)
+            is_root_child = (
+                normalized in ('', 'root')
+                or (raw_parent and raw_parent not in nsf_folders)
+            )
+            if looking_for_root:
+                if is_root_child:
+                    return fuid
+            else:
+                if raw_parent == parent_uid:
+                    return fuid
         return None
 
 

--- a/keepercommander/commands/nested_share_folder/folder_commands.py
+++ b/keepercommander/commands/nested_share_folder/folder_commands.py
@@ -104,12 +104,6 @@ class NestedShareFolderMkdirCommand(Command):
     @staticmethod
     def _parse_path(folder_path):
         """Split *folder_path* into a list of segment names.
-
-        ``//`` inside a segment is treated as a literal ``/`` in the
-        folder name (same escaping convention as legacy ``mkdir``).
-        A single ``/`` is the path separator.
-
-        Returns a list with at least one non-empty segment.
         """
         sentinel = '\x00'
         collapsed = folder_path.replace('//', sentinel)
@@ -128,13 +122,6 @@ class NestedShareFolderMkdirCommand(Command):
         """Insert a just-created folder into the local NSF cache so that
         subsequent segments in the same path can discover it as a parent
         without requiring a full sync round-trip.
-
-        ``folder_key`` is the unencrypted folder key returned by the
-        creation API; caching it under ``folder_key_unencrypted`` lets
-        ``get_folder_key`` find it when encrypting the child segment's
-        key, avoiding the "Parent folder key not found" fallback that
-        would otherwise encrypt the child key with the user data key
-        instead of the parent's key.
         """
         nsf = getattr(params, 'nested_share_folders', None)
         if nsf is None:
@@ -151,13 +138,6 @@ class NestedShareFolderMkdirCommand(Command):
     def _find_existing_child(params, folder_name, parent_uid):
         """Find an existing NSF folder named *folder_name* whose parent matches
         *parent_uid*. ``parent_uid=None`` means "root level".
-
-        A folder is considered at root level when its ``parent_uid`` is empty,
-        is the well-known root sentinel (``ROOT_FOLDER_UID`` / ``'root'``), or
-        points to a UID that is not itself a known NSF folder (the per-account
-        vault-drive container UID — e.g. ``AAAAAAAAAAAAAAAAAUIpTQ`` — which
-        ``normalize_parent_uid`` does not recognise but which behaves as root
-        in every other folder traversal in the codebase).
         """
         nsf_folders = getattr(params, 'nested_share_folders', {})
         name_lower = folder_name.lower()

--- a/keepercommander/commands/nested_share_folder/folder_commands.py
+++ b/keepercommander/commands/nested_share_folder/folder_commands.py
@@ -529,7 +529,7 @@ class NestedShareFolderRemoveCommand(Command):
                     self._impact_summary(pr['folder_uid'], name, operation, pr.get('impact'), quiet)
                 )
 
-        if summary_lines:
+        if summary_lines and (dry_run or not force):
             for line in summary_lines:
                 print(line)
 

--- a/keepercommander/commands/nested_share_folder/parsers.py
+++ b/keepercommander/commands/nested_share_folder/parsers.py
@@ -36,7 +36,9 @@ nested_share_folder_mkdir_parser = _make_parser(
     'nsf-mkdir', 'Create a new Nested Share Folder using v3 API')
 nested_share_folder_mkdir_parser.add_argument(
     'folder', type=str,
-    help='Folder name to create (use "//" to embed a literal "/" in the name)')
+    help='Folder name or path (e.g. "Parent/Child/Grand") to create. '
+         'Intermediate folders are created automatically. '
+         'Use "//" to embed a literal "/" in a segment name.')
 nested_share_folder_mkdir_parser.add_argument(
     '--color', type=str,
     choices=['none', 'red', 'orange', 'yellow', 'green', 'blue', 'gray'],

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -179,6 +179,26 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
     def get_parser(self):
         return nested_share_record_update_parser
 
+    def _resolve_field_value(self, parsed):
+        raw = parsed.value
+        if not raw:
+            return raw
+
+        action_params = []
+        if self.is_json_value(raw, action_params):
+            return action_params[0] if action_params else None
+        action_params.clear()
+        if self.is_generate_value(raw, action_params):
+            if parsed.type == 'password':
+                return self.generate_password(action_params)
+            if parsed.type in ('oneTimeCode', 'otp'):
+                return self.generate_totp_url()
+            return raw
+        action_params.clear()
+        if self.is_base64_value(raw, action_params):
+            return action_params[0] if action_params else None
+        return raw
+
     def execute(self, params, **kwargs):
         if kwargs.get('syntax_help'):
             print(record_fields_description)
@@ -198,14 +218,23 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
         for spec in [f.strip() for f in kwargs.get('fields', []) if f.strip()]:
             try:
                 parsed = RecordEditMixin.parse_field(spec)
+                value = self._resolve_field_value(parsed)
+                if value is None:
+                    continue
                 if parsed.type in fields:
                     existing = fields[parsed.type]
                     fields[parsed.type] = ([existing] if not isinstance(existing, list)
-                                           else existing) + [parsed.value]
+                                           else existing) + [value]
                 else:
-                    fields[parsed.type] = parsed.value
+                    fields[parsed.type] = value
             except ValueError as e:
                 raise CommandError('nsf-record-update', f'Invalid field specification: {e}')
+
+        if self.warnings:
+            for w in self.warnings:
+                logging.warning(w)
+            if not kwargs.get('force'):
+                return
 
         with command_error_handler('nsf-record-update'):
             for identifier in record_uids:

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -553,28 +553,41 @@ class NestedShareRecordRemoveCommand(Command):
     def _preview_and_confirm(self, params, removals, operation, force, dry_run):
         result = _nsf.remove_record_v3(params, removals, dry_run=True)
         any_error = False
-        summary_lines = []
+        error_lines = []
+        info_lines = []
 
         for pr in result['preview_results']:
             title = self._record_title(params, pr['record_uid'])
             if pr.get('error'):
                 any_error = True
                 err = pr['error']
-                summary_lines.append(
+                error_lines.append(
                     f"  {title} [{pr['record_uid']}]: "
                     f"{err.get('code', '')} — {err.get('message', '')}"
                 )
             else:
-                summary_lines.extend(
+                info_lines.extend(
                     self._impact_summary(pr['record_uid'], title, operation, pr.get('impact'))
                 )
 
-        for line in summary_lines:
-            print(line)
-
+        # Errors must always surface, even in --force mode, so the caller (or
+        # Service Mode HTTP layer) can see why the operation aborted.
         if any_error:
+            for line in error_lines:
+                print(line)
             print('\nOne or more records could not be previewed. Aborting.')
             return
+
+        # The impact summary uses pre-action ("will be …") tense and contains a
+        # "Warning:" line. Printing it unconditionally caused Service Mode's
+        # response parser to classify successful --force deletions as HTTP 400
+        # status="warning". Match classic `rm -f`: stay silent when --force is
+        # used and the preview is clean. Still print for interactive (no force)
+        # confirmation and for explicit --dry-run.
+        if dry_run or not force:
+            for line in info_lines:
+                print(line)
+
         if dry_run:
             print('\n[Dry-run] No records were deleted.')
             return

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -578,12 +578,6 @@ class NestedShareRecordRemoveCommand(Command):
             print('\nOne or more records could not be previewed. Aborting.')
             return
 
-        # The impact summary uses pre-action ("will be …") tense and contains a
-        # "Warning:" line. Printing it unconditionally caused Service Mode's
-        # response parser to classify successful --force deletions as HTTP 400
-        # status="warning". Match classic `rm -f`: stay silent when --force is
-        # used and the preview is clean. Still print for interactive (no force)
-        # confirmation and for explicit --dry-run.
         if dry_run or not force:
             for line in info_lines:
                 print(line)

--- a/keepercommander/nested_share_folder/folder_api.py
+++ b/keepercommander/nested_share_folder/folder_api.py
@@ -93,7 +93,7 @@ def _prepare_folder_for_creation(params, folder_uid, folder_name, parent_uid,
                              else SetBooleanValue.BOOLEAN_FALSE),
         color=color)
     fd.folderKey = encrypted_fk
-    return fd
+    return fd, folder_key
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -173,13 +173,14 @@ def resolve_folder_identifier(params, folder_identifier):
 def create_folder_v3(params, folder_name, parent_uid=None, color=None,
                      inherit_permissions=True):
     uid = utils.generate_uid()
-    fd = _prepare_folder_for_creation(params, uid, folder_name, parent_uid,
-                                       color, inherit_permissions)
+    fd, folder_key = _prepare_folder_for_creation(
+        params, uid, folder_name, parent_uid, color, inherit_permissions)
     response = folder_add_v3(params, [fd])
     if response.folderAddResults:
         r = response.folderAddResults[0]
         return {
             'folder_uid': uid,
+            'folder_key_unencrypted': folder_key,
             'status': folder_pb2.FolderModifyStatus.Name(r.status),
             'message': r.message,
             'success': r.status == folder_pb2.SUCCESS,
@@ -190,20 +191,22 @@ def create_folder_v3(params, folder_name, parent_uid=None, color=None,
 def create_folders_batch_v3(params, folder_specs):
     if len(folder_specs) > 100:
         raise ValueError("Maximum 100 folders at a time")
-    fd_list, uid_map = [], {}
+    fd_list, uid_map, key_map = [], {}, {}
     for idx, spec in enumerate(folder_specs):
         uid = utils.generate_uid()
         uid_map[idx] = uid
         name = spec.get('name')
         if not name:
             raise ValueError(f"Spec at index {idx} missing 'name'")
-        fd = _prepare_folder_for_creation(
+        fd, folder_key = _prepare_folder_for_creation(
             params, uid, name, spec.get('parent_uid'),
             spec.get('color'), spec.get('inherit_permissions', True))
         fd_list.append(fd)
+        key_map[idx] = folder_key
     response = folder_add_v3(params, fd_list)
     return [{
         'folder_uid': uid_map.get(i, utils.base64_url_encode(r.folderUid)),
+        'folder_key_unencrypted': key_map.get(i),
         'name': folder_specs[i].get('name'),
         'status': folder_pb2.FolderModifyStatus.Name(r.status),
         'message': r.message,

--- a/keepercommander/nested_share_folder/record_api.py
+++ b/keepercommander/nested_share_folder/record_api.py
@@ -151,7 +151,9 @@ def update_record_v3(params, record_uid, data=None, title=None,
         if 'data_unencrypted' in rec:
             raw = rec['data_unencrypted']
             if isinstance(raw, bytes):
-                existing = json.loads(raw.decode())
+                existing = json.loads(raw.decode('utf-8'))
+            elif isinstance(raw, str):
+                existing = json.loads(raw)
         data = existing.copy() if existing else {'fields': []}
         if title is not None:
             data['title'] = title


### PR DESCRIPTION
- [KC-1295](https://keeper.atlassian.net/browse/KC-1295): Fix `nsf-record-update` storing `$GEN` field-value tokens as literal values.
 - [KC-1293](https://keeper.atlassian.net/browse/KC-1293): Fix `nsf-record-update` inability to update `hostname` and `port` fields for database record types. 
 - [KC-1294](https://keeper.atlassian.net/browse/KC-1294): Add nested path support to `nsf-mkdir`, aligning behavior with classic `mkdir -p`. 
 - [KC-1292](https://keeper.atlassian.net/browse/KC-1292): Fix Service Mode `nsf-rm --force` returning HTTP 400 and `status="warning"` despite successful record deletion.

[KC-1295]: https://keeper.atlassian.net/browse/KC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1293]: https://keeper.atlassian.net/browse/KC-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1294]: https://keeper.atlassian.net/browse/KC-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KC-1292]: https://keeper.atlassian.net/browse/KC-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ