### PR TITLE
KC-1314: Add vault-style passphrase generation to Commander CLI

### DIFF
--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -188,8 +188,11 @@ $<ACTION>[:<PARAMS>, <PARAMS>]   executes an action that returns a field value
 Value                   Field type         Description                      Example
 ====================    ===============    ===================              ==============
 $GEN:[alg],[n]          password           Generates a random password      $GEN:dice,5
-                                           Default algorith is rand         alg: [rand | dice | crypto]
+                                           Default algorith is rand         alg: [rand | dice | crypto | passphrase]
                                            Optional: password length
+                                           Passphrase extras (override      $GEN:passphrase,7,_,true,true
+                                           policy for generation only):
+                                           word_count[,separator][,capitalize][,number]
 $GEN                    oneTimeCode        Generates TOTP URL
 $GEN:[alg,][enc]        keyPair            Generates a key pair and         $GEN:ec,enc
                                            optional passcode                alg: [rsa | ec | ed25519], enc
@@ -398,7 +401,7 @@ class RecordEditMixin:
     @staticmethod
     def generate_password(parameters=None, policy=None):   # type: (Optional[Sequence[str]], Optional[dict]) -> str
         if isinstance(parameters, (tuple, list, set)):
-            algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto')), 'rand')
+            algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto', 'passphrase')), 'rand')
             length = next((x for x in parameters if x.isnumeric()), None)
             if isinstance(length, str) and len(length) > 0:
                 try:
@@ -411,6 +414,20 @@ class RecordEditMixin:
 
         if algorithm == 'crypto':
             gen = generator.CryptoPassphraseGenerator()
+        elif algorithm == 'passphrase':
+            pp_opts = generator.parse_passphrase_gen_parameters(parameters)
+            if policy and policy.get('passphrase-allow') is False:
+                logging.warning('Passphrase generation is disabled by enterprise policy; using random password.')
+                gen = generator.KeeperPasswordGenerator.create_from_policy(
+                    policy, length_override=pp_opts.word_count or length)
+            else:
+                gen = generator.KeeperPassphraseGenerator.create_with_options(
+                    policy,
+                    word_count=pp_opts.word_count if pp_opts.word_count is not None else length,
+                    separator=pp_opts.separator,
+                    capitalize=pp_opts.capitalize,
+                    append_number=pp_opts.append_number,
+                )
         elif algorithm == 'dice':
             if isinstance(length, int):
                 if length < 1:

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -193,6 +193,7 @@ $GEN:[alg],[n]          password           Generates a random password      $GEN
                                            Passphrase extras (override      $GEN:passphrase,7,_,true,true
                                            policy for generation only):
                                            word_count[,separator][,capitalize][,number]
+                                           Separators allowed: - . _ ? ! space
 $GEN                    oneTimeCode        Generates TOTP URL
 $GEN:[alg,][enc]        keyPair            Generates a key pair and         $GEN:ec,enc
                                            optional passcode                alg: [rsa | ec | ed25519], enc

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -45,7 +45,7 @@ from ..display import bcolors, post_login_summary
 from ..error import CommandError
 from ..generator import (
     KeeperPasswordGenerator, DicewarePasswordGenerator, CryptoPassphraseGenerator,
-    KeeperPassphraseGenerator,
+    KeeperPassphraseGenerator, PASSPHRASE_SEPARATOR_HELP,
 )
 from ..params import KeeperParams, LAST_RECORD_UID, LAST_FOLDER_UID, LAST_SHARED_FOLDER_UID
 from ..proto import ssocloud_pb2, enterprise_pb2, APIRequest_pb2
