### PR TITLE
Fix redundant full syncs during Docker Service Mode startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -159,38 +159,31 @@ process_ksm_config() {
 # DEVICE SETUP AND AUTHENTICATION FUNCTIONS
 # =============================================================================
 
-# Setup device registration and persistent login
+# Setup device registration and persistent login.
+# All three steps run in a single Commander process so login + vault sync
+# only happens once instead of three times.
 setup_device() {
     local user="$1"
     local password="$2"
     local server="$3"
-    
-    # Step 1: Register device
-    log "Registering device..."
+
+    log "Running device setup (register, persistent login, timeout)..."
+    local setup_script
+    setup_script=$(mktemp /tmp/keeper_setup_XXXXXX.cmd)
+    cat > "${setup_script}" <<CMDS
+this-device register
+this-device persistent-login on
+this-device timeout ${DEVICE_TIMEOUT}
+CMDS
+
     if ! python3 keeper.py --user "${user}" --password "${password}" \
-        --server "${server}" this-device register; then
-        log "ERROR: Device registration failed"
-        exit 1
-    fi
-    
-    # Step 2: Enable persistent login
-    log "Enabling persistent login..."
-    if ! python3 keeper.py --user "${user}" --password "${password}" \
-        --server "${server}" this-device persistent-login on; then
-        log "ERROR: Persistent login setup failed"
+        --server "${server}" "${setup_script}"; then
+        log "ERROR: Device setup failed"
+        rm -f "${setup_script}"
         exit 1
     fi
 
-    # Step 3: Set timeout
-    log "Setting device logout timeout to 30 Days..."
-    if ! python3 keeper.py --user "${user}" --password "${password}" \
-        --server "${server}" this-device timeout "${DEVICE_TIMEOUT}" \
-        > /dev/null; then
-        log "ERROR: Timeout setup failed"
-        exit 1
-    fi
-    
-    log "Device Logout Timeout set successfully"
+    rm -f "${setup_script}"
     log "Device setup completed successfully"
 }
 

--- a/keepercommander/service/commands/handle_service.py
+++ b/keepercommander/service/commands/handle_service.py
@@ -39,11 +39,14 @@ class StopService(Command):
 
 class ServiceStatus(Command):
     """Command to get service status."""
+
+    skip_sync_on_auth = True
+
     @debug_decorator
     def get_parser(self):
         parser = argparse.ArgumentParser(prog='service-status', parents=[report_output_parser], description='Displays if the Commander API service is running or stopped')
         return parser
-    
+
     def execute(self, params: KeeperParams, **kwargs) -> str:
         status = ServiceManager.get_status()
         print(f"Current status: {status}")

--- a/keepercommander/service/docker/printer.py
+++ b/keepercommander/service/docker/printer.py
@@ -13,6 +13,8 @@
 Output formatting utilities for Docker setup commands.
 """
 
+import shlex
+
 from ...display import bcolors
 from .models import SetupResult
 
@@ -68,7 +70,7 @@ class DockerSetupPrinter:
         
         config_file = config_path if config_path else '~/.keeper/config.json'
         print(f"\n{bcolors.BOLD}Step 2: Delete the local config.json file{bcolors.ENDC}")
-        print(f"  {bcolors.OKGREEN}rm {config_file}{bcolors.ENDC}")
+        print(f"  {bcolors.OKGREEN}rm {shlex.quote(config_file)}{bcolors.ENDC}")
         print(f"  Why? Prevents device token conflicts - Docker will download its own config.")
         
         print(f"\n{bcolors.BOLD}Step 3: Review docker-compose.yml{bcolors.ENDC}")

--- a/unit-tests/service/test_service_manager.py
+++ b/unit-tests/service/test_service_manager.py
@@ -115,6 +115,10 @@ class TestServiceManagement(unittest.TestCase):
             status_cmd.execute(self.params)
             mock_print.assert_called_with("Current status: No Commander Service is running currently")
 
+    def test_service_status_skips_sync_on_auth(self):
+        """service-status still requires login but must not trigger a full vault sync."""
+        self.assertTrue(ServiceStatus.skip_sync_on_auth)
+
     def test_process_info_save_load(self):
         """Test ProcessInfo save and load operations"""
         test_pid = 12345


### PR DESCRIPTION
### Summary
Reduces unnecessary full vault syncs when starting Service Mode in Docker, improving container startup time on large vaults.
### Changes
- Batch user/password device setup into one Commander process (3 syncs → 1)
- Skip full vault sync on `service-status` auto-login; login still required (2 syncs → 1 on KSM/config startup)
- Quote paths in docker setup `rm` instructions for macOS folders with spaces
- Add unit test for `service-status` skip-sync behavior