### PR TITLE
Fix pam connection edit (connection settings + launch/admin credentials)

### DIFF
--- a/keepercommander/commands/pam_debug/dump.py
+++ b/keepercommander/commands/pam_debug/dump.py
@@ -135,11 +135,11 @@ class PAMDebugDumpCommand(Command):
             if not config_uid:
                 from ..tunnel.port_forward.tunnel_helpers import (
                     get_config_uid_from_local_vault,
-                    get_config_uid_from_krouter,
+                    get_config_uid_via_pam_link,
                 )
                 config_uid = (
                     get_config_uid_from_local_vault(params, rec_uid)
-                    or get_config_uid_from_krouter(params, rec_uid)
+                    or get_config_uid_via_pam_link(params, rec_uid)
                 )
 
             if config_uid:

--- a/keepercommander/commands/tunnel/port_forward/TunnelGraph.py
+++ b/keepercommander/commands/tunnel/port_forward/TunnelGraph.py
@@ -73,6 +73,27 @@ def ensure_resource_meta_v1(content):
     return out
 
 
+def build_meta_version_upgrade():
+    """Meta payload that bumps a resource's meta to v1 WITHOUT re-asserting any
+    allowedSettings flags.
+
+    Used by the launch-credential / version-upgrade Layer-B calls. krouter
+    deep-merges the ``meta`` JSON edge (krouter Serialization.kt ``mergeJson``)
+    and never deletes keys absent from the new payload, so an EMPTY
+    ``allowedSettings`` preserves the server's current connections / portForwards /
+    recording flags while still bumping ``version``. ``allowedSettings`` must be
+    present (even if empty) because krouter strictly decodes the incoming meta
+    into its non-nullable ``Meta.allowedSettings`` DTO before merging.
+
+    This avoids the revert bug: ``set_resource_allowed``'s Layer-B path enables
+    ``connections`` on the server but does not refresh the in-memory vertex, so a
+    follow-up ``ensure_resource_meta_v1(get_vertex_content(...))`` would re-send a
+    STALE ``connections=false`` that deep-merges and flips connections back off —
+    making the vault hide the (still-present) connection port/protocol.
+    """
+    return {"version": int(RESOURCE_META_VERSION_V1), "allowedSettings": {}}
+
+
 class TunnelDAG:
     def __init__(self, params, encrypted_session_token, encrypted_transmission_key, record_uid: str,
                  is_config=False, transmission_key=None):
@@ -469,10 +490,19 @@ class TunnelDAG:
             endpoint = 'configure_resource'
             if not is_layer_b_feature_disabled(host, endpoint):
                 try:
+                    # adminUid must ride ALONGSIDE connectUsers: krouter only flips
+                    # is_admin on an already-existing ACL edge when connectUsers is
+                    # present (UserRest.kt:295-318); a standalone adminUid no-ops on
+                    # an existing edge (UserRest.kt:331-341). Send the resource's
+                    # CURRENT launch credentials as connectUsers so the reconciliation
+                    # sets is_admin without clearing any existing launch credential.
+                    launch_uids = self.get_launch_credentials(resource_uid)
                     rq = pam_pb2.PAMResourceConfig(
                         recordUid=url_safe_str_to_bytes(resource_uid),
                         networkUid=url_safe_str_to_bytes(self.record.record_uid),
                         adminUid=url_safe_str_to_bytes(user_uid),
+                        connectUsers=pam_pb2.UidList(
+                            uids=[url_safe_str_to_bytes(u) for u in launch_uids]),
                     )
                     router_configure_resource(self.params, rq)
                     logging.debug(
@@ -568,6 +598,20 @@ class TunnelDAG:
                     return user_vertex.uid
         return False
 
+    def get_launch_credentials(self, resource_uid):
+        """Return the list of user UIDs currently flagged is_launch_credential on the resource."""
+        result = []
+        resource_vertex = self.linking_dag.get_vertex(resource_uid)
+        if resource_vertex is None:
+            return result
+        for user_vertex in resource_vertex.has_vertices(EdgeType.ACL):
+            acl_edge = user_vertex.get_edge(resource_vertex, EdgeType.ACL)
+            if acl_edge:
+                content = acl_edge.content_as_dict
+                if content and content.get('is_launch_credential'):
+                    result.append(user_vertex.uid)
+        return result
+
     def clear_launch_credential_for_resource(self, resource_uid, exclude_user_uid=None):
         """Remove is_launch_credential from all users on a resource except exclude_user_uid."""
         resource_vertex = self.linking_dag.get_vertex(resource_uid)
@@ -589,9 +633,10 @@ class TunnelDAG:
         if dirty:
             self.linking_dag.save()
 
-    def set_launch_credentials(self, resource_uid, launch_uid=None):
+    def set_launch_credentials(self, resource_uid, launch_uid=None, admin_uid=None):
         """
-        Set or clear the launch credential for a resource via Layer-B configure_resource.
+        Set or clear the launch credential (and optionally the admin) for a resource
+        via a single Layer-B configure_resource round-trip.
 
         krouter's connectUsers field has replacement semantics
         (UserRest.kt:generateResourceConnectionEdges): sending [launch_uid] sets
@@ -600,19 +645,31 @@ class TunnelDAG:
         the v1 upgrade in the same call. This replaces the legacy 2-3 op sequence
         (clear + link + meta-upgrade) with one permission-checked round-trip.
 
+        admin_uid (optional): when given, adminUid is sent in the SAME request as
+        connectUsers. This is required for the admin to actually take effect on an
+        ALREADY-EXISTING ACL edge: a standalone configure_resource(adminUid) with no
+        connectUsers no-ops on an existing edge (UserRest.kt:331-341 only touches
+        is_launch_credential), whereas adminUid alongside connectUsers flips is_admin
+        on that edge (UserRest.kt:295-318). Sent on a user NOT in connectUsers so the
+        admin does not also become a launch credential.
+
         For a fresh launch_uid (no existing edge), krouter creates the new edge with
         belongs_to=null; a follow-up local DAG-write of belongs_to=True preserves
         legacy parity. For existing edges, krouter preserves belongs_to already so
         the follow-up is a no-op.
 
         Fallback on RRC_NOT_ALLOWED* (or feature-disabled) with KEEPER_DAG_LB_FALLBACK
-        enabled: legacy clear + link (if set) + meta-upgrade.
+        enabled: legacy clear + link (if set) + admin link (if set) + meta-upgrade.
         """
         resource_vertex = self.linking_dag.get_vertex(resource_uid)
         if resource_vertex is None:
             return
 
-        upgraded_meta = ensure_resource_meta_v1(get_vertex_content(resource_vertex))
+        # Version-only meta: bump to v1 (so the vault reads ACL launch credentials)
+        # WITHOUT re-asserting a possibly-stale allowedSettings snapshot. See
+        # build_meta_version_upgrade() — re-sending the in-memory allowedSettings
+        # here would clobber connections that set_resource_allowed just enabled.
+        upgraded_meta = build_meta_version_upgrade()
         uids = [url_safe_str_to_bytes(launch_uid)] if launch_uid is not None else []
 
         from ...pam.router_helper import router_configure_resource, get_router_url
@@ -627,10 +684,12 @@ class TunnelDAG:
                     connectUsers=pam_pb2.UidList(uids=uids),
                     meta=json.dumps(upgraded_meta).encode(),
                 )