@@ -409,7 +409,8 @@ passphrase_group.add_argument('--passphrase', dest='passphrase', action='store_t
                               help='Generate a vault-style passphrase from the EFF word list')
 passphrase_group.add_argument(
     '--pp-separator', '-pps', dest='pp_separator', action='store',
-    help='Word separator (single character, or "space"). Overrides enterprise policy for this command.'
+    help=f'Word separator (single character, or "space"). Allowed: {PASSPHRASE_SEPARATOR_HELP}. '
+         'Overrides enterprise policy for this command.'
 )
 passphrase_group.add_argument(
     '--pp-capitalize', '-ppc', dest='pp_capitalize', action='store_true',

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -43,7 +43,10 @@ from .. import api, rest_api, loginv3, crypto, utils, constants, error, vault_ex
 from ..breachwatch import BreachWatch
 from ..display import bcolors, post_login_summary
 from ..error import CommandError
-from ..generator import KeeperPasswordGenerator, DicewarePasswordGenerator, CryptoPassphraseGenerator
+from ..generator import (
+    KeeperPasswordGenerator, DicewarePasswordGenerator, CryptoPassphraseGenerator,
+    KeeperPassphraseGenerator,
+)
 from ..params import KeeperParams, LAST_RECORD_UID, LAST_FOLDER_UID, LAST_SHARED_FOLDER_UID
 from ..proto import ssocloud_pb2, enterprise_pb2, APIRequest_pb2
 from ..security_audit import needs_security_audit, update_security_audit_data
@@ -402,6 +405,29 @@ random_group.add_argument(
 )
 
 passphrase_group = generate_parser.add_argument_group('Keeper Passphrase')
+passphrase_group.add_argument('--passphrase', dest='passphrase', action='store_true',
+                              help='Generate a vault-style passphrase from the EFF word list')
+passphrase_group.add_argument(
+    '--pp-separator', '-pps', dest='pp_separator', action='store',
+    help='Word separator (single character, or "space"). Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-capitalize', '-ppc', dest='pp_capitalize', action='store_true',
+    help='Capitalize the first letter of each word. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-no-capitalize', dest='pp_capitalize', action='store_false',
+    help='Do not capitalize words. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-number', '-ppn', dest='pp_number', action='store_true',
+    help='Append a digit (0-9) to the first word only. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-no-number', dest='pp_number', action='store_false',
+    help='Do not append a digit to the first word. Overrides enterprise policy for this command.'
+)
+passphrase_group.set_defaults(pp_capitalize=None, pp_number=None)
 passphrase_group.add_argument('--recoveryphrase', dest='recoveryphrase', action='store_true',
                               help='Generate Generate a 24-word recovery phrase')
 
@@ -2208,7 +2234,29 @@ class GenerateCommand(Command):
 
         if kwargs.get('crypto') is True:
             kpg = CryptoPassphraseGenerator()
-        if kwargs.get('recoveryphrase') is True:
+        elif kwargs.get('passphrase') is True:
+            from ..enforcement import PasswordComplexityEnforcer
+            policy = PasswordComplexityEnforcer.get_policy(params)
+            word_count = length if length != 20 else None
+            pp_separator = kwargs.get('pp_separator')
+            if isinstance(pp_separator, str) and pp_separator.lower() in ('space', 'sp'):
+                pp_separator = ' '
+            elif isinstance(pp_separator, str) and pp_separator:
+                pp_separator = pp_separator[0]
+            else:
+                pp_separator = None
+            if policy and policy.get('passphrase-allow') is False:
+                logging.warning('Passphrase generation is disabled by enterprise policy; using random password.')
+                kpg = KeeperPasswordGenerator.create_from_policy(policy, length_override=word_count)
+            else:
+                kpg = KeeperPassphraseGenerator.create_with_options(
+                    policy,
+                    word_count=word_count,
+                    separator=pp_separator,
+                    capitalize=kwargs.get('pp_capitalize'),
+                    append_number=kwargs.get('pp_number'),
+                )
+        elif kwargs.get('recoveryphrase') is True:
             kpg = DicewarePasswordGenerator(24, word_list_file='bip-39.english.txt', delimiter=' ')
         elif isinstance(kwargs.get('dice_rolls'), int):
             dice_rolls = kwargs.get('dice_rolls')

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -533,7 +533,7 @@ class PasswordComplexityEnforcer:
                         f'Password must contain at least {required} special character(s) (got {count}).')
 
         if not failures:
-            return failures
+            return []
 
         # Vault re-validates as a passphrase when random password rules fail.
         if policy.get('passphrase-allow') is False:

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -24,7 +24,8 @@ from .display import bcolors
 from .params import KeeperParams
 from .error import KeeperApiError, CommandError
 from .generator import (
-    DEFAULT_PASSPHRASE_WORD_COUNT, PP_SEPARATOR_CHARACTERS, _passphrase_separators_from_policy,
+    DEFAULT_PASSPHRASE_WORD_COUNT, DEFAULT_PASSPHRASE_CAPITALIZE, DEFAULT_PASSPHRASE_NUMBER,
+    PP_SEPARATOR_CHARACTERS, _passphrase_separators_from_policy,
     format_passphrase_separators_for_display,
 )
 
@@ -469,8 +470,8 @@ class PasswordComplexityEnforcer:
             failures.append(
                 f'Passphrase must contain at least {min_words} words (got {len(words)}).')
 
-        capitalize = bool(policy.get('passphrase-capitalize', False))
-        append_number = bool(policy.get('passphrase-number', False))
+        capitalize = bool(policy.get('passphrase-capitalize', DEFAULT_PASSPHRASE_CAPITALIZE))
+        append_number = bool(policy.get('passphrase-number', DEFAULT_PASSPHRASE_NUMBER))
 
         if capitalize:
             word_re = re.compile(r'^[A-Z][a-z]{2,}$')

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -23,7 +23,10 @@ from .proto import APIRequest_pb2, record_pb2
 from .display import bcolors
 from .params import KeeperParams
 from .error import KeeperApiError, CommandError
-from .generator import DEFAULT_PASSPHRASE_WORD_COUNT, PP_SEPARATOR_CHARACTERS
+from .generator import (
+    DEFAULT_PASSPHRASE_WORD_COUNT, PP_SEPARATOR_CHARACTERS, _passphrase_separators_from_policy,
+    format_passphrase_separators_for_display,
+)
 
 
 def _find_enforcement_value(enforcements, key):
@@ -428,11 +431,7 @@ class PasswordComplexityEnforcer:
     def _normalize_passphrase_separators(cls, policy):   # type: (Dict[str, Any]) -> Optional[str]
         raw = policy.get('passphrase-separator')
         if isinstance(raw, str) and raw.strip():
