### PR TITLE
KC-1313 Add domain user match to PAM domain configuration

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2353,6 +2353,19 @@ class PamConfigurationEditMixin(RecordEditMixin):
                 rec = recs[0]
         return rec
 
+    @staticmethod
+    def _domain_kwarg_supplied(kwargs, key, config_edit):
+        """Return whether a domain text kwarg should be applied to the record.
+
+        pam config new only sets non-empty values; omitted or empty strings are skipped.
+        pam config edit must support unsetting: an explicit empty string clears the field,
+        while a missing kwarg (None) leaves the existing value unchanged.
+        """
+        val = kwargs.get(key)
+        if config_edit:
+            return val is not None
+        return bool(val)
+
     def parse_properties(self, params, record, **kwargs):  # type: (KeeperParams, vault.TypedRecord, ...) -> None
         extra_properties = []
         self.parse_pam_configuration(params, record, **kwargs)
@@ -2431,14 +2444,35 @@ class PamConfigurationEditMixin(RecordEditMixin):
                 rg = '\n'.join(resource_groups)
                 extra_properties.append(f'multiline.resourceGroups={rg}')
         elif record.record_type == 'pamDomainConfiguration':
+            config_edit = kwargs.get('config_edit', False) is True
             domain_id = kwargs.get('domain_id')
-            if domain_id:
+            if self._domain_kwarg_supplied(kwargs, 'domain_id', config_edit):
                 extra_properties.append(f'text.pamDomainId={domain_id}')
-            host = str(kwargs.get('domain_hostname') or '').strip()
-            port = str(kwargs.get('domain_port') or '').strip()
-            if host or port:
-                val = json.dumps({"hostName": host, "port": port})
-                extra_properties.append(f"f.pamHostname=$JSON:{val}")
+            domain_hostname = kwargs.get('domain_hostname')
+            domain_port = kwargs.get('domain_port')
+            if config_edit:
+                if domain_hostname is not None or domain_port is not None:
+                    existing_host = ''
+                    existing_port = ''
+                    pam_host_field = record.get_typed_field('pamHostname')
+                    if pam_host_field:
+                        current = pam_host_field.get_default_value(dict) or {}
+                        if isinstance(current, dict):
+                            existing_host = str(current.get('hostName') or '').strip()
+                            existing_port = str(current.get('port') or '').strip()
+                    host = str(domain_hostname or '').strip() if domain_hostname is not None else existing_host
+                    port = str(domain_port or '').strip() if domain_port is not None else existing_port
+                    if host or port:
+                        val = json.dumps({"hostName": host, "port": port})
+                        extra_properties.append(f"f.pamHostname=$JSON:{val}")
+                    else:
+                        extra_properties.append('f.pamHostname=')
+            else:
+                host = str(domain_hostname or '').strip()
+                port = str(domain_port or '').strip()
+                if host or port:
+                    val = json.dumps({"hostName": host, "port": port})
+                    extra_properties.append(f"f.pamHostname=$JSON:{val}")
             domain_use_ssl = utils.value_to_boolean(kwargs.get('domain_use_ssl'))
             if domain_use_ssl is not None:
                 val = 'true' if domain_use_ssl else 'false'
@@ -2448,10 +2482,10 @@ class PamConfigurationEditMixin(RecordEditMixin):
                 val = 'true' if domain_scan_dc_cidr else 'false'
                 extra_properties.append(f'checkbox.scanDCCIDR={val}')
             domain_network_cidr = kwargs.get('domain_network_cidr')
-            if domain_network_cidr:
+            if self._domain_kwarg_supplied(kwargs, 'domain_network_cidr', config_edit):
                 extra_properties.append(f'text.networkCIDR={domain_network_cidr}')
             domain_user_match = kwargs.get('domain_user_match')
-            if domain_user_match:
+            if self._domain_kwarg_supplied(kwargs, 'domain_user_match', config_edit):
                 extra_properties.append(f'text.userMatch={domain_user_match}')
             domain_administrative_credential = kwargs.get('domain_administrative_credential')
             dac = str(domain_administrative_credential or '')
@@ -2739,7 +2773,7 @@ class PAMConfigurationEditCommand(Command, PamConfigurationEditMixin):
             orig_shared_folder_uid = value.get('folderUid') or ''
             orig_admin_cred_ref = value.get('adminCredentialRef') or ''
 
-        self.parse_properties(params, configuration, **kwargs)
+        self.parse_properties(params, configuration, config_edit=True, **kwargs)
         self.verify_required(configuration)
 
         record_management.update_record(params, configuration)

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2222,6 +2222,8 @@ domain_group.add_argument('--domain-network-cidr', dest='domain_network_cidr', a
                           help='Domain Network CIDR')
 domain_group.add_argument('--domain-admin', dest='domain_administrative_credential', action='store',
                           help='Domain administrative credential')
