### PR TITLE
pam launch: don't show guacd_error notice on normal logout

### DIFF
--- a/keepercommander/commands/pam_launch/launch.py
+++ b/keepercommander/commands/pam_launch/launch.py
@@ -286,6 +286,7 @@ def _print_close_reason_notice(
     reason: Optional[str],
     *,
     pending_exit_code: Optional[int],
+    session_established: bool = False,
 ) -> Optional[int]:
     """Show a user-facing notice for an involuntary remote close.
 
@@ -294,7 +295,19 @@ def _print_close_reason_notice(
     stopped and the local terminal is back in cooked mode — the message is the
     last thing the user sees before returning to Commander, so no acknowledge
     prompt is needed.
+
+    ``session_established`` reflects whether the guac session was live (≥1 sync /
+    data flowing) at the moment of close. A guacd-initiated disconnect — the user
+    typing ``exit`` / ``logout`` — is tagged ``GuacdError`` (code 14) by the
+    gateway, and ``server_disconnect`` when guacd sends an explicit ``disconnect``
+    opcode. Neither is an error once the session was running, so both are treated
+    as a normal close to avoid the misleading "Session ended (guacd_error)." line
+    on a clean logout. A ``guacd_error`` that arrives *before* the session went
+    live is a genuine connect-time fault and is still surfaced.
     """
+    if reason == 'server_disconnect' or (reason == 'guacd_error' and session_established):
+        reason = 'normal'
+
     if not reason or reason in ('normal', 'client'):
         return pending_exit_code
 
@@ -1557,6 +1570,10 @@ class PAMLaunchCommand(Command):
         # PyCloseConnectionReason). Set asynchronously by _on_session_disconnect
         # below; consumed in the inner finally to print a user-facing notice.
         closure_reason: Optional[str] = None
+        # Whether the guac session was live (≥1 sync) at the moment of remote
+        # close. Captured in _on_session_disconnect; lets the notice treat a
+        # guacd_error after an established session as a normal logout.
+        session_established_at_close: bool = False
         # Distinct exit code for involuntary terminations (KeeperAI, admin).
         # Raised as SystemExit at the end of the method so the inner/outer
         # finally cleanup blocks run first.
@@ -1628,9 +1645,15 @@ class PAMLaunchCommand(Command):
             # admin, etc.). Runs on the rust callback thread — do not print
             # here; terminal is still in raw mode.
             def _on_session_disconnect(reason: str) -> None:
-                nonlocal closure_reason, shutdown_requested
+                nonlocal closure_reason, shutdown_requested, session_established_at_close
                 closure_reason = reason
                 shutdown_requested = True
+                # Snapshot whether data was flowing so the notice can tell a clean
+                # guacd-initiated logout from a real connect-time guacd fault.
+                try:
+                    session_established_at_close = bool(python_handler.is_data_flowing())
+                except Exception:
+                    pass
 
             python_handler.on_disconnect = _on_session_disconnect
 
@@ -2128,6 +2151,7 @@ class PAMLaunchCommand(Command):
                 pending_exit_code = _print_close_reason_notice(
                     closure_reason,
                     pending_exit_code=pending_exit_code,
+                    session_established=session_established_at_close,
                 )
 
                 # Cleanup - check if connection is already closed to avoid deadlock

--- a/unit-tests/pam/test_pam_launch_close_notice.py
+++ b/unit-tests/pam/test_pam_launch_close_notice.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for ``_print_close_reason_notice`` — the user-facing notice shown when a
+``pam launch`` guac session is closed by the remote end.
+
+Regression: a normal logout (user types ``exit`` / ``logout``) is reported by the
+gateway as ``guacd_error`` (CloseConnectionReason code 14) or ``server_disconnect``.
+The notice must NOT print the misleading "Session ended (guacd_error)." line once the
+session was actually live, while still surfacing a genuine connect-time guacd fault
+(``guacd_error`` before any data flowed).
+"""
+import importlib
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+skip_tests = False
+skip_reason = ""
+try:
+    importlib.import_module('keepercommander.commands.pam_import.keeper_ai_settings')
+    from keepercommander.commands.pam_launch import launch as launch_mod
+    from keepercommander.commands.pam_launch.launch import (
+        _print_close_reason_notice,
+        EXIT_CODE_AI_TERMINATED,
+        EXIT_CODE_ADMIN_TERMINATED,
+    )
+except ImportError as e:  # pragma: no cover
+    skip_tests = True
+    skip_reason = f"Cannot import pam_launch.launch: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPrintCloseReasonNotice(unittest.TestCase):
+
+    def _notice(self, reason, *, session_established=False, pending_exit_code=None):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = _print_close_reason_notice(
+                reason,
+                pending_exit_code=pending_exit_code,
+                session_established=session_established,
+            )
+        return rc, buf.getvalue()
+
+    # --- the regression: clean logout must be silent -----------------------
+
+    def test_guacd_error_after_established_session_is_silent(self):
+        rc, out = self._notice('guacd_error', session_established=True)
+        self.assertEqual(out, '')
+        self.assertIsNone(rc)
+
+    def test_server_disconnect_is_silent_regardless_of_state(self):
+        for established in (True, False):
+            rc, out = self._notice('server_disconnect', session_established=established)
+            self.assertEqual(out, '')
+            self.assertIsNone(rc)
+
+    # --- genuine faults still surface --------------------------------------
+
+    def test_guacd_error_before_session_established_is_shown(self):
+        rc, out = self._notice('guacd_error', session_established=False)
+        self.assertIn('Session ended (guacd_error).', out)
+        self.assertIsNone(rc)
+
+    # --- unchanged behaviour for the other reasons -------------------------
+
+    def test_normal_and_client_are_silent(self):
+        for reason in ('normal', 'client', None):
+            rc, out = self._notice(reason, session_established=True)
+            self.assertEqual(out, '')
+
+    def test_ai_closed_returns_ai_exit_code(self):
+        rc, out = self._notice('ai_closed', session_established=True)
+        self.assertEqual(rc, EXIT_CODE_AI_TERMINATED)
+        self.assertIn('KeeperAI', out)
+
+    def test_admin_closed_returns_admin_exit_code(self):
+        rc, out = self._notice('admin_closed', session_established=True)
+        self.assertEqual(rc, EXIT_CODE_ADMIN_TERMINATED)
+        self.assertIn('administrator', out)
+
+    def test_other_reason_prints_generic_notice(self):
+        rc, out = self._notice('timeout', session_established=True)
+        self.assertIn('Session ended (timeout).', out)
+
+    def test_pending_exit_code_preserved_on_silent_close(self):
+        rc, out = self._notice('guacd_error', session_established=True, pending_exit_code=7)
+        self.assertEqual(out, '')
+        self.assertEqual(rc, 7)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
On a clean logout (typing exit), the gateway reports the guacd-initiated disconnect as guacd_error (CloseConnectionReason 14), so pam launch printed a misleading `Session ended (guacd_error).` Treat guacd_error as a normal close once the session was live (≥1 sync), and server_disconnect as clean always; a guacd_error before any data flowed (real connect-time fault) is still surfaced.