### PR TITLE
fix: Fall back to manual token entry when SSO clipboard is empty or inaccessible

### DIFF
--- a/keepercommander/auth/console_ui.py
+++ b/keepercommander/auth/console_ui.py
@@ -387,7 +387,11 @@ class ConsoleLoginUi(login_steps.LoginUi):
                     token = pyperclip.paste()
                 except:
                     token = ''
-                    logging.warning('Failed to paste from clipboard')
+                if len(token) < 10:
+                    try:
+                        token = input(f'{Fore.GREEN}Paste SSO Token: {Fore.RESET}').strip()
+                    except KeyboardInterrupt:
+                        token = ''
             else:
                 if len(token) < 10:
                     logging.warning(f'Unsupported menu option: {token}')


### PR DESCRIPTION
## Summary

- When using Commander over SSH, `pyperclip.paste()` reads the remote machine's clipboard rather than the local browser's clipboard, returning empty or stale content
- Selecting `p` now falls back to a `Paste SSO Token:` prompt if the clipboard is unreadable or returns fewer than 10 characters (too short to be a valid SSO token)
- No menu changes — the fix is transparent to local users where clipboard works correctly

## Test plan

- [x] Local session: select `p` with a valid token in clipboard — should work as before
- [x] Remote/SSH session: select `p` with empty or inaccessible clipboard — should prompt for manual token input
- [x] Remote/SSH session: paste valid SSO token at the `Paste SSO Token:` prompt — should log in successfully
