### PR TITLE
Fix circular KSM import

### DIFF
--- a/keepercommander/commands/pam/gateway_helper.py
+++ b/keepercommander/commands/pam/gateway_helper.py
@@ -5,7 +5,7 @@ from typing import Sequence, Optional, List
 from keeper_secrets_manager_core.utils import url_safe_str_to_bytes
 
 from ... import api, utils
-from ...commands.utils import KSMCommand
+from ...commands.ksm import KSMCommand
 from ...loginv3 import CommonHelperMethods
 from ...params import KeeperParams
 from ...proto import pam_pb2, enterprise_pb2

--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -27,9 +27,6 @@ import requests
 
 from . import record_edit, base, record_totp, record_file_report
 from .base import Command, GroupCommand, RecordMixin, FolderMixin, fields_to_titles
-from .ksm import KSMCommand
-from .pam import gateway_helper
-from .pam.router_helper import router_get_connected_gateways
 from .. import api, display, crypto, utils, vault, vault_extensions, subfolder, record_types
 from ..breachwatch import BreachWatch
 from ..display import bcolors
@@ -1302,6 +1299,8 @@ class RecordGetUidCommand(Command):
 
 
 def _resolve_gateways_by_pattern(params, pattern):
+    from .pam import gateway_helper
+    from .pam.router_helper import router_get_connected_gateways
     """Resolve a `--device` pattern to a list of Gateway controller objects.
 
     Matches both: exact controllerUid AND case-insensitive substring on
@@ -1372,6 +1371,7 @@ def _find_pam_configs_for_gateway(params, gateway_uid_str):
 
 
 def _build_gateway_info(c, connected_instances, params, is_router_down, is_verbose):
+    from .ksm import KSMCommand
     """Build a dict describing one Gateway, suitable for table or JSON rendering."""
     gateway_uid_str = utils.base64_url_encode(c.controllerUid)
     ksm_app_uid_str = utils.base64_url_encode(c.applicationUid)


### PR DESCRIPTION
Moved KSM, gateway_helper and router_helper into their respective functions to avoid an issue with circular imports when importing commands, eg:   
`from keepercommander.commands.utils import WhoamiCommand`  
`from keepercommander.commands.discoveryrotation import PAMGatewayListCommand`