-            normalized = raw.replace('\u2423', ' ')
-            allowed = ''
-            for ch in PP_SEPARATOR_CHARACTERS:
-                if ch in normalized:
-                    allowed += ch
+            allowed = _passphrase_separators_from_policy(raw.strip())
             return allowed or None
         return PP_SEPARATOR_CHARACTERS
 
@@ -445,7 +444,9 @@ class PasswordComplexityEnforcer:
 
         allowed_seps = cls._normalize_passphrase_separators(policy)
         if not allowed_seps:
-            failures.append('Passphrase cannot meet separator criteria set by policy.')
+            failures.append(
+                'Passphrase cannot meet separator criteria set by policy. '
+                f'Allowed: {format_passphrase_separators_for_display(PP_SEPARATOR_CHARACTERS)}.')
             return failures
 
         separator = next((ch for ch in allowed_seps if ch in password), None)
@@ -453,7 +454,9 @@ class PasswordComplexityEnforcer:
             # Allow CLI-selected separators even when not listed in policy.
             separator = next((ch for ch in PP_SEPARATOR_CHARACTERS if ch in password), None)
         if separator is None:
-            failures.append('Passphrase must contain an allowed separator character.')
+            failures.append(
+                'Passphrase must contain an allowed separator character. '
+                f'Allowed: {format_passphrase_separators_for_display(PP_SEPARATOR_CHARACTERS)}.')
             return failures
 
         words = password.split(separator)

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -13,6 +13,7 @@ import itertools
 import json
 import logging
 import getpass
+import re
 import threading
 from datetime import datetime, timedelta
 from typing import Tuple, Optional, List, Dict, Any, Set
@@ -22,6 +23,7 @@ from .proto import APIRequest_pb2, record_pb2
 from .display import bcolors
 from .params import KeeperParams
 from .error import KeeperApiError, CommandError
+from .generator import DEFAULT_PASSPHRASE_WORD_COUNT, PP_SEPARATOR_CHARACTERS
 
 
 def _find_enforcement_value(enforcements, key):
@@ -423,6 +425,78 @@ class PasswordComplexityEnforcer:
         return None
 
     @classmethod
