### PR TITLE
NSF folder data support for share-report command

### DIFF
--- a/keepercommander/commands/nested_share_folder/folder_commands.py
+++ b/keepercommander/commands/nested_share_folder/folder_commands.py
@@ -443,7 +443,7 @@ class NestedShareFolderShareCommand(Command):
             else:
                 logging.warning("%s share '%s' failed", kind, recipient)
         except ValueError as e:
-            logging.warning("%s '%s': %s", kind, recipient, e)
+            logging.warning("nsf-share-folder: %s", e)
         except Exception as e:
             raise CommandError('nsf-share-folder', str(e))
 

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -1088,6 +1088,128 @@ class ShareReportCommand(Command):
         return share_report_parser
 
     @staticmethod
+    def _resolve_nested_folder_name(params, folder_uid):
+        folder = getattr(params, 'nested_share_folders', {}).get(folder_uid) or {}
+        return folder.get('name') or folder_uid
+
+    @staticmethod
+    def _resolve_team_name(params, team_uid):
+        if params.enterprise:
+            teams = params.enterprise.get('teams') or []
+            team_name = next((t.get('name') for t in teams if t.get('team_uid') == team_uid), None)
+            if team_name:
+                return team_name
+        return team_uid
+
+    @staticmethod
+    def _get_team_users(params, team_uid):
+        if not params.enterprise:
+            return []
+        users = {u.get('enterprise_user_id'): u.get('username')
+                 for u in (params.enterprise.get('users') or [])}
+        team_users = []
+        for team_user in params.enterprise.get('team_users') or []:
+            if team_user.get('team_uid') != team_uid:
+                continue
+            username = users.get(team_user.get('enterprise_user_id'))
+            if username:
+                team_users.append(username)
+        return team_users
+
+    @staticmethod
+    def _is_nested_folder_owner(folder_info, accessor):
+        owner_username = folder_info.get('owner_username')
+        owner_account_uid = folder_info.get('owner_account_uid')
+        username = accessor.get('username')
+        if owner_username and username and owner_username.lower() == username.lower():
+            return True
+        accessor_uid = accessor.get('accessor_uid')
+        return bool(owner_account_uid and accessor_uid and owner_account_uid == accessor_uid)
+
+    @staticmethod
+    def _get_nested_folder_permission_label(accessor):
+        def format_permission_label(role):
+            labels = {
+                'viewer': 'Viewer',
+                'share-manager': 'Share Manager',
+                'content-manager': 'Content Manager',
+                'content-share-manager': 'Content and Share Manager',
+                'full-manager': 'Full Manager',
+                'contributor': 'Contributor',
+                'requestor': 'Requestor',
+                'navigator': 'Navigator',
+                'unresolved': 'Unresolved',
+            }
+            return labels.get(role, role.replace('-', ' ').title() if role else '')
+
+        if not isinstance(accessor, dict):
+            return ''
+        role_name = accessor.get('role')
+        if role_name:
+            from .nested_share_folder.helpers import format_role_display
+            return format_permission_label(format_role_display(role_name))
+        perms = accessor.get('permissions') or {}
+        if not perms:
+            return ''
+        from .nested_share_folder.helpers import get_access_role_label
+        return format_permission_label(get_access_role_label({
+            'can_change_ownership': perms.get('can_change_ownership', False),
+            'can_delete':           perms.get('can_delete', False),
+            'can_update_access':    perms.get('can_update_access', False),
+            'can_approve_access':   perms.get('can_approve_access', False),
+            'can_edit':             perms.get('can_edit_records', False),
+            'can_view':             perms.get('can_view_records', False),
+            'can_list_access':      perms.get('can_list_access', False),
+        }))
+
+    @staticmethod
+    def _get_nested_folder_report_rows(params, show_team_users=False):
+        rows = []
+        nsf_folders = getattr(params, 'nested_share_folders', {}) or {}
+        if not nsf_folders:
+            return rows
+
+        from .. import nested_share_folder as _nsf
+
+        sharing_states = getattr(params, 'nested_share_folder_sharing_states', {}) or {}
+        for folder_uid, folder_info in nsf_folders.items():
+            sharing_state = sharing_states.get(folder_uid)
+            if sharing_state and not sharing_state.get('shared') and sharing_state.get('count', 0) <= 0:
+                continue
+            try:
+                result = _nsf.get_folder_access_v3(params, [folder_uid], resolve_usernames=True)
+            except Exception as e:
+                logging.debug('Could not retrieve Nested Share Folder access for %s: %s', folder_uid, e)
+                continue
+
+            folder_name = folder_info.get('name') or folder_uid
+            folder_path = get_folder_path(params, folder_uid)
+            for folder_result in result.get('results', []):
+                if not folder_result.get('success'):
+                    continue
+                for accessor in folder_result.get('accessors', []):
+                    if ShareReportCommand._is_nested_folder_owner(folder_info, accessor):
+                        continue
+                    permissions = ShareReportCommand._get_nested_folder_permission_label(accessor)
+                    access_type = accessor.get('access_type')
+                    if access_type == 'AT_TEAM':
+                        team_uid = accessor.get('accessor_uid')
+                        team_name = ShareReportCommand._resolve_team_name(params, team_uid)
+                        rows.append([folder_uid, folder_name, 'Nested Share Folder',
+                                     f'(Team) {team_name}', permissions, folder_path])
+                        if show_team_users:
+                            for username in ShareReportCommand._get_team_users(params, team_uid):
+                                rows.append([folder_uid, folder_name, 'Nested Share Folder',
+                                             f'(Team User) {username}', permissions, folder_path])
+                    else:
+                        username = accessor.get('username') or accessor.get('accessor_uid')
+                        if username:
+                            rows.append([folder_uid, folder_name, 'Nested Share Folder',
+                                         username, permissions, folder_path])
+
+        return rows
+
+    @staticmethod
     def sf_report(params, out=None, fmt=None, show_team_users=False):
         def get_share_info(share_target, name_key):  # type: (Dict[str, Any], str) -> Dict[str, str]
             manage_users = share_target.get('manage_users')
