### PR TITLE
get command: mask all secret-type fields and custom fields in detail/fields output

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -635,6 +635,41 @@ class RecordGetUidCommand(Command):
                             'value': r.notes,
                         }
                         fields.append(field)
+                    # custom fields (v2 type in c['type']; v3 encode type as "type:label" in c['name'])
+                    # Keep _MASKED_FIELD_TYPES in sync with _MASKED_TYPES in record.py.
+                    # 'note' = Secured Note — sensitive, masked by design.
+                    # 'passkey' omitted: early-exit handler renders only non-sensitive sub-fields.
+                    _MASKED_FIELD_TYPES = frozenset({
+                        'secret', 'pinCode', 'note', 'json', 'oneTimeCode',
+                        'paymentCard', 'bankAccount', 'keyPair', 'securityQuestion',
+                    })
+                    unmask = kwargs.get('unmask') is True
+                    for cf in (r.custom_fields or []):
+                        cf_value = cf.get('value')
+                        if not cf_value and cf_value != 0:
+                            continue
+                        cf_name = str(cf.get('name') or cf.get('type') or '')
+                        is_sensitive = (cf.get('type') in _MASKED_FIELD_TYPES or
+                                        cf_name.split(':')[0] in _MASKED_FIELD_TYPES)
+                        is_sq = (cf.get('type') == 'securityQuestion' or
+                                 cf_name == 'securityQuestion' or
+                                 cf_name.startswith('securityQuestion:'))
+                        if is_sq:
+                            val = cf_value
+                            entry = val[0] if (isinstance(val, list) and val) else val
+                            if isinstance(entry, dict):
+                                display_val = {
+                                    'question': entry.get('question') or '',
+                                    'answer': (entry.get('answer') or '') if unmask else '********',
+                                }
+                            else:
+                                display_val = cf_value if unmask else '********'
+                        else:
+                            display_val = cf_value if (unmask or not is_sensitive) else '********'
+                        fields.append({
+                            'name': cf_name,
+                            'value': display_val,
+                        })
 
                     print(json.dumps(fields, indent=2))
                 else:

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -1035,7 +1035,7 @@ class RecordAddCommand(Command, RecordEditMixin):
 
             if plugin_name == 'azureadpwd':
                 # Import Azure AD plugin
-                from ...plugins.azureadpwd import azureadpwd
+                from ..plugins.azureadpwd import azureadpwd
 
                 # Call the rotate function with PAM config record
                 success = azureadpwd.rotate(pam_record, password)
@@ -1047,7 +1047,7 @@ class RecordAddCommand(Command, RecordEditMixin):
 
             elif plugin_name == 'awspswd':
                 # Import AWS plugin and common rotator
-                from ...plugins.awspswd import aws_passwd
+                from ..plugins.awspswd import aws_passwd
 
                 # Extract AWS credentials from PAM config
                 aws_access_key = None
@@ -1078,7 +1078,6 @@ class RecordAddCommand(Command, RecordEditMixin):
 
                 # Set AWS credentials in environment or use profile
                 if aws_access_key and aws_secret_key:
-                    import os
                     original_access_key = os.environ.get('AWS_ACCESS_KEY_ID')
                     original_secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
 
@@ -1145,7 +1144,6 @@ class RecordAddCommand(Command, RecordEditMixin):
         # Load email configuration
         from .email_commands import find_email_config_record, load_email_config_from_record
         from ..email_service import EmailSender, build_onboarding_email
-        from .helpers.timeout import parse_timeout
 
         config_uid = find_email_config_record(params, email_config_name)
         if not config_uid:
@@ -1170,7 +1168,7 @@ class RecordAddCommand(Command, RecordEditMixin):
                 else:  # minutes
                     minutes = expire_seconds // 60
                     expiration_text = f"{minutes} minute{'s' if minutes > 1 else ''}"