+    def _normalize_passphrase_separators(cls, policy):   # type: (Dict[str, Any]) -> Optional[str]
+        raw = policy.get('passphrase-separator')
+        if isinstance(raw, str) and raw.strip():
+            normalized = raw.replace('\u2423', ' ')
+            allowed = ''
+            for ch in PP_SEPARATOR_CHARACTERS:
+                if ch in normalized:
+                    allowed += ch
+            return allowed or None
+        return PP_SEPARATOR_CHARACTERS
+
+    @classmethod
+    def validate_passphrase(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
+        """Validate password as a vault-style passphrase per policy passphrase-* fields."""
+        failures = []   # type: List[str]
+        if policy.get('passphrase-allow') is False:
+            return failures
+
+        allowed_seps = cls._normalize_passphrase_separators(policy)
+        if not allowed_seps:
+            failures.append('Passphrase cannot meet separator criteria set by policy.')
+            return failures
+
+        separator = next((ch for ch in allowed_seps if ch in password), None)
+        if separator is None:
+            # Allow CLI-selected separators even when not listed in policy.
+            separator = next((ch for ch in PP_SEPARATOR_CHARACTERS if ch in password), None)
+        if separator is None:
+            failures.append('Passphrase must contain an allowed separator character.')
+            return failures
+
+        words = password.split(separator)
+        if not words or any(not word for word in words):
+            failures.append('Passphrase contains an empty word.')
+            return failures
+
+        min_words = _coerce_int(policy.get('passphrase-length')) or DEFAULT_PASSPHRASE_WORD_COUNT
+        if len(words) < min_words:
+            failures.append(
+                f'Passphrase must contain at least {min_words} words (got {len(words)}).')
+
+        capitalize = bool(policy.get('passphrase-capitalize', False))
+        append_number = bool(policy.get('passphrase-number', False))
+
+        if capitalize:
+            word_re = re.compile(r'^[A-Z][a-z]{2,}$')
+            if append_number:
+                first_re = re.compile(r'^[A-Z][a-z]{2,}[0-9]$')
+            else:
+                first_re = re.compile(r'^[A-Z][a-z]{2,}[0-9]?$')
+        else:
+            word_re = re.compile(r'^[A-Za-z]{3,}$')
+            if append_number:
+                first_re = re.compile(r'^[A-Za-z]{3,}[0-9]$')
+            else:
+                first_re = re.compile(r'^[A-Za-z]{3,}[0-9]?$')
+
+        for index, word in enumerate(words):
+            pattern = first_re if index == 0 else word_re
+            if not pattern.match(word):
+                if index == 0 and append_number:
+                    failures.append('First passphrase word must end with a digit (0-9).')
+                elif capitalize:
+                    failures.append(
+                        'Each passphrase word must start with a capital letter and contain at least 3 letters.')
+                else:
+                    failures.append('Each passphrase word must contain at least 3 letters.')
+                break
+
+        return failures
+
+    @classmethod
     def validate_password(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
         failures = []   # type: List[str]
         if not policy or not isinstance(password, str) or not password:
@@ -454,7 +528,18 @@ class PasswordComplexityEnforcer:
                     failures.append(
                         f'Password must contain at least {required} special character(s) (got {count}).')
 
-        return failures
+        if not failures:
+            return failures
+
+        # Vault re-validates as a passphrase when random password rules fail.
+        if policy.get('passphrase-allow') is False:
+            return failures
+
+        passphrase_failures = cls.validate_passphrase(password, policy)
+        if not passphrase_failures:
+            return []
+
+        return passphrase_failures
 
     @classmethod
     def validate_record(cls, params, source):   # type: (KeeperParams, Any) -> List[str]

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -27,6 +27,8 @@ PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
 PP_SEPARATOR_CHARACTERS = '-._?! '
 DEFAULT_PASSPHRASE_SEPARATOR = '-'
 DEFAULT_PASSPHRASE_WORD_COUNT = 5
+DEFAULT_PASSPHRASE_CAPITALIZE = True
+DEFAULT_PASSPHRASE_NUMBER = True
 DEFAULT_DICEWARE_WORDLIST = 'diceware.wordlist.asc.txt'
 PASSPHRASE_SEPARATOR_HELP = '- . _ ? ! space'
 
@@ -312,7 +314,8 @@ class KeeperPassphraseGenerator(PasswordGenerator):
     """Vault-style passphrase generator using the bundled EFF large word list."""
 
     def __init__(self, word_count=DEFAULT_PASSPHRASE_WORD_COUNT, separator=DEFAULT_PASSPHRASE_SEPARATOR,
-                 capitalize=False, append_number=False, word_list_file=None):
+                 capitalize=DEFAULT_PASSPHRASE_CAPITALIZE, append_number=DEFAULT_PASSPHRASE_NUMBER,
+                 word_list_file=None):
         # type: (int, str, bool, bool, Optional[str]) -> None
         if isinstance(word_count, int):
             if word_count < 1:
@@ -373,11 +376,11 @@ class KeeperPassphraseGenerator(PasswordGenerator):
 
         cap = capitalize
         if cap is None:
-            cap = bool(policy.get('passphrase-capitalize', False)) if policy else False
+            cap = DEFAULT_PASSPHRASE_CAPITALIZE
 
         num = append_number
         if num is None:
-            num = bool(policy.get('passphrase-number', False)) if policy else False
+            num = DEFAULT_PASSPHRASE_NUMBER
 
         return cls(word_count=wc, separator=sep, capitalize=cap, append_number=num)
 

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -28,6 +28,18 @@ PP_SEPARATOR_CHARACTERS = '-._?! '
 DEFAULT_PASSPHRASE_SEPARATOR = '-'
 DEFAULT_PASSPHRASE_WORD_COUNT = 5
 DEFAULT_DICEWARE_WORDLIST = 'diceware.wordlist.asc.txt'
+PASSPHRASE_SEPARATOR_HELP = '- . _ ? ! space'
+
+
+def format_passphrase_separators_for_display(separators=None):
+    # type: (Optional[str]) -> str
+    """Human-readable list of allowed passphrase separator characters."""
+    if not separators:
+        separators = PP_SEPARATOR_CHARACTERS
+    parts = []   # type: List[str]
+    for ch in separators:
+        parts.append('space' if ch == ' ' else ch)
+    return ', '.join(parts)
 
 PasswordStrength = namedtuple('PasswordStrength', 'length caps lower digits symbols')
 PassphraseGenOptions = namedtuple(
@@ -166,6 +178,26 @@ def _normalize_passphrase_separator(separator):
     if separator == '\u2423':  # OPEN BOX (Vault UI glyph for space)
         return ' '
     return separator[0]
+
+
+def _passphrase_separators_from_policy(policy_sep):
+    # type: (str) -> str
+    """Return allowed separators in Vault order (see getPasswordRules.ts)."""
+    normalized = policy_sep.replace('\u2423', ' ')
+    allowed = ''
+    for ch in PP_SEPARATOR_CHARACTERS:
+        if ch in normalized:
+            allowed += ch
+    return allowed
+
+
+def _default_passphrase_separator_from_policy(policy_sep):
+    # type: (Optional[str]) -> str
+    """Pick the default generation separator matching Vault / PowerCommander."""
+    if not policy_sep or not isinstance(policy_sep, str) or not policy_sep.strip():
+        return DEFAULT_PASSPHRASE_SEPARATOR
+    allowed = _passphrase_separators_from_policy(policy_sep.strip())
+    return allowed[0] if allowed else DEFAULT_PASSPHRASE_SEPARATOR
 
 
 def _parse_gen_bool(value):
@@ -326,13 +358,16 @@ class KeeperPassphraseGenerator(PasswordGenerator):
                 wc = DEFAULT_PASSPHRASE_WORD_COUNT
 
         sep = separator
+        if sep is not None and sep not in PP_SEPARATOR_CHARACTERS:
+            logging.warning(
+                'Ignoring invalid passphrase separator %r. Allowed: %s.',
+                sep, format_passphrase_separators_for_display())
+            sep = None
         if sep is None:
             if policy:
                 policy_sep = policy.get('passphrase-separator')
-                if isinstance(policy_sep, str) and policy_sep.strip():
-                    sep = _normalize_passphrase_separator(policy_sep.strip())
-                else:
-                    sep = DEFAULT_PASSPHRASE_SEPARATOR
+                sep = _default_passphrase_separator_from_policy(
+                    policy_sep if isinstance(policy_sep, str) else None)
             else:
                 sep = DEFAULT_PASSPHRASE_SEPARATOR
 

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -15,7 +15,7 @@ import os
 import secrets
 import string
 from secrets import choice
-from typing import Optional, List, Iterator
+from typing import Optional, List, Iterator, Sequence
 from collections import namedtuple
 
 from . import crypto
@@ -24,8 +24,14 @@ from Cryptodome.Random.random import shuffle
 
 DEFAULT_PASSWORD_LENGTH = 20
 PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
+PP_SEPARATOR_CHARACTERS = '-._?! '
+DEFAULT_PASSPHRASE_SEPARATOR = '-'
+DEFAULT_PASSPHRASE_WORD_COUNT = 5
+DEFAULT_DICEWARE_WORDLIST = 'diceware.wordlist.asc.txt'
 
 PasswordStrength = namedtuple('PasswordStrength', 'length caps lower digits symbols')
+PassphraseGenOptions = namedtuple(
+    'PassphraseGenOptions', ('word_count', 'separator', 'capitalize', 'append_number'))
 
 
 def get_password_strength(password):  # type: (str) -> PasswordStrength
@@ -153,37 +159,113 @@ class KeeperPasswordGenerator(PasswordGenerator):
         )
 
 
+def _normalize_passphrase_separator(separator):
+    # type: (Optional[str]) -> str
+    if not separator:
+        return DEFAULT_PASSPHRASE_SEPARATOR
+    if separator == '\u2423':  # OPEN BOX (Vault UI glyph for space)
+        return ' '
+    return separator[0]
+
+
+def _parse_gen_bool(value):
+    # type: (str) -> Optional[bool]
+    normalized = value.strip().lower()
+    if normalized in ('true', '1', 'yes', 'on'):
+        return True
+    if normalized in ('false', '0', 'no', 'off'):
+        return False
+    return None
+
+
+def parse_passphrase_gen_parameters(parameters):
+    # type: (Optional[Sequence[str]]) -> PassphraseGenOptions
+    """Parse $GEN:passphrase optional parameters.
+
+    Format: $GEN:passphrase[,word_count][,separator][,capitalize][,number]
+    Examples:
+        $GEN:passphrase,7
+        $GEN:passphrase,7,_
+        $GEN:passphrase,7,_,true,true
+        $GEN:passphrase,7,space,false,true
+    """
+    if not parameters:
+        return PassphraseGenOptions(None, None, None, None)
+
+    extras = [p.strip() for p in parameters if p.strip() and p.strip() != 'passphrase']
+    word_count = None
+    separator = None
+    capitalize = None
+    append_number = None
+    idx = 0
+
+    if idx < len(extras) and extras[idx].isdigit():
+        word_count = int(extras[idx])
+        idx += 1
+
+    if idx < len(extras):
+        candidate = extras[idx]
+        if _parse_gen_bool(candidate) is None:
+            if candidate.lower() in ('space', 'sp'):
+                separator = ' '
+            else:
+                separator = _normalize_passphrase_separator(candidate)
+            idx += 1
+
+    if idx < len(extras):
+        parsed = _parse_gen_bool(extras[idx])
+        if parsed is not None:
+            capitalize = parsed
+            idx += 1
+
+    if idx < len(extras):
+        parsed = _parse_gen_bool(extras[idx])
+        if parsed is not None:
+            append_number = parsed
+
+    return PassphraseGenOptions(word_count, separator, capitalize, append_number)
+
+
+def _resolve_wordlist_path(word_list_file=None):
+    # type: (Optional[str]) -> str
+    if word_list_file:
+        dice_path = os.path.join(os.path.dirname(__file__), 'resources', word_list_file)
+        if not os.path.isfile(dice_path):
+            dice_path = os.path.expanduser(word_list_file)
+    else:
+        dice_path = os.path.join(os.path.dirname(__file__), 'resources', DEFAULT_DICEWARE_WORDLIST)
+    return dice_path
+
+
+def _load_wordlist(word_list_file=None):
+    # type: (Optional[str]) -> List[str]
+    dice_path = _resolve_wordlist_path(word_list_file)
+    if not os.path.isfile(dice_path):
+        raise Exception(f'Word list file \"{dice_path}\" not found.')
+
+    vocabulary = []   # type: List[str]
+    unique_words = set()
+    with open(dice_path, 'r', encoding='utf-8') as dw:
+        for line in dw:
+            line = line.strip()
+            if not line or line.startswith('--'):
+                continue
+            if line.lower().startswith('source url:') or line.lower().startswith('title:'):
+                continue
+            parts = line.split()
+            word = parts[1] if len(parts) >= 2 else parts[0]
+            vocabulary.append(word)
+            unique_words.add(word.lower())
+    if len(vocabulary) != len(unique_words):
+        raise Exception(f'Word list file \"{dice_path}\" contains non-unique words.')
+    return vocabulary
+
+
 class DicewarePasswordGenerator(PasswordGenerator):
     def __init__(self, number_of_rolls, word_list_file=None, delimiter=' '):   # type: (int, Optional[str], str) -> None
         self._number_of_rolls = number_of_rolls if number_of_rolls > 0 else 5
         self.delimiter = delimiter
-
-        if word_list_file:
-            dice_path = os.path.join(os.path.dirname(__file__), 'resources', word_list_file)
-            if not os.path.isfile(dice_path):
-                dice_path = os.path.expanduser(word_list_file)
-        else:
-            dice_path = os.path.join(os.path.dirname(__file__), 'resources', 'diceware.wordlist.asc.txt')
-        self._vocabulary = None    # type: Optional[List[str]]
-        if os.path.isfile(dice_path):
-            with open(dice_path, 'r', encoding='utf-8') as dw:
-                self._vocabulary = []
-                line_count = 0
-                unique_words = set()
-                for line in dw.readlines():
-                    if not line:
-                        continue
-                    if line.startswith('--'):
-                        continue
-                    line_count += 1
-                    words = [x.strip() for x in line.split()]
-                    word = words[1] if len(words) >= 2 else words[0]
-                    self._vocabulary.append(word)
-                    unique_words.add(word.lower())
-                if line_count != len(unique_words):
-                    raise Exception(f'Word list file \"{dice_path}\" contains non-unique words.')
-        else:
-            raise Exception(f'Word list file \"{dice_path}\" not found.')
+        self._vocabulary = _load_wordlist(word_list_file)
 
     def generate(self):
         if not self._vocabulary:
@@ -192,6 +274,86 @@ class DicewarePasswordGenerator(PasswordGenerator):
         words = [secrets.choice(self._vocabulary) for _ in range(self._number_of_rolls)]
         shuffle(words)
         return self.delimiter.join(words)
+
+
+class KeeperPassphraseGenerator(PasswordGenerator):
+    """Vault-style passphrase generator using the bundled EFF large word list."""
+
+    def __init__(self, word_count=DEFAULT_PASSPHRASE_WORD_COUNT, separator=DEFAULT_PASSPHRASE_SEPARATOR,
+                 capitalize=False, append_number=False, word_list_file=None):
+        # type: (int, str, bool, bool, Optional[str]) -> None
+        if isinstance(word_count, int):
+            if word_count < 1:
+                word_count = 1
+            elif word_count > 40:
+                word_count = 40
+        else:
+            word_count = DEFAULT_PASSPHRASE_WORD_COUNT
+        self.word_count = word_count
+        self.separator = _normalize_passphrase_separator(separator)
+        self.capitalize = capitalize
+        self.append_number = append_number
+        self._vocabulary = _load_wordlist(word_list_file)
+
+    def generate(self):
+        if not self._vocabulary:
+            raise Exception('Passphrase word list was not loaded')
+
+        passphrase = ''
+        first_word = True
+        for _ in range(self.word_count):
+            word = secrets.choice(self._vocabulary)
+            if self.capitalize and word:
+                word = word[0].upper() + word[1:]
+            if self.append_number and first_word:
+                word += str(secrets.randbelow(10))
+            if not first_word:
+                passphrase += self.separator
+            passphrase += word
+            first_word = False
+        return passphrase
+
+    @classmethod
+    def create_with_options(cls, policy=None, word_count=None, separator=None,
+                            capitalize=None, append_number=None):
+        # type: (Optional[dict], Optional[int], Optional[str], Optional[bool], Optional[bool]) -> KeeperPassphraseGenerator
+        """Build a generator from CLI/$GEN overrides with optional policy defaults."""
+        wc = word_count
+        if wc is None:
+            if policy:
+                wc = policy.get('passphrase-length', DEFAULT_PASSPHRASE_WORD_COUNT)
+            else:
+                wc = DEFAULT_PASSPHRASE_WORD_COUNT
+
+        sep = separator
+        if sep is None:
+            if policy:
+                policy_sep = policy.get('passphrase-separator')
+                if isinstance(policy_sep, str) and policy_sep.strip():
+                    sep = _normalize_passphrase_separator(policy_sep.strip())
+                else:
+                    sep = DEFAULT_PASSPHRASE_SEPARATOR
+            else:
+                sep = DEFAULT_PASSPHRASE_SEPARATOR
+
+        cap = capitalize
+        if cap is None:
+            cap = bool(policy.get('passphrase-capitalize', False)) if policy else False
+
+        num = append_number
+        if num is None:
+            num = bool(policy.get('passphrase-number', False)) if policy else False
+
+        return cls(word_count=wc, separator=sep, capitalize=cap, append_number=num)
+
+    @classmethod
+    def create_from_policy(cls, policy, length_override=None, separator_override=None):
+        # type: (dict, Optional[int], Optional[str]) -> KeeperPassphraseGenerator
+        return cls.create_with_options(
+            policy,
+            word_count=length_override,
+            separator=separator_override,
+        )
 
 
 class CryptoPassphraseGenerator(PasswordGenerator):

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+
+from keepercommander.enforcement import PasswordComplexityEnforcer
+
+
+STRICT_RANDOM_POLICY = {
+    'length': 8,
+    'upper-use': True,
+    'upper-min': 5,
+    'digit-use': True,
+    'digit-min': 3,
+    'passphrase-allow': True,
+    'passphrase-length': 5,
+    'passphrase-capitalize': False,
+    'passphrase-number': False,
+    'passphrase-separator': '-',
+}
+
+
+class TestPassphraseEnforcement(TestCase):
+
+    def test_passphrase_accepted_when_random_rules_fail(self):
+        password = 'alpha-bravo-charlie-delta-echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
+        self.assertEqual(failures, [])
+
+    def test_passphrase_with_capitalized_words_and_one_digit_accepted(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy.update({
+            'passphrase-length': 7,
+            'passphrase-capitalize': True,
+            'passphrase-number': True,
+            'passphrase-separator': '_',
+        })
+        password = 'Alpha7_Bravo_Charlie_Delta_Echo_Foxtrot_Golf'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_random_rules_apply_when_passphrase_disabled(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-allow'] = False
+        password = 'alpha-bravo-charlie-delta-echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('uppercase' in f for f in failures))
+        self.assertTrue(any('digit' in f for f in failures))
+
+    def test_passphrase_with_cli_style_digit_when_policy_number_off(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-number'] = False
+        password = 'Alpha7_Bravo_Charlie_Delta_Echo_Foxtrot_Golf'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_passphrase_accepts_underscore_separator_not_in_policy(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-separator'] = '-'
+        password = 'alpha_bravo_charlie_delta_echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_invalid_passphrase_returns_passphrase_errors(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        password = 'ab-cd-ef'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('word' in f.lower() for f in failures))
+
+    def test_random_password_still_validated(self):
+        password = 'ABCDE123!!!'
+        failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
+        self.assertEqual(failures, [])

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -58,6 +58,12 @@ class TestPassphraseEnforcement(TestCase):
         failures = PasswordComplexityEnforcer.validate_password(password, policy)
         self.assertEqual(failures, [])
 
+    def test_invalid_separator_error_lists_allowed_characters(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        password = 'alpha~bravo~charlie~delta~echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('Allowed:' in f and 'space' in f for f in failures))
+
     def test_invalid_passphrase_returns_passphrase_errors(self):
         policy = dict(STRICT_RANDOM_POLICY)
         password = 'ab-cd-ef'

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -1,0 +1,101 @@
+from unittest import TestCase, mock
+
+from keepercommander import generator
+
+
+class TestKeeperPassphraseGenerator(TestCase):
+
+  def test_default_generates_five_hyphen_separated_words(self):
+    gen = generator.KeeperPassphraseGenerator()
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
+      result = gen.generate()
+    self.assertEqual(result, 'alpha-bravo-charlie-delta-echo')
+
+  def test_does_not_shuffle_words_like_diceware(self):
+    gen = generator.KeeperPassphraseGenerator(word_count=3, separator=' ')
+    with mock.patch('secrets.choice', side_effect=['one', 'two', 'three']):
+      result = gen.generate()
+    self.assertEqual(result, 'one two three')
+
+  def test_capitalize_and_number_apply_to_first_word_only(self):
+    gen = generator.KeeperPassphraseGenerator(
+      word_count=2, separator='-', capitalize=True, append_number=True)
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+      with mock.patch('secrets.randbelow', return_value=7):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha7-Bravo')
+
+  def test_create_from_policy_honors_passphrase_fields(self):
+    gen = generator.KeeperPassphraseGenerator.create_from_policy({
+      'passphrase-length': 3,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': True,
+      'passphrase-number': True,
+    })
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+      with mock.patch('secrets.randbelow', return_value=4):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha4-Bravo-Charlie')
+
+  def test_parse_passphrase_gen_parameters(self):
+    opts = generator.parse_passphrase_gen_parameters(['passphrase', '7', '_', 'true', 'false'])
+    self.assertEqual(opts.word_count, 7)
+    self.assertEqual(opts.separator, '_')
+    self.assertTrue(opts.capitalize)
+    self.assertFalse(opts.append_number)
+
+  def test_create_with_options_overrides_policy(self):
+    policy = {
+      'passphrase-length': 5,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    }
+    gen = generator.KeeperPassphraseGenerator.create_with_options(
+      policy, word_count=3, separator='_', capitalize=True, append_number=True)
+    self.assertEqual(gen.word_count, 3)
+    self.assertEqual(gen.separator, '_')
+    self.assertTrue(gen.capitalize)
+    self.assertTrue(gen.append_number)
+
+  def test_loads_bundled_eff_wordlist(self):
+    words = generator._load_wordlist()
+    self.assertEqual(len(words), 7776)
+    self.assertEqual(words[0], 'abacus')
+
+
+class TestGeneratePasswordPassphrase(TestCase):
+
+  def test_record_edit_generate_password_passphrase(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
+      result = RecordEditMixin.generate_password(['passphrase'])
+    self.assertEqual(result, 'alpha-bravo-charlie-delta-echo')
+
+  def test_record_edit_passphrase_uses_policy_when_allowed(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    policy = {
+      'passphrase-allow': True,
+      'passphrase-length': 2,
+      'passphrase-separator': '_',
+      'passphrase-capitalize': True,
+      'passphrase-number': False,
+    }
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+      result = RecordEditMixin.generate_password(['passphrase'], policy=policy)
+    self.assertEqual(result, 'Alpha_Bravo')
+
+  def test_record_edit_passphrase_cli_overrides_policy(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    policy = {
+      'passphrase-allow': True,
+      'passphrase-length': 2,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    }
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+      with mock.patch('secrets.randbelow', return_value=9):
+        result = RecordEditMixin.generate_password(
+          ['passphrase', '3', '_', 'true', 'true'], policy=policy)
+    self.assertEqual(result, 'Alpha9_Bravo_Charlie')

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -8,11 +8,13 @@ class TestKeeperPassphraseGenerator(TestCase):
   def test_default_generates_five_hyphen_separated_words(self):
     gen = generator.KeeperPassphraseGenerator()
     with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
-      result = gen.generate()
-    self.assertEqual(result, 'alpha-bravo-charlie-delta-echo')
+      with mock.patch('secrets.randbelow', return_value=3):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha3-Bravo-Charlie-Delta-Echo')
 
   def test_does_not_shuffle_words_like_diceware(self):
-    gen = generator.KeeperPassphraseGenerator(word_count=3, separator=' ')
+    gen = generator.KeeperPassphraseGenerator(
+      word_count=3, separator=' ', capitalize=False, append_number=False)
     with mock.patch('secrets.choice', side_effect=['one', 'two', 'three']):
       result = gen.generate()
     self.assertEqual(result, 'one two three')
@@ -58,6 +60,14 @@ class TestKeeperPassphraseGenerator(TestCase):
     self.assertTrue(gen.capitalize)
     self.assertTrue(gen.append_number)
 
+  def test_commander_defaults_override_policy_capitalize_and_number(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options({
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    })
+    self.assertTrue(gen.capitalize)
+    self.assertTrue(gen.append_number)
+
   def test_policy_separator_uses_vault_order_not_raw_first_char(self):
     gen = generator.KeeperPassphraseGenerator.create_with_options({
       'passphrase-separator': '!._?-',
@@ -80,8 +90,9 @@ class TestGeneratePasswordPassphrase(TestCase):
   def test_record_edit_generate_password_passphrase(self):
     from keepercommander.commands.record_edit import RecordEditMixin
     with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
-      result = RecordEditMixin.generate_password(['passphrase'])
-    self.assertEqual(result, 'alpha-bravo-charlie-delta-echo')
+      with mock.patch('secrets.randbelow', return_value=5):
+        result = RecordEditMixin.generate_password(['passphrase'])
+    self.assertEqual(result, 'Alpha5-Bravo-Charlie-Delta-Echo')
 
   def test_record_edit_passphrase_uses_policy_when_allowed(self):
     from keepercommander.commands.record_edit import RecordEditMixin
@@ -93,8 +104,9 @@ class TestGeneratePasswordPassphrase(TestCase):
       'passphrase-number': False,
     }
     with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
-      result = RecordEditMixin.generate_password(['passphrase'], policy=policy)
-    self.assertEqual(result, 'Alpha_Bravo')
+      with mock.patch('secrets.randbelow', return_value=4):
+        result = RecordEditMixin.generate_password(['passphrase'], policy=policy)
+    self.assertEqual(result, 'Alpha4_Bravo')
 
   def test_record_edit_passphrase_cli_overrides_policy(self):
     from keepercommander.commands.record_edit import RecordEditMixin

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -58,6 +58,17 @@ class TestKeeperPassphraseGenerator(TestCase):
     self.assertTrue(gen.capitalize)
     self.assertTrue(gen.append_number)
 
+  def test_policy_separator_uses_vault_order_not_raw_first_char(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options({
+      'passphrase-separator': '!._?-',
+    })
+    self.assertEqual(gen.separator, '-')
+
+  def test_invalid_separator_override_falls_back_to_default(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options(
+      None, separator='~', word_count=3)
+    self.assertEqual(gen.separator, '-')
+
   def test_loads_bundled_eff_wordlist(self):
     words = generator._load_wordlist()
     self.assertEqual(len(words), 7776)


### PR DESCRIPTION
### Summary
Added Vault-style passphrase generation to Commander using the bundled EFF word list, with support on generate --passphrase, $GEN:passphrase on record commands (including NSF), optional CLI overrides for word count/separator/capitals/digit, enterprise passphrase-* policy integration for generation, and Vault-aligned passphrase validation so valid passphrases are accepted on record add/update without --force when random-password rules would otherwise fail.

### Changes

- Added KeeperPassphraseGenerator in generator.py using the bundled EFF word list (7776 words), matching Vault behavior: pick-order words, configurable separator, optional capitalization per word, optional single digit on the first word only
- Added $GEN:passphrase to record-add, record-update, and NSF record commands via RecordEditMixin.generate_password(), with optional parameters: word_count[,separator][,capitalize][,number]
- Added generate --passphrase and passphrase-only CLI overrides: --pp-separator, --pp-capitalize / --pp-no-capitalize, --pp-number / --pp-no-number; --count sets word count in passphrase mode
- Integrated enterprise GENERATED_PASSWORD_COMPLEXITY passphrase-* fields for generation; fall back to random password with a warning when passphrase-allow is false
- Added Vault-aligned passphrase validation in PasswordComplexityEnforcer: re-validate as a passphrase when random-password rules fail; accept valid passphrases on record commands without --force
- Refactored DicewarePasswordGenerator to share word-list loading; left $GEN:dice behavior unchanged for backward compatibility
- Added unit tests in test_passphrase_generator.py and test_passphrase_enforcement.py