### PR TITLE
Fix role sorting in user-report command

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -3846,7 +3846,7 @@ class UserReportCommand(EnterpriseCommand):
 
             path = self.get_node_path(params, user['node_id'])
             teams = self.user_teams.get(user['enterprise_user_id']) or []
-            roles = self.user_roles.get(user['enterprise_user_id']) or []
+            roles = [x['role_name'] for x in self.user_roles.get(user['enterprise_user_id'],[])]
             teams.sort(key=str.lower)
             roles.sort(key=str.lower)
             ll = user.get('last_login')


### PR DESCRIPTION
UserReportCommand returns this error:
`TypeError: descriptor 'lower' for 'str' objects doesn't apply to a 'dict' object`  
This is because we're trying to sort an array of dicts for roles, instead of an array of strings.

Reported in issue https://github.com/Keeper-Security/Commander/issues/2110