### PR TITLE
Add secret-ids arg in Thycotic import

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -79,6 +79,8 @@ import_parser.add_argument('--file-cache', dest='tmpdir', action='store',
                            help='temp directory used to cache encrypted attachment imports')
 import_parser.add_argument('--show-skipped', dest='show_skipped', action='store_true',
                            help='Display skipped records')
+import_parser.add_argument('--secret-ids', dest='secret_ids', action='store',
+                           help='Comma separated list of secret IDs to fetch (Thycotic)')
 import_parser.add_argument(
     'name', type=str, help='file name (json, csv, keepass, 1password), account name (lastpass), or URL (ManageEngine, Thycotic)'
 )

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -715,6 +715,7 @@ def _import(params, file_format, filename, **kwargs):
     filter_folder = kwargs.get('filter_folder')
     dry_run = kwargs.get('dry_run') is True
     show_skipped = kwargs.get('show_skipped') is True
+    secret_ids = kwargs.get('secret_ids')
 
     import_into = kwargs.get('import_into') or ''
     if import_into:
@@ -732,7 +733,7 @@ def _import(params, file_format, filename, **kwargs):
     filter_folder_lower = filter_folder.lower() if isinstance(filter_folder, str) else ''
 
     for x in importer.execute(filename, params=params, users_only=import_users, filter_folder=filter_folder,
-                              old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, dry_run=dry_run):
+                              old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids, dry_run=dry_run):
         if isinstance(x, ImportRecord):
             if filter_folder and not importer.support_folder_filter():
                 if not x.folders:

--- a/keepercommander/importer/thycotic/thycotic.py
+++ b/keepercommander/importer/thycotic/thycotic.py
@@ -342,6 +342,30 @@ class ThycoticImporter(BaseImporter, ThycoticMixin):
         else:
             secrets_ids = [x['id'] for x in auth.thycotic_search(f'/v1/secrets/lookup')]
 
+        # secret_ids arg
+        debug_ids = kwargs.get('secret_ids')
+        if debug_ids is not None:
+          # Convert CLI string input into list
+          if isinstance(debug_ids,str):
+              debug_ids = debug_ids.replace(' ','').split(',')
+          # Handle secret IDs list
+          if isinstance(debug_ids,list):
+              # Deduplicate
+              debug_ids = list(set(debug_ids))
+              # Check whether secrets were found in the lookup
+              stringified_secrets_ids = [str(x) for x in secrets_ids]
+              stringified_debug_ids = [str(x) for x in debug_ids]
+              found_secrets = [x for x in stringified_debug_ids if x in stringified_secrets_ids]
+              logging.info(f'From the specified {len(debug_ids)} secret IDs, {len(found_secrets)} were found in the secret server lookup.')
+              logging.info(', '.join(found_secrets))
+              
+              # Replace import list with specified IDs
+              secrets_ids = debug_ids
+          else:
+              # Quit if secret IDs != list
+              logging.warning('Invalid input for secret IDs, exiting.')
+              return
+
         self._send_keep_alive_if_needed(params)
         print(f'Loading {len(secrets_ids)} Records ', flush=True, end='')
         secrets = []


### PR DESCRIPTION
New PR for https://github.com/Keeper-Security/Commander/pull/2145 after Commander update

If user sets secret-ids, the import will:

Check if any of those IDs have come up in the lookup and would have been imported.
Import only the secret-ids list
This is useful to only import some secret IDs for testing, but also for debugging, because the /lookup API may not return all Thycotic secrets - eg if there is a security policy on them, even though they may still be fetched with the /v1/secrets API.

Usage:
String (comma separated IDs)
import --format thycotic server_name --secret-ids "123, 124,125"
Python List (strings or integers)
secret_ids=[123, 124, 125]