### PR TITLE
Remove force_close escalation on workflow lease expiry; soft-close only

### DIFF
--- a/keepercommander/commands/pam_launch/launch.py
+++ b/keepercommander/commands/pam_launch/launch.py
@@ -62,7 +62,6 @@ from ..tunnel.port_forward.tunnel_helpers import (
     unregister_tunnel_session,
     unregister_conversation_key,
     get_keeper_tokens,
-    escalate_close,
     CloseConnectionReasons,
 )
 from ..tunnel.port_forward.TunnelGraph import TunnelDAG
@@ -1570,17 +1569,13 @@ class PAMLaunchCommand(Command):
 
         original_handler = signal.signal(signal.SIGINT, signal_handler_fn)
 
-        # Workflow lease expiry: schedule a hard kill at expiresOn matching
+        # Workflow lease expiry: schedule teardown at expiresOn matching
         # the web vault (immediate teardown, no grace period, no reconnect).
         # The "Access expired" line is printed AFTER terminal reset in finally
         # so the message survives reset_local_terminal_after_pam_session().
-        # On expiry we soft-close the tube and escalate to force_close_tube
-        # after FORCE_CLOSE_DELAY_SECONDS so any in-flight forwarded streams
-        # (SSH bytes etc.) are severed instead of lingering until the user
-        # disconnects manually. Escalation is gated on local hasattr +
-        # remote SDP version (FORCE_CLOSE_MIN_VERSION).
+        # On expiry we close the tube; the connection-closed cleanup path then
+        # stops the websocket and unregisters the tunnel session.
         lease_timer = None
-        force_close_timer_holder = {}  # mutable holder so cleanup can cancel
         if workflow_expires_on_ms and workflow_expires_on_ms > 0:
             seconds_until_expiry = (workflow_expires_on_ms / 1000.0) - time.time()
             _lease_tube_id = tunnel_result['tunnel'].get('tube_id')
@@ -1591,27 +1586,20 @@ class PAMLaunchCommand(Command):
                 lease_expired = True
                 shutdown_requested = True
                 if _lease_tube_id and _lease_tube_registry is not None:
