### PR TITLE
KC-1337: Fix iam_user rotation schedule not applied on initial create

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -179,6 +179,18 @@ def parse_schedule_data(kwargs):
     return schedule_data
 
 
+def resolve_record_rotation_revision(params, record_uid):
+    # type: (KeeperParams, str) -> int
+    """Return server-assigned rotation revision from cache, syncing when missing (not sequential)."""
+    cached = params.record_rotation_cache.get(record_uid)
+    if cached is None or cached.get('revision') is None:
+        api.sync_down(params)
+        cached = params.record_rotation_cache.get(record_uid)
+    if cached is None or cached.get('revision') is None:
+        return 0
+    return cached['revision']
+
+
 def register_commands(commands):
     commands['pam'] = PAMControllerCommand()
 
@@ -706,8 +718,11 @@ class PAMCreateRecordRotationCommand(Command):
                             str(noop_field.value[0]).upper() == 'TRUE'):
                         noop_rotation = True
 
+                rotation_revision = resolve_record_rotation_revision(params, target_record.record_uid)
+                current_record_rotation = params.record_rotation_cache.get(target_record.record_uid)
+
                 rq = router_pb2.RouterRecordRotationRequest()
-                rq.revision = current_record_rotation.get('revision', 0)
+                rq.revision = rotation_revision
                 rq.recordUid = utils.base64_url_decode(target_record.record_uid)
                 rq.configurationUid = utils.base64_url_decode(record_config_uid)
                 rq.resourceUid = utils.base64_url_decode(record_resource_uid) if record_resource_uid else b''
@@ -743,6 +758,9 @@ class PAMCreateRecordRotationCommand(Command):
                         _dag.unlink_user_from_resource(target_record.record_uid, old_resource_uid)
                     _dag.link_user_to_resource(target_record.record_uid, old_resource_uid, belongs_to=False)
                 _dag.link_user_to_config(target_record.record_uid)
+
+            rotation_revision = resolve_record_rotation_revision(params, target_record.record_uid)
+            current_record_rotation = params.record_rotation_cache.get(target_record.record_uid)
 
             # 1. PAM Configuration UID
             record_config_uid = _dag.record.record_uid
@@ -853,8 +871,7 @@ class PAMCreateRecordRotationCommand(Command):
 
             # 6. Construct Request object for IAM: empty resourceUid and noop=False
             rq = router_pb2.RouterRecordRotationRequest()
-            if current_record_rotation:
-                rq.revision = current_record_rotation.get('revision', 0)
+            rq.revision = rotation_revision
             rq.recordUid = utils.base64_url_decode(target_record.record_uid)
             rq.configurationUid = utils.base64_url_decode(record_config_uid)
             rq.resourceUid = b''  # non-empty resourceUid sets is as General rotation

--- a/unit-tests/pam/test_pam_rotation.py
+++ b/unit-tests/pam/test_pam_rotation.py
@@ -56,7 +56,8 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from keepercommander import crypto, utils
 from keepercommander.commands.discoveryrotation import (PAMCreateRecordRotationCommand, PAMListRecordRotationCommand,
-                                                        PAMGatewayListCommand, PAMRouterGetRotationInfo)
+                                                        PAMGatewayListCommand, PAMRouterGetRotationInfo,
+                                                        resolve_record_rotation_revision)
 
 class TestPAMCreateRecordRotationCommand(unittest.TestCase):
 
@@ -661,4 +662,179 @@ class TestPAMRouterGetRotationInfo(unittest.TestCase):
         cmd = PAMRouterGetRotationInfo()
         result = cmd.execute(mock_params, record_uid=record_uid, format='table')
         self.assertIsNone(result)