+domain_group.add_argument('--domain-user-match', dest='domain_user_match', action='store',
+                          help='Domain user match filter')
 oci_group = common_parser.add_argument_group('oci', 'OCI configuration')
 oci_group.add_argument('--oci-id', dest='oci_id', action='store', help='OCI ID')
 oci_group.add_argument('--oci-admin-id', dest='oci_admin_id', action='store', help='OCI Admin ID')
@@ -2448,6 +2450,9 @@ class PamConfigurationEditMixin(RecordEditMixin):
             domain_network_cidr = kwargs.get('domain_network_cidr')
             if domain_network_cidr:
                 extra_properties.append(f'text.networkCIDR={domain_network_cidr}')
+            domain_user_match = kwargs.get('domain_user_match')
+            if domain_user_match:
+                extra_properties.append(f'text.userMatch={domain_user_match}')
             domain_administrative_credential = kwargs.get('domain_administrative_credential')
             dac = str(domain_administrative_credential or '')
             if dac:

--- a/keepercommander/commands/pam_import/README.md
+++ b/keepercommander/commands/pam_import/README.md
@@ -253,6 +253,7 @@ _You can have only one `pam_configuration` section and the only required paramet
 		"dom_use_ssl": true,
 		"dom_scan_dc_cidr": true,
 		"dom_network_cidr": "192.168.1.0/28",
+		"dom_user_match": "OU=Office Users,DC=example,DC=com",
 		"dom_administrative_credential": "admin1"
 	}
 }

--- a/keepercommander/commands/pam_import/base.py
+++ b/keepercommander/commands/pam_import/base.py
@@ -156,6 +156,7 @@ class PamConfigEnvironment():
         self.dom_use_ssl: bool = False          # required, checkbox:useSSL
         self.dom_scan_dc_cidr: bool = False     # optional, checkbox:scanDCCIDR
         self.dom_network_cidr: str = ""         # optional, text:networkCIDR
+        self.dom_user_match: str = ""           # optional, text:userMatch
         self.dom_administrative_credential: str = ""  # required, existing pamUser: pamResources.value[0][adminCredentialRef]
         self.admin_credential_ref: str = ""     # UID resolved from dom_administrative_credential by record title
         # Domain Administrator User: pamUser record should have an ACL edge to the pamDomainConfiguration record with is_admin = True
@@ -303,6 +304,8 @@ class PamConfigEnvironment():
             if isinstance(val, bool): self.dom_scan_dc_cidr = val
             val = settings.get("dom_network_cidr", None) # optional
             if isinstance(val, str): self.dom_network_cidr = val
+            val = settings.get("dom_user_match", None) # optional
+            if isinstance(val, str): self.dom_user_match = val
             val = settings.get("dom_administrative_credential", None) # required, existing pamUser
             if isinstance(val, str): self.dom_administrative_credential = val
             # self.admin_credential_ref - will be resolved from dom_administrative_credential (later)

--- a/keepercommander/commands/pam_import/edit.py
+++ b/keepercommander/commands/pam_import/edit.py
@@ -508,6 +508,7 @@ class PAMProjectImportCommand(Command):
                 if pce.dom_use_ssl is not None: args["domain_use_ssl"] = pce.dom_use_ssl
                 if pce.dom_scan_dc_cidr is not None: args["domain_scan_dc_cidr"] = pce.dom_scan_dc_cidr
                 if pce.dom_network_cidr: args["domain_network_cidr"] = pce.dom_network_cidr
+                if pce.dom_user_match: args["domain_user_match"] = pce.dom_user_match
                 if pce.admin_credential_ref:
                     args["domain_administrative_credential"] = pce.admin_credential_ref
                     args["force_domain_admin"] = True  # add now - ACL link later


### PR DESCRIPTION
Support User Match in `pam project import` and `--domain-user-match` on `pam config new/edit`, mapping to text:userMatch on `pamDomainConfiguration`

Summary
- Add `dom_user_match` to `pam project import` JSON (`pam_configuration` section), mapped to `text:userMatch`
- Add `--domain-user-match` to `pam config new` and `pam config edit` for `pamDomainConfiguration` records
- Document the new field in the PAM import `README.md` and GitBook [PR#2400](https://app.gitbook.com/o/-LO5CAzoigGmCWBUbw9z/s/-MJXOXEifAmpyvNVL1to/~/changes/2400/commander-cli/command-reference/keeperpam-commands)