### PR TITLE
Add event type and event timestamps to nhi-report command

### DIFF
--- a/keepercommander/commands/nhi_report.py
+++ b/keepercommander/commands/nhi_report.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 import re
-from typing import Optional, Set, Tuple
+from typing import Optional, Set, Tuple, List, Dict
 
 from .aram import AuditReportCommand
 from .base import dump_report_data, raise_parse_exception, report_output_parser, suppress_exit, Command
@@ -72,6 +72,10 @@ nhi_report_parser.add_argument(
          'last_month, year_to_date, last_year. Custom: "between YYYY-MM-DD and YYYY-MM-DD". '
          '(Default: year_to_date)',
 )
+nhi_report_parser.add_argument(
+    '-v','--verbose', dest='verbose', action='store_true', default=False,
+    help='Obtain a detailed list in the CLI. Defaults to a summary.',
+)
 nhi_report_parser.error = raise_parse_exception
 nhi_report_parser.exit = suppress_exit
 
@@ -82,6 +86,7 @@ class NhiReportCommand(Command):
 
     def execute(self, params: KeeperParams, **kwargs):
         created = kwargs.get('created') or 'year_to_date'
+        verbose = kwargs.get('verbose')
         fmt = kwargs.get('format') or 'table'
         output = kwargs.get('output')
 
@@ -103,58 +108,62 @@ class NhiReportCommand(Command):
             'NHI summary: %d PAM users, %d PAM resources, %d gateways',
             len(pam_users), len(pam_resources), len(gateways),
         )
-
+        
         if fmt == 'json':
             return self._export_json(pam_users, pam_resources, gateways, output)
         elif fmt == 'csv':
             return self._export_csv(pam_users, pam_resources, gateways, output)
+        elif verbose:
+            return self._print_verbose(pam_users, pam_resources, gateways, created)
         else:
             self._print_summary(pam_users, pam_resources, gateways, created)
 
     @staticmethod
     def _collect_nhi_data(
         pam_events: list,
-    ) -> Tuple[Set[str], Set[str], Set[str]]:
-        pam_users: Set[str] = set()
-        pam_resources: Set[str] = set()
-        gateways: Set[str] = set()
+    ) -> Tuple[List[Dict], List[Dict], List[Dict]]:
+        pam_users = {}
+        pam_resources = {}
+        gateways = {}
 
         for event in pam_events:
             event_type = event.get('audit_event_type', '')
+            event_data = {"recorded_event":event_type,"timestamp":event.get('created','')}
             message = event.get('message', '')
             if event_type in PAM_GATEWAY_EVENT_TYPES:
                 m = _GATEWAY_ONLINE_UID_RE.search(message)
                 if m:
-                    gateways.add(m.group(1))
+                    gateways[m.group(1)] = {'uid':m.group(1), 'nhi_type':'gateway'} | event_data
             elif event_type in PAM_USER_EVENT_TYPES:
                 uid = _extract_uid(message)
                 if uid:
-                    pam_users.add(uid)
+                    pam_users[uid] = {"uid":uid, 'nhi_type':'pam_user'} | event_data
             elif event_type in PAM_RESOURCE_EVENT_TYPES:
                 uid = _extract_uid(message)
                 if uid:
-                    pam_resources.add(uid)
+                    pam_resources[uid] = {"uid":uid, 'nhi_type':'pam_resource'} | event_data
 
-        return pam_users, pam_resources, gateways
+        # Sort each list by first recorded event
+        sorted_pam_users = sorted(list(pam_users.values()), key=lambda d: d["timestamp"])
+        sorted_pam_resources = sorted(list(pam_resources.values()), key=lambda d: d["timestamp"])
+        sorted_gateways = sorted(list(gateways.values()), key=lambda d: d["timestamp"])
+
+        return sorted_pam_users, sorted_pam_resources, sorted_gateways
 
     @staticmethod
     def _export_json(
-        pam_users: Set[str],
-        pam_resources: Set[str],
-        gateways: Set[str],
+        pam_users: List[Dict],
+        pam_resources: List[Dict],
+        gateways: List[Dict],
         output: Optional[str],
     ):
-        all_items = (
-            [{'identifier': uid, 'type': 'PAM User'} for uid in sorted(pam_users)] +
-            [{'identifier': uid, 'type': 'PAM Resource'} for uid in sorted(pam_resources)] +
-            [{'identifier': name, 'type': 'Gateway'} for name in sorted(gateways)]
-        )
+        all_items = pam_users + pam_resources + gateways
         report = {
             'note': NHI_SCOPE_NOTE,
             'all': all_items,
-            'pam_users': sorted(pam_users),
-            'pam_resources': sorted(pam_resources),
-            'gateways': sorted(gateways),
+            'pam_users': pam_users,
+            'pam_resources': pam_resources,
+            'gateways': gateways,
         }
         if output:
             _, ext = os.path.splitext(output)