+                if admin_uid is not None:
+                    rq.adminUid = url_safe_str_to_bytes(admin_uid)
                 router_configure_resource(self.params, rq)
                 logging.debug(
                     f"set_launch_credentials: resource={resource_uid} "
-                    f"launch_uid={launch_uid} via configure_resource"
+                    f"launch_uid={launch_uid} admin_uid={admin_uid} via configure_resource"
                 )
                 if launch_uid is not None:
                     self.link_user(launch_uid, resource_vertex, belongs_to=True)
@@ -645,6 +704,9 @@ class TunnelDAG:
                 )
 
         self.clear_launch_credential_for_resource(resource_uid, exclude_user_uid=launch_uid)
+        if admin_uid is not None:
+            # Legacy fallback: write is_admin directly on the resource ACL edge.
+            self.link_user(admin_uid, resource_vertex, is_admin=True, belongs_to=True)
         if launch_uid is not None:
             self.link_user_to_resource(launch_uid, resource_uid,
                                        is_launch_credential=True, belongs_to=True)
@@ -660,11 +722,13 @@ class TunnelDAG:
             return
         upgraded = ensure_resource_meta_v1(content)
 
-        # Primary: Layer-B configure_resource (permission-checked). Same meta
-        # shape we use in set_resource_allowed(meta_version=1): the versioned
-        # payload {version, allowedSettings, rotateOnTermination} is sent as
-        # the proto's `meta` field. krouter's mergeJson honors version with the
-        # `oldMetaVersion <= newMetaVersion` upgrade check.
+        # Primary: Layer-B configure_resource (permission-checked). Send a
+        # version-only meta — krouter deep-merges the meta edge, so an empty
+        # allowedSettings bumps `version` (the `oldMetaVersion <= newMetaVersion`
+        # upgrade check) while preserving the server's current flags. Re-sending
+        # the in-memory `upgraded` here would clobber flags set earlier in the
+        # same command (the Layer-B set_resource_allowed does not refresh the
+        # in-memory vertex). See build_meta_version_upgrade().
         from ...pam.router_helper import router_configure_resource, get_router_url
         from ...pam._layer_b import is_layer_b_feature_disabled
         host = get_router_url(self.params)