@@ -1134,13 +1256,13 @@ class ShareReportCommand(Command):
             return team_user_shares
 
         title = 'Shared folders'
-        headers = ['Folder UID', 'Folder Name', 'Shared To', 'Permissions', 'Folder Path']
+        headers = ['Folder UID', 'Folder Name', 'Type', 'Shared To', 'Permissions', 'Folder Path']
         shared_folders = {**params.shared_folder_cache}
         table = []
         for uid, props in shared_folders.items():
             path = get_folder_path(params, uid)
             name = props['name_unencrypted']
-            row = [uid, name]
+            row = [uid, name, 'Shared Folder']
             users = props.get('users') or []
             teams = props.get('teams') or []
             user_shares = [get_share_info(u, 'username') for u in users]
@@ -1150,6 +1272,7 @@ class ShareReportCommand(Command):
                 shared_to.extend(get_team_shares(ts))
             rows = [(*row, target.get('name'), target.get('permissions'), path) for target in shared_to]
             table += rows
+        table += ShareReportCommand._get_nested_folder_report_rows(params, show_team_users=show_team_users)
         return dump_report_data(table, headers, title=title, fmt=fmt, filename=out)
 
     def execute(self, params, **kwargs):
@@ -1255,7 +1378,8 @@ class ShareReportCommand(Command):
                     for user in sf_shares:
                         for shared_folder_uid in sf_shares[user]:
                             sf = api.get_shared_folder(params, shared_folder_uid)
-                            row = [user, shared_folder_uid, sf.name if sf else '']
+                            folder_name = sf.name if sf else self._resolve_nested_folder_name(params, shared_folder_uid)
+                            row = [user, shared_folder_uid, folder_name]
                             table.append(row)
 
                     if output_format == 'table':