-                    # Fetch remote version lazily: the SDP answer arrives
-                    # asynchronously; capturing eagerly at schedule time
-                    # would race for short leases scheduled before SDP.
-                    remote_ver = tunnel_result['tunnel'].get('remote_webrtc_version')
-                    if not remote_ver:
-                        sess = get_tunnel_session(_lease_tube_id)
-                        remote_ver = (
-                            getattr(sess, 'remote_webrtc_version', None)
-                            if sess else None
+                    try:
+                        _lease_tube_registry.close_tube(
+                            _lease_tube_id,
+                            reason=CloseConnectionReasons.AdminClosed,
                         )
-                    force_close_timer_holder['t'] = escalate_close(
-                        _lease_tube_registry,
-                        _lease_tube_id,
-                        remote_webrtc_version=remote_ver,
-                        reason=CloseConnectionReasons.AdminClosed,
-                        log_prefix=f"[lease-expiry launch tube={_lease_tube_id[:8]}] ",
-                    )
+                    except Exception as e:
+                        logging.debug(
+                            f"[lease-expiry launch tube={_lease_tube_id[:8]}] "
+                            f"close_tube failed: {e}"
+                        )
 
             if seconds_until_expiry <= 0:
-                # Already expired at session start: run the close-and-escalate
-                # path immediately so cleanup goes through the same flow as a
+                # Already expired at session start: run the close path
+                # immediately so cleanup goes through the same flow as a
                 # mid-session expiry.
                 _on_lease_expired()
             else:

--- a/keepercommander/commands/pam_launch/rust_log_filter.py
+++ b/keepercommander/commands/pam_launch/rust_log_filter.py
@@ -191,23 +191,9 @@ def enter_pam_launch_terminal_rust_logging():
 # the channel is torn down, or TURN ``fail to refresh permissions`` warnings
 # from the relay-conn task as it observes the deallocated allocation.
 #
-# The window must outlive both:
-#   1. The soft→hard close escalation in ``escalate_close``
-#      (``FORCE_CLOSE_DELAY_SECONDS`` = 3 s)
-#   2. A brief TURN refresh-task latency after the PeerConnection drop cascade
-#
-# Imported lazily below to avoid a top-level cycle (this module is imported
-# during pam_launch init, before the tunnel helpers are loaded for some
-# callers).
-def _force_close_delay_seconds():
-    try:
-        from ..tunnel.port_forward.tunnel_helpers import FORCE_CLOSE_DELAY_SECONDS
-        return FORCE_CLOSE_DELAY_SECONDS
-    except Exception:
-        return 3.0
-
-
-_DEFAULT_RUST_LOG_FILTER_GRACE_SEC = _force_close_delay_seconds() + 1.5
+# The window must outlive both the tube close + teardown cascade (~3 s) and a
+# brief TURN refresh-task latency after the PeerConnection drop cascade.
+_DEFAULT_RUST_LOG_FILTER_GRACE_SEC = 4
 
 # Refcount of active pam-launch sessions that have rust-log filtering installed.
 # Incremented in enter_*, decremented at the END of the grace timer in
@@ -282,7 +268,8 @@ def _do_exit_rust_logging(token):
 def exit_pam_launch_terminal_rust_logging(token, grace_sec=_DEFAULT_RUST_LOG_FILTER_GRACE_SEC):
     """Restore Rust/webrtc logger state after pam launch terminal session.
 
-    The filter is removed after ``grace_sec`` seconds (default 2.5s) so that
+    The filter is removed after ``grace_sec`` seconds (default
+    ``_DEFAULT_RUST_LOG_FILTER_GRACE_SEC``) so that
     late records from the Rust runtime (e.g. ``webrtc-sctp`` stream teardown
     messages that arrive just after session exit) are still caught by the
     filter and do not leak to the console in front of the subsequent

--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -129,20 +129,6 @@ def _version_at_least(version, min_version):
         return False
 
 
-# Minimum keeper-pam-webrtc-rs version that exposes force_close_tube. Both the
-# local Rust crate AND the remote peer must satisfy this gate before Commander
-# escalates a soft close to a force close. Local check uses hasattr (the binding
-# attribute is missing on older crates), remote check uses the SDP-advertised
-# version string.
-FORCE_CLOSE_MIN_VERSION = "2.1.18"
-
-# Default delay between the soft close and the force-close escalation. Matches
-# the consumer-side budget agreed with the gateway (gateway-side
-# KEEPER_GATEWAY_FORCE_CLOSE_TIMEOUT is 6s; we run faster on the consumer because
-# at lease expiry there is no reason to wait long).
-FORCE_CLOSE_DELAY_SECONDS = 3.0
-
-
 def print_above_keeper_prompt(msg):
     """Print ``msg`` so the keeper-shell prompt redraws itself underneath it.
 
@@ -179,66 +165,6 @@ def print_above_keeper_prompt(msg):
             app.invalidate()
         except Exception:
             pass
-
-
-def escalate_close(
-    tube_registry,
-    tube_id,
-    *,
-    remote_webrtc_version=None,
-    reason=None,
-    hard_after_seconds=FORCE_CLOSE_DELAY_SECONDS,
-    log_prefix="",
-):
-    """
-    Soft-close a tube now, then escalate to force_close_tube after
-    `hard_after_seconds` if both endpoints support it.
-
-    The soft close stops new channel creation and emits CloseConnection control
-    frames; the force close (when available) drops the local TCP listener,
-    severs in-flight forwarded TCP streams (SSH, MySQL, etc.) and tears down
-    the peer connection on a short bounded budget.
-
-    Returns the scheduled `threading.Timer` (or None if escalation is not
-    available) so callers can cancel it on a clean exit.
-    """
-    if reason is None:
-        reason = CloseConnectionReasons.AdminClosed
-
-    try:
-        tube_registry.close_tube(tube_id, reason=reason)
-    except Exception as e:
-        logging.debug(f"{log_prefix}soft close_tube failed: {e}")
-
-    has_local = hasattr(tube_registry, "force_close_tube")
-    has_remote = _version_at_least(remote_webrtc_version, FORCE_CLOSE_MIN_VERSION)
-    if not has_local:
-        logging.debug(
-            f"{log_prefix}force_close_tube unavailable in local keeper_pam_webrtc_rs - "
-            f"soft close only"
-        )
-        return None
-    if not has_remote:
-        logging.debug(
-            f"{log_prefix}remote keeper-pam-webrtc {remote_webrtc_version!r} < "
-            f"{FORCE_CLOSE_MIN_VERSION} - soft close only"
-        )
-        return None
-
-    def _do_force_close():
-        try:
-            logging.debug(
-                f"{log_prefix}escalating to force_close_tube({tube_id}) after "
-                f"{hard_after_seconds}s"
-            )
-            tube_registry.force_close_tube(tube_id, reason=reason)
-        except Exception as e:
-            logging.debug(f"{log_prefix}force_close_tube failed: {e}")
-
-    timer = threading.Timer(hard_after_seconds, _do_force_close)
-    timer.daemon = True
-    timer.start()
-    return timer
 
 
 # Constants

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -33,7 +33,7 @@ from .tunnel.port_forward.tunnel_helpers import find_open_port, get_config_uid, 
     get_keeper_tokens, \
     get_or_create_tube_registry, get_gateway_uid_from_record, resolve_record, resolve_pam_config, resolve_folder, \
     remove_field, start_rust_tunnel, get_tunnel_session, unregister_tunnel_session, CloseConnectionReasons, \
-    wait_for_tunnel_connection, create_rust_webrtc_settings, escalate_close, \
+    wait_for_tunnel_connection, create_rust_webrtc_settings, \
     print_above_keeper_prompt
 from .pam.router_helper import get_dag_leafs
 from .tunnel_registry import (
@@ -1015,13 +1015,9 @@ class PAMTunnelStartCommand(Command):
                 self._print_keeperdb_proxy_banner(host, port, db_type_for_banner)
             # Workflow lease expiry handling.
             #
-            # At expiresOn we soft-close the tube (stops new channels, sends
-            # CloseConnection control frames) and, after a short delay, escalate
-            # to force_close_tube which drops the local TCP listener and severs
-            # any active forwarded streams (SSH, MySQL, etc.). The escalation
-            # only fires when both the local Rust crate and the remote peer
-            # advertise FORCE_CLOSE_MIN_VERSION; older peers get the soft close
-            # only and the in-flight session lingers until natural disconnect.
+            # At expiresOn we close the tube (stops new channels, sends
+            # CloseConnection control frames); the connection-closed cleanup
+            # path then stops the websocket and unregisters the tunnel session.
             if workflow_expires_on_ms and workflow_expires_on_ms > 0:
                 seconds_until_expiry = (workflow_expires_on_ms / 1000.0) - time.time()
                 tube_id = result.get('tube_id')
@@ -1046,15 +1042,15 @@ class PAMTunnelStartCommand(Command):
                                 f"forwarded connections will be terminated."
                                 f"{bcolors.ENDC}"
                             )
-                            sess = get_tunnel_session(_tube_id)
-                            remote_ver = getattr(sess, 'remote_webrtc_version', None) if sess else None
-                            escalate_close(
-                                tube_registry,
-                                _tube_id,
-                                remote_webrtc_version=remote_ver,
-                                reason=CloseConnectionReasons.AdminClosed,
-                                log_prefix=f"[lease-expiry tunnel record={_record_uid}] ",
-                            )
+                            try:
+                                tube_registry.close_tube(
+                                    _tube_id, reason=CloseConnectionReasons.AdminClosed,
+                                )
+                            except Exception as e:
+                                logging.debug(
+                                    f"[lease-expiry tunnel record={_record_uid}] "
+                                    f"close_tube failed: {e}"
+                                )
                             # Wake any --foreground / --run blocking wait so the
                             # process self-terminates. Default interactive mode
                             # does not register an event here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests>=2.31.0
 cryptography>=46.0.6
 protobuf>=5.29.6
 keeper-secrets-manager-core>=16.6.0
-keeper_pam_webrtc_rs>=2.1.17
+keeper_pam_webrtc_rs>=2.1.18
 pydantic>=2.6.4
 flask
 pyngrok>=7.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     requests>=2.31.0
     tabulate
     websockets
-    keeper_pam_webrtc_rs>=2.1.17
+    keeper_pam_webrtc_rs>=2.1.18
     pydantic>=2.6.4
     fpdf2>=2.8.3
     tzlocal>=5.0


### PR DESCRIPTION
- Reverts the force_close_tube hard-kill escalation added in #2021; lease expiry now does a plain soft close_tube - Depends on soft close fix from branch [fix/tunnel-leak-on-connection-closed](https://github.com/Keeper-Security/Commander/tree/fix/tunnel-leak-on-connection-closed)
- Relocates the rust-log grace constant into rust_log_filter.py (_DEFAULT_RUST_LOG_FILTER_GRACE_SEC = 4)
- Bumps keeper_pam_webrtc_rs>=2.1.18
- Keeps _version_at_least, print_above_keeper_prompt, and the concurrent-session refcount guard intact.
