### PR TITLE
PAM import/extend: new DB protocols, RBI settings, and scrollback aligned with Web Vault

### DIFF
--- a/keepercommander/commands/pam_import/README.md
+++ b/keepercommander/commands/pam_import/README.md
@@ -600,6 +600,7 @@ Workflow controls how privileged access to a resource is gated: how many approva
 			"disable_paste": true,
 			"color_scheme": "gray-black",
 			"font_size": "18",
+			"scrollback": 5000,
 			"public_host_key": "<Public Host Key (Base64)>",
 			"command": "/bin/bash",
 			"sftp": {
@@ -715,6 +716,7 @@ Workflow controls how privileged access to a resource is gated: how many approva
 			"disable_paste": true,
 			"color_scheme": "gray-black",
 			"font_size": "18",
+			"scrollback": 5000,
 			"username_regex": "regex: username",
 			"password_regex": "regex: password",
 			"login_success_regex": "regex: login success",
@@ -768,6 +770,7 @@ Workflow controls how privileged access to a resource is gated: how many approva
 			"recording_include_keys": true,
 			"color_scheme": "gray-black",
 			"font_size": "18",
+			"scrollback": 5000,
 			"namespace": "namespace",
 			"pod_name": "pod name",
 			"container": "container name",
@@ -828,6 +831,9 @@ Workflow controls how privileged access to a resource is gated: how many approva
 						"recording_include_keys": true,
 						"disable_copy": true,
 						"disable_paste": true,
+						"color_scheme": "gray-black",
+						"font_size": "18",
+						"scrollback": 5000,
 						"disable_csv_import": true,
 						"disable_csv_export": true,
 						"default_database": "db1"
@@ -899,6 +905,7 @@ Workflow controls how privileged access to a resource is gated: how many approva
 						"disable_paste": true,
 						"color_scheme": "gray-black",
 						"font_size": "18",
+						"scrollback": 5000,
 						"public_host_key": "<Public Host Key (Base64)>",
 						"command": "/bin/bash",
 						"sftp": {

--- a/keepercommander/commands/pam_import/README.md
+++ b/keepercommander/commands/pam_import/README.md
@@ -820,7 +820,7 @@ Workflow controls how privileged access to a resource is gated: how many approva
 					},
 					"connection" : {
 						"protocol": "mysql",
-						"_comment": "protocol types: <sql-server|postgresql|mysql>",
+						"_comment": "DB protocol types: <sql-server|postgresql|mysql|mariadb|oracle|mongodb|redis|elasticsearch|clickhouse|dynamodb>",
 						"port": "2222",
 						"allow_supply_user": true,
 						"administrative_credentials": "admin1",

--- a/keepercommander/commands/pam_import/README.md
+++ b/keepercommander/commands/pam_import/README.md
@@ -952,7 +952,17 @@ Workflow controls how privileged access to a resource is gated: how many approva
 						"allowed_url_patterns": "*.com\n*.org",
 						"allowed_resource_url_patterns": "*.org\n*.gov",
 						"autofill_targets": "autofil_target1\nautofil_target2",
-						"ignore_server_cert": true
+						"ignore_server_cert": true,
+						"session_persistence": "none",
+						"_comment_session_persistence": "none | user | resource",
+						"allow_file_uploads": true,
+						"allow_file_downloads": true,
+						"disable_audio": false,
+						"audio_channels": 2,
+						"_comment_audio_channels": "1 (mono) or 2 (stereo)",
+						"audio_bps": 16,
+						"_comment_audio_bps": "8 or 16",
+						"audio_sample_rate": 44100
 					}
 				}
 			},

--- a/keepercommander/commands/pam_import/base.py
+++ b/keepercommander/commands/pam_import/base.py
@@ -2303,7 +2303,14 @@ class ConnectionSettingsHTTP(BaseConnectionSettings, ClipboardConnectionSettings
         allowedResourceUrlPatterns: Optional[str] = None,
         httpCredentials: Optional[List[str]] = None, # autofill_credentials: login|pamUser
         autofillConfiguration: Optional[str] = None,
-        ignoreInitialSslCert: Optional[bool] = None
+        ignoreInitialSslCert: Optional[bool] = None,
+        sessionPersistence: Optional[str] = None,
+        allowFileUploads: Optional[bool] = None,
+        allowFileDownloads: Optional[bool] = None,
+        disableAudio: Optional[bool] = None,
+        audioChannels: Optional[int] = None,
+        audioBps: Optional[int] = None,
+        audioSampleRate: Optional[int] = None
     ):
         BaseConnectionSettings.__init__(self, port, allowSupplyUser, userRecords, recordingIncludeKeys)
         ClipboardConnectionSettings.__init__(self, disableCopy, disablePaste)