+
+
+USER_UID = 'AAAAAAAAAAAAAAAAAAAAAA'
+CONFIG_UID = 'BBBBBBBBBBBBBBBBBBBBBB'
+CRON_SCHEDULE_JSON = '{"type":"CRON","cron":"0 0 3 ? * 2","tz":"Etc/UTC"}'
+
+
+class TestResolveRecordRotationRevision(unittest.TestCase):
+
+    def test_returns_cached_revision_without_sync(self):
+        params = MagicMock()
+        params.record_rotation_cache = {USER_UID: {'revision': 42}}
+        with patch('keepercommander.commands.discoveryrotation.api.sync_down') as sync_down:
+            revision = resolve_record_rotation_revision(params, USER_UID)
+        self.assertEqual(revision, 42)
+        sync_down.assert_not_called()
+
+    def test_syncs_when_revision_missing_from_cache(self):
+        params = MagicMock()
+        params.record_rotation_cache = {}
+
+        def _sync(p):
+            params.record_rotation_cache[USER_UID] = {'revision': 17}
+
+        with patch('keepercommander.commands.discoveryrotation.api.sync_down', side_effect=_sync):
+            revision = resolve_record_rotation_revision(params, USER_UID)
+        self.assertEqual(revision, 17)
+
+    def test_returns_zero_when_no_rotation_after_sync(self):
+        params = MagicMock()
+        params.record_rotation_cache = {}
+        with patch('keepercommander.commands.discoveryrotation.api.sync_down'):
+            revision = resolve_record_rotation_revision(params, USER_UID)
+        self.assertEqual(revision, 0)
+
+
+class TestIamUserRotationScheduleOnCreate(unittest.TestCase):
+
+    def setUp(self):
+        self.command = PAMCreateRecordRotationCommand()
+
+    @patch('keepercommander.commands.discoveryrotation.router_set_record_rotation_information')
+    @patch('keepercommander.commands.discoveryrotation.dump_report_data')
+    @patch('keepercommander.commands.discoveryrotation.api.sync_down')
+    @patch('keepercommander.vault_extensions.find_records')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    @patch('keepercommander.commands.discoveryrotation.get_keeper_tokens')
+    @patch('keepercommander.commands.discoveryrotation.TunnelDAG')
+    @patch('keepercommander.rest_api.SERVER_PUBLIC_KEYS', {8: ec.generate_private_key(ec.SECP256R1()).public_key()})
+    def test_iam_user_initial_create_applies_schedule_with_synced_revision(
+            self, mock_tunnel_dag, mock_get_keeper_tokens, mock_load, mock_find_records,
+            mock_sync_down, mock_dump_report, mock_set_rotation):
+        mock_params = MagicMock()
+        mock_params.rest_context.server_key_id = 8
+        mock_params.session_token = 'base64_encoded_session_token'
+        mock_params.record_cache = {USER_UID: MagicMock()}
+        mock_params.record_rotation_cache = {}
+        mock_params.rest_context.server_base = 'https://fake.keepersecurity.com'
+
+        mock_user = MagicMock(spec=vault.TypedRecord)
+        mock_user.record_type = 'pamUser'
+        mock_user.record_uid = USER_UID
+        mock_user.title = 'IAM User'
+        mock_user.record_key = b'\x00' * 16
+        mock_user.get_typed_field.return_value = None
+
+        mock_config = MagicMock(spec=vault.TypedRecord)
+        mock_config.record_uid = CONFIG_UID
+        mock_config.version = 6
+        mock_config.get_typed_field.return_value = None
+
+        mock_load.return_value = mock_user
+        mock_find_records.return_value = [mock_config]
+        mock_get_keeper_tokens.return_value = (b'token', b'encrypted_key', b'transmission_key')
+
+        mock_dag = mock_tunnel_dag.return_value
+        mock_dag.linking_dag.has_graph = True
+        mock_dag.user_belongs_to_config.return_value = False
+        mock_dag.get_resource_uid.return_value = None
+        mock_dag.record.record_uid = CONFIG_UID
+
+        def _sync_down(params):
+            params.record_rotation_cache[USER_UID] = {
+                'revision': 1,
+                'configuration_uid': CONFIG_UID,
+                'schedule': '',
+                'pwd_complexity': '',
+            }
+
+        mock_sync_down.side_effect = _sync_down
+
+        kwargs = {
+            'record_name': USER_UID,
+            'rotation_profile': 'iam_user',
+            'config': CONFIG_UID,
+            'enable': True,
+            'force': True,
+            'schedule_json_data': [CRON_SCHEDULE_JSON],
+        }
+
+        self.command.execute(mock_params, **kwargs)
+
+        mock_dag.link_user_to_config.assert_called_once_with(USER_UID)
+        mock_sync_down.assert_called_once_with(mock_params)
+        mock_set_rotation.assert_called_once()
+        rq = mock_set_rotation.call_args[0][1]
+        self.assertEqual(rq.revision, 1)
+        self.assertIn('CRON', rq.schedule)
+        self.assertEqual(json.loads(rq.schedule)[0]['cron'], '0 0 3 ? * 2')
+        self.assertEqual(rq.resourceUid, b'')
+        self.assertFalse(rq.noop)
+
+    @patch('keepercommander.commands.discoveryrotation.router_set_record_rotation_information')
+    @patch('keepercommander.commands.discoveryrotation.dump_report_data')
+    @patch('keepercommander.commands.discoveryrotation.api.sync_down')
+    @patch('keepercommander.vault_extensions.find_records')
+    @patch('keepercommander.vault.KeeperRecord.load')
+    @patch('keepercommander.commands.discoveryrotation.get_keeper_tokens')
+    @patch('keepercommander.commands.discoveryrotation.TunnelDAG')
+    @patch('keepercommander.rest_api.SERVER_PUBLIC_KEYS', {8: ec.generate_private_key(ec.SECP256R1()).public_key()})
+    def test_iam_user_already_linked_skips_link_but_still_applies_schedule(
+            self, mock_tunnel_dag, mock_get_keeper_tokens, mock_load, mock_find_records,
+            mock_sync_down, mock_dump_report, mock_set_rotation):
+        mock_params = MagicMock()
+        mock_params.rest_context.server_key_id = 8
+        mock_params.session_token = 'base64_encoded_session_token'
+        mock_params.record_cache = {USER_UID: MagicMock()}
+        mock_params.record_rotation_cache = {
+            USER_UID: {
+                'revision': 3,
+                'configuration_uid': CONFIG_UID,
+                'schedule': '',
+                'pwd_complexity': '',
+            }
+        }
+        mock_params.rest_context.server_base = 'https://fake.keepersecurity.com'
+
+        mock_user = MagicMock(spec=vault.TypedRecord)
+        mock_user.record_type = 'pamUser'
+        mock_user.record_uid = USER_UID
+        mock_user.title = 'IAM User'
+        mock_user.record_key = b'\x00' * 16
+        mock_user.get_typed_field.return_value = None
+
+        mock_config = MagicMock(spec=vault.TypedRecord)
+        mock_config.record_uid = CONFIG_UID
+        mock_config.version = 6
+        mock_config.get_typed_field.return_value = None
+
+        mock_load.return_value = mock_user
+        mock_find_records.return_value = [mock_config]
+        mock_get_keeper_tokens.return_value = (b'token', b'encrypted_key', b'transmission_key')
+
+        mock_dag = mock_tunnel_dag.return_value
+        mock_dag.linking_dag.has_graph = True
+        mock_dag.user_belongs_to_config.return_value = True
+        mock_dag.record.record_uid = CONFIG_UID
+
+        kwargs = {
+            'record_name': USER_UID,
+            'rotation_profile': 'iam_user',
+            'config': CONFIG_UID,
+            'enable': True,
+            'force': True,
+            'schedule_json_data': [CRON_SCHEDULE_JSON],
+        }
+
+        self.command.execute(mock_params, **kwargs)
+
+        mock_dag.link_user_to_config.assert_not_called()
+        mock_sync_down.assert_not_called()
+        mock_set_rotation.assert_called_once()
+        rq = mock_set_rotation.call_args[0][1]
+        self.assertEqual(rq.revision, 3)
+        self.assertIn('CRON', rq.schedule)
 


### PR DESCRIPTION
- Fix `pam rotation edit --rotation-profile iam_user` so a cron/`--schedulejson` schedule is applied on first setup instead of failing with `revision 0 less than 1`.
- After `link_user_to_config` runs its IAM permission-check `set_record_rotation` (which creates rotation at revision 1 without a schedule), sync vault and use the server revision for the follow-up request that carries the schedule.
- Add unit tests for `resolve_record_rotation_revision` and the iam_user initial-create / already-linked paths.
