### PR TITLE
KC-1342: Fix pam config list dropping seconds from 6-part Quartz CRON

### DIFF
--- a/keepercommander/vault.py
+++ b/keepercommander/vault.py
@@ -475,8 +475,7 @@ class TypedField(object):
                 cron = value.get('cron')
                 if isinstance(cron, str):
                     comps = [x for x in cron.split(' ') if x]
-                    if len(comps) >= 6:
-                        comps = comps[1:6]
+                    if comps:
                         return ' '.join(comps)
                 return ''
 

--- a/unit-tests/test_importer.py
+++ b/unit-tests/test_importer.py
@@ -230,3 +230,13 @@ class TestImporterUtils(TestCase):
         self.assertEqual(sc.get('type'), 'MONTHLY_BY_WEEKDAY')
         self.assertEqual(sc.get('weekday'), 'WEDNESDAY')
         self.assertEqual(sc.get('occurrence'), 'SECOND')
+
+    def test_export_schedule_field_preserves_quartz_cron_seconds(self):
+        schedule = {"type": "CRON", "cron": "1 5 1 * * ?", "tz": "Etc/UTC"}
+        self.assertEqual(vault.TypedField.export_schedule_field(schedule), '1 5 1 * * ?')
+
+        schedule = {"type": "CRON", "cron": "0 5 1 * * ?"}
+        self.assertEqual(vault.TypedField.export_schedule_field(schedule), '0 5 1 * * ?')
+
+        schedule = {"type": "CRON", "cron": "5 1 * * ?"}
+        self.assertEqual(vault.TypedField.export_schedule_field(schedule), '5 1 * * ?')


### PR DESCRIPTION
### Summary
pam config list showed truncated rotation schedules for PAM configs stored with 6-part Quartz CRON expressions. export_schedule_field() was dropping the seconds field when exporting type: CRON schedules, so list output did not match the stored value (e.g. "1 5 1 * * ?" displayed as "5 1 * * ?"). This fix preserves the full stored cron string.

### Changes

- vault.py — return the complete cron value for CRON-type schedules instead of stripping the first field from 6-part expressions
- test_importer.py — added test_export_schedule_field_preserves_quartz_cron_seconds covering 6-part and 5-part Quartz cron export