### PR TITLE
KC-1314: Add vault-style passphrase generation to Commander CLI

### DIFF
--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -77,7 +77,12 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         folder_uid = self._resolve_folder(params, kwargs.get('folder_uid'))
 
         data = self._build_record_data(params, record_type, title, notes, record_fields)
+        if self.abort_if_errors():
+            return
         self._check_password_policy(params, data, **kwargs)
+
+        if self.abort_if_errors():
+            return
 
         if self.warnings:
             for w in self.warnings:
@@ -205,8 +210,14 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             return action_params[0] if action_params else None
         action_params.clear()
         if self.is_generate_value(raw, action_params):
+            if self.warn_wrong_password_gen_field(parsed):
+                return None
             if parsed.type == 'password':
-                return self.generate_password(action_params, policy=self._password_policy)
+                password, gen_error = self.generate_password(action_params, policy=self._password_policy)
+                if gen_error:
+                    self.on_error(gen_error)
+                    return None
+                return password
             if parsed.type in ('oneTimeCode', 'otp'):
                 return self.generate_totp_url()
             return raw
@@ -238,6 +249,8 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
         for spec in [f.strip() for f in kwargs.get('fields', []) if f.strip()]:
             try:
                 parsed = RecordEditMixin.parse_field(spec)
+                if self.warn_wrong_password_gen_field(parsed):
+                    continue
                 value = self._resolve_field_value(parsed)
                 if value is None:
                     continue
@@ -249,6 +262,9 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     fields[parsed.type] = value
             except ValueError as e:
                 raise CommandError('nsf-record-update', f'Invalid field specification: {e}')
+
+        if self.abort_if_errors():
+            return
 
         if self.warnings:
             for w in self.warnings:

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -192,7 +192,7 @@ $GEN:[alg],[n]          password           Generates a random password      $GEN
                                            Optional: password length
                                            Passphrase extras (override      $GEN:passphrase,7,_,true,true
                                            policy for generation only):
-                                           word_count[,separator][,capitalize][,number]
+                                           word_count(5-9)[,separator][,capitalize][,number]
                                            Separators allowed: - . _ ? ! space
 $GEN                    oneTimeCode        Generates TOTP URL
 $GEN:[alg,][enc]        keyPair            Generates a key pair and         $GEN:ec,enc
@@ -234,19 +234,49 @@ pam rotation edit --config=PAM_CONFIG_UID \
 
 
 ParsedFieldValue = collections.namedtuple('ParsedFieldValue', ['section', 'type', 'label', 'value'])
+PASSWORD_GEN_FIELD_LABELS = frozenset(('password', 'passphrase', 'pwd', 'secret'))
 
 
 class RecordEditMixin:
     def __init__(self):
         self.warnings = []
+        self.errors = []
         self._password_policy = None   # type: Optional[Dict[str, Any]]
 
     def on_warning(self, message):
         if message:
             self.warnings.append(message)
 
+    def on_error(self, message):
+        if message:
+            self.errors.append(message)
+
+    def abort_if_errors(self):
+        # type: () -> bool
+        """Log command errors and return True when execution must stop."""
+        if not self.errors:
+            return False
+        for error in self.errors:
+            logging.warning(error)
+        self.errors.clear()
+        return True
+
     def on_info(self, message):
         logging.info(message)
+
+    def warn_wrong_password_gen_field(self, parsed_field):
+        # type: (ParsedFieldValue) -> bool
+        """Warn when $GEN is used with a label like Password= instead of password=."""
+        if not parsed_field.value or not parsed_field.value.startswith('$GEN'):
+            return False
+        if parsed_field.type == 'password':
+            return False
+        if (parsed_field.label or '').lower() not in PASSWORD_GEN_FIELD_LABELS:
+            return False
+        self.on_error(
+            f'Use lowercase field type password=\'{parsed_field.value}\' '
+            f'instead of {parsed_field.label}=... ($GEN only works on password fields).')
+        return True
 
     @staticmethod
     def parse_field(field):   # type: (str) -> ParsedFieldValue
@@ -296,7 +326,11 @@ class RecordEditMixin:
             elif parsed_field.type == 'password':
                 action_params.clear()
                 if self.is_generate_value(parsed_field.value, action_params):
-                    record.password = self.generate_password(action_params, policy=self._password_policy)
+                    password, gen_error = self.generate_password(action_params, policy=self._password_policy)
+                    if gen_error:
+                        self.on_error(gen_error)
+                    elif password is not None:
+                        record.password = password
                 elif self.is_base64_value(parsed_field.value, action_params):
                     if action_params:
                         record.password = action_params[0]
@@ -346,7 +380,8 @@ class RecordEditMixin:
             if value.startswith(':'):
                 gen_parameters = value[1:]
                 if gen_parameters and isinstance(parameters, list):
-                    parameters.extend((x.strip() for x in gen_parameters.split(',')))
+                    for part in gen_parameters.split(','):
+                        parameters.append(part.strip() if part.strip() else '')
             return True
 
     def is_base64_value(self, value, parameters):    # type: (str, List[str]) -> Optional[bool]
@@ -400,23 +435,27 @@ class RecordEditMixin:
         }
 
     @staticmethod
-    def generate_password(parameters=None, policy=None):   # type: (Optional[Sequence[str]], Optional[dict]) -> str
+    def generate_password(parameters=None, policy=None):   # type: (Optional[Sequence[str]], Optional[dict]) -> tuple
+        algorithm, error = generator.resolve_gen_password_algorithm(
+            parameters if isinstance(parameters, (tuple, list, set)) else None)
+        if error:
+            return None, error
+
+        length = None
         if isinstance(parameters, (tuple, list, set)):
-            algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto', 'passphrase')), 'rand')
             length = next((x for x in parameters if x.isnumeric()), None)
             if isinstance(length, str) and len(length) > 0:
                 try:
                     length = int(length)
                 except ValueError:
                     pass
-        else:
-            algorithm = 'rand'
-            length = None
 
         if algorithm == 'crypto':
             gen = generator.CryptoPassphraseGenerator()
         elif algorithm == 'passphrase':
