### PR TITLE
test: make API key status checks deterministic

### DIFF
--- a/unit-tests/test_command_enterprise_api_keys.py
+++ b/unit-tests/test_command_enterprise_api_keys.py
@@ -29,6 +29,14 @@ class TestEnterpriseApiKeys(TestCase):
     def tearDown(self):
         mock.patch.stopall()
 
+    @staticmethod
+    def execute_with_fixed_time(cmd, params, **kwargs):
+        """Execute a command with time fixed before the active test token expires."""
+        fixed_now = datetime.datetime(2026, 1, 1)
+        with mock.patch.object(enterprise_api_keys, 'datetime', wraps=datetime) as mocked_datetime:
+            mocked_datetime.datetime.now.return_value = fixed_now
+            return cmd.execute(params, **kwargs)
+
     def test_api_key_list_success(self):
         """Test successful listing of API keys matching Commander terminal output"""
         params = get_connected_params()
@@ -65,7 +73,7 @@ class TestEnterpriseApiKeys(TestCase):
         cmd = enterprise_api_keys.ApiKeyListCommand()
         TestEnterpriseApiKeys.expected_commands = ['list_token']
         
-        result = cmd.execute(params, format='json')
+        result = self.execute_with_fixed_time(cmd, params, format='json')
         
         self.assertEqual(len(TestEnterpriseApiKeys.expected_commands), 0)
         self.assertIsNotNone(result)
@@ -582,7 +590,7 @@ class TestEnterpriseApiKeys(TestCase):
         
         captured_output = io.StringIO()
         with mock.patch('sys.stdout', captured_output):
-            result = cmd.execute(params)
+            result = self.execute_with_fixed_time(cmd, params)
         
         output = captured_output.getvalue()
         


### PR DESCRIPTION
## Summary
- freeze the current time in API key list tests that assert active/expired status
- preserve the existing historical fixtures and exact JSON expectations
- avoid changing production behavior or adding dependencies

## Problem
The `SIEM Tool` fixture expires on 2026-07-08, but two tests expect it to be active. Once the real date passed that expiration, the tests began failing even though the production status calculation was correct.

## How this was discovered
This surfaced while installing the `keeper-commander` package from the Arch User Repository. The package build runs the upstream test suite during `check()`, where these two tests failed after the fixture expiration date passed. Investigating the build failure showed that the package and production status logic were behaving correctly; the failure came from the tests depending on the real calendar date.

## Test plan
- [x] Confirmed both affected tests fail before the change
- [x] Affected tests: 2 passed
- [x] Enterprise API key test module: 30 passed
- [x] Full unit suite on Python 3.14: 1451 passed, 59 skipped, 186 subtests passed