--- a/keepercommander/nested_share_folder/folder_api.py
+++ b/keepercommander/nested_share_folder/folder_api.py
@@ -21,6 +21,7 @@ from .common import (
     resolve_uid_email, encrypt_for_recipient, load_user_public_key,
     parse_folder_access_result,
     resolve_team_identifier, get_team_keys, encrypt_for_team,
+    handle_share_invite,
 )
 from .permissions import (
     FolderUsageType, SetBooleanValue, resolve_role_name, ROLE_NAME_MAP,
@@ -339,9 +340,15 @@ def grant_folder_access_v3(params, folder_uid, user_uid, role='viewer',
         user_email = user_uid if is_email else None
         if is_email:
             try:
-                user_public_key, use_ecc, actual_uid_bytes, _inv = get_user_public_key(params, user_email)
+                user_public_key, use_ecc, actual_uid_bytes, needs_invite = \
+                    get_user_public_key(params, user_email)
             except Exception as e:
                 raise ValueError(f"User '{user_email}' not found or has no public key. {e}")
+            if not user_public_key:
+                handle_share_invite(params, user_email, needs_invite)
+                raise ValueError(f"User '{user_email}' has no public key")
+            if not actual_uid_bytes:
+                raise ValueError(f"User '{user_email}' not found")
         else:
             actual_uid_bytes, user_email = resolve_uid_email(params, user_uid)
             if not actual_uid_bytes:

--- a/keepercommander/shared_record.py
+++ b/keepercommander/shared_record.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 from typing import Dict, List
 
@@ -176,9 +177,10 @@ class SharedRecord:
         ordered = list(self.permissions.values())
         for user_perms in self.user_permissions.values():
             if user_perms.to_uid:
-                ordered.remove(user_perms)
                 team_perms = self.team_permissions.get(user_perms.to_uid)
-                ordered.insert(ordered.index(team_perms) + 1, user_perms)
+                if team_perms in ordered and user_perms in ordered:
+                    ordered.remove(user_perms)
+                    ordered.insert(ordered.index(team_perms) + 1, user_perms)
         return ordered
 
     def merge_permissions(self, share_target, perms_to_merge, sp_type):
@@ -274,6 +276,54 @@ class SharedRecord:
             load_user_permissions(user_perms)
 
         sf_perms = shares.get('shared_folder_permissions', [])
+        is_nested_share_record = self.uid in getattr(params, 'nested_share_records', {})
+        if is_nested_share_record and not user_perms and not sf_perms:
+            try:
+                from . import nested_share_folder as _nsf
+                nested_accesses = _nsf.get_record_accesses_v3(params, [self.uid]).get('record_accesses', [])
+                for access in nested_accesses:
+                    if access.get('record_uid') != self.uid:
+                        continue
+
+                    share_target = access.get('accessor_name') or access.get('access_type_uid') or ''
+                    if not share_target:
+                        continue
+
+                    if access.get('owner'):
+                        self.owner = share_target
+
+                    share_info = {
+                        'editable': access.get('can_edit', False),
+                        'shareable': access.get('can_update_access', False) or access.get('can_approve_access', False),
+                        'view': access.get('can_view', True),
+                    }
+                    inherited = access.get('inherited', False)
+                    access_type = access.get('access_type')
+                    if access_type == 'AT_TEAM':
+                        team_uid = access.get('access_type_uid')
+                        if inherited:
+                            team_usernames = team_members.get(team_uid, set())
+                            for folder_uid in self.folder_uids:
+                                update_sf_shares(share_target, folder_uid)
+                                for username in team_usernames:
+                                    update_sf_shares(username, folder_uid)
+                        share_info['team_uid'] = access.get('access_type_uid')
+                        share_info['name'] = share_target
+                        load_team_permissions([share_info], None)
+                    else:
+                        if inherited:
+                            for folder_uid in self.folder_uids:
+                                update_sf_shares(share_target, folder_uid)
+                        share_info['username'] = share_target
+                        share_type = SharePermissions.SharePermissionsType.SF_USER if inherited \
+                            else SharePermissions.SharePermissionsType.USER
+                        load_user_permissions([share_info], None, share_type)
+
+                apply_role_restrictions()
+                return
+            except Exception as e:
+                logging.debug('Could not load Nested Share Folder permissions for %s: %s', self.uid, e)
+
         SF_UID = 'shared_folder_uid'
         sf_cache = params.shared_folder_cache
         shared_folders = {sfp.get(SF_UID): sf_cache.get(sfp.get(SF_UID)) for sfp in sf_perms}

--- a/unit-tests/test_command_register.py
+++ b/unit-tests/test_command_register.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from contextlib import contextmanager
 from unittest import TestCase, mock
 
@@ -7,6 +8,7 @@ from keepercommander.commands import register
 from keepercommander.error import CommandError
 from keepercommander.proto import APIRequest_pb2, record_pb2
 from keepercommander import utils
+from keepercommander.subfolder import NestedShareFolderNode
 
 vault_env = VaultEnvironment()
 
@@ -347,6 +349,121 @@ class TestRegister(TestCase):
             cmd.execute(params, action='grant', user=['user2@keepersecurity.com'],
                         folder=shared_folder_uid, expire_in='1d', rotate_on_expiration=True)
         self.assertIn('pamUser', str(ctx.exception))
+
+    @staticmethod
+    def _attach_nested_share_folder(params, record_uid, folder_name='Drive'):
+        folder_uid = utils.generate_uid()
+        folder_node = NestedShareFolderNode()
+        folder_node.uid = folder_uid
+        folder_node.name = folder_name
+        folder_node.parent_uid = None
+        params.folder_cache[folder_uid] = folder_node
+        params.root_folder.subfolders.append(folder_uid)
+
+        params.nested_share_folders[folder_uid] = {
+            'folder_uid': folder_uid,
+            'name': folder_name,
+            'owner_username': params.user,
+        }
+        params.nested_share_folder_records[folder_uid] = {record_uid}
+        params.nested_share_records[record_uid] = {
+            'record_uid': record_uid,
+            'shared': True,
+        }
+        params.subfolder_cache[folder_uid] = {
+            'folder_uid': folder_uid,
+            'type': 'user_folder',
+            'name': folder_name,
+            'source': 'nested_share_folder',
+        }
+        for record_uids in params.subfolder_record_cache.values():
+            record_uids.discard(record_uid)
+        params.subfolder_record_cache[folder_uid] = {record_uid}
+        params.record_cache[record_uid]['shared'] = True
+        params.record_cache[record_uid].pop('shares', None)
+        return folder_uid
+
+    def test_share_report_owner_supports_nested_share_records(self):
+        params = get_synced_params()
+        record_uid = next(uid for uid, rec in params.record_cache.items() if not rec.get('shared'))
+        folder_uid = self._attach_nested_share_folder(params, record_uid)
+
+        access_result = {
+            'record_accesses': [
+                {
+                    'record_uid': record_uid,
+                    'accessor_name': params.user,
+                    'access_type': 'AT_USER',
+                    'access_type_uid': utils.generate_uid(),
+                    'owner': True,
+                    'inherited': False,
+                    'can_view': True,
+                    'can_edit': True,
+                    'can_update_access': True,
+                    'can_approve_access': True,
+                },
+                {
+                    'record_uid': record_uid,
+                    'accessor_name': 'user2@keepersecurity.com',
+                    'access_type': 'AT_USER',
+                    'access_type_uid': utils.generate_uid(),
+                    'owner': False,
+                    'inherited': True,
+                    'can_view': True,
+                    'can_edit': True,
+                    'can_update_access': True,
+                    'can_approve_access': True,
+                }
+            ]
+        }
+
+        with mock.patch('keepercommander.api.get_record_shares', return_value=None), \
+                mock.patch('keepercommander.nested_share_folder.record_api.get_record_accesses_v3',
+                           return_value=access_result):
+            cmd = register.ShareReportCommand()
+            report = cmd.execute(params, format='json', owner=True, verbose=True, container=[folder_uid])
+
+        data = json.loads(report)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['record_uid'], record_uid)
+        self.assertEqual(data[0]['record_owner'], params.user)
+        self.assertEqual(data[0]['folder_path'], 'Drive')
+        self.assertIn('user2@keepersecurity.com', data[0]['shared_with'])
+
+    def test_share_report_folders_supports_nested_share_folders(self):
+        params = get_synced_params()
+        record_uid = next(uid for uid in params.record_cache)
+        folder_uid = self._attach_nested_share_folder(params, record_uid)
+        params.nested_share_folder_sharing_states[folder_uid] = {
+            'shared': True,
+            'count': 1,
+        }
+        access_result = {
+            'results': [{
+                'folder_uid': folder_uid,
+                'success': True,
+                'accessors': [{
+                    'username': 'user2@keepersecurity.com',
+                    'accessor_uid': utils.generate_uid(),
+                    'access_type': 'AT_USER',
+                    'role': 'CONTENT_SHARE_MANAGER',
+                }]
+            }]
+        }
+
+        with mock.patch('keepercommander.nested_share_folder.folder_api.get_folder_access_v3',
+                        return_value=access_result):
+            cmd = register.ShareReportCommand()
+            report = cmd.execute(params, format='json', folders=True)
+
+        data = json.loads(report)
+        row = next((x for x in data if x['Folder UID'] == folder_uid), None)
+        self.assertIsNotNone(row)
+        self.assertEqual(row['Folder Name'], 'Drive')
+        self.assertEqual(row['Type'], 'Nested Share Folder')
+        self.assertEqual(row['Shared To'], 'user2@keepersecurity.com')
+        self.assertEqual(row['Folder Path'], 'Drive')
+        self.assertEqual(row['Permissions'], 'Content and Share Manager')
 
     @staticmethod
     def record_share_rq_rs(rq):

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -582,6 +582,52 @@ class TestNestedShareFolderSharingCommands(TestCase):
                         record=ruid, email='user@example.com',
                         action='revoke')
 