-            pp_opts = generator.parse_passphrase_gen_parameters(parameters)
+            pp_opts, pp_error = generator.parse_passphrase_gen_parameters(parameters)
+            if pp_error:
+                return None, pp_error
             if policy and policy.get('passphrase-allow') is False:
                 logging.warning('Passphrase generation is disabled by enterprise policy; using random password.')
                 gen = generator.KeeperPasswordGenerator.create_from_policy(
@@ -450,7 +489,7 @@ class RecordEditMixin:
                 else:
                     length = 20
                 gen = generator.KeeperPasswordGenerator(length=length)
-        return gen.generate()
+        return gen.generate(), None
 
     @staticmethod
     def generate_totp_url():
@@ -569,6 +608,8 @@ class RecordEditMixin:
         parsed_fields = collections.deque(fields)
         while len(parsed_fields) > 0:
             parsed_field = parsed_fields.popleft()
+            if self.warn_wrong_password_gen_field(parsed_field):
+                continue
             field_type = parsed_field.type or 'text'
             field_label = parsed_field.label or ''
             skip_validation = not parsed_field.value or parsed_field.value.startswith('$JSON')
@@ -626,12 +667,20 @@ class RecordEditMixin:
                 action_params = []
                 if self.is_generate_value(parsed_field.value, action_params):
                     if record_field.type == 'password':
-                        value = self.generate_password(action_params, policy=self._password_policy)
+                        value, gen_error = self.generate_password(action_params, policy=self._password_policy)
+                        if gen_error:
+                            self.on_error(gen_error)
+                            continue
                     elif record_field.type in ('oneTimeCode', 'otp'):
                         value = self.generate_totp_url()
                     elif record_field.type in ('keyPair', 'privateKey'):
                         should_encrypt = 'enc' in action_params
-                        passphrase = self.generate_password() if should_encrypt else None
+                        passphrase = None
+                        if should_encrypt:
+                            passphrase, gen_error = self.generate_password()
+                            if gen_error:
+                                self.on_error(gen_error)
+                                continue
                         key_type = next((x for x in action_params if x in ('rsa', 'ec', 'ed25519')), 'rsa')
                         value = self.generate_key_pair(key_type, passphrase)
                         if passphrase:
@@ -906,6 +955,9 @@ class RecordAddCommand(Command, RecordEditMixin):
                     field.required = True
                 record.fields.append(field)
             self.assign_typed_fields(record, record_fields)
+
+        if self.abort_if_errors():
+            return
 
         record_uid = str(kwargs.get('record_uid', ''))
         if RecordV3.is_valid_ref_uid(record_uid):
@@ -1298,6 +1350,9 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             self.assign_typed_fields(record, record_fields)
         else:
             raise CommandError('record-update', f'Record \"{record_name}\" can not be edited.')
+
+        if self.abort_if_errors():
+            return
 
         if isinstance(record, vault.TypedRecord):
             pw_failures = PasswordComplexityEnforcer.validate_record(params, record)

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -188,8 +188,12 @@ $<ACTION>[:<PARAMS>, <PARAMS>]   executes an action that returns a field value
 Value                   Field type         Description                      Example
 ====================    ===============    ===================              ==============
 $GEN:[alg],[n]          password           Generates a random password      $GEN:dice,5
-                                           Default algorith is rand         alg: [rand | dice | crypto]
+                                           Default algorith is rand         alg: [rand | dice | crypto | passphrase]
                                            Optional: password length
+                                           Passphrase extras (override      $GEN:passphrase,7,_,true,true
+                                           policy for generation only):
+                                           word_count[,separator][,capitalize][,number]
+                                           Separators allowed: - . _ ? ! space
 $GEN                    oneTimeCode        Generates TOTP URL
 $GEN:[alg,][enc]        keyPair            Generates a key pair and         $GEN:ec,enc
                                            optional passcode                alg: [rsa | ec | ed25519], enc
@@ -398,7 +402,7 @@ class RecordEditMixin:
     @staticmethod
     def generate_password(parameters=None, policy=None):   # type: (Optional[Sequence[str]], Optional[dict]) -> str
         if isinstance(parameters, (tuple, list, set)):
-            algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto')), 'rand')
+            algorithm = next((x for x in parameters if x in ('rand', 'dice', 'crypto', 'passphrase')), 'rand')
             length = next((x for x in parameters if x.isnumeric()), None)
             if isinstance(length, str) and len(length) > 0:
                 try:
@@ -411,6 +415,20 @@ class RecordEditMixin:
 
         if algorithm == 'crypto':
             gen = generator.CryptoPassphraseGenerator()
+        elif algorithm == 'passphrase':
+            pp_opts = generator.parse_passphrase_gen_parameters(parameters)
+            if policy and policy.get('passphrase-allow') is False:
+                logging.warning('Passphrase generation is disabled by enterprise policy; using random password.')
+                gen = generator.KeeperPasswordGenerator.create_from_policy(
+                    policy, length_override=pp_opts.word_count or length)
+            else:
+                gen = generator.KeeperPassphraseGenerator.create_with_options(
+                    policy,
+                    word_count=pp_opts.word_count if pp_opts.word_count is not None else length,
+                    separator=pp_opts.separator,
+                    capitalize=pp_opts.capitalize,
+                    append_number=pp_opts.append_number,
+                )
         elif algorithm == 'dice':
             if isinstance(length, int):
                 if length < 1:

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -2240,10 +2240,12 @@ class GenerateCommand(Command):
             policy = PasswordComplexityEnforcer.get_policy(params)
             word_count = length if length != 20 else None
             pp_separator = kwargs.get('pp_separator')
-            if isinstance(pp_separator, str) and pp_separator.lower() in ('space', 'sp'):
-                pp_separator = ' '
-            elif isinstance(pp_separator, str) and pp_separator:
-                pp_separator = pp_separator[0]
+            if isinstance(pp_separator, str) and pp_separator.strip():
+                pp_separator, pp_sep_error = generator._parse_passphrase_separator_token(
+                    pp_separator.strip())
+                if pp_sep_error:
+                    logging.error(pp_sep_error)
+                    return
             else:
                 pp_separator = None
             if policy and policy.get('passphrase-allow') is False:

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -43,7 +43,10 @@ from .. import api, rest_api, loginv3, crypto, utils, constants, error, vault_ex
 from ..breachwatch import BreachWatch
 from ..display import bcolors, post_login_summary
 from ..error import CommandError
-from ..generator import KeeperPasswordGenerator, DicewarePasswordGenerator, CryptoPassphraseGenerator
+from ..generator import (
+    KeeperPasswordGenerator, DicewarePasswordGenerator, CryptoPassphraseGenerator,
+    KeeperPassphraseGenerator, PASSPHRASE_SEPARATOR_HELP,
+)
 from ..params import KeeperParams, LAST_RECORD_UID, LAST_FOLDER_UID, LAST_SHARED_FOLDER_UID
 from ..proto import ssocloud_pb2, enterprise_pb2, APIRequest_pb2
 from ..security_audit import needs_security_audit, update_security_audit_data
@@ -402,6 +405,30 @@ random_group.add_argument(
 )
 
 passphrase_group = generate_parser.add_argument_group('Keeper Passphrase')
+passphrase_group.add_argument('--passphrase', dest='passphrase', action='store_true',
+                              help='Generate a vault-style passphrase from the EFF word list')
+passphrase_group.add_argument(
+    '--pp-separator', '-pps', dest='pp_separator', action='store',
+    help=f'Word separator (single character, or "space"). Allowed: {PASSPHRASE_SEPARATOR_HELP}. '
+         'Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-capitalize', '-ppc', dest='pp_capitalize', action='store_true',
+    help='Capitalize the first letter of each word. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-no-capitalize', dest='pp_capitalize', action='store_false',
+    help='Do not capitalize words. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-number', '-ppn', dest='pp_number', action='store_true',
+    help='Append a digit (0-9) to the first word only. Overrides enterprise policy for this command.'
+)
+passphrase_group.add_argument(
+    '--pp-no-number', dest='pp_number', action='store_false',
+    help='Do not append a digit to the first word. Overrides enterprise policy for this command.'
+)
+passphrase_group.set_defaults(pp_capitalize=None, pp_number=None)
 passphrase_group.add_argument('--recoveryphrase', dest='recoveryphrase', action='store_true',
                               help='Generate Generate a 24-word recovery phrase')
 
@@ -2208,7 +2235,29 @@ class GenerateCommand(Command):
 
         if kwargs.get('crypto') is True:
             kpg = CryptoPassphraseGenerator()
-        if kwargs.get('recoveryphrase') is True:
+        elif kwargs.get('passphrase') is True:
+            from ..enforcement import PasswordComplexityEnforcer
+            policy = PasswordComplexityEnforcer.get_policy(params)
+            word_count = length if length != 20 else None
+            pp_separator = kwargs.get('pp_separator')
+            if isinstance(pp_separator, str) and pp_separator.lower() in ('space', 'sp'):
+                pp_separator = ' '
+            elif isinstance(pp_separator, str) and pp_separator:
+                pp_separator = pp_separator[0]
+            else:
+                pp_separator = None
+            if policy and policy.get('passphrase-allow') is False:
+                logging.warning('Passphrase generation is disabled by enterprise policy; using random password.')
+                kpg = KeeperPasswordGenerator.create_from_policy(policy, length_override=word_count)
+            else:
+                kpg = KeeperPassphraseGenerator.create_with_options(
+                    policy,
+                    word_count=word_count,
+                    separator=pp_separator,
+                    capitalize=kwargs.get('pp_capitalize'),
+                    append_number=kwargs.get('pp_number'),
+                )
+        elif kwargs.get('recoveryphrase') is True:
             kpg = DicewarePasswordGenerator(24, word_list_file='bip-39.english.txt', delimiter=' ')
         elif isinstance(kwargs.get('dice_rolls'), int):
             dice_rolls = kwargs.get('dice_rolls')

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -25,6 +25,7 @@ from .params import KeeperParams
 from .error import KeeperApiError, CommandError
 from .generator import (
     DEFAULT_PASSPHRASE_WORD_COUNT, DEFAULT_PASSPHRASE_CAPITALIZE, DEFAULT_PASSPHRASE_NUMBER,
+    MAX_PASSPHRASE_WORD_COUNT,
     PP_SEPARATOR_CHARACTERS, _passphrase_separators_from_policy,
     format_passphrase_separators_for_display,
 )
@@ -469,6 +470,9 @@ class PasswordComplexityEnforcer:
         if len(words) < min_words:
             failures.append(
                 f'Passphrase must contain at least {min_words} words (got {len(words)}).')
+        if len(words) > MAX_PASSPHRASE_WORD_COUNT:
+            failures.append(
+                f'Passphrase must contain at most {MAX_PASSPHRASE_WORD_COUNT} words (got {len(words)}).')
 
         capitalize = bool(policy.get('passphrase-capitalize', DEFAULT_PASSPHRASE_CAPITALIZE))
         append_number = bool(policy.get('passphrase-number', DEFAULT_PASSPHRASE_NUMBER))

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -13,6 +13,7 @@ import itertools
 import json
 import logging
 import getpass
+import re
 import threading
 from datetime import datetime, timedelta
 from typing import Tuple, Optional, List, Dict, Any, Set
@@ -22,6 +23,11 @@ from .proto import APIRequest_pb2, record_pb2
 from .display import bcolors
 from .params import KeeperParams
 from .error import KeeperApiError, CommandError
+from .generator import (
+    DEFAULT_PASSPHRASE_WORD_COUNT, DEFAULT_PASSPHRASE_CAPITALIZE, DEFAULT_PASSPHRASE_NUMBER,
+    PP_SEPARATOR_CHARACTERS, _passphrase_separators_from_policy,
+    format_passphrase_separators_for_display,
+)
 
 
 def _find_enforcement_value(enforcements, key):
@@ -423,6 +429,78 @@ class PasswordComplexityEnforcer:
         return None
 
     @classmethod
+    def _normalize_passphrase_separators(cls, policy):   # type: (Dict[str, Any]) -> Optional[str]
+        raw = policy.get('passphrase-separator')
+        if isinstance(raw, str) and raw.strip():
+            allowed = _passphrase_separators_from_policy(raw.strip())
+            return allowed or None
+        return PP_SEPARATOR_CHARACTERS
+
+    @classmethod
+    def validate_passphrase(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
+        """Validate password as a vault-style passphrase per policy passphrase-* fields."""
+        failures = []   # type: List[str]
+        if policy.get('passphrase-allow') is False:
+            return failures
+
+        allowed_seps = cls._normalize_passphrase_separators(policy)
+        if not allowed_seps:
+            failures.append(
+                'Passphrase cannot meet separator criteria set by policy. '
+                f'Allowed: {format_passphrase_separators_for_display(PP_SEPARATOR_CHARACTERS)}.')
+            return failures
+
+        separator = next((ch for ch in allowed_seps if ch in password), None)
+        if separator is None:
+            # Allow CLI-selected separators even when not listed in policy.
+            separator = next((ch for ch in PP_SEPARATOR_CHARACTERS if ch in password), None)
+        if separator is None:
+            failures.append(
+                'Passphrase must contain an allowed separator character. '
+                f'Allowed: {format_passphrase_separators_for_display(PP_SEPARATOR_CHARACTERS)}.')
+            return failures
+
+        words = password.split(separator)
+        if not words or any(not word for word in words):
+            failures.append('Passphrase contains an empty word.')
+            return failures
+
+        min_words = _coerce_int(policy.get('passphrase-length')) or DEFAULT_PASSPHRASE_WORD_COUNT
+        if len(words) < min_words:
+            failures.append(
+                f'Passphrase must contain at least {min_words} words (got {len(words)}).')
+
+        capitalize = bool(policy.get('passphrase-capitalize', DEFAULT_PASSPHRASE_CAPITALIZE))
+        append_number = bool(policy.get('passphrase-number', DEFAULT_PASSPHRASE_NUMBER))
+
+        if capitalize:
+            word_re = re.compile(r'^[A-Z][a-z]{2,}$')
+            if append_number:
+                first_re = re.compile(r'^[A-Z][a-z]{2,}[0-9]$')
+            else:
+                first_re = re.compile(r'^[A-Z][a-z]{2,}[0-9]?$')
+        else:
+            word_re = re.compile(r'^[A-Za-z]{3,}$')
+            if append_number:
+                first_re = re.compile(r'^[A-Za-z]{3,}[0-9]$')
+            else:
+                first_re = re.compile(r'^[A-Za-z]{3,}[0-9]?$')
+
+        for index, word in enumerate(words):
+            pattern = first_re if index == 0 else word_re
+            if not pattern.match(word):
+                if index == 0 and append_number:
+                    failures.append('First passphrase word must end with a digit (0-9).')
+                elif capitalize:
+                    failures.append(
+                        'Each passphrase word must start with a capital letter and contain at least 3 letters.')
+                else:
+                    failures.append('Each passphrase word must contain at least 3 letters.')
+                break
+
+        return failures
+
+    @classmethod
     def validate_password(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
         failures = []   # type: List[str]
         if not policy or not isinstance(password, str) or not password:
@@ -454,7 +532,18 @@ class PasswordComplexityEnforcer:
                     failures.append(
                         f'Password must contain at least {required} special character(s) (got {count}).')
 
-        return failures
+        if not failures:
+            return []
+
+        # Vault re-validates as a passphrase when random password rules fail.
+        if policy.get('passphrase-allow') is False:
+            return failures
+
+        passphrase_failures = cls.validate_passphrase(password, policy)
+        if not passphrase_failures:
+            return []
+
+        return passphrase_failures
 
     @classmethod
     def validate_record(cls, params, source):   # type: (KeeperParams, Any) -> List[str]

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -15,7 +15,7 @@ import os
 import secrets
 import string
 from secrets import choice
-from typing import Optional, List, Iterator
+from typing import Optional, List, Iterator, Sequence
 from collections import namedtuple
 
 from . import crypto
@@ -24,8 +24,28 @@ from Cryptodome.Random.random import shuffle
 
 DEFAULT_PASSWORD_LENGTH = 20
 PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
+PP_SEPARATOR_CHARACTERS = '-._?! '
+DEFAULT_PASSPHRASE_SEPARATOR = '-'
+DEFAULT_PASSPHRASE_WORD_COUNT = 5
+DEFAULT_PASSPHRASE_CAPITALIZE = True
+DEFAULT_PASSPHRASE_NUMBER = True
+DEFAULT_DICEWARE_WORDLIST = 'diceware.wordlist.asc.txt'
+PASSPHRASE_SEPARATOR_HELP = '- . _ ? ! space'
+
+
+def format_passphrase_separators_for_display(separators=None):
+    # type: (Optional[str]) -> str
+    """Human-readable list of allowed passphrase separator characters."""
+    if not separators:
+        separators = PP_SEPARATOR_CHARACTERS
+    parts = []   # type: List[str]
+    for ch in separators:
+        parts.append('space' if ch == ' ' else ch)
+    return ', '.join(parts)
 
 PasswordStrength = namedtuple('PasswordStrength', 'length caps lower digits symbols')
+PassphraseGenOptions = namedtuple(
+    'PassphraseGenOptions', ('word_count', 'separator', 'capitalize', 'append_number'))
 
 
 def get_password_strength(password):  # type: (str) -> PasswordStrength
@@ -153,37 +173,133 @@ class KeeperPasswordGenerator(PasswordGenerator):
         )
 
 
+def _normalize_passphrase_separator(separator):
+    # type: (Optional[str]) -> str
+    if not separator:
+        return DEFAULT_PASSPHRASE_SEPARATOR
+    if separator == '\u2423':  # OPEN BOX (Vault UI glyph for space)
+        return ' '
+    return separator[0]
+
+
+def _passphrase_separators_from_policy(policy_sep):
+    # type: (str) -> str
+    """Return allowed separators in Vault order (see getPasswordRules.ts)."""
+    normalized = policy_sep.replace('\u2423', ' ')
+    allowed = ''
+    for ch in PP_SEPARATOR_CHARACTERS:
+        if ch in normalized:
+            allowed += ch
+    return allowed
+
+
+def _default_passphrase_separator_from_policy(policy_sep):
+    # type: (Optional[str]) -> str
+    """Pick the default generation separator matching Vault / PowerCommander."""
+    if not policy_sep or not isinstance(policy_sep, str) or not policy_sep.strip():
+        return DEFAULT_PASSPHRASE_SEPARATOR
+    allowed = _passphrase_separators_from_policy(policy_sep.strip())
+    return allowed[0] if allowed else DEFAULT_PASSPHRASE_SEPARATOR
+
+
+def _parse_gen_bool(value):
+    # type: (str) -> Optional[bool]
+    normalized = value.strip().lower()
+    if normalized in ('true', '1', 'yes', 'on'):
+        return True
+    if normalized in ('false', '0', 'no', 'off'):
+        return False
+    return None
+
+
+def parse_passphrase_gen_parameters(parameters):
+    # type: (Optional[Sequence[str]]) -> PassphraseGenOptions
+    """Parse $GEN:passphrase optional parameters.
+
+    Format: $GEN:passphrase[,word_count][,separator][,capitalize][,number]
+    Examples:
+        $GEN:passphrase,7
+        $GEN:passphrase,7,_
+        $GEN:passphrase,7,_,true,true
+        $GEN:passphrase,7,space,false,true
+    """
+    if not parameters:
+        return PassphraseGenOptions(None, None, None, None)
+
+    extras = [p.strip() for p in parameters if p.strip() and p.strip() != 'passphrase']
+    word_count = None
+    separator = None
+    capitalize = None
+    append_number = None
+    idx = 0
+
+    if idx < len(extras) and extras[idx].isdigit():
+        word_count = int(extras[idx])
+        idx += 1
+
+    if idx < len(extras):
+        candidate = extras[idx]
+        if _parse_gen_bool(candidate) is None:
+            if candidate.lower() in ('space', 'sp'):
+                separator = ' '
+            else:
+                separator = _normalize_passphrase_separator(candidate)
+            idx += 1
+
+    if idx < len(extras):
+        parsed = _parse_gen_bool(extras[idx])
+        if parsed is not None:
+            capitalize = parsed
+            idx += 1
+
+    if idx < len(extras):
+        parsed = _parse_gen_bool(extras[idx])
+        if parsed is not None:
+            append_number = parsed
+
+    return PassphraseGenOptions(word_count, separator, capitalize, append_number)
+
+
+def _resolve_wordlist_path(word_list_file=None):
+    # type: (Optional[str]) -> str
+    if word_list_file:
+        dice_path = os.path.join(os.path.dirname(__file__), 'resources', word_list_file)
+        if not os.path.isfile(dice_path):
+            dice_path = os.path.expanduser(word_list_file)
+    else:
+        dice_path = os.path.join(os.path.dirname(__file__), 'resources', DEFAULT_DICEWARE_WORDLIST)
+    return dice_path
+
+
+def _load_wordlist(word_list_file=None):
+    # type: (Optional[str]) -> List[str]
+    dice_path = _resolve_wordlist_path(word_list_file)
+    if not os.path.isfile(dice_path):
+        raise Exception(f'Word list file \"{dice_path}\" not found.')
+
+    vocabulary = []   # type: List[str]
+    unique_words = set()
+    with open(dice_path, 'r', encoding='utf-8') as dw:
+        for line in dw:
+            line = line.strip()
+            if not line or line.startswith('--'):
+                continue
+            if line.lower().startswith('source url:') or line.lower().startswith('title:'):
+                continue
+            parts = line.split()
+            word = parts[1] if len(parts) >= 2 else parts[0]
+            vocabulary.append(word)
+            unique_words.add(word.lower())
+    if len(vocabulary) != len(unique_words):
+        raise Exception(f'Word list file \"{dice_path}\" contains non-unique words.')
+    return vocabulary
+
+
 class DicewarePasswordGenerator(PasswordGenerator):
     def __init__(self, number_of_rolls, word_list_file=None, delimiter=' '):   # type: (int, Optional[str], str) -> None
         self._number_of_rolls = number_of_rolls if number_of_rolls > 0 else 5
         self.delimiter = delimiter
-
-        if word_list_file:
-            dice_path = os.path.join(os.path.dirname(__file__), 'resources', word_list_file)
-            if not os.path.isfile(dice_path):
-                dice_path = os.path.expanduser(word_list_file)
-        else:
-            dice_path = os.path.join(os.path.dirname(__file__), 'resources', 'diceware.wordlist.asc.txt')
-        self._vocabulary = None    # type: Optional[List[str]]
-        if os.path.isfile(dice_path):
-            with open(dice_path, 'r', encoding='utf-8') as dw:
-                self._vocabulary = []
-                line_count = 0
-                unique_words = set()
-                for line in dw.readlines():
-                    if not line:
-                        continue
-                    if line.startswith('--'):
-                        continue
-                    line_count += 1
-                    words = [x.strip() for x in line.split()]
-                    word = words[1] if len(words) >= 2 else words[0]
-                    self._vocabulary.append(word)
-                    unique_words.add(word.lower())
-                if line_count != len(unique_words):
-                    raise Exception(f'Word list file \"{dice_path}\" contains non-unique words.')
-        else:
-            raise Exception(f'Word list file \"{dice_path}\" not found.')
+        self._vocabulary = _load_wordlist(word_list_file)
 
     def generate(self):
         if not self._vocabulary:
@@ -192,6 +308,90 @@ class DicewarePasswordGenerator(PasswordGenerator):
         words = [secrets.choice(self._vocabulary) for _ in range(self._number_of_rolls)]
         shuffle(words)
         return self.delimiter.join(words)
+
+
+class KeeperPassphraseGenerator(PasswordGenerator):
+    """Vault-style passphrase generator using the bundled EFF large word list."""
+
+    def __init__(self, word_count=DEFAULT_PASSPHRASE_WORD_COUNT, separator=DEFAULT_PASSPHRASE_SEPARATOR,
+                 capitalize=DEFAULT_PASSPHRASE_CAPITALIZE, append_number=DEFAULT_PASSPHRASE_NUMBER,
+                 word_list_file=None):
+        # type: (int, str, bool, bool, Optional[str]) -> None
+        if isinstance(word_count, int):
+            if word_count < 1:
+                word_count = 1
+            elif word_count > 40:
+                word_count = 40
+        else:
+            word_count = DEFAULT_PASSPHRASE_WORD_COUNT
+        self.word_count = word_count
+        self.separator = _normalize_passphrase_separator(separator)
+        self.capitalize = capitalize
+        self.append_number = append_number
+        self._vocabulary = _load_wordlist(word_list_file)
+
+    def generate(self):
+        if not self._vocabulary:
+            raise Exception('Passphrase word list was not loaded')
+
+        passphrase = ''
+        first_word = True
+        for _ in range(self.word_count):
+            word = secrets.choice(self._vocabulary)
+            if self.capitalize and word:
+                word = word[0].upper() + word[1:]
+            if self.append_number and first_word:
+                word += str(secrets.randbelow(10))
+            if not first_word:
+                passphrase += self.separator
+            passphrase += word
+            first_word = False
+        return passphrase
+
+    @classmethod
+    def create_with_options(cls, policy=None, word_count=None, separator=None,
+                            capitalize=None, append_number=None):
+        # type: (Optional[dict], Optional[int], Optional[str], Optional[bool], Optional[bool]) -> KeeperPassphraseGenerator
+        """Build a generator from CLI/$GEN overrides with optional policy defaults."""
+        wc = word_count
+        if wc is None:
+            if policy:
+                wc = policy.get('passphrase-length', DEFAULT_PASSPHRASE_WORD_COUNT)
+            else:
+                wc = DEFAULT_PASSPHRASE_WORD_COUNT
+
+        sep = separator
+        if sep is not None and sep not in PP_SEPARATOR_CHARACTERS:
+            logging.warning(
+                'Ignoring invalid passphrase separator %r. Allowed: %s.',
+                sep, format_passphrase_separators_for_display())
+            sep = None
+        if sep is None:
+            if policy:
+                policy_sep = policy.get('passphrase-separator')
+                sep = _default_passphrase_separator_from_policy(
+                    policy_sep if isinstance(policy_sep, str) else None)
+            else:
+                sep = DEFAULT_PASSPHRASE_SEPARATOR
+
+        cap = capitalize
+        if cap is None:
+            cap = DEFAULT_PASSPHRASE_CAPITALIZE
+
+        num = append_number
+        if num is None:
+            num = DEFAULT_PASSPHRASE_NUMBER
+
+        return cls(word_count=wc, separator=sep, capitalize=cap, append_number=num)
+
+    @classmethod
+    def create_from_policy(cls, policy, length_override=None, separator_override=None):
+        # type: (dict, Optional[int], Optional[str]) -> KeeperPassphraseGenerator
+        return cls.create_with_options(
+            policy,
+            word_count=length_override,
+            separator=separator_override,
+        )
 
 
 class CryptoPassphraseGenerator(PasswordGenerator):

--- a/keepercommander/generator.py
+++ b/keepercommander/generator.py
@@ -9,13 +9,14 @@
 #
 
 import abc
+import difflib
 import hashlib
 import logging
 import os
 import secrets
 import string
 from secrets import choice
-from typing import Optional, List, Iterator, Sequence
+from typing import Optional, List, Iterator, Sequence, Tuple
 from collections import namedtuple
 
 from . import crypto
@@ -27,10 +28,30 @@ PW_SPECIAL_CHARACTERS = '!@#$%()+;<>=?[]{}^.,'
 PP_SEPARATOR_CHARACTERS = '-._?! '
 DEFAULT_PASSPHRASE_SEPARATOR = '-'
 DEFAULT_PASSPHRASE_WORD_COUNT = 5
+MIN_PASSPHRASE_WORD_COUNT = 5
+MAX_PASSPHRASE_WORD_COUNT = 9
 DEFAULT_PASSPHRASE_CAPITALIZE = True
 DEFAULT_PASSPHRASE_NUMBER = True
+GEN_PASSWORD_ALGORITHMS = ('rand', 'dice', 'crypto', 'passphrase')
 DEFAULT_DICEWARE_WORDLIST = 'diceware.wordlist.asc.txt'
 PASSPHRASE_SEPARATOR_HELP = '- . _ ? ! space'
+
+
+def clamp_passphrase_word_count(word_count):
+    # type: (Optional[int]) -> int
+    """Clamp passphrase word count to the Vault range (5-9 words)."""
+    if not isinstance(word_count, int):
+        return DEFAULT_PASSPHRASE_WORD_COUNT
+    original = word_count
+    if word_count < MIN_PASSPHRASE_WORD_COUNT:
+        word_count = MIN_PASSPHRASE_WORD_COUNT
+    elif word_count > MAX_PASSPHRASE_WORD_COUNT:
+        word_count = MAX_PASSPHRASE_WORD_COUNT
+    if word_count != original:
+        logging.warning(
+            'Passphrase word count must be between %d and %d; using %d.',
+            MIN_PASSPHRASE_WORD_COUNT, MAX_PASSPHRASE_WORD_COUNT, word_count)
+    return word_count
 
 
 def format_passphrase_separators_for_display(separators=None):
@@ -202,6 +223,25 @@ def _default_passphrase_separator_from_policy(policy_sep):
     return allowed[0] if allowed else DEFAULT_PASSPHRASE_SEPARATOR
 
 
+def resolve_gen_password_algorithm(parameters):
+    # type: (Optional[Sequence[str]]) -> Tuple[Optional[str], Optional[str]]
+    """Resolve $GEN password algorithm; return (algorithm, error_message)."""
+    if not parameters:
+        return 'rand', None
+    first = parameters[0].strip()
+    first_lower = first.lower()
+    if first_lower in GEN_PASSWORD_ALGORITHMS:
+        return first_lower, None
+    if first.isdigit():
+        return 'rand', None
+    suggestions = difflib.get_close_matches(first_lower, GEN_PASSWORD_ALGORITHMS, n=1, cutoff=0.6)
+    message = f'Unknown $GEN password algorithm "{first}".'
+    if suggestions:
+        message += f' Did you mean "{suggestions[0]}"?'
+    message += f' Valid algorithms: {", ".join(GEN_PASSWORD_ALGORITHMS)}.'
+    return None, message
+
+
 def _parse_gen_bool(value):
     # type: (str) -> Optional[bool]
     normalized = value.strip().lower()
@@ -212,52 +252,105 @@ def _parse_gen_bool(value):
     return None
 
 
+def _is_strict_gen_bool_token(value):
+    # type: (str) -> bool
+    return value.strip().lower() in ('true', 'false')
+
+
+def _parse_gen_bool_strict(value, param_name):
+    # type: (str, str) -> Tuple[Optional[bool], Optional[str]]
+    normalized = value.strip().lower()
+    if normalized == 'true':
+        return True, None
+    if normalized == 'false':
+        return False, None
+    return None, (
+        f'Invalid $GEN:passphrase {param_name} parameter "{value}". '
+        f'Expected true or false.')
+
+
+def _is_passphrase_separator_token(token):
+    # type: (str) -> bool
+    if token.lower() in ('space', 'sp'):
+        return True
+    return len(token) == 1 and token in PP_SEPARATOR_CHARACTERS
+
+
+def _parse_passphrase_separator_token(token):
+    # type: (str) -> Tuple[Optional[str], Optional[str]]
+    if token.lower() in ('space', 'sp'):
+        return ' ', None
+    if len(token) == 1 and token in PP_SEPARATOR_CHARACTERS:
+        return token, None
+    return None, (
+        f'Invalid passphrase separator "{token}". '
+        f'Allowed: {format_passphrase_separators_for_display(PP_SEPARATOR_CHARACTERS)}.')
+
+
 def parse_passphrase_gen_parameters(parameters):
-    # type: (Optional[Sequence[str]]) -> PassphraseGenOptions
+    # type: (Optional[Sequence[str]]) -> Tuple[PassphraseGenOptions, Optional[str]]
     """Parse $GEN:passphrase optional parameters.
 
     Format: $GEN:passphrase[,word_count][,separator][,capitalize][,number]
-    Examples:
-        $GEN:passphrase,7
-        $GEN:passphrase,7,_
-        $GEN:passphrase,7,_,true,true
-        $GEN:passphrase,7,space,false,true
+    word_count must be between 5 and 9 (Vault range).
     """
+    empty = PassphraseGenOptions(None, None, None, None)
     if not parameters:
-        return PassphraseGenOptions(None, None, None, None)
+        return empty, None
 
-    extras = [p.strip() for p in parameters if p.strip() and p.strip() != 'passphrase']
+    tokens = [p if isinstance(p, str) else str(p) for p in parameters]
+    if not tokens or tokens[0].strip().lower() != 'passphrase':
+        return empty, None
+
+    extras = tokens[1:]
+    if any(t.strip() == '' for t in extras):
+        return empty, (
+            'Incomplete $GEN:passphrase parameters: missing value after comma. '
+            'Format: $GEN:passphrase[,word_count][,separator][,capitalize][,number]')
+
     word_count = None
     separator = None
     capitalize = None
     append_number = None
     idx = 0
 
-    if idx < len(extras) and extras[idx].isdigit():
-        word_count = int(extras[idx])
+    if idx < len(extras):
+        token = extras[idx].strip()
+        if token.isdigit():
+            word_count = int(token)
+            if word_count < MIN_PASSPHRASE_WORD_COUNT or word_count > MAX_PASSPHRASE_WORD_COUNT:
+                return empty, (
+                    f'Passphrase word count must be between {MIN_PASSPHRASE_WORD_COUNT} '
+                    f'and {MAX_PASSPHRASE_WORD_COUNT} (got {word_count}).')
+            idx += 1
+        elif not _is_passphrase_separator_token(token) and not _is_strict_gen_bool_token(token):
+            return empty, (
+                f'Invalid passphrase word count "{token}". '
+                f'Expected an integer between {MIN_PASSPHRASE_WORD_COUNT} '
+                f'and {MAX_PASSPHRASE_WORD_COUNT}.')
+
+    if idx < len(extras) and not _is_strict_gen_bool_token(extras[idx].strip()):
+        separator, sep_error = _parse_passphrase_separator_token(extras[idx].strip())
+        if sep_error:
+            return empty, sep_error
         idx += 1
 
     if idx < len(extras):
-        candidate = extras[idx]
-        if _parse_gen_bool(candidate) is None:
-            if candidate.lower() in ('space', 'sp'):
-                separator = ' '
-            else:
-                separator = _normalize_passphrase_separator(candidate)
-            idx += 1
+        capitalize, cap_error = _parse_gen_bool_strict(extras[idx].strip(), 'capitalize')
+        if cap_error:
+            return empty, cap_error
+        idx += 1
 
     if idx < len(extras):
-        parsed = _parse_gen_bool(extras[idx])
-        if parsed is not None:
-            capitalize = parsed
-            idx += 1
+        append_number, num_error = _parse_gen_bool_strict(extras[idx].strip(), 'number')
+        if num_error:
+            return empty, num_error
+        idx += 1
 
     if idx < len(extras):
-        parsed = _parse_gen_bool(extras[idx])
-        if parsed is not None:
-            append_number = parsed
+        return empty, f'Unexpected $GEN:passphrase parameter "{extras[idx].strip()}".'
 
-    return PassphraseGenOptions(word_count, separator, capitalize, append_number)
+    return PassphraseGenOptions(word_count, separator, capitalize, append_number), None
 
 
 def _resolve_wordlist_path(word_list_file=None):
@@ -317,14 +410,8 @@ class KeeperPassphraseGenerator(PasswordGenerator):
                  capitalize=DEFAULT_PASSPHRASE_CAPITALIZE, append_number=DEFAULT_PASSPHRASE_NUMBER,
                  word_list_file=None):
         # type: (int, str, bool, bool, Optional[str]) -> None
-        if isinstance(word_count, int):
-            if word_count < 1:
-                word_count = 1
-            elif word_count > 40:
-                word_count = 40
-        else:
-            word_count = DEFAULT_PASSPHRASE_WORD_COUNT
-        self.word_count = word_count
+        self.word_count = clamp_passphrase_word_count(
+            word_count if isinstance(word_count, int) else DEFAULT_PASSPHRASE_WORD_COUNT)
         self.separator = _normalize_passphrase_separator(separator)
         self.capitalize = capitalize
         self.append_number = append_number
@@ -361,11 +448,6 @@ class KeeperPassphraseGenerator(PasswordGenerator):
                 wc = DEFAULT_PASSPHRASE_WORD_COUNT
 
         sep = separator
-        if sep is not None and sep not in PP_SEPARATOR_CHARACTERS:
-            logging.warning(
-                'Ignoring invalid passphrase separator %r. Allowed: %s.',
-                sep, format_passphrase_separators_for_display())
-            sep = None
         if sep is None:
             if policy:
                 policy_sep = policy.get('passphrase-separator')
@@ -382,7 +464,9 @@ class KeeperPassphraseGenerator(PasswordGenerator):
         if num is None:
             num = DEFAULT_PASSPHRASE_NUMBER
 
-        return cls(word_count=wc, separator=sep, capitalize=cap, append_number=num)
+        return cls(
+            word_count=clamp_passphrase_word_count(wc) if isinstance(wc, int) else wc,
+            separator=sep, capitalize=cap, append_number=num)
 
     @classmethod
     def create_from_policy(cls, policy, length_override=None, separator_override=None):

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+
+from keepercommander.enforcement import PasswordComplexityEnforcer
+
+
+STRICT_RANDOM_POLICY = {
+    'length': 8,
+    'upper-use': True,
+    'upper-min': 5,
+    'digit-use': True,
+    'digit-min': 3,
+    'passphrase-allow': True,
+    'passphrase-length': 5,
+    'passphrase-capitalize': False,
+    'passphrase-number': False,
+    'passphrase-separator': '-',
+}
+
+
+class TestPassphraseEnforcement(TestCase):
+
+    def test_passphrase_accepted_when_random_rules_fail(self):
+        password = 'alpha-bravo-charlie-delta-echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
+        self.assertEqual(failures, [])
+
+    def test_passphrase_with_capitalized_words_and_one_digit_accepted(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy.update({
+            'passphrase-length': 7,
+            'passphrase-capitalize': True,
+            'passphrase-number': True,
+            'passphrase-separator': '_',
+        })
+        password = 'Alpha7_Bravo_Charlie_Delta_Echo_Foxtrot_Golf'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_random_rules_apply_when_passphrase_disabled(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-allow'] = False
+        password = 'alpha-bravo-charlie-delta-echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('uppercase' in f for f in failures))
+        self.assertTrue(any('digit' in f for f in failures))
+
+    def test_passphrase_with_cli_style_digit_when_policy_number_off(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-number'] = False
+        password = 'Alpha7_Bravo_Charlie_Delta_Echo_Foxtrot_Golf'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_passphrase_accepts_underscore_separator_not_in_policy(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy['passphrase-separator'] = '-'
+        password = 'alpha_bravo_charlie_delta_echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertEqual(failures, [])
+
+    def test_invalid_separator_error_lists_allowed_characters(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        password = 'alpha~bravo~charlie~delta~echo'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('Allowed:' in f and 'space' in f for f in failures))
+
+    def test_invalid_passphrase_returns_passphrase_errors(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        password = 'ab-cd-ef'
+        failures = PasswordComplexityEnforcer.validate_password(password, policy)
+        self.assertTrue(any('word' in f.lower() for f in failures))
+
+    def test_random_password_still_validated(self):
+        password = 'ABCDE123!!!'
+        failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
+        self.assertEqual(failures, [])

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -70,6 +70,14 @@ class TestPassphraseEnforcement(TestCase):
         failures = PasswordComplexityEnforcer.validate_password(password, policy)
         self.assertTrue(any('word' in f.lower() for f in failures))
 
+    def test_passphrase_rejects_more_than_nine_words(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        password = '-'.join(
+            ['alpha', 'bravo', 'charlie', 'delta', 'echo',
+             'foxtrot', 'golf', 'hotel', 'india', 'juliet'])
+        failures = PasswordComplexityEnforcer.validate_passphrase(password, policy)
+        self.assertTrue(any('at most 9 words' in f for f in failures))
+
     def test_random_password_still_validated(self):
         password = 'ABCDE123!!!'
         failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -1,0 +1,124 @@
+from unittest import TestCase, mock
+
+from keepercommander import generator
+
+
+class TestKeeperPassphraseGenerator(TestCase):
+
+  def test_default_generates_five_hyphen_separated_words(self):
+    gen = generator.KeeperPassphraseGenerator()
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
+      with mock.patch('secrets.randbelow', return_value=3):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha3-Bravo-Charlie-Delta-Echo')
+
+  def test_does_not_shuffle_words_like_diceware(self):
+    gen = generator.KeeperPassphraseGenerator(
+      word_count=3, separator=' ', capitalize=False, append_number=False)
+    with mock.patch('secrets.choice', side_effect=['one', 'two', 'three']):
+      result = gen.generate()
+    self.assertEqual(result, 'one two three')
+
+  def test_capitalize_and_number_apply_to_first_word_only(self):
+    gen = generator.KeeperPassphraseGenerator(
+      word_count=2, separator='-', capitalize=True, append_number=True)
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+      with mock.patch('secrets.randbelow', return_value=7):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha7-Bravo')
+
+  def test_create_from_policy_honors_passphrase_fields(self):
+    gen = generator.KeeperPassphraseGenerator.create_from_policy({
+      'passphrase-length': 3,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': True,
+      'passphrase-number': True,
+    })
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+      with mock.patch('secrets.randbelow', return_value=4):
+        result = gen.generate()
+    self.assertEqual(result, 'Alpha4-Bravo-Charlie')
+
+  def test_parse_passphrase_gen_parameters(self):
+    opts = generator.parse_passphrase_gen_parameters(['passphrase', '7', '_', 'true', 'false'])
+    self.assertEqual(opts.word_count, 7)
+    self.assertEqual(opts.separator, '_')
+    self.assertTrue(opts.capitalize)
+    self.assertFalse(opts.append_number)
+
+  def test_create_with_options_overrides_policy(self):
+    policy = {
+      'passphrase-length': 5,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    }
+    gen = generator.KeeperPassphraseGenerator.create_with_options(
+      policy, word_count=3, separator='_', capitalize=True, append_number=True)
+    self.assertEqual(gen.word_count, 3)
+    self.assertEqual(gen.separator, '_')
+    self.assertTrue(gen.capitalize)
+    self.assertTrue(gen.append_number)
+
+  def test_commander_defaults_override_policy_capitalize_and_number(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options({
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    })
+    self.assertTrue(gen.capitalize)
+    self.assertTrue(gen.append_number)
+
+  def test_policy_separator_uses_vault_order_not_raw_first_char(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options({
+      'passphrase-separator': '!._?-',
+    })
+    self.assertEqual(gen.separator, '-')
+
+  def test_invalid_separator_override_falls_back_to_default(self):
+    gen = generator.KeeperPassphraseGenerator.create_with_options(
+      None, separator='~', word_count=3)
+    self.assertEqual(gen.separator, '-')
+
+  def test_loads_bundled_eff_wordlist(self):
+    words = generator._load_wordlist()
+    self.assertEqual(len(words), 7776)
+    self.assertEqual(words[0], 'abacus')
+
+
+class TestGeneratePasswordPassphrase(TestCase):
+
+  def test_record_edit_generate_password_passphrase(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
+      with mock.patch('secrets.randbelow', return_value=5):
+        result = RecordEditMixin.generate_password(['passphrase'])
+    self.assertEqual(result, 'Alpha5-Bravo-Charlie-Delta-Echo')
+
+  def test_record_edit_passphrase_uses_policy_when_allowed(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    policy = {
+      'passphrase-allow': True,
+      'passphrase-length': 2,
+      'passphrase-separator': '_',
+      'passphrase-capitalize': True,
+      'passphrase-number': False,
+    }
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+      with mock.patch('secrets.randbelow', return_value=4):
+        result = RecordEditMixin.generate_password(['passphrase'], policy=policy)
+    self.assertEqual(result, 'Alpha4_Bravo')
+
+  def test_record_edit_passphrase_cli_overrides_policy(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    policy = {
+      'passphrase-allow': True,
+      'passphrase-length': 2,
+      'passphrase-separator': '-',
+      'passphrase-capitalize': False,
+      'passphrase-number': False,
+    }
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+      with mock.patch('secrets.randbelow', return_value=9):
+        result = RecordEditMixin.generate_password(
+          ['passphrase', '3', '_', 'true', 'true'], policy=policy)
+    self.assertEqual(result, 'Alpha9_Bravo_Charlie')

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -109,9 +109,14 @@ class TestKeeperPassphraseGenerator(TestCase):
     self.assertEqual(generator.clamp_passphrase_word_count(2), 5)
     self.assertEqual(generator.clamp_passphrase_word_count(9), 9)
     self.assertEqual(generator.clamp_passphrase_word_count(12), 9)
-    with self.assertLogs('root', level='WARNING') as logs:
+
+  def test_word_count_clamp_logs_warning(self):
+    with mock.patch('keepercommander.generator.logging.warning') as mock_warning:
       generator.clamp_passphrase_word_count(12)
-    self.assertIn('between 5 and 9', logs.output[0])
+    mock_warning.assert_called_once()
+    args, _ = mock_warning.call_args
+    self.assertIn('between', args[0])
+    self.assertEqual(args[1:], (5, 9, 9))
 
   def test_loads_bundled_eff_wordlist(self):
     words = generator._load_wordlist()

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -14,37 +14,63 @@ class TestKeeperPassphraseGenerator(TestCase):
 
   def test_does_not_shuffle_words_like_diceware(self):
     gen = generator.KeeperPassphraseGenerator(
-      word_count=3, separator=' ', capitalize=False, append_number=False)
-    with mock.patch('secrets.choice', side_effect=['one', 'two', 'three']):
+      word_count=5, separator=' ', capitalize=False, append_number=False)
+    with mock.patch('secrets.choice', side_effect=['one', 'two', 'three', 'four', 'five']):
       result = gen.generate()
-    self.assertEqual(result, 'one two three')
+    self.assertEqual(result, 'one two three four five')
 
   def test_capitalize_and_number_apply_to_first_word_only(self):
     gen = generator.KeeperPassphraseGenerator(
-      word_count=2, separator='-', capitalize=True, append_number=True)
-    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+      word_count=5, separator='-', capitalize=True, append_number=True)
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
       with mock.patch('secrets.randbelow', return_value=7):
         result = gen.generate()
-    self.assertEqual(result, 'Alpha7-Bravo')
+    self.assertEqual(result, 'Alpha7-Bravo-Charlie-Delta-Echo')
 
   def test_create_from_policy_honors_passphrase_fields(self):
     gen = generator.KeeperPassphraseGenerator.create_from_policy({
-      'passphrase-length': 3,
+      'passphrase-length': 5,
       'passphrase-separator': '-',
       'passphrase-capitalize': True,
       'passphrase-number': True,
     })
-    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
       with mock.patch('secrets.randbelow', return_value=4):
         result = gen.generate()
-    self.assertEqual(result, 'Alpha4-Bravo-Charlie')
+    self.assertEqual(result, 'Alpha4-Bravo-Charlie-Delta-Echo')
 
   def test_parse_passphrase_gen_parameters(self):
-    opts = generator.parse_passphrase_gen_parameters(['passphrase', '7', '_', 'true', 'false'])
+    opts, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '7', '_', 'true', 'false'])
+    self.assertIsNone(error)
     self.assertEqual(opts.word_count, 7)
     self.assertEqual(opts.separator, '_')
     self.assertTrue(opts.capitalize)
     self.assertFalse(opts.append_number)
+
+  def test_parse_passphrase_rejects_invalid_separator(self):
+    _, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '7', '@', 'true', 'true'])
+    self.assertIn('Invalid passphrase separator', error)
+
+  def test_parse_passphrase_rejects_invalid_boolean(self):
+    _, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '7', '_', 'tr', 'true'])
+    self.assertIn('capitalize', error)
+
+  def test_parse_passphrase_rejects_trailing_comma(self):
+    _, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '9', '_', 'true', ''])
+    self.assertIn('missing value after comma', error)
+
+  def test_parse_passphrase_rejects_extra_parameters(self):
+    _, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '7', '_', 'true', 'true', 'test'])
+    self.assertIn('Unexpected', error)
+
+  def test_parse_passphrase_rejects_out_of_range_word_count(self):
+    _, error = generator.parse_passphrase_gen_parameters(['passphrase', '12'])
+    self.assertIn('between 5 and 9', error)
 
   def test_create_with_options_overrides_policy(self):
     policy = {
@@ -55,7 +81,7 @@ class TestKeeperPassphraseGenerator(TestCase):
     }
     gen = generator.KeeperPassphraseGenerator.create_with_options(
       policy, word_count=3, separator='_', capitalize=True, append_number=True)