@@ -674,7 +738,7 @@ class TunnelDAG:
                 rq = pam_pb2.PAMResourceConfig(
                     recordUid=url_safe_str_to_bytes(resource_uid),
                     networkUid=url_safe_str_to_bytes(self.record.record_uid),
-                    meta=json.dumps(upgraded).encode(),
+                    meta=json.dumps(build_meta_version_upgrade()).encode(),
                 )
                 router_configure_resource(self.params, rq)
                 logging.debug(

--- a/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
+++ b/keepercommander/commands/tunnel/port_forward/tunnel_helpers.py
@@ -793,7 +793,18 @@ def get_config_uid(params, encrypted_session_token, encrypted_transmission_key, 
     if local_config_uid:
         return local_config_uid
 
-    # Tier 2: legacy gateway-mediated lookup via the old `/api/user/get_leafs`.
+    # Tier 2: krouter per-graph PAM_LINK get_leafs (server-side, no gateway).
+    # Precise single-owner resolution — the Web Vault uses the same call. The
+    # legacy graphId=0 lookup below can return a stale/duplicate config when a
+    # resource still carries link edges under more than one PAM config; loading
+    # that graph then raises DAGPathException ("Found multiple vertex that use
+    # the path") on the next get_vertex. Resolving the owner precisely here
+    # avoids it. Mirrors the dag-api-migration resolution order.
+    link_config_uid = get_config_uid_via_pam_link(params, record_uid)
+    if link_config_uid:
+        return link_config_uid
+
+    # Tier 3: legacy gateway-mediated lookup via the old `/api/user/get_leafs`.
     try:
         rs = get_dag_leafs(params, encrypted_session_token, encrypted_transmission_key, record_uid)
         # response: "[{\"type\":\"rec\",\"value\":\"Jagbt2dxrft_91FovB5dwg\",\"name\":null}]"

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -65,6 +65,28 @@ _LEASE_EXPIRY_TIMERS_BY_RECORD: Dict[str, threading.Timer] = {}
 _LEASE_SHUTDOWN_EVENTS_BY_RECORD: Dict[str, threading.Event] = {}
 
 
+def _coerce_settings_subdicts(entry, *keys):
+    """Coerce the named sub-fields of a pamSettings / pamRemoteBrowserSettings
+    entry to dicts, in place.
+
+    Discovery and the Web Vault may publish ``connection`` / ``portForward`` as an
+    empty string (``""``) or omit them entirely (e.g. ``{"portForward": ""}`` with
+    no ``connection``). Code that then indexes ``entry["connection"][...]`` /
+    ``entry["portForward"][...]`` raises ``KeyError`` (missing) or ``TypeError``
+    (string). Call this first so those writes always land on a real dict.
+
+    Returns True if anything was coerced (callers may use it to flag the record dirty).
+    """
+    changed = False
+    if not isinstance(entry, dict):
+        return changed
+    for key in keys:
+        if not isinstance(entry.get(key), dict):
+            entry[key] = {}
+            changed = True
+    return changed
+
+
 # Group Commands
 class PAMTunnelCommand(GroupCommand):
 
@@ -466,6 +488,12 @@ class PAMTunnelEditCommand(Command):
                     tmp_dag.link_resource_to_config(record_uid)
                 if not pam_settings.value:
                     pam_settings.value.append({"connection": {}, "portForward": {}})
+                # Discovery may publish value[0] with portForward as "" (empty
+                # string) or absent; coerce to a dict before indexing, else the
+                # writes below raise TypeError (string) / KeyError (missing).
+                if not isinstance(pam_settings.value[0], dict):
+                    pam_settings.value[0] = {"connection": {}, "portForward": {}}
+                _coerce_settings_subdicts(pam_settings.value[0], "connection", "portForward")
                 if _tunneling and tunneling_override_port:
                     pam_settings.value[0]['portForward']['port'] = tunneling_override_port
                     dirty = True
@@ -2763,8 +2791,14 @@ class PAMConnectionEditCommand(Command):
             else:
                 if not pam_settings.value:
                     pam_settings.value.append({"connection": {}, "portForward": {}})
-                if not pam_settings.value[0]:
+                if not isinstance(pam_settings.value[0], dict):
                     pam_settings.value[0] = {"connection": {}, "portForward": {}}
+                # An existing pamSettings may carry only one of the two sub-dicts,
+                # or publish them as "" (empty string) instead of a dict — e.g.
+                # discovery publishes {"portForward": ""} with no usable "connection".
+                # Coerce both to dicts before indexing, otherwise -cn on -p rdp -cop
+                # raises KeyError (missing key) or TypeError (string) below.
+                _coerce_settings_subdicts(pam_settings.value[0], "connection", "portForward")
                 if _connections:
                     if connection_override_port:
                         pam_settings.value[0]["connection"]["port"] = connection_override_port
@@ -2934,13 +2968,18 @@ class PAMConnectionEditCommand(Command):
                                           typescript_recording=kwargs.get('typescriptrecording', None),
                                           rotate_on_termination=rot_bool)
 
-            # admin parameter is optional yet if not set connections may fail
+            # admin (-a) and launch (-lu / --clear-launch-user) credentials are
+            # applied together in a SINGLE configure_resource round-trip. krouter
+            # only flips is_admin on an already-existing ACL edge when adminUid is
+            # sent alongside connectUsers (UserRest.kt:295-318); a standalone
+            # adminUid call no-ops on an existing edge. So fold admin into the
+            # launch call instead of issuing two separate requests.
             admin_name = kwargs.get('admin')
             adm_rec = RecordMixin.resolve_single_record(params, admin_name)
             admin_uid = adm_rec.record_uid if adm_rec else None
-            if admin_uid and record_type in launch_credential_record_types:
-                tdag.link_user_to_resource(admin_uid, record_uid, is_admin=True, belongs_to=True)
-                # tdag.link_user_to_config(admin_uid)  # is_iam_user=True
+            # admin credential is only meaningful on launch-capable resources
+            if admin_uid and record_type not in launch_credential_record_types:
+                admin_uid = None
 
             # launch-user parameter sets the launch credential; --clear-launch-user removes it
             clear_launch_user = bool(kwargs.get('clear_launch_user'))
@@ -2949,13 +2988,16 @@ class PAMConnectionEditCommand(Command):
             if clear_launch_user and launch_user_name:
                 raise CommandError('pam connection edit',
                     f'{bcolors.FAIL}Use either --clear-launch-user or --launch-user, not both.{bcolors.ENDC}')
+
+            launch_uid = None
+            apply_launch = False
             if clear_launch_user:
                 if record_type not in launch_credential_record_types:
                     raise CommandError('pam connection edit',
                         f'{bcolors.FAIL}--clear-launch-user is only supported for pamMachine, pamDatabase, and '
                         f'pamDirectory records. Record "{record_uid}" is of type "{record_type}" and does not '
                         f'support launch credentials.{bcolors.ENDC}')
-                tdag.set_launch_credentials(record_uid)
+                apply_launch = True  # launch_uid stays None -> clears the launch credential
             elif launch_user_name:
                 launch_rec = RecordMixin.resolve_single_record(params, launch_user_name)
                 if not launch_rec:
@@ -2964,9 +3006,21 @@ class PAMConnectionEditCommand(Command):
                 if not isinstance(launch_rec, vault.TypedRecord) or launch_rec.record_type != 'pamUser':
                     raise CommandError('',
                         f'{bcolors.FAIL}Launch user record must be a pamUser record type.{bcolors.ENDC}')
-                launch_uid = launch_rec.record_uid
                 if record_type in launch_credential_record_types:
-                    tdag.set_launch_credentials(record_uid, launch_uid=launch_uid)
+                    apply_launch = True
+                    launch_uid = launch_rec.record_uid
+
+            if apply_launch:
+                # set/clear launch credential and (optionally) the admin in one call
+                tdag.set_launch_credentials(record_uid, launch_uid=launch_uid, admin_uid=admin_uid)
+            elif admin_uid:
+                # admin-only: preserve the current launch credential in the same
+                # request so krouter sets is_admin on the (possibly pre-existing)
+                # edge without clearing an existing launch credential.
+                current_launch = tdag.check_if_resource_has_launch_credential(record_uid)
+                tdag.set_launch_credentials(record_uid,
+                                            launch_uid=(current_launch or None),
+                                            admin_uid=admin_uid)
 
             # Print out PAM Settings
             if not kwargs.get("silent", False): tdag.print_tunneling_config(record_uid, record.get_typed_field('pamSettings'), config_uid)
@@ -3363,6 +3417,14 @@ class PAMRbiEditCommand(Command):
         elif not rbs_fld.value:
             rbs_fld.value.append({'connection': {'protocol': 'http'}}) # type: ignore
             dirty = True
+
+        # A pre-existing pamRemoteBrowserSettings may lack a usable "connection"
+        # dict (absent, or published as ""); coerce it once so the writes below
+        # (rbs_fld.value[0]["connection"][...]) don't KeyError/TypeError.
+        if (isinstance(rbs_fld, vault.TypedField) and rbs_fld.value
+                and isinstance(rbs_fld.value[0], dict)):
+            if _coerce_settings_subdicts(rbs_fld.value[0], 'connection'):
+                dirty = True
 
         if autofill:
             af_rec = RecordMixin.resolve_single_record(params, autofill)

--- a/unit-tests/pam/test_coerce_settings_subdicts.py
+++ b/unit-tests/pam/test_coerce_settings_subdicts.py
@@ -1,0 +1,84 @@
+"""
+Unit tests for ``_coerce_settings_subdicts`` — the guard that protects pamSettings /
+pamRemoteBrowserSettings sub-field writes from KeyError/TypeError.
+
+Discovery and the Web Vault may publish ``connection`` / ``portForward`` as an empty
+string (``""``) or omit them entirely (e.g. ``{"portForward": ""}`` with no
+``connection``). The command code then indexes ``entry["connection"][...]`` /
+``entry["portForward"][...]``, which would raise without this coercion. Covers the
+"pam connection edit" (bug #1), "pam tunnel edit" portForward, and "pam rbi edit"
+connection guards.
+"""
+import importlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+skip_tests = False
+skip_reason = ""
+try:
+    # Pre-warm the circular-import chain (same pattern as the other pam tests).
+    importlib.import_module('keepercommander.commands.pam_import.keeper_ai_settings')
+    from keepercommander.commands.tunnel_and_connections import _coerce_settings_subdicts
+except ImportError as e:  # pragma: no cover
+    skip_tests = True
+    skip_reason = f"Cannot import tunnel_and_connections: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestCoerceSettingsSubdicts(unittest.TestCase):
+
+    def test_missing_key_is_created_as_dict(self):
+        entry = {"portForward": {}}  # discovery published no "connection"
+        changed = _coerce_settings_subdicts(entry, "connection", "portForward")
+        self.assertEqual(entry["connection"], {})
+        self.assertEqual(entry["portForward"], {})
+        self.assertTrue(changed)
+
+    def test_empty_string_value_is_coerced_to_dict(self):
+        entry = {"connection": {"port": 3389}, "portForward": ""}  # real dump shape
+        changed = _coerce_settings_subdicts(entry, "connection", "portForward")
+        self.assertEqual(entry["portForward"], {})
+        # existing connection dict is preserved untouched
+        self.assertEqual(entry["connection"], {"port": 3389})
+        self.assertTrue(changed)
+
+    def test_none_value_is_coerced_to_dict(self):
+        entry = {"connection": None}
+        changed = _coerce_settings_subdicts(entry, "connection")
+        self.assertEqual(entry["connection"], {})
+        self.assertTrue(changed)
+
+    def test_existing_dicts_are_left_unchanged_and_returns_false(self):
+        entry = {"connection": {"protocol": "rdp"}, "portForward": {"port": "10389"}}
+        changed = _coerce_settings_subdicts(entry, "connection", "portForward")
+        self.assertEqual(entry["connection"], {"protocol": "rdp"})
+        self.assertEqual(entry["portForward"], {"port": "10389"})
+        self.assertFalse(changed)
+
+    def test_single_key_only_touches_that_key(self):
+        entry = {"connection": "", "portForward": ""}
+        changed = _coerce_settings_subdicts(entry, "connection")  # RBI: connection only
+        self.assertEqual(entry["connection"], {})
+        self.assertEqual(entry["portForward"], "")  # untouched
+        self.assertTrue(changed)
+
+    def test_non_dict_entry_is_a_noop(self):
+        # Caller is responsible for ensuring entry is a dict; helper must not raise.
+        self.assertFalse(_coerce_settings_subdicts("", "connection"))
+        self.assertFalse(_coerce_settings_subdicts(None, "connection"))
+
+    def test_indexing_after_coercion_does_not_raise(self):
+        # Reproduces the bug-#1 / tunnel-edit crash shape, then confirms the write lands.
+        entry = {"portForward": ""}
+        _coerce_settings_subdicts(entry, "connection", "portForward")
+        entry["connection"]["port"] = 3389          # would KeyError pre-fix
+        entry["portForward"]["port"] = "10389"       # would TypeError pre-fix (str)
+        self.assertEqual(entry["connection"]["port"], 3389)
+        self.assertEqual(entry["portForward"]["port"], "10389")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_dag_layer_b_migration.py
+++ b/unit-tests/pam/test_dag_layer_b_migration.py
@@ -488,10 +488,17 @@ class TestTunnelGraphLinkUserToResourceMigration:
         tg.linking_dag.get_vertex.return_value = resource_vertex
         # Mark the resource as belonging to the config so the early-out doesn't fire.
         tg.resource_belongs_to_config = MagicMock(return_value=True)
+        # No existing launch credentials by default (admin-only case).
+        tg.get_launch_credentials = MagicMock(return_value=[])
         return tg, resource_vertex
 
     def test_is_admin_true_routes_to_configure_resource(self):
-        """is_admin=True triggers a configure_resource POST with the right adminUid."""
+        """is_admin=True triggers a configure_resource POST with the right adminUid.
+
+        With no existing launch credentials (a valid pamMachine state — admin only),
+        connectUsers is sent as an EMPTY-but-present wrapper so krouter still flips
+        is_admin on the existing edge (UserRest.kt:295-318) rather than no-opping
+        (UserRest.kt:331-341)."""
         tg, _ = self._build_tg()
         captured = {}
 
@@ -513,8 +520,34 @@ class TestTunnelGraphLinkUserToResourceMigration:
         assert len(rq.recordUid) == 16
         # networkUid is the config (the TunnelGraph's record)
         assert len(rq.networkUid) == 16
+        # connectUsers wrapper must be PRESENT (so krouter takes the flip-on-existing
+        # branch) but empty here (no launch creds to preserve).
+        assert rq.HasField('connectUsers')
+        assert len(rq.connectUsers.uids) == 0
         # Critical: legacy link_user must NOT be called when configure_resource succeeded
         link_user_mock.assert_not_called()
+
+    def test_is_admin_true_preserves_existing_launch_creds_in_connect_users(self):
+        """When the resource already has launch credentials, they ride in connectUsers
+        so krouter sets is_admin WITHOUT clearing them (replacement semantics)."""
+        tg, _ = self._build_tg()
+        tg.get_launch_credentials = MagicMock(return_value=[USER_UID_STR.replace('D', 'F')])
+        captured = {}
+
+        def _capture(params, rq):
+            captured['rq'] = rq
+
+        with patch('keepercommander.commands.pam.router_helper.router_configure_resource',
+                   side_effect=_capture), \
+             patch.object(tg, 'link_user'):
+            tg.link_user_to_resource(USER_UID_STR, TARGET_RES_UID_STR, is_admin=True)
+
+        rq = captured['rq']
+        assert len(rq.adminUid) == 16
+        assert len(rq.connectUsers.uids) == 1            # existing launch cred preserved
+        assert len(rq.connectUsers.uids[0]) == 16
+        # admin is NOT the launch cred (distinct users)
+        assert bytes(rq.adminUid) != bytes(rq.connectUsers.uids[0])
 
     def test_is_admin_true_with_fallback_invokes_legacy_link_user_on_denial(self):
         """RRC_NOT_ALLOWED with fallback ON -> legacy link_user runs."""
@@ -575,6 +608,42 @@ class TestTunnelGraphLinkUserToResourceMigration:
         assert result is False
         cr_mock.assert_not_called()
         link_user_mock.assert_not_called()
+
+
+class TestTunnelGraphGetLaunchCredentials:
+    """get_launch_credentials enumerates is_launch_credential ACL edges on a resource."""
+
+    @staticmethod
+    def _make_user_vertex(uid, acl_content):
+        uv = MagicMock()
+        uv.uid = uid
+        edge = MagicMock()
+        edge.content_as_dict = acl_content
+        uv.get_edge.return_value = edge
+        return uv
+
+    def _build_tg(self, user_vertices):
+        from keepercommander.commands.tunnel.port_forward.TunnelGraph import TunnelDAG
+        tg = TunnelDAG.__new__(TunnelDAG)
+        tg.linking_dag = MagicMock()
+        resource_vertex = MagicMock()
+        resource_vertex.has_vertices.return_value = user_vertices
+        tg.linking_dag.get_vertex.return_value = resource_vertex
+        return tg
+
+    def test_returns_only_launch_credential_users(self):
+        uv_launch = self._make_user_vertex('LAUNCH_UID', {'belongs_to': True, 'is_launch_credential': True})
+        uv_admin = self._make_user_vertex('ADMIN_UID', {'is_admin': True})
+        uv_plain = self._make_user_vertex('PLAIN_UID', {'belongs_to': True})
+        tg = self._build_tg([uv_launch, uv_admin, uv_plain])
+        assert tg.get_launch_credentials('RES') == ['LAUNCH_UID']
+
+    def test_returns_empty_when_no_resource_vertex(self):
+        from keepercommander.commands.tunnel.port_forward.TunnelGraph import TunnelDAG
+        tg = TunnelDAG.__new__(TunnelDAG)
+        tg.linking_dag = MagicMock()
+        tg.linking_dag.get_vertex.return_value = None
+        assert tg.get_launch_credentials('RES') == []
 
 
 # --------------------------------------------------------------------------- #
@@ -1053,7 +1122,7 @@ class TestTunnelGraphUpgradeResourceMetaToV1Migration:
 
     def test_v0_upgrade_uses_configure_resource(self):
         """No version or version=0 -> upgrade to v1 via configure_resource(meta=...).
-        The proto's meta carries the versioned JSON payload."""
+        The proto's meta carries a VERSION-ONLY payload (empty allowedSettings)."""
         from keepercommander.commands.tunnel.port_forward import TunnelGraph as tg_mod
         from keepercommander.commands.tunnel.port_forward.TunnelGraph import RESOURCE_META_VERSION_V1
 
@@ -1075,11 +1144,12 @@ class TestTunnelGraphUpgradeResourceMetaToV1Migration:
         assert len(rq.recordUid) == 16
         assert len(rq.networkUid) == 16
         assert rq.recordUid != rq.networkUid
-        # meta carries the versioned payload
+        # meta bumps version only; allowedSettings is sent EMPTY so krouter's
+        # deep-merge preserves the server's existing flags (connections stays True)
+        # rather than re-asserting a possibly-stale in-memory snapshot.
         meta = json.loads(rq.meta.decode())
         assert meta.get('version') == RESOURCE_META_VERSION_V1
-        assert 'allowedSettings' in meta
-        assert meta['allowedSettings'].get('connections') is True
+        assert meta['allowedSettings'] == {}
 
     def test_no_resource_vertex_returns_early(self):
         """If get_vertex returns None, no write at all."""

--- a/unit-tests/pam/test_get_config_uid_local_vault.py
+++ b/unit-tests/pam/test_get_config_uid_local_vault.py
@@ -155,10 +155,30 @@ def test_get_config_uid_uses_local_match_and_skips_get_dag_leafs():
     mock_dl.assert_not_called()
 
 
-def test_get_config_uid_falls_back_to_get_dag_leafs_when_no_local_match():
-    """No local match -> legacy get_dag_leafs path; whatever it returns flows through."""
+def test_get_config_uid_uses_pam_link_before_get_dag_leafs():
+    """No local match -> precise PAM_LINK resolution wins and legacy get_dag_leafs is skipped.
+
+    Regression guard for the "Found multiple vertex that use the path" bug: the
+    legacy graphId=0 get_dag_leafs can return a stale/duplicate config when a
+    resource still has link edges under more than one PAM config. Resolving the
+    owner precisely via the per-graph PAM_LINK get_leafs avoids loading that
+    ambiguous graph, so it must run before the legacy path.
+    """
     params = MagicMock()
     with patch('keepercommander.vault_extensions.find_records', return_value=iter([])), \
+         patch.object(tunnel_helpers, 'get_config_uid_via_pam_link', return_value=CONFIG_UID) as mock_link, \
+         patch.object(tunnel_helpers, 'get_dag_leafs') as mock_dl:
+        result = tunnel_helpers.get_config_uid(params, b'tok', b'tk', RESOURCE_UID)
+    assert result == CONFIG_UID
+    mock_link.assert_called_once()
+    mock_dl.assert_not_called()
+
+
+def test_get_config_uid_falls_back_to_get_dag_leafs_when_no_local_match():
+    """No local match and no PAM_LINK owner -> legacy get_dag_leafs path; its result flows through."""
+    params = MagicMock()
+    with patch('keepercommander.vault_extensions.find_records', return_value=iter([])), \
+         patch.object(tunnel_helpers, 'get_config_uid_via_pam_link', return_value=''), \
          patch.object(tunnel_helpers, 'get_dag_leafs',
                       return_value=[{'type': 'rec', 'value': CONFIG_UID, 'name': None}]) as mock_dl:
         result = tunnel_helpers.get_config_uid(params, b'tok', b'tk', RESOURCE_UID)
@@ -167,9 +187,10 @@ def test_get_config_uid_falls_back_to_get_dag_leafs_when_no_local_match():
 
 
 def test_get_config_uid_returns_none_when_neither_path_resolves():
-    """No local match and get_dag_leafs returns None -> None propagates."""
+    """No local match, no PAM_LINK owner, and get_dag_leafs returns None -> None propagates."""
     params = MagicMock()
     with patch('keepercommander.vault_extensions.find_records', return_value=iter([])), \
+         patch.object(tunnel_helpers, 'get_config_uid_via_pam_link', return_value=''), \
          patch.object(tunnel_helpers, 'get_dag_leafs', return_value=None):
         result = tunnel_helpers.get_config_uid(params, b'tok', b'tk', RESOURCE_UID)
     assert result is None

--- a/unit-tests/pam/test_set_launch_credentials.py
+++ b/unit-tests/pam/test_set_launch_credentials.py
@@ -35,6 +35,7 @@ from keepercommander.commands.pam._layer_b import RouterResponseError  # noqa: E
 RESOURCE_UID = 'AAAAAAAAAAAAAAAAAAAAAA'   # 22-char base64url, decodes to 16 bytes
 NETWORK_UID  = 'BBBBBBBBBBBBBBBBBBBBBB'
 LAUNCH_UID   = 'CCCCCCCCCCCCCCCCCCCCCC'
+ADMIN_UID    = 'DDDDDDDDDDDDDDDDDDDDDD'
 
 
 # --------------------------------------------------------------------------- #
@@ -135,16 +136,29 @@ def test_clear_path_builds_proto_with_empty_uids():
     assert len(rq.connectUsers.uids) == 0
     meta = json.loads(rq.meta.decode())
     assert meta['version'] == RESOURCE_META_VERSION_V1
-    assert meta['allowedSettings'] == {'connections': True}
+    # Version-only meta: empty allowedSettings so krouter's deep-merge preserves
+    # the server's current flags (connections stays True) instead of re-asserting
+    # a stale in-memory snapshot.
+    assert meta['allowedSettings'] == {}
     # CLEAR path doesn't do a belongs_to follow-up.
     tdag.link_user.assert_not_called()
 
 
-def test_set_path_preserves_existing_meta_fields():
-    """The meta-upgrade carries existing allowedSettings / rotateOnTermination."""
+def test_set_path_sends_version_only_meta_and_does_not_clobber_allowed_settings():
+    """Regression: the launch-cred meta must NOT re-assert a (possibly stale)
+    in-memory allowedSettings snapshot.
+
+    set_resource_allowed's Layer-B path enables connections on the SERVER but does
+    not refresh the in-memory vertex, so get_vertex_content here still reports the
+    pre-command flags (e.g. connections=False). If we sent those, krouter's
+    deep-merge would flip connections back off and the vault would hide the
+    connection port/protocol. The fix sends version=1 with an EMPTY allowedSettings
+    so the server's just-enabled connections survives the merge untouched.
+    """
+    # Simulate the stale in-memory snapshot (connections still off / rotation set).
     initial = {
         'version': 0,
-        'allowedSettings': {'connections': True, 'rotation': False},
+        'allowedSettings': {'connections': False, 'rotation': False},
         'rotateOnTermination': True,
     }
     tdag, _ = _make_tdag(initial_meta=initial)
@@ -162,8 +176,101 @@ def test_set_path_preserves_existing_meta_fields():
 
     meta = json.loads(captured['rq'].meta.decode())
     assert meta['version'] == RESOURCE_META_VERSION_V1
-    assert meta['allowedSettings'] == {'connections': True, 'rotation': False}
-    assert meta['rotateOnTermination'] is True
+    # No stale flags re-asserted — empty allowedSettings, no rotateOnTermination.
+    assert meta['allowedSettings'] == {}
+    assert 'connections' not in meta['allowedSettings']
+    assert 'rotateOnTermination' not in meta
+
+
+# --------------------------------------------------------------------------- #
+# Admin credential — sent ALONGSIDE connectUsers in the same request           #
+# --------------------------------------------------------------------------- #
+
+
+def test_set_path_with_admin_sends_admin_uid_alongside_connect_users():
+    """Admin + launch in one configure_resource: connectUsers carries the launch
+    uid AND adminUid is set (so krouter flips is_admin even on an existing edge),
+    with admin NOT in connectUsers (so it does not also become a launch cred)."""
+    tdag, _ = _make_tdag(initial_meta={'allowedSettings': {'connections': True}})
+
+    captured = {}
+
+    def _capture(params, rq):
+        captured['rq'] = rq
+
+    with patch('keepercommander.commands.pam._layer_b.is_layer_b_feature_disabled', return_value=False), \
+         patch('keepercommander.commands.pam.router_helper.get_router_url', return_value='krouter.test'), \
+         patch('keepercommander.commands.pam.router_helper.router_configure_resource',
+               side_effect=_capture):
+        tdag.set_launch_credentials(RESOURCE_UID, launch_uid=LAUNCH_UID, admin_uid=ADMIN_UID)
+
+    rq = captured['rq']
+    assert len(rq.connectUsers.uids) == 1
+    assert len(rq.connectUsers.uids[0]) == 16            # launch uid present
+    assert len(rq.adminUid) == 16                        # admin uid present
+    assert bytes(rq.adminUid) != bytes(rq.connectUsers.uids[0])  # admin not the launch cred
+    meta = json.loads(rq.meta.decode())
+    assert meta['version'] == RESOURCE_META_VERSION_V1
+    assert meta['allowedSettings'] == {}
+    # belongs_to follow-up fires for the launch user only.
+    tdag.link_user.assert_called_once()
+
+
+def test_admin_only_sends_admin_uid_with_empty_connect_users():
+    """Admin-only (no launch): empty connectUsers wrapper + adminUid, so krouter
+    sets is_admin on the existing edge and there is no launch follow-up."""
+    tdag, _ = _make_tdag(initial_meta=None)
+
+    captured = {}
+
+    def _capture(params, rq):
+        captured['rq'] = rq
+
+    with patch('keepercommander.commands.pam._layer_b.is_layer_b_feature_disabled', return_value=False), \
+         patch('keepercommander.commands.pam.router_helper.get_router_url', return_value='krouter.test'), \
+         patch('keepercommander.commands.pam.router_helper.router_configure_resource',
+               side_effect=_capture):
+        tdag.set_launch_credentials(RESOURCE_UID, launch_uid=None, admin_uid=ADMIN_UID)
+
+    rq = captured['rq']
+    assert len(rq.connectUsers.uids) == 0
+    assert len(rq.adminUid) == 16
+    tdag.link_user.assert_not_called()
+
+
+def test_no_admin_uid_leaves_admin_field_unset():
+    """Without admin_uid the adminUid field stays empty (admin untouched)."""
+    tdag, _ = _make_tdag(initial_meta=None)
+
+    captured = {}
+
+    def _capture(params, rq):
+        captured['rq'] = rq
+
+    with patch('keepercommander.commands.pam._layer_b.is_layer_b_feature_disabled', return_value=False), \
+         patch('keepercommander.commands.pam.router_helper.get_router_url', return_value='krouter.test'), \
+         patch('keepercommander.commands.pam.router_helper.router_configure_resource',
+               side_effect=_capture):
+        tdag.set_launch_credentials(RESOURCE_UID, launch_uid=LAUNCH_UID)
+
+    assert len(captured['rq'].adminUid) == 0
+
+
+def test_admin_fallback_links_admin_via_legacy_when_feature_disabled():
+    """Under feature-disabled fallback, admin is written via legacy link_user(is_admin=True)."""
+    tdag, resource_vertex = _make_tdag(initial_meta=None)
+
+    with patch('keepercommander.commands.pam._layer_b.is_layer_b_feature_disabled', return_value=True), \
+         patch('keepercommander.commands.pam.router_helper.get_router_url', return_value='krouter.test'), \
+         patch('keepercommander.commands.pam.router_helper.router_configure_resource') as mock_cr:
+        tdag.set_launch_credentials(RESOURCE_UID, launch_uid=LAUNCH_UID, admin_uid=ADMIN_UID)
+        mock_cr.assert_not_called()
+
+    admin_calls = [c for c in tdag.link_user.call_args_list if c.args and c.args[0] == ADMIN_UID]
+    assert len(admin_calls) == 1
+    assert admin_calls[0].kwargs.get('is_admin') is True
+    # launch still goes through the legacy link_user_to_resource path.
+    tdag.link_user_to_resource.assert_called_once()
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes multiple `pam connection edit` regressions and related latent bugs.

  - pam connection edit: guard pamSettings sub-fields before indexing so command no longer crashes when discovery publishes `connection`/`portForward` as empty, missing or `""`.
  - pam tunnel edit / pam rbi edit: same sub-field coercion guard (portForward / connection).
  - pam connection edit: send `adminUid` alongside `connectUsers` in one `configure_resource` so `-a` sets `is_admin` even on an already-existing ACL edge.
  - pam connection edit: send a version-only resource meta when setting launch credentials so the server merge no longer flips `allowedSettings.connections` off (connection port/protocol no longer "revert" on the vault).
  - get_config_uid: restore precise per-graph PAM_LINK resolution, fixing "Found multiple vertex that use the path" on pre-existing PAM configs.
  - pam action debug dump: repoint the dropped `get_config_uid_from_krouter` import to `get_config_uid_via_pam_link`.
  - link_user_to_resource: admin link now rides with `connectUsers`, fixing `pam rotation edit` and `pam import edit/extend` admin-on-existing-edge.