+    @patch('keepercommander.nested_share_folder.folder_api.grant_folder_access_v3')
+    def test_share_folder_invite_message_uses_command_prefix(self, mock_grant):
+        from keepercommander.commands.nested_share_folder import NestedShareFolderShareCommand
+
+        fuid, fobj = _make_folder()
+        email = 'user@example.com'
+        mock_grant.side_effect = ValueError(
+            f"Share invitation has been sent to '{email}'. "
+            "Please repeat this command once the invitation is accepted.")
+
+        cmd = NestedShareFolderShareCommand()
+        with self.assertLogs(level='WARNING') as logs:
+            cmd.execute(_make_params(nested_share_folders={fuid: fobj}),
+                        folder=[fuid], user=[email], action='grant', role='viewer')
+
+        output = '\n'.join(logs.output)
+        self.assertIn('nsf-share-folder: Share invitation has been sent', output)
+        self.assertNotIn("User '", output)
+
+
+class TestNestedShareFolderFolderApi(TestCase):
+
+    @patch('keepercommander.nested_share_folder.folder_api.folder_access_update_v3')
+    @patch('keepercommander.nested_share_folder.folder_api.handle_share_invite')
+    @patch('keepercommander.nested_share_folder.folder_api.get_user_public_key')
+    def test_grant_folder_access_sends_invite_when_no_active_share(
+            self, mock_get_public_key, mock_handle_invite, mock_access_update):
+        from keepercommander.nested_share_folder.folder_api import grant_folder_access_v3
+
+        fuid, fobj = _make_folder()
+        params = _make_params(nested_share_folders={fuid: fobj})
+        email = 'user@example.com'
+
+        mock_get_public_key.return_value = (None, False, None, True)
+        mock_handle_invite.side_effect = ValueError(
+            f"Share invitation has been sent to '{email}'. "
+            "Please repeat this command once the invitation is accepted.")
+
+        with self.assertRaises(ValueError) as ctx:
+            grant_folder_access_v3(params, fuid, email, role='viewer')
+
+        self.assertIn('Share invitation has been sent', str(ctx.exception))
+        mock_get_public_key.assert_called_once_with(params, email)
+        mock_handle_invite.assert_called_once_with(params, email, True)
+        mock_access_update.assert_not_called()
+
 
 class TestNestedShareFolderDisplayCommands(TestCase):
 


### PR DESCRIPTION
## PR Description

This PR adds support for NSF folder data in the `share-report` command.


## Added
- Support for NSF folder data retrieval in the `share-report` command.
- Added a "Type" field to distinguish between "Shared Folders" and "Nested Shared Folders".