### PR TITLE
KC-1330 bugfix: Launch/Admin credential don't stick after pam connection edit

### DIFF
--- a/keepercommander/commands/tunnel/port_forward/TunnelGraph.py
+++ b/keepercommander/commands/tunnel/port_forward/TunnelGraph.py
@@ -733,13 +733,16 @@ class TunnelDAG:
         ALREADY-EXISTING ACL edge: a standalone configure_resource(adminUid) with no
         connectUsers no-ops on an existing edge (UserRest.kt:331-341 only touches
         is_launch_credential), whereas adminUid alongside connectUsers flips is_admin
-        on that edge (UserRest.kt:295-318). Sent on a user NOT in connectUsers so the
-        admin does not also become a launch credential.
+        on that edge (UserRest.kt:295-318). When admin and launch are different
+        users, adminUid must not appear in connectUsers. When they are the same
+        pamUser, krouter sets both is_admin and is_launch_credential on one edge
+        (UserRest.kt:258-273).
 
         For a fresh launch_uid (no existing edge), krouter creates the new edge with
-        belongs_to=null; a follow-up local DAG-write of belongs_to=True preserves
-        legacy parity. For existing edges, krouter preserves belongs_to already so
-        the follow-up is a no-op.
+        belongs_to=null; a follow-up local DAG-write must set belongs_to=True AND
+        preserve is_launch_credential (and is_admin when admin_uid == launch_uid).
+        Writing belongs_to alone clobbers krouter flags (KC-1330). For existing
+        edges where belongs_to is already true, an unchanged follow-up is a no-op.
 
         Fallback on RRC_NOT_ALLOWED* (or feature-disabled) with KEEPER_DAG_LB_FALLBACK
         enabled: legacy clear + link (if set) + admin link (if set) + meta-upgrade.
@@ -775,7 +778,10 @@ class TunnelDAG:
                     f"launch_uid={launch_uid} admin_uid={admin_uid} via configure_resource"
                 )
                 if launch_uid is not None:
-                    self.link_user(launch_uid, resource_vertex, belongs_to=True)
+                    link_kwargs = dict(belongs_to=True, is_launch_credential=True)
+                    if admin_uid is not None and admin_uid == launch_uid:
+                        link_kwargs['is_admin'] = True
+                    self.link_user(launch_uid, resource_vertex, **link_kwargs)
                 return
             except Exception as err:
                 if not should_fallback_on_layer_b_error(err, host=host, endpoint=endpoint):

--- a/unit-tests/pam/test_set_launch_credentials.py
+++ b/unit-tests/pam/test_set_launch_credentials.py
@@ -7,7 +7,7 @@ Behavior matrix:
 
 | Case                              | configure_resource sent? | connectUsers.uids       | meta has version=1? | local link_user(belongs_to=True) follow-up? |
 | --------------------------------- | ------------------------ | ----------------------- | ------------------- | ------------------------------------------- |
-| set, Layer-B enabled, success     | yes                      | [launch_uid bytes]      | yes                 | yes (preserve legacy parity)                |
+| set, Layer-B enabled, success     | yes                      | [launch_uid bytes]      | yes                 | yes (belongs_to + is_launch_credential)     |
 | clear, Layer-B enabled, success   | yes                      | []                      | yes                 | no (no launch user to mark)                 |
 | set, Layer-B feature-disabled     | no                       | n/a                     | n/a                 | legacy fallback (link+clear+meta)           |
 | set, Layer-B RRC_NOT_ALLOWED + FB | yes (then fall back)     | n/a                     | n/a                 | legacy fallback                             |
@@ -104,11 +104,13 @@ def test_set_path_builds_proto_with_launch_uid_and_meta_v1():
     assert len(rq.connectUsers.uids[0]) == 16  # decoded launch_uid
     meta = json.loads(rq.meta.decode())
     assert meta['version'] == RESOURCE_META_VERSION_V1
-    # belongs_to=True follow-up fires only for SET path.
+    # Follow-up preserves krouter flags (KC-1330).
     tdag.link_user.assert_called_once()
     args, kwargs = tdag.link_user.call_args
     assert args[0] == LAUNCH_UID
     assert kwargs.get('belongs_to') is True
