### PR TITLE
Add --online filter to pam gateway list command

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -1399,7 +1399,7 @@ class PAMGatewayListCommand(Command):
                         help='Verbose output')
     parser.add_argument('--format', dest='format', action='store', choices=['table', 'json'], default='table',
                         help='Output format (table, json)')
-    parser.add_argument('--online', required=False, default=False, dest='online_only', action='store_true',
+    parser.add_argument('--online', '-o', required=False, default=False, dest='online_only', action='store_true',
                         help='Show only online gateways')
 
     def get_parser(self):

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -1399,6 +1399,8 @@ class PAMGatewayListCommand(Command):
                         help='Verbose output')
     parser.add_argument('--format', dest='format', action='store', choices=['table', 'json'], default='table',
                         help='Output format (table, json)')
+    parser.add_argument('--online', required=False, default=False, dest='online_only', action='store_true',
+                        help='Show only online gateways')
 
     def get_parser(self):
         return PAMGatewayListCommand.parser
@@ -1408,6 +1410,7 @@ class PAMGatewayListCommand(Command):
         is_force = kwargs.get('is_force')
         is_verbose = kwargs.get('is_verbose')
         format_type = kwargs.get('format', 'table')
+        online_only = kwargs.get('online_only', False)
 
         is_router_down = False
         krouter_url = router_helper.get_router_url(params)
@@ -1478,12 +1481,25 @@ class PAMGatewayListCommand(Command):
                     connected_controllers_dict[controller.controllerUid] = []
                 connected_controllers_dict[controller.controllerUid].append(controller)
 
+        gateway_counts = {'online': 0, 'offline': 0, 'total': len(enterprise_controllers_all)}
+
         # Process each gateway and handle multiple instances
         for c in enterprise_controllers_all:
             gateway_uid_bytes = c.controllerUid
             gateway_uid_str = utils.base64_url_encode(c.controllerUid)
 
             connected_instances = connected_controllers_dict.get(gateway_uid_bytes, [])
+
+            is_online = not is_router_down and len(connected_instances) > 0
+            if is_router_down:
+                pass
+            elif is_online:
+                gateway_counts['online'] += 1
+            else:
+                gateway_counts['offline'] += 1
+
+            if online_only and not is_online:
+                continue
 
             ksm_app_uid_str = utils.base64_url_encode(c.applicationUid)
             ksm_app = KSMCommand.get_app_record(params, ksm_app_uid_str)
@@ -1714,6 +1730,9 @@ class PAMGatewayListCommand(Command):
             else:
                 result = {"gateways": gateways_data}
 
+            if online_only:
+                result["gateway_counts"] = gateway_counts
+
             return json.dumps(result, indent=2)
         else:
             # Separate rows into groups: each parent with its instances
@@ -1745,6 +1764,14 @@ class PAMGatewayListCommand(Command):
 
             dump_report_data(table, headers, fmt='table', filename="",
                              row_number=False, column_width=None)
+
+            if online_only:
+                print(
+                    f"\n{bcolors.BOLD}Gateways: "
+                    f"{bcolors.OKGREEN}Online: {gateway_counts['online']}{bcolors.ENDC}, "
+                    f"{bcolors.FAIL}Offline: {gateway_counts['offline']}{bcolors.ENDC}, "
+                    f"Total: {gateway_counts['total']}{bcolors.ENDC}\n"
+                )
 
 
 class PAMConfigurationListCommand(Command):

--- a/unit-tests/pam/test_pam_rotation.py
+++ b/unit-tests/pam/test_pam_rotation.py
@@ -420,6 +420,9 @@ class TestPAMGatewayListCommand(unittest.TestCase):
         args = self.parser.parse_args(['--online'])
         self.assertTrue(args.online_only)
 
+        args = self.parser.parse_args(['-o'])
+        self.assertTrue(args.online_only)
+
     @patch('keepercommander.commands.discoveryrotation.router_get_connected_gateways')
     @patch('keepercommander.commands.discoveryrotation.router_helper.get_router_url')
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')

--- a/unit-tests/pam/test_pam_rotation.py
+++ b/unit-tests/pam/test_pam_rotation.py
@@ -416,6 +416,10 @@ class TestPAMGatewayListCommand(unittest.TestCase):
         self.assertTrue(args.is_verbose)
         self.assertTrue(args.is_force)
 
+    def test_parser_online(self):
+        args = self.parser.parse_args(['--online'])
+        self.assertTrue(args.online_only)
+
     @patch('keepercommander.commands.discoveryrotation.router_get_connected_gateways')
     @patch('keepercommander.commands.discoveryrotation.router_helper.get_router_url')
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
@@ -487,6 +491,61 @@ class TestPAMGatewayListCommand(unittest.TestCase):
         self.assertTrue(mock_router_get_connected_gateways.called)
         self.assertTrue(mock_get_all_gateways.called)
         self.assertTrue(mock_get_router_url.called)
+
+    @patch('keepercommander.commands.discoveryrotation.print')
+    @patch('keepercommander.commands.discoveryrotation.router_get_connected_gateways')
+    @patch('keepercommander.commands.discoveryrotation.router_helper.get_router_url')
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    @patch('keepercommander.commands.discoveryrotation.dump_report_data')
+    def test_execute_online_only(self, mock_dump_report_data, mock_get_app_record, mock_get_all_gateways,
+                                 mock_get_router_url, mock_router_get_connected_gateways, mock_print):
+        mock_params = create_mock_params()
+
+        online_uid = utils.base64_url_decode('controller_uid')
+        offline_uid = utils.base64_url_decode('offline_uid')
+
+        mock_router_get_connected_gateways.return_value.controllers = [
+            MagicMock(controllerUid=online_uid, version='1.0.0')
+        ]
+
+        mock_get_all_gateways.return_value = [
+            MagicMock(
+                applicationUid=utils.base64_url_decode('app_uid'),
+                controllerUid=online_uid,
+                controllerName='Online Gateway',
+                deviceName='Device 1',
+                deviceToken='Token 1',
+                created=int(datetime.now().timestamp() * 1000),
+                lastModified=int(datetime.now().timestamp() * 1000),
+                nodeId='Node 1'
+            ),
+            MagicMock(
+                applicationUid=utils.base64_url_decode('app_uid2'),
+                controllerUid=offline_uid,
+                controllerName='Offline Gateway',
+                deviceName='Device 2',
+                deviceToken='Token 2',
+                created=int(datetime.now().timestamp() * 1000),
+                lastModified=int(datetime.now().timestamp() * 1000),
+                nodeId='Node 2'
+            )
+        ]
+
+        mock_get_app_record.return_value = {
+            'data_unencrypted': json.dumps({'title': 'App Title'})
+        }
+
+        kwargs = {'is_force': True, 'online_only': True}
+        self.command.execute(mock_params, **kwargs)
+
+        self.assertTrue(mock_dump_report_data.called)
+        table = mock_dump_report_data.call_args[0][0]
+        self.assertEqual(len(table), 1)
+        self.assertIn('Online Gateway', table[0][1])
+
+        totals_printed = any('Online: 1' in str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertTrue(totals_printed)
 
     @patch('keepercommander.commands.discoveryrotation.router_get_connected_gateways')
     @patch('keepercommander.commands.discoveryrotation.router_helper.get_router_url')


### PR DESCRIPTION
- Add `--online` flag to `pam gateway list` to show only gateways with at least one connected instance
- In table format, print gateway totals after the list: online, offline, and total counts
- In JSON format with `--online`, include a `gateway_counts` object with the same totals (counts reflect all gateways, not just the filtered list)

Usage: `pam gateway list --online`