### PR TITLE
Fix import command/only update if same folder

### DIFF
--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -2120,7 +2120,7 @@ def prepare_record_add_or_update(update_flag, params, records):
 
         record_hash = build_record_hash(tokenize_full_import_record(import_record))
         if record_hash in preexisting_entire_record_hash:
-            record_uid = preexisting_entire_record_hash[record_hash]
+            record_uid = preexisting_entire_record_hash[record_hash]["uid"]
             if import_record.uid:
                 external_lookup[import_record.uid] = record_uid
             import_record.uid = record_uid

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -2079,10 +2079,14 @@ def prepare_record_add_or_update(update_flag, params, records):
         import_record = convert_keeper_record(params.record_cache[record_uid])
         if import_record:
             record_hash = build_record_hash(tokenize_full_import_record(import_record))
-            preexisting_entire_record_hash[record_hash] = record_uid
+            folder_uids = [x for x in params.subfolder_record_cache if record_uid in params.subfolder_record_cache[x]]
+            preexisting_entire_record_hash[record_hash] = {"uid": record_uid,"folders": folder_uids}
             if update_flag:
                 record_hash = build_record_hash(tokenize_record_key(import_record))
-                preexisting_partial_record_hash[record_hash] = record_uid
+                if record_hash in preexisting_partial_record_hash:
+                    preexisting_partial_record_hash[record_hash].append({"uid": record_uid,"folders": folder_uids})
+                else:
+                    preexisting_partial_record_hash[record_hash] = [{"uid": record_uid,"folders":folder_uids}]
         else:
             pass
 

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -2129,15 +2129,24 @@ def prepare_record_add_or_update(update_flag, params, records):
             continue
         elif update_flag:
             record_hash = build_record_hash(tokenize_record_key(import_record))
+            matched_uid = None
             if record_hash in preexisting_partial_record_hash:
-                record_uid = preexisting_partial_record_hash[record_hash]
+                for hash_match in preexisting_partial_record_hash[record_hash]:
+                    existing_folder_uids = hash_match["folders"]
+                    import_folder_uids = [fol.uid for fol in (import_record.folders or []) if fol.uid]
+                    same_folder = any([f in existing_folder_uids for f in import_folder_uids]) if import_folder_uids else True
+                    if same_folder:
+                        matched_uid = hash_match["uid"]
+
+            if matched_uid:
                 if import_record.uid:
-                    external_lookup[import_record.uid] = record_uid
-                if record_uid not in record_uid_to_update:
-                    record_uid_to_update.add(record_uid)
-                    import_record.uid = record_uid
+                    external_lookup[import_record.uid] = matched_uid
+                if matched_uid not in record_uid_to_update:
+                    record_uid_to_update.add(matched_uid)
+                    import_record.uid = matched_uid
                     record_to_import.append(import_record)
                 continue
+            # else: fall through and treat as a brand-new record
 
         record_uid = utils.generate_uid()
         if import_record.uid:


### PR DESCRIPTION
Consider this CSV:
`,Administrator,administrator,pass123,,,INFRA`
Which imports this content:  
```
INFRA/
  └ Administrator
        ├ login: administrator
        └ password: pass123
```
I wish to run an import that updates this record + adds another administrator login in a different path:  
```
DEV/
  └ Administrator
        ├ login: administrator
        └ password: pass789
```
`,Administrator,administrator,pass456,,,INFRA`
`,Administrator,administrator,pass789,,,DEV`
So I run:
`import --format csv --update my_csv.csv`
However this causes the following problems:
- Because the DEV admin has the same hash as the INFRA admin, we don't create a new record but instead a shortcut from INFRA to DEV
- This leads to the INFRA admin and DEV admin records having the same record (`pass789`)

This commit introduces change to the import process so that:
- If the --update flag is used, the record will only be updated if it's in the same folder
- If it's in a different folder and doesn't match, a new record is created
- If it's in a different folder and is the same, a shortcut is still created.
