### PR TITLE
feat: Add RDP/Kubernetes security options to pam connection edit

### DIFF
--- a/keepercommander/commands/pam_launch/terminal_connection.py
+++ b/keepercommander/commands/pam_launch/terminal_connection.py
@@ -595,9 +595,9 @@ def _extract_kubernetes_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
         'namespace': connection.get('namespace', 'default'),
         'pod': connection.get('pod', ''),
         'container': connection.get('container', ''),
-        'ignoreServerCertificate': connection.get('ignoreServerCertificate', False),
-        'caCertificate': connection.get('caCertificate', ''),
-        'clientCertificate': connection.get('clientCertificate', ''),
+        'ignoreServerCertificate': connection.get('ignoreCert', False),
+        'caCertificate': connection.get('caCert', ''),
+        'clientCertificate': connection.get('clientCert', ''),
         'clientKey': connection.get('clientKey', ''),
     }
 

--- a/keepercommander/commands/pam_launch/terminal_connection.py
+++ b/keepercommander/commands/pam_launch/terminal_connection.py
@@ -511,7 +511,7 @@ def extract_terminal_settings(
                 elif protocol == ConnectionProtocol.KUBERNETES.value:
                     settings['protocol_specific'] = _extract_kubernetes_settings(connection)
                 elif protocol in DATABASE:
-                    settings['protocol_specific'] = _extract_database_settings(connection, protocol)
+                    settings['protocol_specific'] = _extract_database_settings(connection)
 
             # allowSupplyHost is at top level of pamSettings value, not inside connection
             settings['allowSupplyHost'] = pam_settings_value.get('allowSupplyHost', False)
@@ -573,28 +573,33 @@ def extract_terminal_settings(
 
 
 def _extract_ssh_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract SSH-specific settings"""
+    """Extract SSH-specific settings from pamSettings.connection (record JSON)."""
+    sftp = connection.get('sftp') or {}
     return {
-        'publicHostKey': connection.get('publicHostKey', ''),
-        'executeCommand': connection.get('executeCommand', ''),
-        'sftpEnabled': connection.get('sftpEnabled', False),
+        'publicHostKey': connection.get('hostKey', ''),
+        'executeCommand': connection.get('command', ''),
+        'sftpEnabled': bool(sftp.get('enableSftp', False)),
+        'sftpRootDirectory': sftp.get('sftpRootDirectory', ''),
     }
 
 
 def _extract_telnet_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract Telnet-specific settings"""
+    """Extract Telnet-specific settings from pamSettings.connection (record JSON)."""
     return {
         'usernameRegex': connection.get('usernameRegex', ''),
         'passwordRegex': connection.get('passwordRegex', ''),
+        'loginSuccessRegex': connection.get('loginSuccessRegex', ''),
+        'loginFailureRegex': connection.get('loginFailureRegex', ''),
     }
 
 
 def _extract_kubernetes_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
-    """Extract Kubernetes-specific settings"""
+    """Extract Kubernetes-specific settings from pamSettings.connection (record JSON)."""
     return {
         'namespace': connection.get('namespace', 'default'),
         'pod': connection.get('pod', ''),
         'container': connection.get('container', ''),
+        'useSSL': connection.get('useSSL', False),
         'ignoreServerCertificate': connection.get('ignoreCert', False),
         'caCertificate': connection.get('caCert', ''),
         'clientCertificate': connection.get('clientCert', ''),
@@ -602,23 +607,13 @@ def _extract_kubernetes_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _extract_database_settings(connection: Dict[str, Any], protocol: str) -> Dict[str, Any]:
-    """Extract database-specific settings"""
-    settings = {
-        'defaultDatabase': connection.get('defaultDatabase', ''),
+def _extract_database_settings(connection: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract database-specific settings from pamSettings.connection (record JSON)."""
+    return {
+        'defaultDatabase': connection.get('database', ''),
         'disableCsvExport': connection.get('disableCsvExport', False),
         'disableCsvImport': connection.get('disableCsvImport', False),
     }
-
-    # Add protocol-specific database settings
-    if protocol == ConnectionProtocol.MYSQL.value:
-        settings['useSSL'] = connection.get('useSSL', False)
-    elif protocol == ConnectionProtocol.POSTGRESQL.value:
-        settings['useSSL'] = connection.get('useSSL', False)
-    elif protocol == ConnectionProtocol.SQLSERVER.value:
-        settings['useSSL'] = connection.get('useSSL', True)  # SQL Server typically uses SSL by default
-
-    return settings
 
 
 def create_connection_context(params: KeeperParams,
@@ -1117,6 +1112,8 @@ def _build_guacamole_connection_settings(
         # Enable SFTP if configured
         if protocol_specific.get('sftpEnabled'):
             guacd_params['enable-sftp'] = 'true'
+        if protocol_specific.get('sftpRootDirectory'):
+            guacd_params['sftp-root-directory'] = protocol_specific['sftpRootDirectory']
 
     elif protocol == ConnectionProtocol.TELNET.value:
         # Telnet-specific params
@@ -1124,6 +1121,10 @@ def _build_guacamole_connection_settings(
             guacd_params['username-regex'] = protocol_specific['usernameRegex']
         if protocol_specific.get('passwordRegex'):
             guacd_params['password-regex'] = protocol_specific['passwordRegex']
+        if protocol_specific.get('loginSuccessRegex'):
+            guacd_params['login-success-regex'] = protocol_specific['loginSuccessRegex']
+        if protocol_specific.get('loginFailureRegex'):
+            guacd_params['login-failure-regex'] = protocol_specific['loginFailureRegex']
 
     elif protocol == ConnectionProtocol.KUBERNETES.value:
         # Kubernetes-specific params
@@ -1141,11 +1142,17 @@ def _build_guacamole_connection_settings(
             guacd_params['client-key'] = protocol_specific['clientKey']
         if protocol_specific.get('ignoreServerCertificate'):
             guacd_params['ignore-cert'] = 'true'
+        if protocol_specific.get('useSSL'):
+            guacd_params['use-ssl'] = 'true'
 
     elif protocol in DATABASE:
         # Database-specific params
         if protocol_specific.get('defaultDatabase'):
             guacd_params['database'] = protocol_specific['defaultDatabase']
+        if protocol_specific.get('disableCsvExport'):
+            guacd_params['disable-csv-export'] = 'true'
+        if protocol_specific.get('disableCsvImport'):
+            guacd_params['disable-csv-import'] = 'true'
 
     # CLI mode: named pipe for terminal STDOUT (guacr terminal handlers; not graphical RDP/VNC)
     guacd_params['enable-pipe'] = 'true'

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -1934,6 +1934,7 @@ class PAMTunnelDiagnoseCommand(Command):
                                 print(f'      {self._green("connection.protocol"):<36}{_val(cn.get("protocol"))}')
                                 print(f'      {self._green("connection.httpCredentialsUid"):<36}{_val(cn.get("httpCredentialsUid") or None)}')
                                 print(f'      {self._green("connection.recordingIncludeKeys"):<36}{_val(cn.get("recordingIncludeKeys"))}')
+                                print(f'      {self._green("connection.ignoreInitialSslCert"):<36}{_val(cn.get("ignoreInitialSslCert"))}')
                             else:
                                 pam_settings_field = record_obj.get_typed_field('pamSettings') if record_obj else None
                                 ps = {}
@@ -1948,6 +1949,8 @@ class PAMTunnelDiagnoseCommand(Command):
                                 print(f'      {self._green("connection.protocol"):<36}{_val(cn.get("protocol"))}')
                                 print(f'      {self._green("connection.allowKeeperDBProxy"):<36}{_val(cn.get("allowKeeperDBProxy"))}')
                                 print(f'      {self._green("connection.recordingIncludeKeys"):<36}{_val(cn.get("recordingIncludeKeys"))}')
+                                print(f'      {self._green("connection.security"):<36}{_val(cn.get("security"))}')
+                                print(f'      {self._green("connection.ignoreCert"):<36}{_val(cn.get("ignoreCert"))}')
                                 print(f'      {self._green("allowSupplyHost"):<36}{_val(ps.get("allowSupplyHost"))}')
                                 if ps.get('configUid'):
                                     print(f'      {self._green("configUid"):<36}{_val(ps.get("configUid"))}')
@@ -2668,6 +2671,13 @@ class PAMConnectionEditCommand(Command):
                         help='Maximum Scrollback Size (terminal history). Integer to set, '
                              'empty string to remove. Supported for pamDatabase (mysql/postgresql/sql-server) '
                              'and pamMachine/pamDirectory (ssh/telnet/kubernetes).')
+    parser.add_argument('--ignore-server-cert', '-isc', required=False, dest='ignore_server_cert', choices=choices,
+                        help='Ignore server certificate errors (on/off/default). Supported for rdp and '
+                             'kubernetes protocols.')
+    parser.add_argument('--security-mode', '-sm', required=False, dest='security_mode',
+                        choices=['any', 'nla', 'tls', 'vmconnect', 'rdp', 'default'],
+                        help='RDP Security Mode (any/nla/tls/vmconnect/rdp, or default to unset). '
+                             'Supported for rdp protocol only.')
     parser.add_argument('--rotate-on-termination', required=False, dest='rotate_on_termination',
                         choices=['on', 'off'],
                         help='Rotate launch credentials when the PAM session ends (DAG resource meta)')
@@ -2716,6 +2726,19 @@ class PAMConnectionEditCommand(Command):
                                    f"pamRemoteBrowser, pamNetworkConfiguration pamAwsConfiguration, and "
                                    f"pamAzureConfiguration records{bcolors.ENDC}")
 
+        # Effective protocol (existing, or the one being set by this same call via
+        # --connections=on --protocol) — shared by --scrollback, --ignore-server-cert,
+        # and --security-mode gating below.
+        def _get_effective_protocol():
+            existing_ps = record.get_typed_field('pamSettings')
+            existing_protocol = ''
+            if existing_ps and existing_ps.value and isinstance(existing_ps.value[0], dict):
+                existing_protocol = existing_ps.value[0].get('connection', {}).get('protocol') or ''
+            new_protocol_arg = kwargs.get('protocol', None)
+            if kwargs.get('connections') == 'on' and new_protocol_arg is not None:
+                return new_protocol_arg  # may be '' to clear
+            return existing_protocol
+
         # --scrollback: validate record type + effective protocol before any mutation
         scrollback_arg = kwargs.get('scrollback', None)
         scrollback_clear = False
@@ -2732,15 +2755,7 @@ class PAMConnectionEditCommand(Command):
                     f'{bcolors.FAIL}--scrollback is only supported for pamDatabase, pamMachine, and pamDirectory '
                     f'records. Record "{record_uid}" is of type "{record_type}".{bcolors.ENDC}')
 
-            existing_ps = record.get_typed_field('pamSettings')
-            existing_protocol = ''
-            if existing_ps and existing_ps.value and isinstance(existing_ps.value[0], dict):
-                existing_protocol = existing_ps.value[0].get('connection', {}).get('protocol') or ''
-            new_protocol_arg = kwargs.get('protocol', None)
-            if kwargs.get('connections') == 'on' and new_protocol_arg is not None:
-                effective_protocol = new_protocol_arg  # may be '' to clear
-            else:
-                effective_protocol = existing_protocol
+            effective_protocol = _get_effective_protocol()
             if effective_protocol not in allowed_protocols:
                 raise CommandError('pam connection edit',
                     f'{bcolors.FAIL}--scrollback is not supported for protocol "{effective_protocol or "(unset)"}" '
@@ -2759,6 +2774,37 @@ class PAMConnectionEditCommand(Command):
                     raise CommandError('pam connection edit',
                         f'{bcolors.FAIL}--scrollback must be a non-negative integer or empty string. '
                         f'Got: "{scrollback_arg}".{bcolors.ENDC}')
+
+        pam_settings_record_types = ('pamMachine', 'pamDatabase', 'pamDirectory')
+
+        # --ignore-server-cert: validate record type + effective protocol before any mutation
+        ignore_server_cert_arg = kwargs.get('ignore_server_cert', None)
+        if ignore_server_cert_arg is not None:
+            if record_type not in pam_settings_record_types:
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--ignore-server-cert is only supported for pamMachine, pamDatabase, and '
+                    f'pamDirectory records. Record "{record_uid}" is of type "{record_type}". For pamRemoteBrowser '
+                    f'records, use `pam rbi edit --ignore-server-cert` instead.{bcolors.ENDC}')
+            effective_protocol = _get_effective_protocol()
+            if effective_protocol not in ('rdp', 'kubernetes'):
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--ignore-server-cert is not supported for protocol '
+                    f'"{effective_protocol or "(unset)"}" on {record_type} records. '
+                    f'Allowed protocols: kubernetes, rdp.{bcolors.ENDC}')
+
+        # --security-mode: validate record type + effective protocol before any mutation
+        security_mode_arg = kwargs.get('security_mode', None)
+        if security_mode_arg is not None:
+            if record_type not in pam_settings_record_types:
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--security-mode is only supported for pamMachine, pamDatabase, and '
+                    f'pamDirectory records. Record "{record_uid}" is of type "{record_type}".{bcolors.ENDC}')
+            effective_protocol = _get_effective_protocol()
+            if effective_protocol != 'rdp':
+                raise CommandError('pam connection edit',
+                    f'{bcolors.FAIL}--security-mode is not supported for protocol '
+                    f'"{effective_protocol or "(unset)"}" on {record_type} records. '
+                    f'Allowed protocols: rdp.{bcolors.ENDC}')
 
         encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
         if record_type in "pamNetworkConfiguration pamAwsConfiguration pamAzureConfiguration".split():
@@ -2869,6 +2915,46 @@ class PAMConnectionEditCommand(Command):
                         dirty = True
                     else:
                         logging.debug(f'scrollback is already {scrollback_value} on record={record_uid}')
+
+            # --ignore-server-cert: apply (validated above; record_type + effective protocol already checked)
+            if ignore_server_cert_arg is not None:
+                psv = pam_settings.value[0] if pam_settings and pam_settings.value else {}
+                vcon = psv.get('connection', {}) if isinstance(psv, dict) else {}
+                current_ic = vcon.get('ignoreCert') if isinstance(vcon, dict) else None
+                if ignore_server_cert_arg == 'default':
+                    if current_ic is not None:
+                        pam_settings.value[0]["connection"].pop('ignoreCert', None)
+                        dirty = True
+                    else:
+                        logging.debug(f'ignoreCert is already unset on record={record_uid}')
+                else:
+                    target_ic = value_to_boolean(ignore_server_cert_arg)
+                    if current_ic != target_ic:
+                        pam_settings.value[0]["connection"]["ignoreCert"] = target_ic
+                        dirty = True
+                    else:
+                        logging.debug(f'ignoreCert is already {target_ic} on record={record_uid}')
+
+            # --security-mode: apply (validated above; record_type + effective protocol already checked)
+            if security_mode_arg is not None:
+                from .pam_import.base import RDPSecurity
+                psv = pam_settings.value[0] if pam_settings and pam_settings.value else {}
+                vcon = psv.get('connection', {}) if isinstance(psv, dict) else {}
+                current_sec = vcon.get('security') if isinstance(vcon, dict) else None
+                if security_mode_arg == 'default':
+                    if current_sec is not None:
+                        pam_settings.value[0]["connection"].pop('security', None)
+                        dirty = True
+                    else:
+                        logging.debug(f'security is already unset on record={record_uid}')
+                else:
+                    mapped_security = RDPSecurity.map(security_mode_arg)
+                    target_sec = mapped_security.value if mapped_security else security_mode_arg
+                    if current_sec != target_sec:
+                        pam_settings.value[0]["connection"]["security"] = target_sec
+                        dirty = True
+                    else:
+                        logging.debug(f'security is already {target_sec} on record={record_uid}')
 
             if dirty:
                 record_management.update_record(params, record)

--- a/keepercommander/params.py
+++ b/keepercommander/params.py
@@ -13,7 +13,7 @@ import sqlite3
 import threading
 import warnings
 from datetime import datetime
-from typing import Dict, NamedTuple, Optional, Set
+from typing import Dict, NamedTuple, Optional, Set, Union
 from urllib.parse import urlparse, urlunparse
 
 from urllib3.exceptions import InsecureRequestWarning
@@ -133,8 +133,27 @@ class RestApiContext:
             self.proxies = None
 
     @property
-    def certificate_check(self):
-        """Return the ``requests`` ``verify`` value (False or a CA bundle path)."""
+    def certificate_check(self) -> Union[bool, str]:
+        """SSL verification value for ``requests``' ``verify=`` parameter.
+
+        Despite the name and the plain-bool ``_certificate_check`` backing field,
+        this getter never returns a bare ``True``/``bool``. It resolves
+        ``_certificate_check`` (and the ``KEEPER_SSL_CERT_FILE`` env var, via
+        ``utils.resolve_ssl_verify``/``utils.get_ssl_cert_file``) into one of:
+
+          - ``False`` - certificate verification disabled.
+          - ``str``   - path to the CA bundle to verify against (the default
+                        system/certifi bundle, or a user override).
+
+        In practice the return type is ``False | str`` (never ``True``), even
+        though the hint is the more permissive ``Union[bool, str]``. Callers
+        must not do ``is True`` checks against this value - it will always be
+        false. Use ``if certificate_check:`` to test enabled/disabled, or
+        ``isinstance(certificate_check, str)`` to detect a resolved bundle
+        path. The old plain-bool value is still available as the private
+        ``_certificate_check`` attribute for code that only cares about the
+        user's on/off intent, not the resolved ``requests`` verify value.
+        """
         if self._resolved_verify is None:
             from . import utils
             self._resolved_verify = utils.resolve_ssl_verify(

--- a/unit-tests/pam/test_pam_connection_edit_security.py
+++ b/unit-tests/pam/test_pam_connection_edit_security.py
@@ -1,0 +1,377 @@
+"""
+Unit tests for PAM Connection Edit `--ignore-server-cert` and `--security-mode` flags.
+
+Covers argument parsing and the up-front validation that runs before any DAG /
+record mutation: allowed record types (pamMachine, pamDatabase, pamDirectory),
+allowed protocols per flag (rdp/kubernetes for cert, rdp-only for security mode),
+and the record mutation itself (connection.ignoreCert / connection.security).
+"""
+
+import unittest
+from unittest import mock
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.tunnel_and_connections import PAMConnectionEditCommand
+    from keepercommander.error import CommandError
+    from keepercommander import vault
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import tunnel_and_connections: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditSecurityArgs(unittest.TestCase):
+    def setUp(self):
+        self.parser = PAMConnectionEditCommand.parser
+
+    def test_ignore_server_cert_on(self):
+        args = self.parser.parse_args(['rec', '--ignore-server-cert', 'on'])
+        self.assertEqual(args.ignore_server_cert, 'on')
+
+    def test_ignore_server_cert_off(self):
+        args = self.parser.parse_args(['rec', '--ignore-server-cert', 'off'])
+        self.assertEqual(args.ignore_server_cert, 'off')
+
+    def test_ignore_server_cert_default(self):
+        args = self.parser.parse_args(['rec', '--ignore-server-cert', 'default'])
+        self.assertEqual(args.ignore_server_cert, 'default')
+
+    def test_ignore_server_cert_short_alias(self):
+        args = self.parser.parse_args(['rec', '-isc', 'on'])
+        self.assertEqual(args.ignore_server_cert, 'on')
+
+    def test_ignore_server_cert_invalid_choice_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['rec', '--ignore-server-cert', 'bogus'])
+
+    def test_ignore_server_cert_not_provided(self):
+        args = self.parser.parse_args(['rec'])
+        self.assertIsNone(args.ignore_server_cert)
+
+    def test_security_mode_choices(self):
+        for mode in ('any', 'nla', 'tls', 'vmconnect', 'rdp', 'default'):
+            with self.subTest(mode=mode):
+                args = self.parser.parse_args(['rec', '--security-mode', mode])
+                self.assertEqual(args.security_mode, mode)
+
+    def test_security_mode_short_alias(self):
+        args = self.parser.parse_args(['rec', '-sm', 'nla'])
+        self.assertEqual(args.security_mode, 'nla')
+
+    def test_security_mode_invalid_choice_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(['rec', '--security-mode', 'bogus'])
+
+    def test_security_mode_not_provided(self):
+        args = self.parser.parse_args(['rec'])
+        self.assertIsNone(args.security_mode)
+
+    def test_help_includes_new_flags(self):
+        help_text = self.parser.format_help()
+        self.assertIn('--ignore-server-cert', help_text)
+        self.assertIn('-isc', help_text)
+        self.assertIn('--security-mode', help_text)
+        self.assertIn('-sm', help_text)
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditSecurityValidation(unittest.TestCase):
+    """Validation runs before DAG / token operations, so we can drive execute()
+    with mocks that only need to satisfy resolve_single_record + the typed-field
+    accessor for pamSettings."""
+
+    def _mock_record(self, record_type, protocol):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        ps_field = mock.MagicMock()
+        if protocol is None:
+            ps_field.value = []
+        else:
+            ps_field.value = [{'connection': {'protocol': protocol}}]
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else None
+        return rec
+
+    def _execute(self, record, **kwargs):
+        cmd = PAMConnectionEditCommand()
+        params = mock.MagicMock()
+        with mock.patch(
+            'keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record',
+            return_value=record,
+        ):
+            cmd.execute(params, record='rec', **kwargs)
+
+    # --ignore-server-cert: record-type gating
+
+    def test_ignore_server_cert_pam_remote_browser_rejected(self):
+        rec = self._mock_record('pamRemoteBrowser', 'http')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, ignore_server_cert='on')
+        msg = str(ctx.exception)
+        self.assertIn('--ignore-server-cert is only supported for pamMachine, pamDatabase, and pamDirectory', msg)
+        self.assertIn('pam rbi edit', msg)
+
+    def test_ignore_server_cert_pam_network_configuration_rejected(self):
+        rec = self._mock_record('pamNetworkConfiguration', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, ignore_server_cert='on')
+        self.assertIn('--ignore-server-cert is only supported for pamMachine, pamDatabase, and pamDirectory',
+                      str(ctx.exception))
+
+    # --ignore-server-cert: protocol gating
+
+    def test_ignore_server_cert_ssh_rejected(self):
+        rec = self._mock_record('pamMachine', 'ssh')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, ignore_server_cert='on')
+        msg = str(ctx.exception)
+        self.assertIn('not supported for protocol "ssh"', msg)
+        self.assertIn('kubernetes, rdp', msg)
+
+    def test_ignore_server_cert_no_protocol_rejected(self):
+        rec = self._mock_record('pamMachine', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, ignore_server_cert='on')
+        self.assertIn('not supported for protocol "(unset)"', str(ctx.exception))
+
+    def test_ignore_server_cert_rdp_accepted(self):
+        rec = self._mock_record('pamMachine', 'rdp')
+        try:
+            self._execute(rec, ignore_server_cert='on')
+        except CommandError as e:
+            self.assertNotIn('--ignore-server-cert is', str(e))
+        except Exception:
+            pass  # downstream failures not under test
+
+    def test_ignore_server_cert_kubernetes_accepted(self):
+        rec = self._mock_record('pamDirectory', 'kubernetes')
+        try:
+            self._execute(rec, ignore_server_cert='on')
+        except CommandError as e:
+            self.assertNotIn('--ignore-server-cert is', str(e))
+        except Exception:
+            pass  # downstream failures not under test
+
+    # --security-mode: record-type gating
+
+    def test_security_mode_pam_remote_browser_rejected(self):
+        rec = self._mock_record('pamRemoteBrowser', 'http')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, security_mode='nla')
+        self.assertIn('--security-mode is only supported for pamMachine, pamDatabase, and pamDirectory',
+                      str(ctx.exception))
+
+    # --security-mode: protocol gating
+
+    def test_security_mode_kubernetes_rejected(self):
+        rec = self._mock_record('pamMachine', 'kubernetes')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, security_mode='nla')
+        msg = str(ctx.exception)
+        self.assertIn('not supported for protocol "kubernetes"', msg)
+
+    def test_security_mode_no_protocol_rejected(self):
+        rec = self._mock_record('pamMachine', None)
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, security_mode='nla')
+        self.assertIn('not supported for protocol "(unset)"', str(ctx.exception))
+
+    def test_security_mode_rdp_accepted(self):
+        rec = self._mock_record('pamMachine', 'rdp')
+        try:
+            self._execute(rec, security_mode='nla')
+        except CommandError as e:
+            self.assertNotIn('--security-mode is', str(e))
+        except Exception:
+            pass  # downstream failures not under test
+
+    def test_protocol_change_in_same_command_validated_against_new(self):
+        """When --connections=on and --protocol=ssh are passed alongside --security-mode,
+        validation uses the new (post-mutation) protocol -> ssh -> reject."""
+        rec = self._mock_record('pamMachine', 'rdp')
+        with self.assertRaises(CommandError) as ctx:
+            self._execute(rec, security_mode='nla', connections='on', protocol='ssh')
+        self.assertIn('not supported for protocol "ssh"', str(ctx.exception))
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditSecurityMutation(unittest.TestCase):
+    """Verifies the actual JSON keys written to pamSettings.connection."""
+
+    def _mock_record(self, record_type='pamMachine', protocol='rdp', existing_connection=None):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        rec.fields = []
+        rec.custom = []
+        connection = {'protocol': protocol}
+        if existing_connection:
+            connection.update(existing_connection)
+        pam_settings_value = [{'connection': connection, 'portForward': {}}]
+        ps_field = mock.MagicMock()
+        ps_field.value = pam_settings_value
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else (
+            mock.MagicMock(value=['seed']) if name == 'trafficEncryptionSeed' else None
+        )
+        return rec, ps_field
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_ignore_server_cert_on_writes_true(self, mock_tdag, mock_get_config_uid,
+                                                mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec, ps_field = self._mock_record(protocol='rdp')
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', ignore_server_cert='on')
+        self.assertEqual(ps_field.value[0]['connection'].get('ignoreCert'), True)
+        mock_update.assert_called_once()
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_ignore_server_cert_off_writes_false(self, mock_tdag, mock_get_config_uid,
+                                                  mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec, ps_field = self._mock_record(protocol='kubernetes', existing_connection={'ignoreCert': True})
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', ignore_server_cert='off')
+        self.assertEqual(ps_field.value[0]['connection'].get('ignoreCert'), False)
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_ignore_server_cert_default_removes_key(self, mock_tdag, mock_get_config_uid,
+                                                     mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec, ps_field = self._mock_record(protocol='rdp', existing_connection={'ignoreCert': True})
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', ignore_server_cert='default')
+        self.assertNotIn('ignoreCert', ps_field.value[0]['connection'])
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_security_mode_writes_lowercase_value(self, mock_tdag, mock_get_config_uid,
+                                                   mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec, ps_field = self._mock_record(protocol='rdp')
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', security_mode='NLA'.lower())
+        self.assertEqual(ps_field.value[0]['connection'].get('security'), 'nla')
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_security_mode_default_removes_key(self, mock_tdag, mock_get_config_uid,
+                                                mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec, ps_field = self._mock_record(protocol='rdp', existing_connection={'security': 'tls'})
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', security_mode='default')
+        self.assertNotIn('security', ps_field.value[0]['connection'])
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    def test_no_change_does_not_mark_dirty(self, mock_get_config_uid,
+                                            mock_tokens, mock_sync, mock_update, mock_resolve):
+        """Setting a value that already matches the current one should not trigger update_record.
+
+        TunnelDAG is deliberately left unmocked here (unlike the other tests in this file):
+        mocking the whole class also mocks its `_convert_allowed_setting` staticmethod, turning
+        `_connections`/`_recording`/`_typescript_recording` into truthy MagicMocks regardless of
+        input and forcing a spurious dirty=True. Since neither flag under test touches the DAG
+        path, the real staticmethod (called unconditionally near the top of execute()) is safe
+        to leave in place.
+        """
+        rec, ps_field = self._mock_record(protocol='rdp', existing_connection={'ignoreCert': True, 'security': 'nla'})
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', ignore_server_cert='on', security_mode='nla')
+        mock_update.assert_not_called()
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestPamConnectionEditSecurityEarlyReturn(unittest.TestCase):
+    """--ignore-server-cert / --security-mode are record-only edits; passing them alone
+    should not touch the DAG/config lookup, mirroring the --scrollback early-return."""
+
+    def _mock_record(self, record_type='pamMachine', protocol='rdp'):
+        rec = mock.MagicMock(spec=vault.TypedRecord)
+        rec.record_uid = 'rec-uid'
+        rec.record_type = record_type
+        rec.version = 3
+        rec.fields = []
+        rec.custom = []
+        ps_field = mock.MagicMock()
+        ps_field.value = [{'connection': {'protocol': protocol}}]
+        rec.get_typed_field.side_effect = lambda name: ps_field if name == 'pamSettings' else (
+            mock.MagicMock(value=['seed']) if name == 'trafficEncryptionSeed' else None
+        )
+        return rec
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_ignore_server_cert_alone_skips_dag(self, mock_tdag, mock_get_config_uid,
+                                                 mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec = self._mock_record()
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', ignore_server_cert='on')
+        mock_get_config_uid.assert_not_called()
+        mock_tdag.assert_not_called()
+        mock_update.assert_called_once()
+
+    @mock.patch('keepercommander.commands.tunnel_and_connections.RecordMixin.resolve_single_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.record_management.update_record')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.api.sync_down')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_keeper_tokens',
+                return_value=(b'st', b'tk', b'tr'))
+    @mock.patch('keepercommander.commands.tunnel_and_connections.get_config_uid')
+    @mock.patch('keepercommander.commands.tunnel_and_connections.TunnelDAG')
+    def test_security_mode_alone_skips_dag(self, mock_tdag, mock_get_config_uid,
+                                            mock_tokens, mock_sync, mock_update, mock_resolve):
+        rec = self._mock_record()
+        mock_resolve.return_value = rec
+        cmd = PAMConnectionEditCommand()
+        cmd.execute(mock.MagicMock(), record='rec', security_mode='tls')
+        mock_get_config_uid.assert_not_called()
+        mock_tdag.assert_not_called()
+        mock_update.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_import_security_roundtrip.py
+++ b/unit-tests/pam/test_pam_import_security_roundtrip.py
@@ -1,0 +1,123 @@
+"""
+Round-trip unit tests for RDP `security` mode and cert-ignore fields across the
+three connection types that carry them: RDP (security + ignoreCert), Kubernetes
+(ignoreCert), and RBI/HTTP (ignoreInitialSslCert).
+
+Each test loads a `pam project import` YAML/JSON-shaped connection dict via
+`ConnectionSettings*.load()` and re-serializes it via `to_record_dict()`, asserting
+the on-record JSON keys match what Web Vault / Commander expect
+(field-data-pam-settings.ts): `security`, `ignoreCert`, `ignoreInitialSslCert`.
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_import.base import (
+        ConnectionSettingsRDP, ConnectionSettingsKubernetes, ConnectionSettingsHTTP, RDPSecurity,
+    )
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import pam_import.base: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestRDPSecurityRoundTrip(unittest.TestCase):
+    def test_security_and_ignore_cert_round_trip(self):
+        for mode in ('any', 'nla', 'tls', 'vmconnect', 'rdp'):
+            with self.subTest(mode=mode):
+                obj = ConnectionSettingsRDP.load({
+                    'protocol': 'rdp',
+                    'port': '3389',
+                    'security': mode,
+                    'ignore_server_cert': True,
+                })
+                self.assertEqual(obj.security, RDPSecurity.map(mode))
+                self.assertTrue(obj.ignoreCert)
+                record_dict = obj.to_record_dict()
+                self.assertEqual(record_dict['security'], mode)
+                self.assertEqual(record_dict['ignoreCert'], True)
+
+    def test_ignore_cert_false_round_trip(self):
+        obj = ConnectionSettingsRDP.load({'protocol': 'rdp', 'ignore_server_cert': False})
+        self.assertFalse(obj.ignoreCert)
+        record_dict = obj.to_record_dict()
+        self.assertEqual(record_dict['ignoreCert'], False)
+
+    def test_security_absent_not_written(self):
+        obj = ConnectionSettingsRDP.load({'protocol': 'rdp'})
+        self.assertIsNone(obj.security)
+        record_dict = obj.to_record_dict()
+        self.assertNotIn('security', record_dict)
+        self.assertNotIn('ignoreCert', record_dict)
+
+    def test_invalid_security_mode_maps_to_none(self):
+        obj = ConnectionSettingsRDP.load({'protocol': 'rdp', 'security': 'bogus'})
+        self.assertIsNone(obj.security)
+        record_dict = obj.to_record_dict()
+        self.assertNotIn('security', record_dict)
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestKubernetesIgnoreCertRoundTrip(unittest.TestCase):
+    def test_ignore_cert_round_trip(self):
+        obj = ConnectionSettingsKubernetes.load({
+            'protocol': 'kubernetes',
+            'ignore_server_cert': True,
+            'ca_certificate': 'ca-data',
+            'client_certificate': 'client-cert-data',
+            'client_key': 'client-key-data',
+            'namespace': 'prod',
+        })
+        self.assertTrue(obj.ignoreCert)
+        record_dict = obj.to_record_dict()
+        self.assertEqual(record_dict['ignoreCert'], True)
+        self.assertEqual(record_dict['caCert'], 'ca-data')
+        self.assertEqual(record_dict['clientCert'], 'client-cert-data')
+        self.assertEqual(record_dict['clientKey'], 'client-key-data')
+        self.assertEqual(record_dict['namespace'], 'prod')
+
+    def test_ignore_cert_false_round_trip(self):
+        obj = ConnectionSettingsKubernetes.load({'protocol': 'kubernetes', 'ignore_server_cert': False})
+        self.assertFalse(obj.ignoreCert)
+        record_dict = obj.to_record_dict()
+        self.assertEqual(record_dict['ignoreCert'], False)
+
+    def test_ignore_cert_absent_not_written(self):
+        obj = ConnectionSettingsKubernetes.load({'protocol': 'kubernetes'})
+        self.assertIsNone(obj.ignoreCert)
+        record_dict = obj.to_record_dict()
+        self.assertNotIn('ignoreCert', record_dict)
+
+    def test_no_security_field_on_kubernetes(self):
+        """Kubernetes has no security-mode concept (RDP-only)."""
+        self.assertFalse(hasattr(ConnectionSettingsKubernetes(), 'security'))
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestRBIIgnoreInitialSslCertRoundTrip(unittest.TestCase):
+    def test_ignore_server_cert_maps_to_ignore_initial_ssl_cert(self):
+        """RBI/HTTP uses the same YAML key (ignore_server_cert) as RDP/K8s, but the
+        on-record field name differs: ignoreInitialSslCert, not ignoreCert."""
+        obj = ConnectionSettingsHTTP.load({'protocol': 'http', 'ignore_server_cert': True})
+        self.assertTrue(obj.ignoreInitialSslCert)
+        record_dict = obj.to_record_dict()
+        self.assertEqual(record_dict['ignoreInitialSslCert'], True)
+        self.assertNotIn('ignoreCert', record_dict)
+
+    def test_ignore_server_cert_false_round_trip(self):
+        obj = ConnectionSettingsHTTP.load({'protocol': 'http', 'ignore_server_cert': False})
+        self.assertFalse(obj.ignoreInitialSslCert)
+        record_dict = obj.to_record_dict()
+        self.assertEqual(record_dict['ignoreInitialSslCert'], False)
+
+    def test_ignore_server_cert_absent_not_written(self):
+        obj = ConnectionSettingsHTTP.load({'protocol': 'http'})
+        self.assertIsNone(obj.ignoreInitialSslCert)
+        record_dict = obj.to_record_dict()
+        self.assertNotIn('ignoreInitialSslCert', record_dict)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_launch_database_settings.py
+++ b/unit-tests/pam/test_pam_launch_database_settings.py
@@ -1,0 +1,51 @@
+"""
+Unit tests for `_extract_database_settings` in pam_launch/terminal_connection.py.
+
+Record JSON stores the default DB name as `database` (not `defaultDatabase`).
+`useSSL` lives on the pamDatabase record checkbox for rotation/proxy — not on
+pamSettings.connection.
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_launch.terminal_connection import _extract_database_settings
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import terminal_connection: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestExtractDatabaseSettings(unittest.TestCase):
+    def test_reads_record_shaped_fields(self):
+        connection = {
+            'database': 'mydb',
+            'disableCsvExport': True,
+            'disableCsvImport': True,
+        }
+        result = _extract_database_settings(connection)
+        self.assertEqual(result['defaultDatabase'], 'mydb')
+        self.assertTrue(result['disableCsvExport'])
+        self.assertTrue(result['disableCsvImport'])
+
+    def test_legacy_default_database_key_is_ignored(self):
+        connection = {'defaultDatabase': 'wrong-key'}
+        result = _extract_database_settings(connection)
+        self.assertEqual(result['defaultDatabase'], '')
+
+    def test_connection_use_ssl_is_ignored(self):
+        connection = {'database': 'mydb', 'useSSL': True}
+        result = _extract_database_settings(connection)
+        self.assertNotIn('useSSL', result)
+
+    def test_defaults_when_fields_absent(self):
+        result = _extract_database_settings({})
+        self.assertEqual(result['defaultDatabase'], '')
+        self.assertFalse(result['disableCsvExport'])
+        self.assertFalse(result['disableCsvImport'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_launch_kubernetes_settings.py
+++ b/unit-tests/pam/test_pam_launch_kubernetes_settings.py
@@ -1,0 +1,64 @@
+"""
+Unit tests for `_extract_kubernetes_settings` in pam_launch/terminal_connection.py.
+
+The record (and Web Vault) store Kubernetes cert fields as `ignoreCert` / `caCert` /
+`clientCert` (matching `pam_import/base.py` ConnectionSettingsKubernetes and
+field-data-pam-settings.ts). This extractor previously read the wrong, non-existent
+keys (`ignoreServerCertificate` / `caCertificate` / `clientCertificate`), so cert-ignore
+and custom CA/client certs never reached the guacd connection for Kubernetes launches.
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_launch.terminal_connection import _extract_kubernetes_settings
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import terminal_connection: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestExtractKubernetesSettings(unittest.TestCase):
+    def test_reads_record_shaped_cert_fields(self):
+        connection = {
+            'namespace': 'prod',
+            'pod': 'my-pod',
+            'container': 'my-container',
+            'ignoreCert': True,
+            'caCert': 'ca-cert-data',
+            'clientCert': 'client-cert-data',
+            'clientKey': 'client-key-data',
+        }
+        result = _extract_kubernetes_settings(connection)
+        self.assertEqual(result['ignoreServerCertificate'], True)
+        self.assertEqual(result['caCertificate'], 'ca-cert-data')
+        self.assertEqual(result['clientCertificate'], 'client-cert-data')
+        self.assertEqual(result['clientKey'], 'client-key-data')
+
+    def test_legacy_expanded_keys_are_ignored(self):
+        """Confirms the fix: the old (wrong) key names are no longer read."""
+        connection = {
+            'ignoreServerCertificate': True,
+            'caCertificate': 'legacy-ca',
+            'clientCertificate': 'legacy-client-cert',
+        }
+        result = _extract_kubernetes_settings(connection)
+        self.assertEqual(result['ignoreServerCertificate'], False)
+        self.assertEqual(result['caCertificate'], '')
+        self.assertEqual(result['clientCertificate'], '')
+
+    def test_defaults_when_fields_absent(self):
+        result = _extract_kubernetes_settings({})
+        self.assertEqual(result['namespace'], 'default')
+        self.assertEqual(result['pod'], '')
+        self.assertEqual(result['container'], '')
+        self.assertEqual(result['ignoreServerCertificate'], False)
+        self.assertEqual(result['caCertificate'], '')
+        self.assertEqual(result['clientCertificate'], '')
+        self.assertEqual(result['clientKey'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_launch_kubernetes_settings.py
+++ b/unit-tests/pam/test_pam_launch_kubernetes_settings.py
@@ -26,12 +26,14 @@ class TestExtractKubernetesSettings(unittest.TestCase):
             'namespace': 'prod',
             'pod': 'my-pod',
             'container': 'my-container',
+            'useSSL': True,
             'ignoreCert': True,
             'caCert': 'ca-cert-data',
             'clientCert': 'client-cert-data',
             'clientKey': 'client-key-data',
         }
         result = _extract_kubernetes_settings(connection)
+        self.assertTrue(result['useSSL'])
         self.assertEqual(result['ignoreServerCertificate'], True)
         self.assertEqual(result['caCertificate'], 'ca-cert-data')
         self.assertEqual(result['clientCertificate'], 'client-cert-data')
@@ -54,6 +56,7 @@ class TestExtractKubernetesSettings(unittest.TestCase):
         self.assertEqual(result['namespace'], 'default')
         self.assertEqual(result['pod'], '')
         self.assertEqual(result['container'], '')
+        self.assertFalse(result['useSSL'])
         self.assertEqual(result['ignoreServerCertificate'], False)
         self.assertEqual(result['caCertificate'], '')
         self.assertEqual(result['clientCertificate'], '')

--- a/unit-tests/pam/test_pam_launch_ssh_settings.py
+++ b/unit-tests/pam/test_pam_launch_ssh_settings.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for `_extract_ssh_settings` in pam_launch/terminal_connection.py.
+
+Record JSON (Web Vault / pam_import) stores SSH fields as `hostKey`, `command`, and
+`sftp.enableSftp`. The extractor maps them to protocol_specific names consumed by
+`_build_guacamole_connection_settings` (host-key, command, enable-sftp).
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_launch.terminal_connection import _extract_ssh_settings
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import terminal_connection: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestExtractSshSettings(unittest.TestCase):
+    def test_reads_record_shaped_fields(self):
+        connection = {
+            'hostKey': 'AAAAhostkey',
+            'command': '/bin/bash -l',
+            'sftp': {'enableSftp': True, 'sftpRootDirectory': '/uploads'},
+        }
+        result = _extract_ssh_settings(connection)
+        self.assertEqual(result['publicHostKey'], 'AAAAhostkey')
+        self.assertEqual(result['executeCommand'], '/bin/bash -l')
+        self.assertTrue(result['sftpEnabled'])
+        self.assertEqual(result['sftpRootDirectory'], '/uploads')
+
+    def test_legacy_wrong_keys_are_ignored(self):
+        connection = {
+            'publicHostKey': 'legacy-key',
+            'executeCommand': 'legacy-cmd',
+            'sftpEnabled': True,
+        }
+        result = _extract_ssh_settings(connection)
+        self.assertEqual(result['publicHostKey'], '')
+        self.assertEqual(result['executeCommand'], '')
+        self.assertFalse(result['sftpEnabled'])
+
+    def test_defaults_when_fields_absent(self):
+        result = _extract_ssh_settings({})
+        self.assertEqual(result['publicHostKey'], '')
+        self.assertEqual(result['executeCommand'], '')
+        self.assertFalse(result['sftpEnabled'])
+        self.assertEqual(result['sftpRootDirectory'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_pam_launch_telnet_settings.py
+++ b/unit-tests/pam/test_pam_launch_telnet_settings.py
@@ -1,0 +1,40 @@
+"""
+Unit tests for `_extract_telnet_settings` in pam_launch/terminal_connection.py.
+"""
+
+import unittest
+
+skip_tests = False
+skip_reason = ""
+try:
+    from keepercommander.commands.pam_launch.terminal_connection import _extract_telnet_settings
+except ImportError as e:
+    skip_tests = True
+    skip_reason = f"Cannot import terminal_connection: {e}"
+
+
+@unittest.skipIf(skip_tests, skip_reason)
+class TestExtractTelnetSettings(unittest.TestCase):
+    def test_reads_all_regex_fields(self):
+        connection = {
+            'usernameRegex': 'User:',
+            'passwordRegex': 'Pass:',
+            'loginSuccessRegex': 'Welcome',
+            'loginFailureRegex': 'Denied',
+        }
+        result = _extract_telnet_settings(connection)
+        self.assertEqual(result['usernameRegex'], 'User:')
+        self.assertEqual(result['passwordRegex'], 'Pass:')
+        self.assertEqual(result['loginSuccessRegex'], 'Welcome')
+        self.assertEqual(result['loginFailureRegex'], 'Denied')
+
+    def test_defaults_when_fields_absent(self):
+        result = _extract_telnet_settings({})
+        self.assertEqual(result['usernameRegex'], '')
+        self.assertEqual(result['passwordRegex'], '')
+        self.assertEqual(result['loginSuccessRegex'], '')
+        self.assertEqual(result['loginFailureRegex'], '')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add --ignore-server-cert (-isc) and --security-mode (-sm) flags to pam connection edit for RDP and Kubernetes connections on pamMachine, pamDatabase, and pamDirectory records
- Fix _extract_kubernetes_settings to read record-shaped cert fields (ignoreCert, caCert, clientCert) so cert-ignore and custom certs reach guacd on Kubernetes launch
- Show connection.security, connection.ignoreCert, and connection.ignoreInitialSslCert in pam tunnel diagnose output
- Documentation - [PR#2407](https://app.gitbook.com/o/-LO5CAzoigGmCWBUbw9z/s/-MJXOXEifAmpyvNVL1to/~/changes/2407/commander-cli/command-reference/keeperpam-commands)