-            except:
+            except Exception:
                 expiration_text = expiration  # fallback to original if parsing fails
 
         html_body = build_onboarding_email(

--- a/keepercommander/record.py
+++ b/keepercommander/record.py
@@ -275,6 +275,15 @@ class Record:
                 # Strip type prefixes from field names (e.g., "text:Sign-In Address" -> "Sign-In Address")
                 field_type_prefixes = ('text:', 'multiline:', 'url:', 'phone:', 'email:', 'secret:', 'date:', 'name:', 'host:', 'address:')
                 display_name = field_name
+                # v2 records carry the real type in c['type']; v3 encode it as "type:label" in the name.
+                # Keep this list in sync with _MASKED_FIELD_TYPES in commands/record.py.
+                # 'note' = Secured Note — sensitive, masked by design.
+                # 'passkey' omitted: early-exit handler above renders only non-sensitive sub-fields.
+                _MASKED_TYPES = frozenset({
+                    'secret', 'pinCode', 'note', 'json', 'oneTimeCode',
+                    'paymentCard', 'bankAccount', 'keyPair', 'securityQuestion',
+                })
+                is_secret_field = c.get('type') in _MASKED_TYPES
                 for prefix in field_type_prefixes:
                     if field_name.lower().startswith(prefix):
                         display_name = field_name[len(prefix):]
@@ -293,8 +302,26 @@ class Record:
                                 'address:': 'Address',
                             }
                             display_name = type_friendly_names.get(prefix, prefix.rstrip(':').title())
+                        if prefix.rstrip(':') in _MASKED_TYPES:
+                            is_secret_field = True
                         break
-                print('{0:>20s}: {1:<s}'.format(display_name, str(c['value'])))
+                # v3 custom fields without a label are stored as name='fieldType' (no colon)
+                if not is_secret_field and field_name.split(':')[0] in _MASKED_TYPES:
+                    is_secret_field = True
+                if (field_name == 'securityQuestion' or
+                        field_name.startswith('securityQuestion:') or
+                        c.get('type') == 'securityQuestion'):
+                    val = c['value']
+                    entry = val[0] if (isinstance(val, list) and val) else val
+                    if isinstance(entry, dict):
+                        q = (entry.get('question') or '').rstrip('?').strip()
+                        a = entry.get('answer') or ''
+                        display_value = f'{q}? ' + (a if unmask else '********')
+                    else:
+                        display_value = str(c['value']) if unmask else '********'
+                else:
+                    display_value = str(c['value']) if (unmask or not is_secret_field) else '********'
+                print('{0:>20s}: {1:<s}'.format(display_name, display_value))
 
         if self.notes:
             lines = self.notes.split('\n')

--- a/keepercommander/recordv3.py
+++ b/keepercommander/recordv3.py
@@ -1641,7 +1641,10 @@ class RecordV3:
                         if ftyp == 'name':
                             fval.append(vault.TypedField.export_name_field(x))
                         elif ftyp == 'securityQuestion':
-                            fval.append(vault.TypedField.export_q_and_a_field(x))
+                            q = (x.get('question') or '').replace('?', '').strip()
+                            a = x.get('answer') or ''
+                            # answer is masked by default (same as WV initialMasked=true)
+                            fval.append(f'{q}? ' + (a if unmask else '********'))
                         elif ftyp == 'paymentCard':
                             n = x.get('cardNumber') or ''
                             if n and not unmask:
@@ -1719,7 +1722,7 @@ class RecordV3:
                         RecordV3.display_ref(ftyp, fval, **kwargs)
                     else:
                         is_masked = (ftyp not in record_types.RecordFields or
-                                     ftyp in ['password', 'pinCode', 'secret', 'note', 'oneTimeCode']) and not unmask
+                                     ftyp in ['password', 'pinCode', 'secret', 'note', 'oneTimeCode', 'json']) and not unmask
                         if is_masked:
                             print('{0:>20s}: {1:<s}'.format(fkey, '********'))
                         else:

