### PR TITLE
Fix: exempt /health from service-mode API rate limiting

### DIFF
--- a/keepercommander/service/api/routes.py
+++ b/keepercommander/service/api/routes.py
@@ -14,6 +14,7 @@ from typing import Optional
 from .command import create_command_blueprint, create_legacy_command_blueprint
 from .onboarding import create_onboarding_blueprint
 from ..decorators.logging import logger, debug_decorator
+from ..decorators.security import limiter
 
 def _setup_queue_mode(app: Flask) -> None:
     """Setup queue mode with native v2 and synchronous v1 compatibility endpoints."""
@@ -45,7 +46,11 @@ def init_routes(app: Optional[Flask] = None) -> None:
         raise ValueError("App instance is required")
 
     # Add health check endpoint (no authentication required for Docker/orchestrators)
+    # Exempt from rate limiting: liveness/readiness probes and load balancer health
+    # checks poll this frequently and must never consume the API rate-limit budget,
+    # otherwise the limit is eventually exhausted and probes start receiving HTTP 429.
     @app.route("/health", methods=["GET"])
+    @limiter.exempt
     def health_check():
         """Health check endpoint for Docker and orchestrators."""
         return jsonify({"status": "ok"}), 200


### PR DESCRIPTION
## Summary

Exempt the service-mode `/health` endpoint from API rate limiting so that
frequent infrastructure health checks (Kubernetes liveness/readiness probes,
load balancer checks) cannot exhaust the rate-limit budget and trigger pod
restart loops.

## Problem

In service mode, the REST API uses `flask-limiter` configured with a **global
default limit** that applies to **every route**:

```python
limiter = Limiter(
    key_func=get_remote_address,
    default_limits=["60/minute", "600 per hour", "6000/day"],
    storage_uri="memory://",
)
```

The `/health` endpoint had no explicit limiter configuration. In flask-limiter,
routes that are not explicitly decorated or exempted still inherit the
`default_limits`. As a result, `/health` counted against the shared per-client
daily budget.

Health probes poll `/health` continuously, so the daily budget is steadily
consumed and eventually exhausted. From that point on:

1. `/health` returns **HTTP 429** instead of 200.
2. The probes fail, so the orchestrator marks the container unhealthy and
   replaces it.
3. The new container starts with a fresh **in-memory** counter (`memory://`
   storage), so the budget resets.
4. The cycle repeats on a fixed interval.

The result is pods that recycle on a predictable ~12-hour schedule with no
actual fault — purely an artifact of health-check traffic being rate limited.

## Fix

Decorate the endpoint with `@limiter.exempt` so it is removed from **all**
rate-limit calculations (both the global default and any configured limit):

```python
@app.route("/health", methods=["GET"])
@limiter.exempt
def health_check():
    return jsonify({"status": "ok"}), 200
```

`/health` performs no backend calls and returns a static status payload, so
exempting it carries no security or abuse risk. All authenticated command
endpoints remain rate limited exactly as before.

## Verification

Reproduced the behavior against `flask-limiter` using a small `default_limits`
value and a `test_client`:

- **Without** `@limiter.exempt`: `/health` returns 200 until the limit is
  reached, then 429 on every subsequent call (reproduces the restart trigger).
- **With** `@limiter.exempt`: `/health` returns 200 on every call and never
  consumes the budget.