-    self.assertEqual(gen.word_count, 3)
+    self.assertEqual(gen.word_count, 5)
     self.assertEqual(gen.separator, '_')
     self.assertTrue(gen.capitalize)
     self.assertTrue(gen.append_number)
@@ -74,15 +100,33 @@ class TestKeeperPassphraseGenerator(TestCase):
     })
     self.assertEqual(gen.separator, '-')
 
-  def test_invalid_separator_override_falls_back_to_default(self):
-    gen = generator.KeeperPassphraseGenerator.create_with_options(
-      None, separator='~', word_count=3)
-    self.assertEqual(gen.separator, '-')
+  def test_invalid_separator_override_is_rejected_by_parser(self):
+    _, error = generator.parse_passphrase_gen_parameters(
+      ['passphrase', '7', '~', 'true', 'true'])
+    self.assertIn('Invalid passphrase separator', error)
+
+  def test_word_count_clamped_to_vault_range(self):
+    self.assertEqual(generator.clamp_passphrase_word_count(2), 5)
+    self.assertEqual(generator.clamp_passphrase_word_count(9), 9)
+    self.assertEqual(generator.clamp_passphrase_word_count(12), 9)
+    with self.assertLogs('root', level='WARNING') as logs:
+      generator.clamp_passphrase_word_count(12)
+    self.assertIn('between 5 and 9', logs.output[0])
 
   def test_loads_bundled_eff_wordlist(self):
     words = generator._load_wordlist()
     self.assertEqual(len(words), 7776)
     self.assertEqual(words[0], 'abacus')