--- a/unit-tests/pam/test_dag_layer_b_configure_resource.py
+++ b/unit-tests/pam/test_dag_layer_b_configure_resource.py
@@ -102,15 +102,25 @@ def test_configure_resource_hits_correct_url():
 
 
 def test_configure_resource_sends_protobuf_body():
-    """Body is the encrypted PAMResourceConfig protobuf, not JSON."""
+    """Body is the AES-GCM-encrypted PAMResourceConfig protobuf — not plaintext proto, not JSON."""
     from keepercommander.commands.pam.router_helper import router_configure_resource
+    from keepercommander import crypto, utils
     rq = pam_pb2.PAMResourceConfig(recordUid=RESOURCE_UID, networkUid=NETWORK_UID, adminUid=ADMIN_UID)
+    transmission_key = utils.generate_aes_key()
     with patch(REQUESTS_TARGET, return_value=_ok_router_response()) as mock_req:
-        router_configure_resource(_mock_params(), rq)
+        router_configure_resource(_mock_params(), rq, transmission_key=transmission_key)
     _, body = _capture_call(mock_req)
     assert isinstance(body, (bytes, bytearray)), f'body must be bytes, got {type(body)}'
-    # Body is encrypted; check that it's NOT a JSON-encoded payload (sanity).
-    assert not body.startswith(b'{'), 'body should be encrypted protobuf, not JSON'
+    # Must not be the raw (unencrypted) serialisation.
+    # (A first-byte heuristic like `not body.startswith(b'{')` is flaky: ~1/256
+    # of ciphertexts legitimately start with 0x7b.)
+    assert body != rq.SerializeToString()
+    decrypted = crypto.decrypt_aes_v2(body, transmission_key)
+    parsed = pam_pb2.PAMResourceConfig()
+    parsed.ParseFromString(decrypted)
+    assert parsed.recordUid == RESOURCE_UID
+    assert parsed.networkUid == NETWORK_UID
+    assert parsed.adminUid == ADMIN_UID
 
 
 # --------------------------------------------------------------------------- #

--- a/unit-tests/test_command_record.py
+++ b/unit-tests/test_command_record.py
@@ -423,3 +423,219 @@ class TestRecord(TestCase):
 
         raise Exception()
 