@@ -2314,6 +2321,13 @@ class ConnectionSettingsHTTP(BaseConnectionSettings, ClipboardConnectionSettings
         self.autofillConfiguration = autofillConfiguration
         self.ignoreInitialSslCert = ignoreInitialSslCert
         self.httpCredentialsUid = None # resolved from httpCredentials
+        self.sessionPersistence = sessionPersistence
+        self.allowFileUploads = allowFileUploads
+        self.allowFileDownloads = allowFileDownloads
+        self.disableAudio = disableAudio
+        self.audioChannels = audioChannels
+        self.audioBps = audioBps
+        self.audioSampleRate = audioSampleRate
 
     @classmethod
     def load(cls, data: Union[str, dict]):
@@ -2342,6 +2356,40 @@ class ConnectionSettingsHTTP(BaseConnectionSettings, ClipboardConnectionSettings
         obj.httpCredentials = parse_multiline(data, "autofill_credentials", "Error parsing autofill_credentials")
         obj.autofillConfiguration = multiline_to_str(parse_multiline(data, "autofill_targets", "Error parsing autofill_targets"))
         obj.ignoreInitialSslCert = utils.value_to_boolean(data.get("ignore_server_cert", None))
+
+        val = data.get("session_persistence", None)
+        if isinstance(val, str) and val.lower() in ("none", "user", "resource"):
+            obj.sessionPersistence = val.lower()
+        obj.allowFileUploads = utils.value_to_boolean(data.get("allow_file_uploads", None))
+        obj.allowFileDownloads = utils.value_to_boolean(data.get("allow_file_downloads", None))
+        obj.disableAudio = utils.value_to_boolean(data.get("disable_audio", None))
+        val = data.get("audio_channels", None)
+        if val is not None:
+            try:
+                parsed = int(val)
+                if parsed not in (1, 2):
+                    logging.warning(f"ConnectionSettingsHTTP: audio_channels must be 1 or 2, got: {parsed}")
+                else:
+                    obj.audioChannels = parsed
+            except (TypeError, ValueError): logging.warning(f"ConnectionSettingsHTTP: invalid audio_channels value: {val!r}")
+        val = data.get("audio_bps", None)
+        if val is not None:
+            try:
+                parsed = int(val)
+                if parsed not in (8, 16):
+                    logging.warning(f"ConnectionSettingsHTTP: audio_bps must be 8 or 16, got: {parsed}")
+                else:
+                    obj.audioBps = parsed
+            except (TypeError, ValueError): logging.warning(f"ConnectionSettingsHTTP: invalid audio_bps value: {val!r}")
+        val = data.get("audio_sample_rate", None)
+        if val is not None:
+            try:
+                parsed = int(val)
+                if parsed < 0:
+                    logging.warning(f"ConnectionSettingsHTTP: audio_sample_rate must be non-negative, got: {parsed}")
+                else:
+                    obj.audioSampleRate = parsed
+            except (TypeError, ValueError): logging.warning(f"ConnectionSettingsHTTP: invalid audio_sample_rate value: {val!r}")
 
         return obj
 
@@ -2376,6 +2424,21 @@ class ConnectionSettingsHTTP(BaseConnectionSettings, ClipboardConnectionSettings
             kvp["autofillConfiguration"] = self.autofillConfiguration.strip()
         if self.ignoreInitialSslCert is not None and isinstance(self.ignoreInitialSslCert, bool):
             kvp["ignoreInitialSslCert"] = self.ignoreInitialSslCert
+
+        if self.sessionPersistence and isinstance(self.sessionPersistence, str) and self.sessionPersistence in ("none", "user", "resource"):
+            kvp["sessionPersistence"] = self.sessionPersistence
+        if self.allowFileUploads is not None and isinstance(self.allowFileUploads, bool):
+            kvp["allowFileUploads"] = self.allowFileUploads
+        if self.allowFileDownloads is not None and isinstance(self.allowFileDownloads, bool):
+            kvp["allowFileDownloads"] = self.allowFileDownloads
+        if self.disableAudio is not None and isinstance(self.disableAudio, bool):
+            kvp["disableAudio"] = self.disableAudio
+        if self.audioChannels is not None and type(self.audioChannels) is int:
+            kvp["audioChannels"] = self.audioChannels
+        if self.audioBps is not None and type(self.audioBps) is int:
+            kvp["audioBps"] = self.audioBps
+        if self.audioSampleRate is not None and type(self.audioSampleRate) is int:
+            kvp["audioSampleRate"] = self.audioSampleRate
 
         return kvp
 

--- a/keepercommander/commands/pam_import/base.py
+++ b/keepercommander/commands/pam_import/base.py
@@ -2101,9 +2101,11 @@ def sftp_enabled(connection_settings: Union[PamConnectionSettings, ConnectionSet
 
 class TerminalDisplayConnectionSettings:
     fontSizes: List[int] = [8,9,10,11,12,14,18,24,30,36,48,60,72,96]
-    def __init__(self, colorScheme: Optional[str] = None, fontSize: Optional[int] = None):
+    def __init__(self, colorScheme: Optional[str] = None, fontSize: Optional[int] = None,
+                 scrollback: Optional[int] = None):
         self.colorScheme = colorScheme
         self.fontSize = fontSize
+        self.scrollback = scrollback
 
     @classmethod
     def load(cls, data: Union[str, dict]):
@@ -2123,6 +2125,18 @@ class TerminalDisplayConnectionSettings:
             if closest_number != font_size:
                 logging.error(f"Terminal Display Connection Settings - adjusted invalid font_size from: {obj.fontSize} to: {closest_number}")
                 obj.fontSize = closest_number
+
+        # scrollback (Maximum Scrollback Size): must be a positive integer.
+        val = data.get("scrollback", None)
+        if val is not None:
+            try:
+                parsed = int(val)
+                if parsed <= 0:
+                    logging.warning(f"Terminal Display Connection Settings: scrollback must be a positive integer, got: {parsed}")
+                else:
+                    obj.scrollback = parsed
+            except (TypeError, ValueError):
+                logging.warning(f"Terminal Display Connection Settings: invalid scrollback value: {val!r}")
         return obj
 
 class BaseConnectionSettings:
@@ -2554,6 +2568,7 @@ class ConnectionSettingsTelnet(BaseConnectionSettings, ClipboardConnectionSettin
         disablePaste: Optional[bool] = None,
         colorScheme: Optional[str] = None,
         fontSize: Optional[int] = None,
+        scrollback: Optional[int] = None,
         usernameRegex: Optional[str] = None,
         passwordRegex: Optional[str] = None,
         loginSuccessRegex: Optional[str] = None,
@@ -2561,7 +2576,7 @@ class ConnectionSettingsTelnet(BaseConnectionSettings, ClipboardConnectionSettin
     ):
         BaseConnectionSettings.__init__(self, port, allowSupplyUser, userRecords, recordingIncludeKeys)
         ClipboardConnectionSettings.__init__(self, disableCopy, disablePaste)
-        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize)
+        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize, scrollback)
         self.usernameRegex = usernameRegex
         self.passwordRegex = passwordRegex
         self.loginSuccessRegex = loginSuccessRegex
@@ -2592,6 +2607,7 @@ class ConnectionSettingsTelnet(BaseConnectionSettings, ClipboardConnectionSettin
         if tcs:
             obj.colorScheme = tcs.colorScheme
             obj.fontSize = tcs.fontSize
+            obj.scrollback = tcs.scrollback
 
         val = data.get("username_regex", None)
         if isinstance(val, str): obj.usernameRegex = val
@@ -2628,6 +2644,8 @@ class ConnectionSettingsTelnet(BaseConnectionSettings, ClipboardConnectionSettin
             kvp["colorScheme"] = self.colorScheme.strip()
         if self.fontSize and type(self.fontSize) is int and self.fontSize > 4:
             kvp["fontSize"] = str(self.fontSize)
+        if self.scrollback is not None and type(self.scrollback) is int and self.scrollback > 0:
+            kvp["scrollback"] = self.scrollback
         if self.usernameRegex and isinstance(self.usernameRegex, str) and self.usernameRegex.strip():
             kvp["usernameRegex"] = self.usernameRegex.strip()
         if self.passwordRegex and isinstance(self.passwordRegex, str) and self.passwordRegex.strip():
@@ -2656,13 +2674,14 @@ class ConnectionSettingsSSH(BaseConnectionSettings, ClipboardConnectionSettings,
         disablePaste: Optional[bool] = None,
         colorScheme: Optional[str] = None,
         fontSize: Optional[int] = None,
+        scrollback: Optional[int] = None,
         hostKey: Optional[str] = None,
         command: Optional[str] = None,
         sftp: Optional[SFTPRootDirectorySettings] = None
     ):
         BaseConnectionSettings.__init__(self, port, allowSupplyUser, userRecords, recordingIncludeKeys)
         ClipboardConnectionSettings.__init__(self, disableCopy, disablePaste)
-        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize)
+        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize, scrollback)
         self.hostKey = hostKey
         self.command = command
         self.sftp = sftp if isinstance(sftp, SFTPRootDirectorySettings) else None
@@ -2692,6 +2711,7 @@ class ConnectionSettingsSSH(BaseConnectionSettings, ClipboardConnectionSettings,
         if tcs:
             obj.colorScheme = tcs.colorScheme
             obj.fontSize = tcs.fontSize
+            obj.scrollback = tcs.scrollback
 
         val = data.get("public_host_key", None)
         if isinstance(val, str): obj.hostKey = val
@@ -2726,6 +2746,8 @@ class ConnectionSettingsSSH(BaseConnectionSettings, ClipboardConnectionSettings,
             kvp["colorScheme"] = self.colorScheme.strip()
         if self.fontSize and type(self.fontSize) is int and self.fontSize > 4:
             kvp["fontSize"] = str(self.fontSize)
+        if self.scrollback is not None and type(self.scrollback) is int and self.scrollback > 0:
+            kvp["scrollback"] = self.scrollback
         if self.hostKey and isinstance(self.hostKey, str) and self.hostKey.strip():
             kvp["hostKey"] = self.hostKey.strip()
         if self.command and isinstance(self.command, str) and self.command.strip():
@@ -2753,6 +2775,7 @@ class ConnectionSettingsKubernetes(BaseConnectionSettings, TerminalDisplayConnec
         recordingIncludeKeys: Optional[bool] = None,
         colorScheme: Optional[str] = None,
         fontSize: Optional[int] = None,
+        scrollback: Optional[int] = None,
         ignoreCert: Optional[bool] = None,
         caCert: Optional[str] = None,
         namespace: Optional[str] = None,
@@ -2762,7 +2785,7 @@ class ConnectionSettingsKubernetes(BaseConnectionSettings, TerminalDisplayConnec
         clientKey: Optional[str] = None
     ):
         BaseConnectionSettings.__init__(self, port, allowSupplyUser, userRecords, recordingIncludeKeys)
-        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize)
+        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize, scrollback)
         self.ignoreCert = ignoreCert
         self.caCert = caCert
         self.namespace = namespace
@@ -2791,6 +2814,7 @@ class ConnectionSettingsKubernetes(BaseConnectionSettings, TerminalDisplayConnec
         if tcs:
             obj.colorScheme = tcs.colorScheme
             obj.fontSize = tcs.fontSize
+            obj.scrollback = tcs.scrollback
 
         val = data.get("namespace", None)
         if isinstance(val, str): obj.namespace = val
@@ -2824,6 +2848,8 @@ class ConnectionSettingsKubernetes(BaseConnectionSettings, TerminalDisplayConnec
             kvp["colorScheme"] = self.colorScheme.strip()
         if self.fontSize and type(self.fontSize) is int and self.fontSize > 4:
             kvp["fontSize"] = str(self.fontSize)
+        if self.scrollback is not None and type(self.scrollback) is int and self.scrollback > 0:
+            kvp["scrollback"] = self.scrollback
         if self.namespace and isinstance(self.namespace, str) and self.namespace.strip():
             kvp["namespace"] = self.namespace.strip()
         if self.pod and isinstance(self.pod, str) and self.pod.strip():
@@ -2927,143 +2953,91 @@ class BaseDatabaseConnectionSettings(BaseConnectionSettings, ClipboardConnection
         rec_json = json.dumps(dict)
         return rec_json
 
-class ConnectionSettingsSqlServer(BaseDatabaseConnectionSettings):
+class CliCapableDatabaseConnectionSettings(BaseDatabaseConnectionSettings, TerminalDisplayConnectionSettings):
+    """mysql/postgresql/sql-server: CLI-capable DB protocols with terminal display (mirrors WV)."""
+
+    def __init__( # pylint: disable=R0917
+        self,
+        port: Optional[str] = None,  # Override port from host
+        allowSupplyUser: Optional[bool] = None,
+        userRecords: Optional[List[str]] = None,
+        recordingIncludeKeys: Optional[bool] = None,
+        disableCopy: Optional[bool] = None,
+        disablePaste: Optional[bool] = None,
+        database: Optional[str] = None,
+        disableCsvExport: Optional[bool] = None,
+        disableCsvImport: Optional[bool] = None,
+        colorScheme: Optional[str] = None,
+        fontSize: Optional[int] = None,
+        scrollback: Optional[int] = None,
+    ):
+        BaseDatabaseConnectionSettings.__init__(
+            self, port, allowSupplyUser, userRecords, recordingIncludeKeys,
+            disableCopy, disablePaste, database, disableCsvExport, disableCsvImport)
+        TerminalDisplayConnectionSettings.__init__(self, colorScheme, fontSize, scrollback)
+
+    @classmethod
+    def load(cls, data: Union[str, dict]):
+        obj = cls()
+        try: data = json.loads(data) if isinstance(data, str) else data
+        except: logging.error(f"CLI-capable Database Connection Settings failed to load from: {str(data)[:80]}")
+        if not isinstance(data, dict): return obj
+
+        bdcs = BaseDatabaseConnectionSettings.load(data)
+        if bdcs:
+            obj.port = bdcs.port
+            obj.allowSupplyUser = bdcs.allowSupplyUser
+            obj.userRecords = bdcs.userRecords
+            obj.recordingIncludeKeys = bdcs.recordingIncludeKeys
+            obj.disableCopy = bdcs.disableCopy
+            obj.disablePaste = bdcs.disablePaste
+            obj.database = bdcs.database
+            obj.disableCsvExport = bdcs.disableCsvExport
+            obj.disableCsvImport = bdcs.disableCsvImport
+            obj.launch_credentials = getattr(bdcs, "launch_credentials", None)
+            obj.launchRecordUid = getattr(bdcs, "launchRecordUid", None)
+
+        tcs = TerminalDisplayConnectionSettings.load(data)
+        if tcs:
+            obj.colorScheme = tcs.colorScheme
+            obj.fontSize = tcs.fontSize
+            obj.scrollback = tcs.scrollback
+
+        return obj
+
+    def _apply_terminal_display_to_record_dict(self, kvp: Dict[str, Any]):
+        if self.colorScheme and isinstance(self.colorScheme, str) and self.colorScheme.strip():
+            kvp["colorScheme"] = self.colorScheme.strip()
+        if self.fontSize and type(self.fontSize) is int and self.fontSize > 4:
+            kvp["fontSize"] = str(self.fontSize)
+        if self.scrollback is not None and type(self.scrollback) is int and self.scrollback > 0:
+            kvp["scrollback"] = self.scrollback
+
+    def to_record_dict(self):
+        kvp = super().to_record_dict()
+        self._apply_terminal_display_to_record_dict(kvp)
+        return kvp
+
+class ConnectionSettingsSqlServer(CliCapableDatabaseConnectionSettings):
     protocol = ConnectionProtocol.SQLSERVER
-    def __init__( # pylint: disable=W0246
-        self,
-        port: Optional[str] = None,  # Override port from host
-        allowSupplyUser: Optional[bool] = None,
-        userRecords: Optional[List[str]] = None,
-        recordingIncludeKeys: Optional[bool] = None,
-        disableCopy: Optional[bool] = None,
-        disablePaste: Optional[bool] = None,
-        database: Optional[str] = None,
-        disableCsvExport: Optional[bool] = None,
-        disableCsvImport: Optional[bool] = None
-    ):
-        super().__init__(port, allowSupplyUser, userRecords, recordingIncludeKeys,
-                         disableCopy, disablePaste, database,
-                         disableCsvExport, disableCsvImport)
-
-    @classmethod
-    def load(cls, data: Union[str, dict]):
-        obj = cls()
-        try: data = json.loads(data) if isinstance(data, str) else data
-        except: logging.error(f"SQLServer Connection Settings failed to load from: {str(data)[:80]}")
-        if not isinstance(data, dict): return obj
-
-        bdcs = BaseDatabaseConnectionSettings.load(data)
-        if bdcs:
-            obj.port = bdcs.port
-            obj.allowSupplyUser = bdcs.allowSupplyUser
-            obj.userRecords = bdcs.userRecords
-            obj.recordingIncludeKeys = bdcs.recordingIncludeKeys
-            obj.disableCopy = bdcs.disableCopy
-            obj.disablePaste = bdcs.disablePaste
-            obj.database = bdcs.database
-            obj.disableCsvExport = bdcs.disableCsvExport
-            obj.disableCsvImport = bdcs.disableCsvImport
-            obj.launch_credentials = getattr(bdcs, "launch_credentials", None)
-            obj.launchRecordUid = getattr(bdcs, "launchRecordUid", None)
-
-        return obj
-
     def to_record_dict(self):
-        dict = super().to_record_dict()
-        dict["protocol"] = ConnectionProtocol.SQLSERVER.value  # pylint: disable=E1101
-        return dict
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.SQLSERVER.value  # pylint: disable=E1101
+        return d
 
-class ConnectionSettingsPostgreSQL(BaseDatabaseConnectionSettings):
+class ConnectionSettingsPostgreSQL(CliCapableDatabaseConnectionSettings):
     protocol = ConnectionProtocol.POSTGRESQL
-    def __init__( # pylint: disable=W0246,R0917
-        self,
-        port: Optional[str] = None,  # Override port from host
-        allowSupplyUser: Optional[bool] = None,
-        userRecords: Optional[List[str]] = None,
-        recordingIncludeKeys: Optional[bool] = None,
-        disableCopy: Optional[bool] = None,
-        disablePaste: Optional[bool] = None,
-        database: Optional[str] = None,
-        disableCsvExport: Optional[bool] = None,
-        disableCsvImport: Optional[bool] = None
-    ):
-        super().__init__(port, allowSupplyUser, userRecords, recordingIncludeKeys,
-                         disableCopy, disablePaste, database,
-                         disableCsvExport, disableCsvImport)
-
-    @classmethod
-    def load(cls, data: Union[str, dict]):
-        obj = cls()
-        try: data = json.loads(data) if isinstance(data, str) else data
-        except: logging.error(f"PostgreSQL Connection Settings failed to load from: {str(data)[:80]}")
-        if not isinstance(data, dict): return obj
-
-        bdcs = BaseDatabaseConnectionSettings.load(data)
-        if bdcs:
-            obj.port = bdcs.port
-            obj.allowSupplyUser = bdcs.allowSupplyUser
-            obj.userRecords = bdcs.userRecords
-            obj.recordingIncludeKeys = bdcs.recordingIncludeKeys
-            obj.disableCopy = bdcs.disableCopy
-            obj.disablePaste = bdcs.disablePaste
-            obj.database = bdcs.database
-            obj.disableCsvExport = bdcs.disableCsvExport
-            obj.disableCsvImport = bdcs.disableCsvImport
-            obj.launch_credentials = getattr(bdcs, "launch_credentials", None)
-            obj.launchRecordUid = getattr(bdcs, "launchRecordUid", None)
-
-        return obj
-
     def to_record_dict(self):
-        dict = super().to_record_dict()
-        dict["protocol"] = ConnectionProtocol.POSTGRESQL.value  # pylint: disable=E1101
-        return dict
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.POSTGRESQL.value  # pylint: disable=E1101
+        return d
 
-class ConnectionSettingsMySQL(BaseDatabaseConnectionSettings):
+class ConnectionSettingsMySQL(CliCapableDatabaseConnectionSettings):
     protocol = ConnectionProtocol.MYSQL
-    def __init__( # pylint: disable=W0246,R0917
-        self,
-        port: Optional[str] = None,  # Override port from host
-        allowSupplyUser: Optional[bool] = None,
-        userRecords: Optional[List[str]] = None,
-        recordingIncludeKeys: Optional[bool] = None,
-        disableCopy: Optional[bool] = None,
-        disablePaste: Optional[bool] = None,
-        database: Optional[str] = None,
-        disableCsvExport: Optional[bool] = None,
-        disableCsvImport: Optional[bool] = None
-    ):
-        super().__init__(port, allowSupplyUser, userRecords, recordingIncludeKeys,
-                         disableCopy, disablePaste, database,
-                         disableCsvExport, disableCsvImport)
-
-    @classmethod
-    def load(cls, data: Union[str, dict]):
-        obj = cls()
-        try: data = json.loads(data) if isinstance(data, str) else data
-        except: logging.error(f"MySQL Connection Settings failed to load from: {str(data)[:80]}")
-        if not isinstance(data, dict): return obj
-
-        bdcs = BaseDatabaseConnectionSettings.load(data)
-        if bdcs:
-            obj.port = bdcs.port
-            obj.allowSupplyUser = bdcs.allowSupplyUser
-            obj.userRecords = bdcs.userRecords
-            obj.recordingIncludeKeys = bdcs.recordingIncludeKeys
-            obj.disableCopy = bdcs.disableCopy
-            obj.disablePaste = bdcs.disablePaste
-            obj.database = bdcs.database
-            obj.disableCsvExport = bdcs.disableCsvExport
-            obj.disableCsvImport = bdcs.disableCsvImport
-            obj.launch_credentials = getattr(bdcs, "launch_credentials", None)
-            obj.launchRecordUid = getattr(bdcs, "launchRecordUid", None)
-
-        return obj
-
     def to_record_dict(self):
-        dict = super().to_record_dict()
-        dict["protocol"] = ConnectionProtocol.MYSQL.value  # pylint: disable=E1101
-        return dict
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.MYSQL.value  # pylint: disable=E1101
+        return d
 
 # The remaining database protocols share BaseDatabaseConnectionSettings verbatim — they
 # differ only by their wire protocol value. __init__ and load() are inherited unchanged
@@ -3331,6 +3305,12 @@ def is_blank_instance(obj, skiplist: Optional[List[str]] = None):
             return False
     return True
 
+_CLI_CAPABLE_DB_MEMBERS = (
+    ConnectionProtocol.MYSQL,
+    ConnectionProtocol.POSTGRESQL,
+    ConnectionProtocol.SQLSERVER,
+)
+
 def is_database_protocol(protocol):
     """
     Returns True if the protocol is one of the database protocols: MYSQL, POSTGRESQL,
@@ -3356,6 +3336,25 @@ def is_database_protocol(protocol):
     if isinstance(protocol, str):
         return str(protocol).strip().lower() in db_values
     return False
+
+def is_cli_capable_db_protocol(protocol):
+    """
+    Returns True for mysql/postgresql/sql-server — DB protocols with CLI/TTY sessions
+    (mirrors WV: terminal display is shown when !isKeeperDbOnlyProtocol).
+    """
+    cli_values = {m.value for m in _CLI_CAPABLE_DB_MEMBERS}
+    if isinstance(protocol, ConnectionProtocol):
+        return protocol in _CLI_CAPABLE_DB_MEMBERS
+    if isinstance(protocol, str):
+        return str(protocol).strip().lower() in cli_values
+    return False
+
+def is_keeper_db_only_protocol(protocol):
+    """
+    Returns True for keeperDb-only DB protocols (mariadb, oracle, mongodb, redis,
+    elasticsearch, clickhouse, dynamodb). Mirrors WV isKeeperDbOnlyProtocol.
+    """
+    return is_database_protocol(protocol) and not is_cli_capable_db_protocol(protocol)
 
 def get_sftp_attribute(obj, name: str) -> str:
     # Get one of pam_settings.connection.sftp.{sftpResource,sftpResourceUid,sftpUser,sftpUserUid}

--- a/keepercommander/commands/pam_import/base.py
+++ b/keepercommander/commands/pam_import/base.py
@@ -1901,6 +1901,13 @@ class ConnectionProtocol(Enum):
     SQLSERVER = "sql-server"
     POSTGRESQL = "postgresql"
     MYSQL = "mysql"
+    MARIADB = "mariadb"
+    ORACLE = "oracle"
+    MONGODB = "mongodb"
+    REDIS = "redis"
+    ELASTICSEARCH = "elasticsearch"
+    CLICKHOUSE = "clickhouse"
+    DYNAMODB = "dynamodb"
     HTTP = "http"
 
 class RDPSecurity(Enum):
@@ -3058,6 +3065,59 @@ class ConnectionSettingsMySQL(BaseDatabaseConnectionSettings):
         dict["protocol"] = ConnectionProtocol.MYSQL.value  # pylint: disable=E1101
         return dict
 
+# The remaining database protocols share BaseDatabaseConnectionSettings verbatim — they
+# differ only by their wire protocol value. __init__ and load() are inherited unchanged
+# (BaseDatabaseConnectionSettings.load uses cls(), so it builds the right subclass);
+# only to_record_dict needs to stamp the protocol.
+class ConnectionSettingsMariaDB(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.MARIADB
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.MARIADB.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsOracle(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.ORACLE
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.ORACLE.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsMongoDB(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.MONGODB
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.MONGODB.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsRedis(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.REDIS
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.REDIS.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsElasticsearch(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.ELASTICSEARCH
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.ELASTICSEARCH.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsClickHouse(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.CLICKHOUSE
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.CLICKHOUSE.value  # pylint: disable=E1101
+        return d
+
+class ConnectionSettingsDynamoDB(BaseDatabaseConnectionSettings):
+    protocol = ConnectionProtocol.DYNAMODB
+    def to_record_dict(self):
+        d = super().to_record_dict()
+        d["protocol"] = ConnectionProtocol.DYNAMODB.value  # pylint: disable=E1101
+        return d
+
 PamConnectionSettings = Optional[
     Union[
         ConnectionSettingsRDP,
@@ -3067,7 +3127,14 @@ PamConnectionSettings = Optional[
         ConnectionSettingsKubernetes,
         ConnectionSettingsSqlServer,
         ConnectionSettingsPostgreSQL,
-        ConnectionSettingsMySQL
+        ConnectionSettingsMySQL,
+        ConnectionSettingsMariaDB,
+        ConnectionSettingsOracle,
+        ConnectionSettingsMongoDB,
+        ConnectionSettingsRedis,
+        ConnectionSettingsElasticsearch,
+        ConnectionSettingsClickHouse,
+        ConnectionSettingsDynamoDB
     ]
 ]
 
@@ -3174,7 +3241,14 @@ class PamSettingsFieldData:
         ConnectionSettingsKubernetes,
         ConnectionSettingsSqlServer,
         ConnectionSettingsPostgreSQL,
-        ConnectionSettingsMySQL
+        ConnectionSettingsMySQL,
+        ConnectionSettingsMariaDB,
+        ConnectionSettingsOracle,
+        ConnectionSettingsMongoDB,
+        ConnectionSettingsRedis,
+        ConnectionSettingsElasticsearch,
+        ConnectionSettingsClickHouse,
+        ConnectionSettingsDynamoDB
     ]
 
     @classmethod
@@ -3259,14 +3333,22 @@ def is_blank_instance(obj, skiplist: Optional[List[str]] = None):
 
 def is_database_protocol(protocol):
     """
-    Returns True if the protocol is one of the database protocols: MYSQL, POSTGRESQL, or SQLSERVER.
+    Returns True if the protocol is one of the database protocols: MYSQL, POSTGRESQL,
+    SQLSERVER, MARIADB, ORACLE, MONGODB, REDIS, ELASTICSEARCH, CLICKHOUSE, or DYNAMODB.
 
-    Accepts ConnectionProtocol or the string wire values (e.g. 'mysql', 'postgresql', 'sql-server').
+    Accepts ConnectionProtocol or the string wire values (e.g. 'mysql', 'oracle', 'sql-server').
     """
     db_members = (
         ConnectionProtocol.MYSQL,
         ConnectionProtocol.POSTGRESQL,
         ConnectionProtocol.SQLSERVER,
+        ConnectionProtocol.MARIADB,
+        ConnectionProtocol.ORACLE,
+        ConnectionProtocol.MONGODB,
+        ConnectionProtocol.REDIS,
+        ConnectionProtocol.ELASTICSEARCH,
+        ConnectionProtocol.CLICKHOUSE,
+        ConnectionProtocol.DYNAMODB,
     )
     db_values = {m.value for m in db_members}
     if isinstance(protocol, ConnectionProtocol):

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -3327,6 +3327,11 @@ class PAMRbiEditCommand(Command):
     parser.add_argument('--audio-sample-rate', '-sr', dest='audio_sample_rate', type=int,
                         help='Audio sample rate in Hz (e.g., 44100, 48000)')
 
+    # Session Persistence
+    parser.add_argument('--session-persistence', '-sp', dest='session_persistence',
+                        choices=['none', 'user', 'resource', 'default'],
+                        help='RBI session persistence (none/user/resource; default = unset)')
+
     # Utility
     parser.add_argument('--silent', '-s', required=False, dest='silent', action='store_true',
                         help='Silent mode - don\'t print PAM User, PAM Config etc.')
@@ -3357,6 +3362,7 @@ class PAMRbiEditCommand(Command):
         audio_channels = kwargs.get('audio_channels')  # int or None
         audio_bit_depth = kwargs.get('audio_bit_depth')  # int or None
         audio_sample_rate = kwargs.get('audio_sample_rate')  # int or None
+        session_persistence = kwargs.get('session_persistence')  # none/user/resource/default/None
 
         if not record_name:
             raise CommandError('pam rbi edit', 'Record parameter is required.')
@@ -3375,7 +3381,8 @@ class PAMRbiEditCommand(Command):
             disable_audio is not None,
             audio_channels is not None,
             audio_bit_depth is not None,
-            audio_sample_rate is not None
+            audio_sample_rate is not None,
+            session_persistence is not None
         ])
 
         if not (autofill or key_events or config_name or rbi or recording or has_new_settings):
@@ -3542,6 +3549,31 @@ class PAMRbiEditCommand(Command):
                 else:
                     logging.debug(f'{field_name} is already set to {value} on record={record_uid}')
 
+        # Helper for enum string fields (e.g. sessionPersistence): set a literal value,
+        # or remove the key on 'default' so the gateway/vault applies its own default.
+        # Coerces 'connection' to a dict locally (idempotent) so this is safe even if
+        # 'connection' is missing/null/"" — no dependency on the earlier coercion. Removal
+        # keys on presence, so a present-but-null value is cleared too.
+        def update_connection_choice(field_name, value):
+            nonlocal dirty
+            rbs_fld = record.get_typed_field('pamRemoteBrowserSettings')
+            if rbs_fld and rbs_fld.value and isinstance(rbs_fld.value[0], dict):
+                _coerce_settings_subdicts(rbs_fld.value[0], 'connection')
+                connection = rbs_fld.value[0]['connection']
+                if value == 'default':
+                    if field_name in connection:
+                        connection.pop(field_name, None)
+                        dirty = True
+                        logging.debug(f'Removed {field_name} (set to default) on record={record_uid}')
+                    else:
+                        logging.debug(f'{field_name} is already unset on record={record_uid}')
+                elif connection.get(field_name) != value:
+                    connection[field_name] = value
+                    dirty = True
+                    logging.debug(f'Set {field_name}={value} on record={record_uid}')
+                else:
+                    logging.debug(f'{field_name} is already set to {value} on record={record_uid}')
+
         # Browser Settings - allowUrlManipulation (on/off/default)
         if allow_url_navigation:
             update_connection_toggle('allowUrlManipulation', allow_url_navigation)
@@ -3593,6 +3625,10 @@ class PAMRbiEditCommand(Command):
         # Audio Settings - audioSampleRate (integer)
         if audio_sample_rate is not None:
             update_connection_int('audioSampleRate', audio_sample_rate)
+
+        # Session Persistence - sessionPersistence (none/user/resource; default removes)
+        if session_persistence:
+            update_connection_choice('sessionPersistence', session_persistence)
 
         if dirty:
             record_management.update_record(params, record)

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -2629,6 +2629,9 @@ class PAMConnectionEditCommand(Command):
     # any supported PAM resource may use any protocol (see validate_pam_connection in pam_import).
     db_protocols = ['clickhouse', 'dynamodb', 'elasticsearch', 'mariadb', 'mongodb',
                     'mysql', 'oracle', 'postgresql', 'redis', 'sql-server']
+    # CLI-capable DB protocols (mysql/postgresql/sql-server): terminal display incl. scrollback.
+    # Mirrors WV isKeeperDbOnlyProtocol — keeperDb-only DBs have no TTY session settings.
+    cli_capable_db_protocols = ['mysql', 'postgresql', 'sql-server']
     # Non-database protocols (terminal/remote for pamMachine/pamDirectory, http for RBI).
     non_db_protocols = ['http', 'kubernetes', 'rdp', 'ssh', 'telnet', 'vnc']
     # Protocols offered by --protocol ('' clears the protocol).
@@ -2662,8 +2665,8 @@ class PAMConnectionEditCommand(Command):
                         help='Toggle Key Events settings')
     parser.add_argument('--scrollback', '-sb', required=False, dest='scrollback', action='store',
                         help='Maximum Scrollback Size (terminal history). Integer to set, '
-                             'empty string to remove. Supported only for pamDatabase (any DB protocol) and '
-                             'pamMachine/pamDirectory (ssh/telnet/kubernetes).')
+                             'empty string to remove. Supported for pamDatabase (mysql/postgresql/sql-server) '
+                             'and pamMachine/pamDirectory (ssh/telnet/kubernetes).')
     parser.add_argument('--rotate-on-termination', required=False, dest='rotate_on_termination',
                         choices=['on', 'off'],
                         help='Rotate launch credentials when the PAM session ends (DAG resource meta)')
@@ -2717,7 +2720,7 @@ class PAMConnectionEditCommand(Command):
         scrollback_clear = False
         scrollback_value = None  # parsed int, or None to skip apply
         if scrollback_arg is not None:
-            db_scrollback_protocols = set(PAMConnectionEditCommand.db_protocols)
+            db_scrollback_protocols = set(PAMConnectionEditCommand.cli_capable_db_protocols)
             terminal_scrollback_protocols = {'ssh', 'telnet', 'kubernetes'}
             if record_type == 'pamDatabase':
                 allowed_protocols = db_scrollback_protocols

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -2623,7 +2623,16 @@ class PAMTunnelDiagnoseCommand(Command):
 
 class PAMConnectionEditCommand(Command):
     choices = ['on', 'off', 'default']
-    protocols = ['', 'http', 'kubernetes', 'mysql', 'postgresql', 'rdp', 'sql-server', 'ssh', 'telnet', 'vnc']
+    # Database connection protocols (pamDatabase). Kept as its own list so it is the single
+    # source of truth for DB-protocol checks (e.g. --scrollback) and so a future DB-vs-non-DB
+    # split or per-record-type gate is a one-line change. No per-type gating is applied today:
+    # any supported PAM resource may use any protocol (see validate_pam_connection in pam_import).
+    db_protocols = ['clickhouse', 'dynamodb', 'elasticsearch', 'mariadb', 'mongodb',
+                    'mysql', 'oracle', 'postgresql', 'redis', 'sql-server']
+    # Non-database protocols (terminal/remote for pamMachine/pamDirectory, http for RBI).
+    non_db_protocols = ['http', 'kubernetes', 'rdp', 'ssh', 'telnet', 'vnc']
+    # Protocols offered by --protocol ('' clears the protocol).
+    protocols = [''] + sorted(non_db_protocols + db_protocols)
     parser = argparse.ArgumentParser(prog='pam connection edit')
     parser.add_argument('record', type=str, action='store', help='The record UID or path of the PAM '
                         'resource record with network information to use for connections')
@@ -2708,8 +2717,7 @@ class PAMConnectionEditCommand(Command):
         scrollback_clear = False
         scrollback_value = None  # parsed int, or None to skip apply
         if scrollback_arg is not None:
-            db_scrollback_protocols = {'mysql', 'postgresql', 'sql-server', 'mariadb', 'oracle',
-                                       'mongodb', 'redis', 'elasticsearch', 'clickhouse', 'dynamodb'}
+            db_scrollback_protocols = set(PAMConnectionEditCommand.db_protocols)
             terminal_scrollback_protocols = {'ssh', 'telnet', 'kubernetes'}
             if record_type == 'pamDatabase':
                 allowed_protocols = db_scrollback_protocols

--- a/unit-tests/pam/test_pam_connection_edit_scrollback.py
+++ b/unit-tests/pam/test_pam_connection_edit_scrollback.py
@@ -166,6 +166,18 @@ class TestPamConnectionEditScrollbackValidation(unittest.TestCase):
             self._execute(rec, scrollback='100')
         self.assertIn('not supported for protocol "http"', str(ctx.exception))
 
+    def test_pam_database_mariadb_rejected(self):
+        rec = self._mock_record('pamDatabase', 'mariadb')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('not supported for protocol "mariadb"', str(ctx.exception))
+
+    def test_pam_database_mongodb_rejected(self):
+        rec = self._mock_record('pamDatabase', 'mongodb')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, scrollback='100')
+        self.assertIn('not supported for protocol "mongodb"', str(ctx.exception))
+
     def test_non_numeric_rejected(self):
         rec = self._mock_record('pamMachine', 'ssh')
         with self.assertRaises(CommandError) as ctx:
@@ -227,8 +239,9 @@ class TestPamConnectionEditScrollbackAllowedCombinations(unittest.TestCase):
     a scrollback-related error. We don't run the full execute path (which would
     require mocking the entire DAG layer), only verify validation passes."""
 
-    DB_PROTOCOLS = ['mysql', 'postgresql', 'sql-server', 'mariadb', 'oracle',
-                    'mongodb', 'redis', 'elasticsearch', 'clickhouse', 'dynamodb']
+    DB_PROTOCOLS = ['mysql', 'postgresql', 'sql-server']
+    KEEPER_DB_ONLY_PROTOCOLS = ['mariadb', 'oracle', 'mongodb', 'redis',
+                                'elasticsearch', 'clickhouse', 'dynamodb']
     TERMINAL_PROTOCOLS = ['ssh', 'telnet', 'kubernetes']
 
     def _assert_validation_passes(self, record_type, protocol):
@@ -255,10 +268,29 @@ class TestPamConnectionEditScrollbackAllowedCombinations(unittest.TestCase):
             except Exception:
                 pass  # downstream DAG/token failures are not what we're testing
 
-    def test_pam_database_all_db_protocols(self):
+    def test_pam_database_cli_capable_db_protocols(self):
         for proto in self.DB_PROTOCOLS:
             with self.subTest(protocol=proto):
                 self._assert_validation_passes('pamDatabase', proto)
+
+    def test_pam_database_keeper_db_only_rejected(self):
+        for proto in self.KEEPER_DB_ONLY_PROTOCOLS:
+            rec = mock.MagicMock(spec=vault.TypedRecord)
+            rec.record_uid = 'rec-uid'
+            rec.record_type = 'pamDatabase'
+            rec.version = 3
+            ps_field = mock.MagicMock()
+            ps_field.value = [{'connection': {'protocol': proto}}]
+            rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else None
+            cmd = PAMConnectionEditCommand()
+            params = mock.MagicMock()
+            with mock.patch(
+                'keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record',
+                return_value=rec,
+            ):
+                with self.assertRaises(CommandError) as ctx:
+                    cmd.execute(params, record='rec', scrollback='100')
+                self.assertIn(f'not supported for protocol "{proto}"', str(ctx.exception))
 
     def test_pam_machine_terminal_protocols(self):
         for proto in self.TERMINAL_PROTOCOLS:

--- a/unit-tests/pam/test_pam_connection_edit_scrollback.py
+++ b/unit-tests/pam/test_pam_connection_edit_scrollback.py
@@ -48,6 +48,50 @@ class TestPamConnectionEditScrollbackArgs(unittest.TestCase):
 
 
 @unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditProtocolChoices(unittest.TestCase):
+    """--protocol choices: the full DB protocol set is now accepted, and the choices
+    list is composed from the db_protocols / non_db_protocols source-of-truth lists."""
+
+    NEW_DB_PROTOCOLS = ['mariadb', 'oracle', 'mongodb', 'redis',
+                        'elasticsearch', 'clickhouse', 'dynamodb']
+
+    def setUp(self):
+        self.parser = PAMConnectionEditCommand.parser
+
+    def test_new_db_protocols_accepted(self):
+        for proto in self.NEW_DB_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                args = self.parser.parse_args(['rec', '--protocol', proto])
+                self.assertEqual(args.protocol, proto)
+
+    def test_mariadb_and_oracle_accepted(self):
+        # The two protocols this change was specifically about.
+        self.assertEqual(self.parser.parse_args(['rec', '-p', 'mariadb']).protocol, 'mariadb')
+        self.assertEqual(self.parser.parse_args(['rec', '-p', 'oracle']).protocol, 'oracle')
+
+    def test_existing_protocols_still_accepted(self):
+        for proto in ['', 'http', 'kubernetes', 'mysql', 'postgresql', 'rdp', 'sql-server', 'ssh', 'telnet', 'vnc']:
+            with self.subTest(protocol=proto):
+                self.assertEqual(self.parser.parse_args(['rec', '--protocol', proto]).protocol, proto)
+
+    def test_invalid_protocol_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['rec', '--protocol', 'bogus'])
+
+    def test_choices_composed_from_source_lists(self):
+        # protocols is the single source of truth: '' + sorted(non_db + db), no duplicates.
+        expected = [''] + sorted(PAMConnectionEditCommand.non_db_protocols
+                                  + PAMConnectionEditCommand.db_protocols)
+        self.assertEqual(PAMConnectionEditCommand.protocols, expected)
+        self.assertEqual(len(PAMConnectionEditCommand.protocols),
+                         len(set(PAMConnectionEditCommand.protocols)))
+
+    def test_all_db_protocols_present_in_choices(self):
+        for proto in PAMConnectionEditCommand.db_protocols:
+            self.assertIn(proto, PAMConnectionEditCommand.protocols)
+
+
+@unittest.skipIf(skip_tests, skip_reason)
 class TestPamConnectionEditScrollbackValidation(unittest.TestCase):
     """Validation runs before DAG / token operations, so we can drive execute()
     with mocks that only need to satisfy resolve_single_record + the typed-field

--- a/unit-tests/pam/test_pam_import_db_protocols.py
+++ b/unit-tests/pam/test_pam_import_db_protocols.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for the database connection protocols recognized by `pam project import` /
+`pam project extend` (step 2): mariadb, oracle, mongodb, redis, elasticsearch,
+clickhouse, dynamodb — added alongside the pre-existing mysql/postgresql/sql-server.
+
+Verifies the import model round-trips each protocol: protocol string -> connection class
+-> record dict, that pamDatabase validation passes, and that is_database_protocol agrees.
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_import.base import (
+        PamSettingsFieldData,
+        validate_pam_connection,
+        is_database_protocol,
+        ConnectionProtocol,
+        ConnectionSettingsMariaDB,
+        ConnectionSettingsOracle,
+        ConnectionSettingsMongoDB,
+        ConnectionSettingsRedis,
+        ConnectionSettingsElasticsearch,
+        ConnectionSettingsClickHouse,
+        ConnectionSettingsDynamoDB,
+    )
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import pam_import.base: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamImportNewDbProtocols(unittest.TestCase):
+    # (wire value, expected connection class)
+    NEW_PROTOCOLS = [
+        ('mariadb', 'ConnectionSettingsMariaDB'),
+        ('oracle', 'ConnectionSettingsOracle'),
+        ('mongodb', 'ConnectionSettingsMongoDB'),
+        ('redis', 'ConnectionSettingsRedis'),
+        ('elasticsearch', 'ConnectionSettingsElasticsearch'),
+        ('clickhouse', 'ConnectionSettingsClickHouse'),
+        ('dynamodb', 'ConnectionSettingsDynamoDB'),
+    ]
+
+    def test_enum_values_present(self):
+        self.assertEqual(ConnectionProtocol.MARIADB.value, 'mariadb')
+        self.assertEqual(ConnectionProtocol.ORACLE.value, 'oracle')
+        self.assertEqual(ConnectionProtocol.MONGODB.value, 'mongodb')
+        self.assertEqual(ConnectionProtocol.REDIS.value, 'redis')
+        self.assertEqual(ConnectionProtocol.ELASTICSEARCH.value, 'elasticsearch')
+        self.assertEqual(ConnectionProtocol.CLICKHOUSE.value, 'clickhouse')
+        self.assertEqual(ConnectionProtocol.DYNAMODB.value, 'dynamodb')
+
+    def test_registered_in_connection_classes(self):
+        registered = set(PamSettingsFieldData.pam_connection_classes)
+        for cls in (ConnectionSettingsMariaDB, ConnectionSettingsOracle, ConnectionSettingsMongoDB,
+                    ConnectionSettingsRedis, ConnectionSettingsElasticsearch,
+                    ConnectionSettingsClickHouse, ConnectionSettingsDynamoDB):
+            self.assertIn(cls, registered)
+
+    def test_get_connection_class_resolves(self):
+        for proto, cls_name in self.NEW_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                obj = PamSettingsFieldData.get_connection_class({'protocol': proto})
+                self.assertIsNotNone(obj)
+                self.assertEqual(type(obj).__name__, cls_name)
+
+    def test_round_trip_protocol_and_database(self):
+        for proto, _ in self.NEW_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                obj = PamSettingsFieldData.get_connection_class(
+                    {'protocol': proto, 'default_database': 'db1', 'port': '1234'})
+                rd = obj.to_record_dict()
+                self.assertEqual(rd.get('protocol'), proto)
+                self.assertEqual(rd.get('database'), 'db1')
+                self.assertEqual(rd.get('port'), '1234')
+
+    def test_validate_pam_connection_passes_for_pam_database(self):
+        for proto, _ in self.NEW_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                obj = PamSettingsFieldData.get_connection_class({'protocol': proto})
+                self.assertFalse(validate_pam_connection(obj, 'pamDatabase'))
+
+    def test_is_database_protocol(self):
+        for proto, _ in self.NEW_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertTrue(is_database_protocol(proto))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_import_scrollback.py
+++ b/unit-tests/pam/test_pam_import_scrollback.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for `scrollback` (Maximum Scrollback Size) in the `pam project import` /
+`pam project extend` connection settings.
+
+scrollback lives in TerminalDisplayConnectionSettings (mirrors the Web Vault) and is
+threaded through terminal protocols (SSH, Telnet, Kubernetes) and CLI-capable DB protocols
+(mysql, postgresql, sql-server). It is validated as a positive integer (like audio_bps /
+audio_sample_rate): zero, negative, and non-numeric values are rejected with a warning.
+KeeperDb-only DB protocols have no terminal display, so they never carry scrollback.
+"""
+
+import logging
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_import.base import PamSettingsFieldData
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import pam_import.base: {e}"
+
+
+def _record_scrollback(protocol, scrollback):
+    data = {'protocol': protocol}
+    if scrollback is not None:
+        data['scrollback'] = scrollback
+    obj = PamSettingsFieldData.get_connection_class(data)
+    return obj.to_record_dict().get('scrollback') if obj else 'NO_CLASS'
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamImportScrollback(unittest.TestCase):
+    TERMINAL_PROTOCOLS = ['ssh', 'telnet', 'kubernetes']
+    CLI_CAPABLE_DB_PROTOCOLS = ['mysql', 'postgresql', 'sql-server']
+    KEEPER_DB_ONLY_PROTOCOLS = [
+        'mariadb', 'oracle', 'mongodb', 'redis', 'elasticsearch', 'clickhouse', 'dynamodb',
+    ]
+    SCROLLBACK_PROTOCOLS = TERMINAL_PROTOCOLS + CLI_CAPABLE_DB_PROTOCOLS
+
+    def setUp(self):
+        # Silence the expected validation warnings for invalid inputs.
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def test_valid_int_round_trips(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertEqual(_record_scrollback(proto, 5000), 5000)
+
+    def test_valid_string_int_parsed(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertEqual(_record_scrollback(proto, '4096'), 4096)
+
+    def test_zero_rejected(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, 0))
+
+    def test_negative_rejected(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, -10))
+
+    def test_non_numeric_rejected(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, 'abc'))
+
+    def test_float_string_rejected(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, '12.5'))
+
+    def test_not_provided_absent(self):
+        for proto in self.SCROLLBACK_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, None))
+
+    def test_keeper_db_only_protocols_have_no_scrollback(self):
+        for proto in self.KEEPER_DB_ONLY_PROTOCOLS:
+            with self.subTest(protocol=proto):
+                self.assertIsNone(_record_scrollback(proto, 5000))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_rbi_edit.py
+++ b/unit-tests/pam/test_pam_rbi_edit.py
@@ -199,6 +199,34 @@ class TestPamRbiEditArguments(unittest.TestCase):
         self.assertEqual(args.allow_url_navigation, 'on')
         self.assertEqual(args.allowed_urls, ['*.example.com'])
 
+    def test_session_persistence_none(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--session-persistence', 'none'])
+        self.assertEqual(args.session_persistence, 'none')
+
+    def test_session_persistence_user(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--session-persistence', 'user'])
+        self.assertEqual(args.session_persistence, 'user')
+
+    def test_session_persistence_resource(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--session-persistence', 'resource'])
+        self.assertEqual(args.session_persistence, 'resource')
+
+    def test_session_persistence_default(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--session-persistence', 'default'])
+        self.assertEqual(args.session_persistence, 'default')
+
+    def test_session_persistence_short_flag(self):
+        args = self.parser.parse_args(['--record', 'test-record', '-sp', 'user'])
+        self.assertEqual(args.session_persistence, 'user')
+
+    def test_session_persistence_invalid(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['--record', 'test-record', '--session-persistence', 'invalid'])
+
+    def test_session_persistence_not_provided(self):
+        args = self.parser.parse_args(['--record', 'test-record', '--key-events', 'on'])
+        self.assertIsNone(args.session_persistence)
+
 
 @unittest.skipIf(skip_tests, skip_reason)
 class TestPamRbiEditExecute(unittest.TestCase):
@@ -327,6 +355,42 @@ class TestPamRbiEditExecute(unittest.TestCase):
         mock_resolve.return_value = self.mock_record
         self.command.execute(self.mock_params, record='test-record', autofill_targets=['#username', '#password'])
         self.assertEqual(self.pam_settings['connection'].get('autofillConfiguration'), '#username\n#password')
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_session_persistence_sets_value(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', session_persistence='user')
+        self.assertEqual(self.pam_settings['connection'].get('sessionPersistence'), 'user')
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_session_persistence_none_sets_literal(self, mock_sync, mock_update, mock_resolve):
+        # 'none' is a real enum value (no persistence), not a removal sentinel
+        mock_resolve.return_value = self.mock_record
+        self.command.execute(self.mock_params, record='test-record', session_persistence='none')
+        self.assertEqual(self.pam_settings['connection'].get('sessionPersistence'), 'none')
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_session_persistence_default_removes_field(self, mock_sync, mock_update, mock_resolve):
+        mock_resolve.return_value = self.mock_record
+        self.pam_settings['connection']['sessionPersistence'] = 'user'
+        self.command.execute(self.mock_params, record='test-record', session_persistence='default')
+        self.assertNotIn('sessionPersistence', self.pam_settings['connection'])
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    def test_session_persistence_default_removes_present_but_null(self, mock_sync, mock_update, mock_resolve):
+        # A present-but-null value must still be removed (membership check, not None check)
+        mock_resolve.return_value = self.mock_record
+        self.pam_settings['connection']['sessionPersistence'] = None
+        self.command.execute(self.mock_params, record='test-record', session_persistence='default')
+        self.assertNotIn('sessionPersistence', self.pam_settings['connection'])
 
 
 @unittest.skipIf(skip_tests, skip_reason)


### PR DESCRIPTION
Extends Commander PAM import/extend and related CLI commands to match Web Vault capabilities for database protocols, RBI settings, and terminal scrollback.

- **New DB protocols** — `pam project import/extend` recognizes mariadb, oracle, mongodb, redis, elasticsearch, clickhouse, and dynamodb (alongside existing mysql/postgresql/sql-server). Connection classes, validation, and README examples updated.
- **`pam connection edit --protocol`** — accepts all 10 DB protocol wire values.
- **RBI import + CLI** — RBI connection settings in import (session persistence, file upload/download, audio, URL filtering, etc.) and `pam rbi edit --session-persistence` (`none` / `user` / `resource`).
- **Scrollback** — `scrollback` (Maximum Scrollback Size) on import for ssh/telnet/kubernetes and CLI-capable DBs (mysql/postgresql/sql-server). `pam connection edit --scrollback` gated to the same set (mirrors WV `isKeeperDbOnlyProtocol`; keeperDb-only DBs do not get terminal display / scrollback).
- Adds `is_cli_capable_db_protocol` / `is_keeper_db_only_protocol` helpers in `pam_import/base.py` parallel to the vault.