+    assert kwargs.get('is_launch_credential') is True
+    assert 'is_admin' not in kwargs
     # No legacy fallback paths invoked.
     tdag.clear_launch_credential_for_resource.assert_not_called()
     tdag.link_user_to_resource.assert_not_called()
@@ -188,9 +190,8 @@ def test_set_path_sends_version_only_meta_and_does_not_clobber_allowed_settings(
 
 
 def test_set_path_with_admin_sends_admin_uid_alongside_connect_users():
-    """Admin + launch in one configure_resource: connectUsers carries the launch
-    uid AND adminUid is set (so krouter flips is_admin even on an existing edge),
-    with admin NOT in connectUsers (so it does not also become a launch cred)."""
+    """Admin + launch (different users): connectUsers carries the launch uid AND
+    adminUid is set; follow-up preserves is_launch_credential on the launch edge."""
     tdag, _ = _make_tdag(initial_meta={'allowedSettings': {'connections': True}})
 
     captured = {}
@@ -212,8 +213,38 @@ def test_set_path_with_admin_sends_admin_uid_alongside_connect_users():
     meta = json.loads(rq.meta.decode())
     assert meta['version'] == RESOURCE_META_VERSION_V1
     assert meta['allowedSettings'] == {}
-    # belongs_to follow-up fires for the launch user only.
     tdag.link_user.assert_called_once()
+    _, kwargs = tdag.link_user.call_args
+    assert kwargs.get('belongs_to') is True
+    assert kwargs.get('is_launch_credential') is True
+    assert 'is_admin' not in kwargs
+
+
+def test_set_path_same_admin_and_launch_preserves_both_flags_in_follow_up():
+    """Same pamUser for admin + launch: krouter sets both flags; follow-up must
+    not clobber is_admin (KC-1330)."""
+    tdag, _ = _make_tdag(initial_meta={'allowedSettings': {'connections': True}})
+
+    captured = {}
+
+    def _capture(params, rq):
+        captured['rq'] = rq
+
+    with patch('keepercommander.commands.pam._layer_b.is_layer_b_feature_disabled', return_value=False), \
+         patch('keepercommander.commands.pam.router_helper.get_router_url', return_value='krouter.test'), \
+         patch('keepercommander.commands.pam.router_helper.router_configure_resource',
+               side_effect=_capture):
+        tdag.set_launch_credentials(RESOURCE_UID, launch_uid=LAUNCH_UID, admin_uid=LAUNCH_UID)
+
+    rq = captured['rq']
+    assert len(rq.connectUsers.uids) == 1
+    assert bytes(rq.adminUid) == bytes(rq.connectUsers.uids[0])
+    tdag.link_user.assert_called_once()
+    args, kwargs = tdag.link_user.call_args
+    assert args[0] == LAUNCH_UID
+    assert kwargs.get('belongs_to') is True
+    assert kwargs.get('is_launch_credential') is True
+    assert kwargs.get('is_admin') is True
 
 
 def test_admin_only_sends_admin_uid_with_empty_connect_users():


### PR DESCRIPTION
Fixes KC-1330: `pam connection edit` now attaches admin and launch credentials on the **first** run when  `configure_resource` is used.
After krouter sets credential flags, the local `link_user()` follow-up was writing only `{ belongs_to: true }`, which clobbered `is_launch_credential` on the launch user's ACL edge. When admin and launch are the same pamUser, `is_admin` was also lost.
The follow-up now preserves krouter flags:
- Different users: `belongs_to` + `is_launch_credential` on the launch edge
- Same user: also `is_admin` when `admin_uid == launch_uid`
## Root cause
`TunnelDAG.set_launch_credentials()` uses a two-step flow:
1. krouter `configure_resource` with `connectUsers` and optional `adminUid`
2. Local `link_user()` + DAG `save()` on the launch user's ACL edge
Issue 1 (different users): follow-up overwrote the edge without `is_launch_credential`.  
Issue 2 (same user): krouter does not set `is_admin` when the user is in `connectUsers`; the follow-up must preserve it locally.