+
+class TestGetCommandMasking(TestCase):
+    """Sensitive fields are masked in detail/fields output; --unmask reveals them."""
+
+    def setUp(self):
+        mock.patch('keepercommander.api.communicate').start()
+        mock.patch('keepercommander.api.communicate_rest').start()
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def _printed(self, mock_print):
+        return ' '.join(str(a) for call in mock_print.call_args_list for a in call[0])
+
+    # ── Record.display() (v2 / v3-via-Record.load) ─────────────────────────
+
+    def _v2_record(self, custom_fields):
+        from keepercommander.record import Record
+        r = Record(utils.generate_uid())
+        r.title = 'Test'
+        r.custom_fields = list(custom_fields)
+        return r
+
+    def test_detail_masks_secret_type(self):
+        r = self._v2_record([{'type': 'secret', 'name': 'Token', 'value': 'top-secret'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('top-secret', out)
+        self.assertIn('********', out)
+
+    def test_detail_unmask_reveals_secret(self):
+        r = self._v2_record([{'type': 'secret', 'name': 'Token', 'value': 'top-secret'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=True)
+        self.assertIn('top-secret', self._printed(p))
+
+    def test_detail_masks_pincode_type(self):
+        r = self._v2_record([{'type': 'pinCode', 'name': 'PIN', 'value': '1234'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('1234', out)
+        self.assertIn('********', out)
+
+    def test_detail_masks_v3_secret_prefix(self):
+        # v3 with label: Record.load() encodes type in name as "secret:Label"
+        r = self._v2_record([{'type': 'text', 'name': 'secret:Token', 'value': 'top-secret'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('top-secret', out)
+        self.assertIn('********', out)
+
+    def test_detail_masks_v3_secret_no_label(self):
+        # v3 without label: Record.load() stores just the type as the name, no colon
+        r = self._v2_record([{'type': 'text', 'name': 'secret', 'value': 'top-secret'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('top-secret', out)
+        self.assertIn('********', out)
+
+    def test_detail_masks_v3_pincode_no_label(self):
+        r = self._v2_record([{'type': 'text', 'name': 'pinCode', 'value': '9999'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('9999', out)
+        self.assertIn('********', out)
+
+    def test_detail_does_not_mask_text_field(self):
+        r = self._v2_record([{'type': 'text', 'name': 'Note', 'value': 'public info'}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        self.assertIn('public info', self._printed(p))
+
+    def test_detail_masks_security_question_answer_only(self):
+        # v3 custom field: Record.load() stores type='text', name='securityQuestion', value=dict
+        r = self._v2_record([{'type': 'text', 'name': 'securityQuestion',
+                               'value': {'question': 'MyQuestion', 'answer': 'MyAnswer'}}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=False)
+        out = self._printed(p)
+        self.assertNotIn('MyAnswer', out)
+        self.assertIn('MyQuestion', out)
+        self.assertIn('********', out)
+
+    def test_detail_unmask_reveals_security_question_answer(self):
+        r = self._v2_record([{'type': 'text', 'name': 'securityQuestion',
+                               'value': {'question': 'MyQuestion', 'answer': 'MyAnswer'}}])
+        with mock.patch('builtins.print') as p:
+            r.display(unmask=True)
+        out = self._printed(p)
+        self.assertIn('MyQuestion', out)
+        self.assertIn('MyAnswer', out)
+        self.assertNotIn('********', out)
+
+    # ── RecordV3.display() ──────────────────────────────────────────────────
+
+    def _v3_cache_entry(self, fields=None, custom=None):
+        data = json.dumps({
+            'type': 'login', 'title': 'Test',
+            'fields': fields or [],
+            'custom': custom or [],
+        }).encode()
+        return {'record_uid': utils.generate_uid(), 'data_unencrypted': data}
+
+    def test_v3_detail_masks_json_field(self):
+        from keepercommander.recordv3 import RecordV3
+        rec = self._v3_cache_entry(
+            fields=[{'type': 'json', 'label': 'Config', 'value': ['{"k":"v"}']}])
+        with mock.patch('builtins.print') as p:
+            RecordV3.display(rec, unmask=False, params=None)
+        out = self._printed(p)
+        self.assertNotIn('"k"', out)
+        self.assertIn('********', out)
+
+    def test_v3_detail_masks_security_question_answer(self):
+        from keepercommander.recordv3 import RecordV3
+        rec = self._v3_cache_entry(fields=[{
+            'type': 'securityQuestion', 'label': 'SQ',
+            'value': [{'question': 'Mothers maiden name', 'answer': 'Smith'}],
+        }])
+        with mock.patch('builtins.print') as p:
+            RecordV3.display(rec, unmask=False, params=None)
+        out = self._printed(p)
+        self.assertNotIn('Smith', out)
+        self.assertIn('********', out)
+        self.assertIn('Mothers maiden name', out)
+
+    def test_v3_detail_unmask_reveals_security_answer(self):
+        from keepercommander.recordv3 import RecordV3
+        rec = self._v3_cache_entry(fields=[{
+            'type': 'securityQuestion', 'label': 'SQ',
+            'value': [{'question': 'Mothers maiden name', 'answer': 'Smith'}],
+        }])
+        with mock.patch('builtins.print') as p:
+            RecordV3.display(rec, unmask=True, params=None)
+        self.assertIn('Smith', self._printed(p))
+
+    # ── fields format ──────────────────────────────────────────────────────
+
+    def _run_fields(self, custom_fields, unmask=False):
+        from keepercommander.record import Record as LegacyRecord
+        params = get_synced_params()
+        r = LegacyRecord(utils.generate_uid())
+        r.title = 'Test'
+        r.custom_fields = list(custom_fields)
+        params.record_cache[r.record_uid] = {'version': 2, 'shared': False}
+        captured = []
+        cmd = record.RecordGetUidCommand()
+        with mock.patch('builtins.print', side_effect=captured.append), \
+             mock.patch('keepercommander.api.get_record', return_value=r), \
+             mock.patch('keepercommander.api.get_record_shares'), \
+             mock.patch('keepercommander.api.get_share_admins_for_record', return_value=[]):
+            cmd.execute(params, uid=r.record_uid, format='fields', unmask=unmask)
+        return json.loads(captured[-1])
+
+    def test_fields_includes_secret_custom_field_masked(self):
+        fields = self._run_fields([{'type': 'secret', 'name': 'Token', 'value': 'top-secret'}])
+        f = next((x for x in fields if x['name'] == 'Token'), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f['value'], '********')
+
+    def test_fields_masks_v3_secret_no_label(self):
+        # v3 custom secret without label: type='text', name='secret'
+        fields = self._run_fields([{'type': 'text', 'name': 'secret', 'value': 'top-secret'}])
+        f = next((x for x in fields if x['name'] == 'secret'), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f['value'], '********')
+
+    def test_fields_masks_v3_pincode_no_label(self):
+        fields = self._run_fields([{'type': 'text', 'name': 'pinCode', 'value': '9999'}])
+        f = next((x for x in fields if x['name'] == 'pinCode'), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f['value'], '********')
+
+    def test_fields_unmask_reveals_secret(self):
+        fields = self._run_fields(
+            [{'type': 'secret', 'name': 'Token', 'value': 'top-secret'}], unmask=True)
+        f = next((x for x in fields if x['name'] == 'Token'), None)
+        self.assertIsNotNone(f)
+        self.assertEqual(f['value'], 'top-secret')
+
+    def test_fields_excludes_empty_custom_fields(self):
+        fields = self._run_fields([
+            {'type': 'text', 'name': 'Empty', 'value': ''},
+            {'type': 'text', 'name': 'Present', 'value': 'hello'},
+        ])
+        names = [x['name'] for x in fields]
+        self.assertNotIn('Empty', names)
+        self.assertIn('Present', names)
+
+    def test_fields_security_question_masks_answer_only(self):
+        fields = self._run_fields([{
+            'type': 'securityQuestion', 'name': 'securityQuestion',
+            'value': [{'question': 'MyQuestion', 'answer': 'MyAnswer'}],
+        }])
+        f = next((x for x in fields if x['name'] == 'securityQuestion'), None)
+        self.assertIsNotNone(f)
+        self.assertIsInstance(f['value'], dict)
+        self.assertEqual(f['value']['question'], 'MyQuestion')
+        self.assertEqual(f['value']['answer'], '********')
+
+    def test_fields_security_question_unmask_reveals_answer(self):
+        fields = self._run_fields([{
+            'type': 'securityQuestion', 'name': 'securityQuestion',
+            'value': [{'question': 'MyQuestion', 'answer': 'MyAnswer'}],
+        }], unmask=True)
+        f = next((x for x in fields if x['name'] == 'securityQuestion'), None)
+        self.assertIsNotNone(f)
+        self.assertIsInstance(f['value'], dict)
+        self.assertEqual(f['value']['question'], 'MyQuestion')
+        self.assertEqual(f['value']['answer'], 'MyAnswer')
+


### PR DESCRIPTION
- Masks sensitive custom fields (`secret`, `pinCode`, `note`, `json`, `oneTimeCode`, `paymentCard`, `bankAccount`, `keyPair`, `securityQuestion`) in `--format=detail` and `--format=fields`; `--format=json` stays unmasked.
  `--unmask` reveals all.
- Also fixes `record-add --pam-config` crash caused by an extra dot in relative plugin imports (`...plugins` → `..plugins`).