+
+  def test_resolve_gen_password_algorithm_rejects_typos(self):
+    algorithm, error = generator.resolve_gen_password_algorithm(['passphra'])
+    self.assertIsNone(algorithm)
+    self.assertIn('passphrase', error)
+
+  def test_resolve_gen_password_algorithm_accepts_numeric_length(self):
+    algorithm, error = generator.resolve_gen_password_algorithm(['16'])
+    self.assertEqual(algorithm, 'rand')
+    self.assertIsNone(error)
 
 
 class TestGeneratePasswordPassphrase(TestCase):
@@ -91,34 +135,89 @@ class TestGeneratePasswordPassphrase(TestCase):
     from keepercommander.commands.record_edit import RecordEditMixin
     with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
       with mock.patch('secrets.randbelow', return_value=5):
-        result = RecordEditMixin.generate_password(['passphrase'])
+        result, error = RecordEditMixin.generate_password(['passphrase'])
+    self.assertIsNone(error)
     self.assertEqual(result, 'Alpha5-Bravo-Charlie-Delta-Echo')
 
   def test_record_edit_passphrase_uses_policy_when_allowed(self):
     from keepercommander.commands.record_edit import RecordEditMixin
     policy = {
       'passphrase-allow': True,
-      'passphrase-length': 2,
+      'passphrase-length': 5,
       'passphrase-separator': '_',
       'passphrase-capitalize': True,
       'passphrase-number': False,
     }
