### PR TITLE
Make Azure client id and client secret optional for pamAzureConfiguration

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2809,6 +2809,9 @@ class PamConfigurationEditMixin(RecordEditMixin):
         if extra_properties:
             self.assign_typed_fields(record, [RecordEditMixin.parse_field(x) for x in extra_properties])
 
+    # Fields that the backend previously required but now treats as optional for pamAzureConfiguration.
+    AZURE_OPTIONAL_FIELDS = frozenset({'clientId', 'clientSecret'})
+
     def verify_required(self, record):  # type: (vault.TypedRecord) -> None
         for field in record.fields:
             if field.required:
@@ -2817,6 +2820,9 @@ class PamConfigurationEditMixin(RecordEditMixin):
                         field.value = [{
                             'type': 'ON_DEMAND'
                         }]
+                    elif (record.record_type == 'pamAzureConfiguration'
+                          and field.label in self.AZURE_OPTIONAL_FIELDS):
+                        pass
                     else:
                         self.warnings.append(f'Empty required field: "{field.get_field_name()}"')
         for custom in record.custom:

--- a/keepercommander/commands/pam_import/base.py
+++ b/keepercommander/commands/pam_import/base.py
@@ -143,8 +143,8 @@ class PamConfigEnvironment():
 
         # Azure environment: pamAzureConfiguration
         self.az_entra_id: str = ""              # required, text:azureId
-        self.az_client_id: str = ""             # required, secret:clientId
-        self.az_client_secret: str = ""         # required, secret:clientSecret
+        self.az_client_id: str = ""             # optional, secret:clientId
+        self.az_client_secret: str = ""         # optional, secret:clientSecret
         self.az_subscription_id: str = ""       # required, secret:subscriptionId
         self.az_tenant_id: str = ""             # required, secret:tenantId
         self.az_resource_groups: List[str] = [] # optional, multiline:resourceGroups
@@ -277,9 +277,9 @@ class PamConfigEnvironment():
         elif environment_type == "azure":
             val = settings.get("az_entra_id", None) # required
             if isinstance(val, str): self.az_entra_id = val
-            val = settings.get("az_client_id", None) # required
+            val = settings.get("az_client_id", None) # optional
             if isinstance(val, str): self.az_client_id = val
-            val = settings.get("az_client_secret", None) # required
+            val = settings.get("az_client_secret", None) # optional
             if isinstance(val, str): self.az_client_secret = val
             val = settings.get("az_subscription_id", None) # required
             if isinstance(val, str): self.az_subscription_id = val


### PR DESCRIPTION
This is a follow up to https://github.com/Keeper-Security/discovery-and-rotation-kdnrm/pull/289, where we enable Azure Managed Identity authentication for the gateway.