### PR TITLE
Add rules_only flag to pamActionDiscoverProcess command

### DIFF
--- a/keepercommander/commands/discover/result_process.py
+++ b/keepercommander/commands/discover/result_process.py
@@ -71,6 +71,8 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
                         help='Discovery job to process.')
     parser.add_argument('--add-all', required=False, dest='add_all', action='store_true',
                         help='Respond with ADD for all prompts.')
+    parser.add_argument('--rules-only', required=False, dest='rules_only', action='store_true',
+                        help='Auto-process with rules without manual prompts.')
     parser.add_argument('--preview', required=False, dest='do_preview', action='store_true',
                         help='Preview the results')
     parser.add_argument('--debug-gs-level', required=False, dest='debug_level', action='store',
@@ -1466,6 +1468,7 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
         do_preview = kwargs.get("do_preview", False)
         job_id = kwargs.get("job_id")
         add_all = kwargs.get("add_all", False)
+        rules_only = kwargs.get("rules_only", False)
         debug_level = kwargs.get("debug_level", 0)
 
         all_gateways = GatewayContext.all_gateways(params)
@@ -1554,6 +1557,9 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
 
                     # Pass method that will display auto added records.
                     auto_add_result_func=self._display_auto_add_results,
+                    
+                    # Process rules with no prompts.
+                    rules_only=rules_only,
 
                     # Provides a cache of the record key to record UID.
                     record_cache=record_cache,
@@ -1567,6 +1573,7 @@ class PAMGatewayActionDiscoverResultProcessCommand(PAMGatewayActionDiscoverComma
                         "add_all": add_all
                     }
                 )
+                return
 
                 logging.debug(f"Results: {results}")
 

--- a/keepercommander/discovery_common/process.py
+++ b/keepercommander/discovery_common/process.py
@@ -1368,6 +1368,7 @@ class Process:
             prompt_confirm_add_func: Optional[Callable] = None,
             prompt_admin_func: Optional[Callable] = None,
             auto_add_result_func: Optional[Callable] = None,
+            rules_only: bool = False,
             directory_info_func: Optional[Callable] = None,
             context: Optional[Any] = None,
             record_cache: Optional[dict] = None,
@@ -1473,21 +1474,22 @@ class Process:
             # This is the total number of items that processing needs to process.
             # We start with items_left equal to item_count.
             item_count = self._get_count(configuration)
-
-            self._process_level(
-                current_vertex=configuration,
-                bulk_add_records=bulk_add_records,
-                bulk_convert_records=bulk_convert_records,
-                record_lookup_func=record_lookup_func,
-                prompt_func=prompt_func,
-                prompt_admin_func=prompt_admin_func,
-                record_prepare_func=record_prepare_func,
-                directory_info_func=directory_info_func,
-                record_cache=record_cache,
-                indent=0,
-                item_count=item_count,
-                items_left=item_count,
-                context=context)
+            
+            if rules_only is False:
+                self._process_level(
+                    current_vertex=configuration,
+                    bulk_add_records=bulk_add_records,
+                    bulk_convert_records=bulk_convert_records,
+                    record_lookup_func=record_lookup_func,
+                    prompt_func=prompt_func,
+                    prompt_admin_func=prompt_admin_func,
+                    record_prepare_func=record_prepare_func,
+                    directory_info_func=directory_info_func,
+                    record_cache=record_cache,
+                    indent=0,
+                    item_count=item_count,
+                    items_left=item_count,
+                    context=context)
 
             # This mainly for testing.
             # If throw and quit exception, so we can prompt the user.


### PR DESCRIPTION
Add support for `--rules-only` flag to `pam action discover process` command.

> Before  

No way to fully automate Discovery if there are any items left to process after rules.

> After  

Running `pam action discover process -j JOBID --rules-only` will bypass manual prompts and only add results that match Discovery rules.
Needed to fully automate job processing with discovery.