-    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo']):
+    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie', 'delta', 'echo']):
       with mock.patch('secrets.randbelow', return_value=4):
-        result = RecordEditMixin.generate_password(['passphrase'], policy=policy)
-    self.assertEqual(result, 'Alpha4_Bravo')
+        result, error = RecordEditMixin.generate_password(['passphrase'], policy=policy)
+    self.assertIsNone(error)
+    self.assertEqual(result, 'Alpha4_Bravo_Charlie_Delta_Echo')
 
   def test_record_edit_passphrase_cli_overrides_policy(self):
     from keepercommander.commands.record_edit import RecordEditMixin
     policy = {
       'passphrase-allow': True,
-      'passphrase-length': 2,
+      'passphrase-length': 5,
       'passphrase-separator': '-',
       'passphrase-capitalize': False,
       'passphrase-number': False,
     }
-    with mock.patch('secrets.choice', side_effect=['alpha', 'bravo', 'charlie']):
+    with mock.patch('secrets.choice', side_effect=[
+        'alpha', 'bravo', 'charlie', 'delta', 'echo']):
       with mock.patch('secrets.randbelow', return_value=9):
-        result = RecordEditMixin.generate_password(
-          ['passphrase', '3', '_', 'true', 'true'], policy=policy)
-    self.assertEqual(result, 'Alpha9_Bravo_Charlie')
+        result, error = RecordEditMixin.generate_password(
+          ['passphrase', '5', '_', 'true', 'true'], policy=policy)
+    self.assertIsNone(error)
+    self.assertEqual(result, 'Alpha9_Bravo_Charlie_Delta_Echo')
+
+  def test_unknown_gen_algorithm_returns_error(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    result, error = RecordEditMixin.generate_password(['passphra'])
+    self.assertIsNone(result)
+    self.assertIn('passphrase', error)
+
+  def test_password_label_gen_syntax_warning(self):
+    from keepercommander.commands.record_edit import RecordEditMixin, ParsedFieldValue
+    mixin = RecordEditMixin()
+    parsed = ParsedFieldValue('', '', 'Password', '$GEN:passphrase')
+    self.assertTrue(mixin.warn_wrong_password_gen_field(parsed))
+    self.assertEqual(len(mixin.errors), 1)
+    self.assertIn('password=', mixin.errors[0])
+
+  def test_invalid_gen_algorithm_aborts_record_add(self):
+    from keepercommander.commands.record_edit import RecordAddCommand, ParsedFieldValue
+    from keepercommander import vault
+    cmd = RecordAddCommand()
+    record = vault.TypedRecord()
+    record.type_name = 'login'
+    record.fields.append(vault.TypedField.new_field('login', '', ''))
+    record.fields.append(vault.TypedField.new_field('password', '', ''))
+    cmd.assign_typed_fields(record, [
+      ParsedFieldValue('', 'login', '', 'my@email.com'),
+      ParsedFieldValue('', 'password', '', '$GEN:passphra'),
+    ])
+    self.assertEqual(len(cmd.errors), 1)
+    self.assertIn('passphrase', cmd.errors[0])
+
+  def test_invalid_passphrase_separator_aborts_generation(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    result, error = RecordEditMixin.generate_password(
+      ['passphrase', '7', '@', 'true', 'true'])
+    self.assertIsNone(result)
+    self.assertIn('Invalid passphrase separator', error)
+
+  def test_invalid_passphrase_boolean_aborts_generation(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    result, error = RecordEditMixin.generate_password(
+      ['passphrase', '7', '_', 'test', 'true'])
+    self.assertIsNone(result)
+    self.assertIn('capitalize', error)
+
+  def test_trailing_comma_aborts_generation(self):
+    from keepercommander.commands.record_edit import RecordEditMixin
+    action_params = []
+    RecordEditMixin.is_generate_value('$GEN:passphrase,9,_,true,', action_params)
+    result, error = RecordEditMixin.generate_password(action_params)
+    self.assertIsNone(result)
+    self.assertIn('missing value after comma', error)


### PR DESCRIPTION
### Summary

Added Vault-style passphrase generation to Commander using the bundled EFF word list, with support on generate --passphrase, $GEN:passphrase on record commands (including NSF), optional CLI overrides for word count/separator/capitals/digit,and Vault-aligned passphrase validation so valid passphrases are accepted on record add/update without --force.

### Changes

- Added KeeperPassphraseGenerator in generator.py using the bundled EFF word list (7776 words), matching Vault behavior: pick-order words, configurable separator, optional capitalization per word, optional single digit on the first word only; word count limited to 5–9
- Added $GEN:passphrase to record-add, record-update, nsf-record-add, and nsf-record-update via RecordEditMixin.generate_password(), with optional parameters: word_count[,separator][,capitalize][,number]
- Added generate --passphrase and passphrase CLI overrides: --pp-separator, --pp-capitalize / --pp-no-capitalize, --pp-number / --pp-no-number; --count sets word count in passphrase mode
- Integrated enterprise GENERATED_PASSWORD_COMPLEXITY passphrase-* fields for word count and separator; Commander defaults capitals and digit on unless CLI explicitly disables them; fall back to random password with a warning when passphrase-allow is false
- Normalized passphrase-separator policy to Vault order (-._?! space); reject invalid separator overrides at generation with allowed-char list in errors and help
- Added Vault-aligned passphrase validation in PasswordComplexityEnforcer: re-validate as a passphrase when random-password rules fail; accept valid passphrases without --force
- Strict $GEN validation: reject unknown algorithms, invalid/partial booleans (tr, test), invalid separators (*, @), out-of-range word counts, trailing commas, and extra parameters; abort record commands on syntax errors (including with --force)
- Warn when Password= is used instead of lowercase password= for $GEN fields
- Refactored DicewarePasswordGenerator to share word-list loading; left $GEN:dice behavior unchanged
- Added/expanded unit tests in test_passphrase_generator.py and test_passphrase_enforcement.py