@@ -168,15 +177,15 @@ class NhiReportCommand(Command):
 
     @staticmethod
     def _export_csv(
-        pam_users: Set[str],
-        pam_resources: Set[str],
-        gateways: Set[str],
+        pam_users: List[Dict],
+        pam_resources: List[Dict],
+        gateways: List[Dict],
         output: Optional[str],
     ):
         rows = (
-            [[uid, 'PAM User'] for uid in sorted(pam_users)] +
-            [[uid, 'PAM Resource'] for uid in sorted(pam_resources)] +
-            [[name, 'Gateway'] for name in sorted(gateways)]
+            [[x['uid'], 'PAM User', x['recorded_event'], x['timestamp']] for x in pam_users] +
+            [[x['uid'], 'PAM Resource', x['recorded_event'], x['timestamp']] for x in pam_resources] +
+            [[x['uid'], 'Gateway', x['recorded_event'], x['timestamp']] for x in gateways]
         )
 
         import io
@@ -184,7 +193,7 @@ class NhiReportCommand(Command):
         writer = csv.writer(buf)
         writer.writerow([NHI_SCOPE_NOTE])
         writer.writerow([])
-        writer.writerow(['identifier', 'type'])
+        writer.writerow(['UID', 'NHI Type', 'Recorded Event', 'Timestamp'])
         writer.writerows(rows)
         writer.writerow([])
         writer.writerow(['Total', len(rows)])
@@ -201,9 +210,9 @@ class NhiReportCommand(Command):
 
     @staticmethod
     def _print_summary(
-        pam_users: Set[str],
-        pam_resources: Set[str],
-        gateways: Set[str],
+        pam_users: List[Dict],
+        pam_resources: List[Dict],
+        gateways: List[Dict],
         created: str,
     ):
         total = len(pam_users) + len(pam_resources) + len(gateways)
@@ -220,6 +229,18 @@ class NhiReportCommand(Command):
         print('  nhi-report --format=csv --output=nhi_report.csv')
         print('  nhi-report --format=json --output=nhi_report.json')
 
+    @staticmethod
+    def _print_verbose(
+        pam_users: List[Dict],
+        pam_resources: List[Dict],
+        gateways: List[Dict],
+        created: str,
+    ):
+        rows = [[x['uid'], 'PAM User', x['recorded_event'], x['timestamp']] for x in pam_users + pam_resources + gateways]
+        
+        date_label = _CREATED_LABELS.get(created, created)
+        dump_report_data(rows, ['UID', 'NHI Type', 'Recorded Event', 'Event Timestamp'], title=f'NHI Report Summary  |  Date Range: {date_label}', fmt='table')
+        
 
 def _extract_uid(message: str) -> Optional[str]:
     """Return the first 22-char Keeper record UID found anywhere in the


### PR DESCRIPTION
Adds:
- `recorded_event` for nhi-report data with the event we recorded for the NHI.
- `timestamp` for the recorded event so users can locate the event on their reporting.
- `--verbose` flag that returns a table formatted list of all NHI

```
nhi-report -v
Fetching PAM NHI events (created=year_to_date)...
NHI summary: 21 PAM users, 105 PAM resources, 31 gateways

NHI Report Summary  |  Date Range: Year to Date

UID                       NHI Type    Recorded Event                     Event Timestamp
------------------------  ----------  ---------------------------------  -------------------------
GVuuX0crBfh_nX8ukXVmvw    PAM User    record_rotation_on_demand_ok       2026-01-08T14:31:14+00:00
...
```
```
nhi-report --format csv
Fetching PAM NHI events (created=year_to_date)...
NHI summary: 21 PAM users, 105 PAM resources, 31 gateways
Note: This NHI report only includes active PAM record types (PAM Users and PAM Resources) and active Keeper Gateways. KSM Devices are not included in this calculation.

UID,NHI Type,Recorded Event,Timestamp
GVuuX0crBfh_nX8ukXVmvw,PAM User,record_rotation_on_demand_ok,2026-01-08T14:31:14+00:00
...
```
```
nhi-report --format json
Fetching PAM NHI events (created=year_to_date)...
NHI summary: 21 PAM users, 105 PAM resources, 31 gateways
{
  "note": "Note: This NHI report only includes active PAM record types (PAM Users and PAM Resources) and active Keeper Gateways. KSM Devices are not included in this calculation.",
  "all": [
    {
      "uid": "GVuuX0crBfh_nX8ukXVmvw",
      "nhi_type": "pam_user",
      "recorded_event": "record_rotation_on_demand_ok",
      "timestamp": "2026-01-08T14:31:14+00:00"
    },
    ...
```