### PR TITLE
Return enterprise user IDs in verbose mode and add tree --format=json with share permissions

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -781,6 +781,7 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                             user_teams[enterprise_user_id].add(team_uid)
 
                 displayed_columns = [x for x in supported_columns if x in columns]
+                is_verbose = kwargs.get('verbose') or False
                 rows = []
                 for u in users.values():
                     user_status_dict = get_user_status_dict(u)
@@ -796,12 +797,19 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                         elif column == 'transfer_status':
                             row.append(user_status_dict['acct_transfer_status'])
                         elif column == 'node':
-                            row.append(self.get_node_path(params, u['node_id']))
+                            if is_verbose:
+                                row.append(str(u['node_id']))
+                            else:
+                                row.append(self.get_node_path(params, u['node_id']))
                         elif column == 'team_count':
                             row.append(len([1 for t in teams.values() if t['users'] and user_id in t['users']]))
                         elif column == 'teams':
-                            team_names = [t["name"] for t in teams.values() if t['users'] and user_id in t['users']]
-                            row.append(team_names)
+                            user_team_list = [t for t in teams.values()
+                                              if t['users'] and user_id in t['users']]
+                            if is_verbose:
+                                row.append([t['id'] for t in user_team_list])
+                            else:
+                                row.append([t['name'] for t in user_team_list])
                         elif column == 'role_count' or column == 'roles':
                             role_ids = set()
                             if user_id in user_roles:
@@ -813,8 +821,11 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                             if column == 'role_count':
                                 row.append(len(role_ids))
                             else:
-                                role_names = [roles[role_id]['name'] for role_id in role_ids if role_id in roles]
-                                row.append(role_names)
+                                if is_verbose:
+                                    row.append([str(role_id) for role_id in role_ids if role_id in roles])
+                                else:
+                                    role_names = [roles[role_id]['name'] for role_id in role_ids if role_id in roles]
+                                    row.append(role_names)
                         elif column == 'alias':
                             row.append([x['username'] for x in params.enterprise.get('user_aliases', [])
                                         if x['enterprise_user_id'] == user_id and x['username'] != email])

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -1806,6 +1806,12 @@ class FolderTransformCommand(Command, RecordMixin):
 
 
 def _resolve_tree_team_name(params, team_uid):
+    if not team_uid:
+        return ''
+    team = (getattr(params, 'team_cache', None) or {}).get(team_uid) or {}
+    name = team.get('name') if isinstance(team, dict) else getattr(team, 'name', None)
+    if name:
+        return name
     if params.enterprise:
         for t in params.enterprise.get('teams') or []:
             if t.get('team_uid') == team_uid:
@@ -1813,6 +1819,23 @@ def _resolve_tree_team_name(params, team_uid):
                 if name:
                     return name
     return team_uid
+
+
+def _resolve_sf_member_email(params, user_entry):
+    """Resolve a shared-folder user row to an email (never a raw account UID)."""
+    email = (user_entry.get('username') or '').strip()
+    if email and '@' in email:
+        return email
+    account_uid = user_entry.get('account_uid') or ''
+    if account_uid:
+        cached = (getattr(params, 'user_cache', None) or {}).get(account_uid)
+        if cached and '@' in str(cached):
+            return str(cached)
+        if params.enterprise:
+            for u in params.enterprise.get('users') or []:
+                if u.get('user_account_uid') == account_uid and u.get('username'):
+                    return u.get('username')
+    return email if email and '@' in email else ''
 
 
 def _is_compact_share_entry(obj):
@@ -2074,13 +2097,11 @@ def _classic_folder_share_data(params, sf, *, include_uids=False):
 
     Tree text uses a single ``default:`` blob (all default flags).
     JSON splits folder-user defaults vs default record rights:
-      - user_permissions: MU / MR (manage users / manage records on the folder)
+      - user_permissions: MU / MR (default manage users / manage records)
       - record_permissions: CE / CS (default can-edit / can-share on records)
     Named people/teams remain under ``users`` / ``teams``.
     """
-    USER_PERM_KEYS = {
-        'manage_users': 'MU',
-        'manage_records': 'MR',
+    DEFAULT_USER_PERM_KEYS = {
         'default_manage_users': 'MU',
         'default_manage_user': 'MU',  # legacy alias if present
         'default_manage_records': 'MR',
@@ -2089,15 +2110,13 @@ def _classic_folder_share_data(params, sf, *, include_uids=False):
         'default_can_edit': 'CE',
         'default_can_share': 'CS',
     }
-    # Per-user / per-team folder ACL on the shared folder
     MEMBER_PERM_KEYS = {
         'manage_users': 'MU',
         'manage_records': 'MR',
     }
 
     sf = sf or {}
-    user_permissions = [abbr for key, abbr in USER_PERM_KEYS.items() if sf.get(key)]
-    # Preserve stable order MU then MR
+    user_permissions = [abbr for key, abbr in DEFAULT_USER_PERM_KEYS.items() if sf.get(key)]
     user_permissions = [a for a in ('MU', 'MR') if a in user_permissions]
     record_permissions = [abbr for key, abbr in RECORD_PERM_KEYS.items() if sf.get(key)]
     record_permissions = [a for a in ('CE', 'CS') if a in record_permissions]
@@ -2108,22 +2127,48 @@ def _classic_folder_share_data(params, sf, *, include_uids=False):
 
     users = []
     user_parts = []
+    seen_emails = set()
     for u in sf.get('users') or []:
-        email = u.get('username')
-        if not email or email == params.user:
-            continue
-        privs = [abbr for key, abbr in MEMBER_PERM_KEYS.items() if u.get(key)] or ['RO']
+        email = _resolve_sf_member_email(params, u)
+        account_uid = u.get('account_uid') or ''
+        privs = [abbr for key_name, abbr in MEMBER_PERM_KEYS.items() if u.get(key_name)]
         privs = [a for a in ('MU', 'MR') if a in privs] or ['RO']
-        users.append({'email': email, 'permissions': privs})
+        if not email:
+            # Sync often has account_uid only until user_cache fills; still emit membership.
+            if account_uid:
+                entry = {'uid': account_uid, 'permissions': privs}
+                users.append(entry)
+                user_parts.append(f'[{account_uid}:{",".join(privs)}]')
+            continue
+        key = email.lower()
+        if key in seen_emails:
+            continue
+        seen_emails.add(key)
+        entry = {'email': email, 'permissions': privs}
+        if include_uids and account_uid:
+            entry['uid'] = account_uid
+        users.append(entry)
         user_parts.append(f'[{email}:{",".join(privs)}]')
+
     teams = []
     team_parts = []
+    seen_teams = set()
     for t in sf.get('teams') or []:
-        name = t.get('name')
-        privs = [abbr for key, abbr in MEMBER_PERM_KEYS.items() if t.get(key)] or ['RO']
+        team_uid = t.get('team_uid') or ''
+        if team_uid and team_uid in seen_teams:
+            continue
+        if team_uid:
+            seen_teams.add(team_uid)
+        name = (t.get('name') or '').strip()
+        if not name or _looks_like_uid(name):
+            name = _resolve_tree_team_name(params, team_uid) if team_uid else name
+        if not name:
+            if not team_uid:
+                continue
+            name = team_uid
+        privs = [abbr for key_name, abbr in MEMBER_PERM_KEYS.items() if t.get(key_name)]
         privs = [a for a in ('MU', 'MR') if a in privs] or ['RO']
         entry = {'name': name, 'permissions': privs}
-        team_uid = t.get('team_uid') or ''
         if include_uids and team_uid:
             entry['uid'] = team_uid
         teams.append(entry)
@@ -2133,7 +2178,6 @@ def _classic_folder_share_data(params, sf, *, include_uids=False):
         'user_permissions': user_permissions,
         'record_permissions': record_permissions,
     }
-    # Match tree text default:RO when no folder/record default flags are set
     if not user_permissions and not record_permissions:
         data['record_permissions'] = ['RO']
     if users:
@@ -2141,7 +2185,6 @@ def _classic_folder_share_data(params, sf, *, include_uids=False):
     if teams:
         data['teams'] = teams
 
-    # Tree: single default segment (no duplicate "user:")
     parts = ['default:' + ','.join(default_perms)]
     if team_parts:
         parts.append('teams:' + ','.join(team_parts))

--- a/keepercommander/commands/folder.py
+++ b/keepercommander/commands/folder.py
@@ -81,12 +81,16 @@ cd_parser.error = raise_parse_exception
 cd_parser.exit = suppress_exit
 
 
-tree_parser = argparse.ArgumentParser(prog='tree', description='Display the folder structure.')
+tree_parser = argparse.ArgumentParser(prog='tree', description='Display the folder structure.',
+                                      parents=[base.json_output_parser])
 tree_parser.add_argument('-v', '--verbose', dest='verbose', action='store_true', help='print ids')
-tree_parser.add_argument('-r', '--records', action='store_true', help='show records within each folder')
-show_shares_help = 'show share permissions info (shown in parentheses) for each shared folder'
-tree_parser.add_argument('-s', '--shares', action='store_true', help=show_shares_help)
-perms_key_help = 'hide share permissions key (valid only when used with --shares flag, which shows key by default)'
+tree_parser.add_argument('-r', '--records', action='store_true',
+                         help='show records within each folder (includes record type)')
+tree_parser.add_argument('-s', '--shares', action='store_true',
+                         help='show classic shared-folder permissions; with -r also classic record shares')
+tree_parser.add_argument('-ns', '--nsf-shares', dest='nsf_shares', action='store_true',
+                         help='show NSF folder permissions (ACL API); with -r also NSF record shares')
+perms_key_help = 'hide share permissions key (valid with --shares / --nsf-shares)'
 tree_parser.add_argument('-hk', '--hide-shares-key', action='store_true', help=perms_key_help)
 tree_parser.add_argument('-t', '--title', action='store', help='show optional title for folder structure')
 tree_parser.add_argument('folder', nargs='?', type=str, action='store', help='folder path or UID')
@@ -422,18 +426,40 @@ class FolderTreeCommand(Command):
         verbose = kwargs.get('verbose', False)
         records = kwargs.get('records')
         shares = kwargs.get('shares')
-        hide_key = kwargs.get('hide_shares_key', not shares)
+        nsf_shares = kwargs.get('nsf_shares')
+        fmt = kwargs.get('format') or 'table'
+        show_key = bool(shares or nsf_shares)
+        hide_key = kwargs.get('hide_shares_key', not show_key)
         title = kwargs.get('title')
+        trees = []
         if folder_name in params.folder_cache:
             folder = params.folder_cache.get(folder_name)
-            formatted_tree(params, folder, verbose=verbose, show_records=records, shares=shares, hide_shares_key=hide_key, title=title)
+            trees.append(formatted_tree(
+                params, folder, verbose=verbose, show_records=records, shares=shares,
+                nsf_shares=nsf_shares, hide_shares_key=hide_key, title=title, fmt=fmt))
         else:
             folders, pattern = try_resolve_path(params, folder_name, find_all_matches=True)
             if not pattern:
                 for idx, folder in enumerate(folders):
-                    formatted_tree(params, folder, verbose=verbose, show_records=records, shares=shares, hide_shares_key=hide_key or idx > 0, title=title)
+                    trees.append(formatted_tree(
+                        params, folder, verbose=verbose, show_records=records, shares=shares,
+                        nsf_shares=nsf_shares, hide_shares_key=hide_key or idx > 0, title=title,
+                        fmt=fmt))
             else:
                 raise CommandError('tree', f'Folder {folder_name} not found')
+        if fmt == 'json':
+            payload = trees[0] if len(trees) == 1 else {'trees': [t for t in trees if t]}
+            text = _tree_json_dumps(payload)
+            output = kwargs.get('output')
+            if output:
+                _, ext = os.path.splitext(output)
+                path = output if ext else output + '.json'
+                with open(path, 'w', encoding='utf-8') as fd:
+                    fd.write(text)
+                    fd.write('\n')
+                logging.info('Report path: %s', os.path.abspath(path))
+                return None
+            return text
 
 
 class FolderRenameCommand(Command):
@@ -1779,65 +1805,684 @@ class FolderTransformCommand(Command, RecordMixin):
         api.sync_down(params)
 
 
-def formatted_tree(params, folder, verbose=False, show_records=False, shares=False, hide_shares_key=False, title=None):
-    def print_share_permissions_key():
-        perms_key = 'Share Permissions Key:\n' \
-                    '======================\n' \
-                    'RO = Read-Only\n' \
-                    'MU = Can Manage Users\n' \
-                    'MR = Can Manage Records\n' \
-                    'CE = Can Edit\n' \
-                    'CS = Can Share\n' \
-                    '======================\n'
-        print(perms_key)
-
-    def get_share_info(node):
-        MU_KEY = 'manage_users'
-        MR_KEY = 'manage_records'
-        DMR_KEY = 'default_manage_records'
-        DMU_KEY = 'default_manage_user'
-        DCE_KEY = 'default_can_edit'
-        DCS_KEY = 'default_can_share'
-        perm_abbrev_lookup = {MU_KEY: 'MU', MR_KEY: 'MR', DMR_KEY: 'MU', DMU_KEY: 'MU', DCE_KEY: 'CE', DCS_KEY: 'CS'}
-
-        def get_users_info(users):
-            info = []
-            for u in users:
-                email = u.get('username')
-                if email == params.user:
-                    continue
-                privs = [v for k, v in perm_abbrev_lookup.items() if u.get(k)] or ['RO']
-                info.append(f'[{email}:{",".join(privs)}]')
-            return 'users:' + ','.join(info) if info else ''
-
-        def get_teams_info(teams):
-            info = []
-            for t in teams:
+def _resolve_tree_team_name(params, team_uid):
+    if params.enterprise:
+        for t in params.enterprise.get('teams') or []:
+            if t.get('team_uid') == team_uid:
                 name = t.get('name')
-                privs = [v for k, v in perm_abbrev_lookup.items() if t.get(k)] or ['RO']
-                info.append(f'[{name}:{",".join(privs)}]')
-            return 'teams:' + ','.join(info) if info else ''
+                if name:
+                    return name
+    return team_uid
 
-        result = ''
-        if isinstance(node, SharedFolderNode):
-            sf = params.shared_folder_cache.get(node.uid)
-            teams_info = get_teams_info(sf.get('teams', []))
-            users_info = get_users_info(sf.get('users', []))
-            default_perms = [v for k, v in perm_abbrev_lookup.items() if sf.get(k)] or ['RO']
-            default_perms = 'default:' + ','.join(default_perms)
-            user_perms = [v for k, v in perm_abbrev_lookup.items() if sf.get(k)] or ['RO']
-            user_perms = 'user:' + ','.join(user_perms)
-            perms = [default_perms, user_perms, teams_info, users_info]
-            perms = [p for p in perms if p]
-            result = f' ({"; ".join(perms)})' if shares else ''
 
-        return result
+def _is_compact_share_entry(obj):
+    """True for leaf share objects like {email, permissions} / {name, uid, permissions}."""
+    if not isinstance(obj, dict) or not obj:
+        return False
+    allowed = {'email', 'name', 'uid', 'permissions'}
+    if set(obj.keys()) - allowed:
+        return False
+    for k, v in obj.items():
+        if k == 'permissions':
+            if not isinstance(v, list) or not all(isinstance(x, str) for x in v):
+                return False
+        elif not isinstance(v, str):
+            return False
+    return True
 
-    def tree_node(node):
+
+def _dump_compact_share_entry(obj):
+    """Dump a share entry on one line; keep field order name/email, uid, permissions."""
+    parts = []
+    for key in ('name', 'email', 'uid', 'permissions'):
+        if key not in obj:
+            continue
+        val = obj[key]
+        if key == 'permissions':
+            inner = ', '.join(json.dumps(x) for x in val)
+            parts.append(f'"{key}": [{inner}]')
+        else:
+            parts.append(f'"{key}": {json.dumps(val)}')
+    return '{ ' + ', '.join(parts) + ' }'
+
+
+def _tree_json_dumps(obj, level=0, indent=2):
+    """Pretty JSON with share entries / permission arrays kept on one line."""
+    sp = ' ' * (indent * level)
+    sp1 = ' ' * (indent * (level + 1))
+    if isinstance(obj, dict):
+        if not obj:
+            return '{}'
+        if _is_compact_share_entry(obj):
+            return _dump_compact_share_entry(obj)
+        lines = ['{']
+        items = list(obj.items())
+        for i, (k, v) in enumerate(items):
+            comma = ',' if i < len(items) - 1 else ''
+            dumped = _tree_json_dumps(v, level + 1, indent)
+            lines.append(f'{sp1}{json.dumps(k)}: {dumped}{comma}')
+        lines.append(sp + '}')
+        return '\n'.join(lines)
+    if isinstance(obj, list):
+        if not obj:
+            return '[]'
+        if all(isinstance(x, str) for x in obj):
+            return '[' + ', '.join(json.dumps(x) for x in obj) + ']'
+        if all(_is_compact_share_entry(x) for x in obj):
+            lines = ['[']
+            for i, x in enumerate(obj):
+                comma = ',' if i < len(obj) - 1 else ''
+                lines.append(f'{sp1}{_dump_compact_share_entry(x)}{comma}')
+            lines.append(sp + ']')
+            return '\n'.join(lines)
+        lines = ['[']
+        for i, x in enumerate(obj):
+            comma = ',' if i < len(obj) - 1 else ''
+            dumped = _tree_json_dumps(x, level + 1, indent)
+            lines.append(f'{sp1}{dumped}{comma}')
+        lines.append(sp + ']')
+        return '\n'.join(lines)
+    return json.dumps(obj)
+
+
+_NSF_ROLE_ABBREV = {
+    'viewer': 'VW',
+    'contributor': 'CT',
+    'share-manager': 'SM',
+    'content-manager': 'CM',
+    'content-share-manager': 'CSM',
+    'full-manager': 'FM',
+    'unresolved': 'UN',
+    'owner': 'OW',
+}
+
+
+def _nsf_role_label(accessor):
+    from .nested_share_folder.helpers import format_role_display, get_access_role_label
+    role = accessor.get('role')
+    if role:
+        return format_role_display(role)
+    return get_access_role_label(accessor) or 'viewer'
+
+
+def _nsf_role_abbrev(accessor):
+    label = _nsf_role_label(accessor)
+    return _NSF_ROLE_ABBREV.get(label, (label[:2].upper() if label else 'VW'))
+
+
+def _looks_like_uid(value):
+    if not value or not isinstance(value, str) or '@' in value:
+        return False
+    # Keeper UIDs are typically 22-char base64url
+    return bool(re.fullmatch(r'[A-Za-z0-9_-]{16,28}', value))
+
+
+def _resolve_nsf_user_email(params, accessor):
+    """Resolve AT_USER accessor to an email; never return a raw UID as email."""
+    email = (accessor.get('username') or '').strip()
+    if email and not _looks_like_uid(email):
+        return email
+    auid = accessor.get('accessor_uid') or ''
+    if not auid:
+        return email if email and not _looks_like_uid(email) else ''
+    cached = getattr(params, 'user_cache', {}).get(auid) if hasattr(params, 'user_cache') else None
+    if cached:
+        return cached
+    if params.enterprise:
+        for u in params.enterprise.get('users') or []:
+            if u.get('user_account_uid') == auid and u.get('username'):
+                return u.get('username')
+    try:
+        from ..nested_share_folder.folder_api import _resolve_uid_to_username
+        resolved = _resolve_uid_to_username(params, auid)
+        if resolved:
+            if not hasattr(params, 'user_cache') or params.user_cache is None:
+                params.user_cache = {}
+            params.user_cache[auid] = resolved
+            return resolved
+    except Exception as exc:
+        logging.debug('NSF user resolve failed for %s: %s', auid, exc)
+    return ''
+
+
+def _resolve_nsf_app_name(params, app_uid):
+    if not app_uid:
+        return ''
+    try:
+        from .ksm import KSMCommand
+        rec = KSMCommand.get_app_record(params, app_uid)
+        if rec:
+            data = rec.get('data_unencrypted')
+            if data:
+                if isinstance(data, (bytes, bytearray)):
+                    data = data.decode('utf-8')
+                title = json.loads(data).get('title')
+                if title:
+                    return title
+    except Exception as exc:
+        logging.debug('NSF app resolve via KSM failed for %s: %s', app_uid, exc)
+    if app_uid in (params.record_cache or {}):
+        try:
+            r = api.get_record(params, app_uid)
+            if r and getattr(r, 'title', None):
+                return r.title
+        except Exception as exc:
+            logging.debug('NSF app resolve via record cache failed for %s: %s', app_uid, exc)
+    return ''
+
+
+def _nsf_folder_share_data(params, folder_uid, *, include_uids=False):
+    """Return structured NSF folder share perms and a compact text suffix.
+
+    Owner is listed under ``users`` with permission ``OW`` (not a separate label).
+    Applications are listed separately (never as fake user emails / UIDs).
+    """
+    from .. import nested_share_folder as _nsf
+    accessors = _nsf.get_nsf_folder_share_accessors(params, folder_uid)
+    folder_info = (getattr(params, 'nested_share_folders', {}) or {}).get(folder_uid) or {}
+    owner = (folder_info.get('owner_username') or '').strip()
+    if owner and _looks_like_uid(owner):
+        owner = ''
+    users = []
+    teams = []
+    applications = []
+    user_parts = []
+    team_parts = []
+    app_parts = []
+    seen_users = set()
+
+    if owner:
+        users.append({'email': owner, 'permissions': ['OW']})
+        user_parts.append(f'[{owner}:OW]')
+        seen_users.add(owner.lower())
+
+    for a in accessors:
+        at = a.get('access_type') or ''
+        abbrev = _nsf_role_abbrev(a)
+        auid = a.get('accessor_uid') or ''
+
+        if at == 'AT_OWNER':
+            if not owner:
+                email = _resolve_nsf_user_email(params, a)
+                if email and email.lower() not in seen_users:
+                    users.append({'email': email, 'permissions': ['OW']})
+                    user_parts.append(f'[{email}:OW]')
+                    seen_users.add(email.lower())
+            continue
+
+        if at == 'AT_TEAM':
+            name = _resolve_tree_team_name(params, auid)
+            entry = {'name': name, 'permissions': [abbrev]}
+            if include_uids and auid:
+                entry['uid'] = auid
+            teams.append(entry)
+            team_parts.append(f'[{name}:{abbrev}]')
+            continue
+
+        if at == 'AT_APPLICATION':
+            app_name = _resolve_nsf_app_name(params, auid) or (auid if include_uids else 'application')
+            entry = {'name': app_name, 'permissions': [abbrev]}
+            if include_uids and auid:
+                entry['uid'] = auid
+            applications.append(entry)
+            app_parts.append(f'[{app_name}:{abbrev}]')
+            continue
+
+        if at in ('AT_USER', 'AT_UNKNOWN', ''):
+            email = _resolve_nsf_user_email(params, a)
+            if not email:
+                # Unresolved user: only expose UID when -v, never as email.
+                if include_uids and auid:
+                    entry = {'uid': auid, 'permissions': [abbrev]}
+                    users.append(entry)
+                    user_parts.append(f'[{auid}:{abbrev}]')
+                continue
+            if email.lower() in seen_users or email == params.user:
+                continue
+            users.append({'email': email, 'permissions': [abbrev]})
+            user_parts.append(f'[{email}:{abbrev}]')
+            seen_users.add(email.lower())
+
+    data = {}
+    if users:
+        data['users'] = users
+    if teams:
+        data['teams'] = teams
+    if applications:
+        data['applications'] = applications
+    if not data:
+        state = (getattr(params, 'nested_share_folder_sharing_states', {}) or {}).get(folder_uid) or {}
+        if state.get('shared') or state.get('count', 0) > 0:
+            data['shared'] = True
+            data['count'] = state.get('count', 0)
+
+    parts = []
+    if user_parts:
+        parts.append('users:' + ','.join(user_parts))
+    if team_parts:
+        parts.append('teams:' + ','.join(team_parts))
+    if app_parts:
+        parts.append('applications:' + ','.join(app_parts))
+    if not parts and data.get('shared'):
+        parts.append(f'shared:count={data.get("count", 0)}')
+    text = f' ({"; ".join(parts)})' if parts else ''
+    return data or None, text
+
+
+def _classic_folder_share_data(params, sf, *, include_uids=False):
+    """Return structured classic SF share perms and compact text suffix.
+
+    Tree text uses a single ``default:`` blob (all default flags).
+    JSON splits folder-user defaults vs default record rights:
+      - user_permissions: MU / MR (manage users / manage records on the folder)
+      - record_permissions: CE / CS (default can-edit / can-share on records)
+    Named people/teams remain under ``users`` / ``teams``.
+    """
+    USER_PERM_KEYS = {
+        'manage_users': 'MU',
+        'manage_records': 'MR',
+        'default_manage_users': 'MU',
+        'default_manage_user': 'MU',  # legacy alias if present
+        'default_manage_records': 'MR',
+    }
+    RECORD_PERM_KEYS = {
+        'default_can_edit': 'CE',
+        'default_can_share': 'CS',
+    }
+    # Per-user / per-team folder ACL on the shared folder
+    MEMBER_PERM_KEYS = {
+        'manage_users': 'MU',
+        'manage_records': 'MR',
+    }
+
+    sf = sf or {}
+    user_permissions = [abbr for key, abbr in USER_PERM_KEYS.items() if sf.get(key)]
+    # Preserve stable order MU then MR
+    user_permissions = [a for a in ('MU', 'MR') if a in user_permissions]
+    record_permissions = [abbr for key, abbr in RECORD_PERM_KEYS.items() if sf.get(key)]
+    record_permissions = [a for a in ('CE', 'CS') if a in record_permissions]
+
+    default_perms = user_permissions + record_permissions
+    if not default_perms:
+        default_perms = ['RO']
+
+    users = []
+    user_parts = []
+    for u in sf.get('users') or []:
+        email = u.get('username')
+        if not email or email == params.user:
+            continue
+        privs = [abbr for key, abbr in MEMBER_PERM_KEYS.items() if u.get(key)] or ['RO']
+        privs = [a for a in ('MU', 'MR') if a in privs] or ['RO']
+        users.append({'email': email, 'permissions': privs})
+        user_parts.append(f'[{email}:{",".join(privs)}]')
+    teams = []
+    team_parts = []
+    for t in sf.get('teams') or []:
+        name = t.get('name')
+        privs = [abbr for key, abbr in MEMBER_PERM_KEYS.items() if t.get(key)] or ['RO']
+        privs = [a for a in ('MU', 'MR') if a in privs] or ['RO']
+        entry = {'name': name, 'permissions': privs}
+        team_uid = t.get('team_uid') or ''
+        if include_uids and team_uid:
+            entry['uid'] = team_uid
+        teams.append(entry)
+        team_parts.append(f'[{name}:{",".join(privs)}]')
+
+    data = {
+        'user_permissions': user_permissions,
+        'record_permissions': record_permissions,
+    }
+    # Match tree text default:RO when no folder/record default flags are set
+    if not user_permissions and not record_permissions:
+        data['record_permissions'] = ['RO']
+    if users:
+        data['users'] = users
+    if teams:
+        data['teams'] = teams
+
+    # Tree: single default segment (no duplicate "user:")
+    parts = ['default:' + ','.join(default_perms)]
+    if team_parts:
+        parts.append('teams:' + ','.join(team_parts))
+    if user_parts:
+        parts.append('users:' + ','.join(user_parts))
+    return data, f' ({"; ".join(parts)})'
+
+
+def _classic_record_share_data(params, record_uid, *, include_uids=False):
+    """Classic record share perms → structured data + compact text.
+
+    Only direct user shares are listed. Shared-folder inheritance is omitted:
+    the tree already places the record under its parent shared folder(s).
+    """
+    rec = (params.record_cache or {}).get(record_uid) or {}
+    shares_data = rec.get('shares') or {}
+    users = []
+    user_parts = []
+    for up in shares_data.get('user_permissions') or []:
+        email = up.get('username') or ''
+        if not email:
+            continue
+        if up.get('owner'):
+            users.append({'email': email, 'permissions': ['OW']})
+            user_parts.append(f'[{email}:OW]')
+            continue
+        if email == params.user:
+            continue
+        privs = []
+        if up.get('editable'):
+            privs.append('CE')
+        if up.get('shareable'):
+            privs.append('CS')
+        if not privs:
+            privs = ['RO']
+        users.append({'email': email, 'permissions': privs})
+        user_parts.append(f'[{email}:{",".join(privs)}]')
+    if not users:
+        return None, ''
+    data = {'users': users}
+    text = f' (users:{",".join(user_parts)})'
+    return data, text
+
+
+def _nsf_record_share_data(params, record_uid, *, include_uids=False):
+    """NSF record share perms → structured data + compact text.
+
+    Uses warmed ``nested_share_record_share_cache``. Direct (non-inherited)
+    accessors win over folder-inherited rows for the same identity. When the
+    record ACL cache is empty, falls back to the parent NSF folder ACL.
+    """
+    from .. import nested_share_folder as _nsf
+    accessors = list(_nsf.get_nsf_record_share_accessors(params, record_uid) or [])
+    if not accessors:
+        try:
+            parent_uids = _nsf.find_nested_share_folders_for_record(params, record_uid) or []
+        except Exception as exc:
+            logging.debug('NSF parent folder lookup failed for %s: %s', record_uid, exc)
+            parent_uids = []
+        for fuid in parent_uids:
+            data, text = _nsf_folder_share_data(params, fuid, include_uids=include_uids)
+            if data:
+                return data, text
+        return None, ''
+
+    # Direct shares first so inherited folder rows do not hide them.
+    accessors.sort(key=lambda a: 1 if a.get('inherited') else 0)
+
+    users = []
+    teams = []
+    applications = []
+    user_parts = []
+    team_parts = []
+    app_parts = []
+    seen_users = set()
+    seen_teams = set()
+    seen_apps = set()
+
+    for a in accessors:
+        at = a.get('access_type') or ''
+        abbrev = _nsf_role_abbrev(a)
+        auid = a.get('access_type_uid') or a.get('accessor_uid') or ''
+
+        if a.get('owner') or at == 'AT_OWNER':
+            email = (a.get('accessor_name') or '').strip()
+            if email and _looks_like_uid(email):
+                email = ''
+            if not email:
+                email = _resolve_nsf_user_email(params, {
+                    'username': a.get('accessor_name') or a.get('username'),
+                    'accessor_uid': auid,
+                })
+            if email and email.lower() not in seen_users:
+                users.append({'email': email, 'permissions': ['OW']})
+                user_parts.append(f'[{email}:OW]')
+                seen_users.add(email.lower())
+            elif not email and include_uids and auid and auid not in seen_users:
+                users.append({'uid': auid, 'permissions': ['OW']})
+                user_parts.append(f'[{auid}:OW]')
+                seen_users.add(auid)
+            continue
+
+        if at == 'AT_TEAM':
+            if auid and auid in seen_teams:
+                continue
+            name = _resolve_tree_team_name(params, auid)
+            entry = {'name': name, 'permissions': [abbrev]}
+            if include_uids and auid:
+                entry['uid'] = auid
+            teams.append(entry)
+            team_parts.append(f'[{name}:{abbrev}]')
+            if auid:
+                seen_teams.add(auid)
+            continue
+
+        if at == 'AT_APPLICATION':
+            if auid and auid in seen_apps:
+                continue
+            app_name = _resolve_nsf_app_name(params, auid) or (auid if include_uids else 'application')
+            entry = {'name': app_name, 'permissions': [abbrev]}
+            if include_uids and auid:
+                entry['uid'] = auid
+            applications.append(entry)
+            app_parts.append(f'[{app_name}:{abbrev}]')
+            if auid:
+                seen_apps.add(auid)
+            continue
+
+        email = (a.get('accessor_name') or '').strip()
+        if email and _looks_like_uid(email):
+            email = ''
+        if not email:
+            email = _resolve_nsf_user_email(params, {
+                'username': a.get('accessor_name') or a.get('username'),
+                'accessor_uid': auid,
+            })
+        if not email:
+            if include_uids and auid and auid not in seen_users:
+                users.append({'uid': auid, 'permissions': [abbrev]})
+                user_parts.append(f'[{auid}:{abbrev}]')
+                seen_users.add(auid)
+            continue
+        if email.lower() in seen_users or email == params.user:
+            continue
+        users.append({'email': email, 'permissions': [abbrev]})
+        user_parts.append(f'[{email}:{abbrev}]')
+        seen_users.add(email.lower())
+
+    data = {}
+    if users:
+        data['users'] = users
+    if teams:
+        data['teams'] = teams
+    if applications:
+        data['applications'] = applications
+    if not data:
+        try:
+            parent_uids = _nsf.find_nested_share_folders_for_record(params, record_uid) or []
+        except Exception as exc:
+            logging.debug('NSF parent folder lookup failed for %s: %s', record_uid, exc)
+            parent_uids = []
+        for fuid in parent_uids:
+            folder_data, folder_text = _nsf_folder_share_data(
+                params, fuid, include_uids=include_uids)
+            if folder_data:
+                return folder_data, folder_text
+        return None, ''
+
+    parts = []
+    if user_parts:
+        parts.append('users:' + ','.join(user_parts))
+    if team_parts:
+        parts.append('teams:' + ','.join(team_parts))
+    if app_parts:
+        parts.append('applications:' + ','.join(app_parts))
+    text = f' ({"; ".join(parts)})' if parts else ''
+    return data, text
+
+
+def _join_tree_path(parent_path, name):
+    name = name or ''
+    if not parent_path or parent_path == '/':
+        return '/' + name if name else '/'
+    return parent_path.rstrip('/') + '/' + name
+
+
+def _collect_tree_share_targets(params, folder, show_records):
+    """Collect NSF folder UIDs and record UIDs under *folder* for ACL warming."""
+    nsf_folder_uids = set()
+    classic_record_uids = set()
+    nsf_record_uids = set()
+    nsf_folders = getattr(params, 'nested_share_folders', {}) or {}
+    nsf_records = getattr(params, 'nested_share_records', {}) or {}
+    nsf_folder_records = getattr(params, 'nested_share_folder_records', {}) or {}
+    visited = set()
+
+    def walk(node):
+        if isinstance(node, Record):
+            ruid = node.record_uid
+            if ruid in nsf_records:
+                nsf_record_uids.add(ruid)
+            else:
+                classic_record_uids.add(ruid)
+            return
+
+        node_uid = node.uid if hasattr(node, 'uid') else ''
+        walk_key = node_uid or id(node)
+        if walk_key in visited:
+            return
+        visited.add(walk_key)
+
+        is_nsf = (
+            (hasattr(node, 'type') and node.type == 'nested_share_folder')
+            or (node_uid and node_uid in nsf_folders)
+        )
+        if is_nsf and node_uid:
+            nsf_folder_uids.add(node_uid)
+
+        dir_nodes = []
+        if hasattr(node, 'subfolders'):
+            dir_nodes = [params.folder_cache.get(fuid) for fuid in node.subfolders if params.folder_cache.get(fuid)]
+
+        is_root = (isinstance(node, BaseFolderNode) and (node.type == '/' or node_uid == '')) or (
+            hasattr(node, 'type') and node.type == 'nested_share_folder' and not node_uid)
+
+        if is_root and nsf_folders:
+            for nsf_uid, nsf_folder in nsf_folders.items():
+                parent_uid = nsf_folder.get('parent_uid')
+                is_root_folder = (
+                    parent_uid is None or parent_uid == '' or parent_uid == 'root'
+                    or parent_uid == 'AAAAAAAAAAAAAAAAAPmtNA'
+                    or (parent_uid and parent_uid not in nsf_folders)
+                )
+                if not is_root_folder:
+                    continue
+                nsf_folder_uids.add(nsf_uid)
+                if nsf_uid in params.folder_cache:
+                    dir_nodes.append(params.folder_cache.get(nsf_uid))
+                else:
+                    dir_nodes.append(type('FolderNode', (), {
+                        'uid': nsf_uid, 'name': nsf_folder.get('name', ''),
+                        'type': 'nested_share_folder', 'subfolders': []
+                    })())
+        elif node_uid and nsf_folders:
+            for child_uid, child_folder in nsf_folders.items():
+                if child_folder.get('parent_uid', '') == node_uid:
+                    nsf_folder_uids.add(child_uid)
+                    if child_uid in params.folder_cache:
+                        dir_nodes.append(params.folder_cache.get(child_uid))
+                    else:
+                        dir_nodes.append(type('FolderNode', (), {
+                            'uid': child_uid, 'name': child_folder.get('name', ''),
+                            'type': 'nested_share_folder', 'subfolders': []
+                        })())
+
+        if show_records and isinstance(node, BaseFolderNode):
+            node_uid_for_recs = '' if node.type == '/' else node.uid
+            rec_uids = {rec for recs in get_contained_record_uids(params, node_uid_for_recs).values() for rec in recs}
+            for ruid in rec_uids:
+                if ruid in nsf_records:
+                    nsf_record_uids.add(ruid)
+                else:
+                    classic_record_uids.add(ruid)
+            if is_root:
+                shown = set(rec_uids)
+                for folder_uid, nsf_rec_uids in nsf_folder_records.items():
+                    if folder_uid not in nsf_folders:
+                        for ruid in nsf_rec_uids:
+                            if ruid not in shown:
+                                nsf_record_uids.add(ruid)
+                                shown.add(ruid)
+                all_filed = set()
+                for uids in nsf_folder_records.values():
+                    all_filed.update(uids)
+                for ruid in nsf_records:
+                    if ruid not in all_filed and ruid not in shown:
+                        nsf_record_uids.add(ruid)
+            elif node_uid_for_recs in nsf_folder_records:
+                for ruid in nsf_folder_records[node_uid_for_recs]:
+                    nsf_record_uids.add(ruid)
+        elif show_records and is_nsf and node_uid and node_uid in nsf_folder_records:
+            # Temp NSF nodes are not BaseFolderNode; still warm their records.
+            for ruid in nsf_folder_records[node_uid]:
+                nsf_record_uids.add(ruid)
+
+        for child in dir_nodes:
+            if child:
+                walk(child)
+
+    walk(folder)
+    return nsf_folder_uids, classic_record_uids, nsf_record_uids
+
+
+def formatted_tree(params, folder, verbose=False, show_records=False, shares=False,
+                   nsf_shares=False, hide_shares_key=False, title=None, fmt='table'):
+    as_json = (fmt == 'json')
+    need_nsf_folders = bool(nsf_shares)
+    need_nsf_records = bool(nsf_shares and show_records)
+    need_classic_records = bool(shares and show_records)
+    if need_nsf_folders or need_nsf_records or need_classic_records:
+        nsf_folder_uids, classic_record_uids, nsf_record_uids = _collect_tree_share_targets(
+            params, folder, show_records)
+        from .. import nested_share_folder as _nsf
+        _nsf.warm_for_tree(
+            params,
+            nsf_folder_uids=nsf_folder_uids if need_nsf_folders else None,
+            classic_record_uids=classic_record_uids if need_classic_records else None,
+            nsf_record_uids=nsf_record_uids if need_nsf_records else None,
+        )
+
+    def print_share_permissions_key():
+        lines = [
+            'Share Permissions Key:',
+            '======================',
+        ]
+        if shares:
+            lines.extend([
+                'RO = Read-Only',
+                'MU = Can Manage Users',
+                'MR = Can Manage Records',
+                'CE = Can Edit',
+                'CS = Can Share',
+                'OW = Owner',
+            ])
+        if nsf_shares:
+            lines.extend([
+                'OW = NSF Owner',
+                'VW = NSF Viewer',
+                'CT = NSF Contributor',
+                'SM = NSF Share Manager',
+                'CM = NSF Content Manager',
+                'CSM = NSF Content + Share Manager',
+                'FM = NSF Full Manager',
+            ])
+        lines.append('======================')
+        print('\n'.join(lines) + '\n')
+
+    def tree_node(node, parent_path=''):
         node_uid = node.record_uid if isinstance(node, Record) else (node.uid if hasattr(node, 'uid') else '')
         node_name = node.title if isinstance(node, Record) else (node.name if hasattr(node, 'name') else 'Unknown')
-        
-        # Check if it's a Nested Share Folder item and get proper name
+
         is_nested_share = False
         if isinstance(node, Record):
             is_nested_share = hasattr(params, 'nested_share_records') and node.record_uid in params.nested_share_records
@@ -1845,59 +2490,78 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
             is_nested_share = True
         elif isinstance(node, BaseFolderNode) and not isinstance(node, Record):
             is_nested_share = hasattr(params, 'nested_share_folders') and node_uid in params.nested_share_folders
-            # Get folder name from nested_share_folders if available
             if is_nested_share and node_uid in params.nested_share_folders:
                 nsf_folder_name = params.nested_share_folders[node_uid].get('name', node_name)
                 if nsf_folder_name:
                     node_name = nsf_folder_name
-        
-        node_name = f'{node_name} ({node_uid})' if verbose else node_name
-        share_info = get_share_info(node) if isinstance(node, SharedFolderNode) and shares else ''
-        
-        # Format node name based on type
+
+        base_name = node_name
+        if is_nested_share and not isinstance(node, Record) and node_uid in getattr(params, 'nested_share_folders', {}):
+            base_name = params.nested_share_folders[node_uid].get('name') or base_name
+
+        is_vault_root = isinstance(node, BaseFolderNode) and (getattr(node, 'type', None) == '/' or not node_uid)
+        if is_vault_root and not isinstance(node, Record):
+            node_path = '/'
+        else:
+            node_path = _join_tree_path(parent_path, base_name)
+
+        display_name = f'{node_name} ({node_uid})' if verbose else node_name
+        share_text = ''
+        share_data = None
+        kind = 'folder'
+        record_type = None
+
         if isinstance(node, Record):
+            kind = 'nested_record' if is_nested_share else 'record'
+            record_type = getattr(node, 'record_type', None) or ''
+            type_label = f' [{record_type}]' if record_type else ''
             nsf_label = ' [Nested Record]' if is_nested_share else ' [Record]'
-            node_name = f'{Style.DIM}{node_name}{nsf_label}{Style.NORMAL}'
+            if is_nested_share and nsf_shares:
+                share_data, share_text = _nsf_record_share_data(
+                    params, node_uid, include_uids=verbose)
+            elif (not is_nested_share) and shares:
+                share_data, share_text = _classic_record_share_data(
+                    params, node_uid, include_uids=verbose)
+            display_name = f'{Style.DIM}{display_name}{type_label}{nsf_label}{share_text}{Style.NORMAL}'
         elif isinstance(node, SharedFolderNode):
-            node_name = f'{node_name}{Style.BRIGHT} [SHARED]{Style.NORMAL}{share_info}'
+            kind = 'shared_folder'
+            if shares:
+                share_data, share_text = _classic_folder_share_data(
+                    params, params.shared_folder_cache.get(node.uid), include_uids=verbose)
+            display_name = f'{display_name}{Style.BRIGHT} [SHARED]{Style.NORMAL}{share_text}'
         elif is_nested_share:
-            node_name = f'{node_name}{Style.BRIGHT} [Nested Share Folder]{Style.NORMAL}'
+            kind = 'nested_share_folder'
+            if nsf_shares and node_uid:
+                share_data, share_text = _nsf_folder_share_data(
+                    params, node_uid, include_uids=verbose)
+            display_name = f'{display_name}{Style.BRIGHT} [Nested Share Folder]{Style.NORMAL}{share_text}'
 
         dir_nodes = []
         if not isinstance(node, Record):
-            # Get regular subfolders from folder_cache
             if hasattr(node, 'subfolders'):
                 dir_nodes = [params.folder_cache.get(fuid) for fuid in node.subfolders if params.folder_cache.get(fuid)]
-        
-        # Check if this is root folder and add Nested Share Folder root-level folders
+
         is_root = (isinstance(node, BaseFolderNode) and (node.type == '/' or node_uid == '')) or \
                   (hasattr(node, 'type') and node.type == 'nested_share_folder' and not node_uid)
-        
+
         if is_root and hasattr(params, 'nested_share_folders') and params.nested_share_folders:
-            # Add all Nested Share Folders that are at root level
             for nsf_uid, nsf_folder in params.nested_share_folders.items():
                 parent_uid = nsf_folder.get('parent_uid')
-                # Check if this folder is at root:
-                # - parent_uid is None, empty string, 'root', or the special root UID
-                # - Also check if parent doesn't exist in nested_share_folders (orphan = root level)
                 is_root_folder = (
-                    parent_uid is None or 
-                    parent_uid == '' or 
-                    parent_uid == 'root' or 
+                    parent_uid is None or
+                    parent_uid == '' or
+                    parent_uid == 'root' or
                     parent_uid == 'AAAAAAAAAAAAAAAAAPmtNA' or
                     (parent_uid and parent_uid not in params.nested_share_folders)
                 )
                 if is_root_folder:
-                    # Check if already in dir_nodes
                     already_added = any(hasattr(n, 'uid') and n.uid == nsf_uid for n in dir_nodes if n)
                     if not already_added:
-                        # Check if in folder_cache first
                         if nsf_uid in params.folder_cache:
                             nsf_node = params.folder_cache.get(nsf_uid)
                             if nsf_node:
                                 dir_nodes.append(nsf_node)
                         else:
-                            # Create a temporary folder node for Nested Share Folders not in folder_cache
                             temp_node = type('FolderNode', (), {
                                 'uid': nsf_uid,
                                 'name': nsf_folder.get('name', 'Unnamed'),
@@ -1905,14 +2569,11 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                                 'subfolders': []
                             })()
                             dir_nodes.append(temp_node)
-        
-        # Add Nested Share Folder subfolders if this is a Nested Share Folder
+
         elif not isinstance(node, Record) and hasattr(params, 'nested_share_folders') and node_uid:
-            # Find child folders for this Nested Share Folder
             for child_uid, child_folder in params.nested_share_folders.items():
                 parent_uid = child_folder.get('parent_uid', '')
                 if parent_uid == node_uid:
-                    # Check if already in dir_nodes
                     already_added = any(hasattr(n, 'uid') and n.uid == child_uid for n in dir_nodes if n)
                     if not already_added:
                         if child_uid in params.folder_cache:
@@ -1920,7 +2581,6 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                             if child_node:
                                 dir_nodes.append(child_node)
                         else:
-                            # Create a temporary folder node
                             temp_node = type('FolderNode', (), {
                                 'uid': child_uid,
                                 'name': child_folder.get('name', 'Unnamed'),
@@ -1928,25 +2588,19 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                                 'subfolders': []
                             })()
                             dir_nodes.append(temp_node)
-        
+
         rec_nodes = []
         if show_records and isinstance(node, BaseFolderNode):
             node_uid_for_recs = '' if node.type == '/' else node.uid
-            
-            # Get legacy records
             rec_uids = {rec for recs in get_contained_record_uids(params, node_uid_for_recs).values() for rec in recs}
             records = [api.get_record(params, rec_uid) for rec_uid in rec_uids]
             records = [r for r in records if isinstance(r, Record)]
             rec_nodes.extend(records)
-            
-            # Add Nested Share Records for this folder
+
             if hasattr(params, 'nested_share_folder_records'):
-                # For root folder, collect Nested Share Folder records that are not inside any known NSF sub-folder
                 if is_root:
                     nsf_folders = getattr(params, 'nested_share_folders', {})
                     shown_rec_uids = set(rec_uids)
-                    # Records associated with container UIDs that are NOT real NSF sub-folders
-                    # (includes the NSF root UID and any other non-folder containers)
                     for folder_uid, nsf_rec_uids in params.nested_share_folder_records.items():
                         if folder_uid not in nsf_folders:
                             for rec_uid in nsf_rec_uids:
@@ -1955,7 +2609,6 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                                     if isinstance(rec, Record):
                                         rec_nodes.append(rec)
                                         shown_rec_uids.add(rec_uid)
-                    # Also show Nested Share Folder records that have NO folder association at all
                     if hasattr(params, 'nested_share_records'):
                         all_filed = set()
                         for uids in params.nested_share_folder_records.values():
@@ -1966,7 +2619,6 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
                                 if isinstance(rec, Record):
                                     rec_nodes.append(rec)
                                     shown_rec_uids.add(rec_uid)
-                # For specific folders
                 elif node_uid_for_recs in params.nested_share_folder_records:
                     nsf_rec_uids = params.nested_share_folder_records[node_uid_for_recs]
                     for rec_uid in nsf_rec_uids:
@@ -1979,17 +2631,52 @@ def formatted_tree(params, folder, verbose=False, show_records=False, shares=Fal
         rec_nodes.sort(key=lambda r: r.title.lower(), reverse=False)
         child_nodes = dir_nodes + rec_nodes
 
-        tns = [tree_node(n) for n in child_nodes]
-        return node_name, OrderedDict(tns)
+        child_path = '' if is_vault_root else node_path
+        child_results = [tree_node(n, child_path) for n in child_nodes]
+        ascii_children = OrderedDict((disp, br) for disp, br, _ in child_results)
 
-    root, branches = tree_node(folder)
-    tree = {root: branches}
+        # Nested JSON node (omit empty children; uid only with -v)
+        item = {'name': base_name, 'path': node_path}
+        if verbose and node_uid:
+            item['uid'] = node_uid
+        item['kind'] = kind
+        if record_type:
+            item['record_type'] = record_type
+        if share_data:
+            item['share_permissions'] = share_data
+        json_children = [jr for _, _, jr in child_results if jr]
+        if json_children:
+            item['children'] = json_children
+        return display_name, ascii_children, item
+
+    root_name, branches, json_root = tree_node(folder, '')
+    payload = {'tree': json_root}
+    if title:
+        payload['title'] = title
+    if (shares or nsf_shares) and not hide_shares_key:
+        key = {}
+        if shares:
+            key['classic'] = {
+                'RO': 'Read-Only', 'MU': 'Can Manage Users', 'MR': 'Can Manage Records',
+                'CE': 'Can Edit', 'CS': 'Can Share', 'OW': 'Owner',
+            }
+        if nsf_shares:
+            key['nsf'] = {
+                'OW': 'Owner', 'VW': 'Viewer', 'CT': 'Contributor', 'SM': 'Share Manager',
+                'CM': 'Content Manager', 'CSM': 'Content + Share Manager', 'FM': 'Full Manager',
+            }
+        payload['share_permissions_key'] = key
+
+    if as_json:
+        return payload
+
     tr = LeftAligned(draw=BoxStyle(gfx=drawing.BOX_LIGHT))
-    if shares and not hide_shares_key:
+    if (shares or nsf_shares) and not hide_shares_key:
         print_share_permissions_key()
     if title:
         print(title)
-    tree_txt = tr(tree)
+    tree_txt = tr({root_name: branches})
     tree_txt = re.sub(r'\s+\(\)', '', tree_txt)
     print(tree_txt)
     print('')
+    return None

--- a/keepercommander/nested_share_folder/__init__.py
+++ b/keepercommander/nested_share_folder/__init__.py
@@ -62,6 +62,11 @@ _SUBMODULE_MAP = {
         'find_nested_share_folders_for_record',
         'resolve_nested_share_record_uid', 'resolve_nested_share_folder_uid',
     ],
+    'acl_cache': [
+        'warm_for_tree', 'warm_nsf_folder_share_cache', 'warm_nsf_record_share_cache',
+        'warm_classic_record_shares', 'clear_share_caches', 'ensure_share_caches',
+        'get_nsf_folder_share_accessors', 'get_nsf_record_share_accessors',
+    ],
 }
 
 _LAZY_REGISTRY = {}

--- a/keepercommander/nested_share_folder/acl_cache.py
+++ b/keepercommander/nested_share_folder/acl_cache.py
@@ -1,0 +1,230 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Session ACL caches for NSF (and helpers to warm classic record shares).
+
+Sync-down only stores the current user's NSF access rows plus sharing-state
+flags. Full accessor lists require ``get_folder_access_v3`` /
+``get_record_accesses_v3``. This module batch-fetches those once and keeps
+them in dedicated in-memory caches so ``tree -s`` (and other callers) can
+read without re-hitting the ACL APIs.
+
+These caches are intentionally separate from ``nested_share_folder_accesses`` /
+``nested_share_record_accesses`` so permission checks and key decrypt that
+rely on sync-shaped self rows are not overwritten.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Sequence, Set
+
+from .. import api
+
+_FOLDER_BATCH = 100
+_RECORD_BATCH = 10
+_RECORD_BATCH_MIN = 1
+
+_FOLDER_SHARE_CACHE = 'nested_share_folder_share_cache'
+_RECORD_SHARE_CACHE = 'nested_share_record_share_cache'
+
+
+def ensure_share_caches(params) -> None:
+    if not hasattr(params, _FOLDER_SHARE_CACHE) or getattr(params, _FOLDER_SHARE_CACHE) is None:
+        setattr(params, _FOLDER_SHARE_CACHE, {})
+    if not hasattr(params, _RECORD_SHARE_CACHE) or getattr(params, _RECORD_SHARE_CACHE) is None:
+        setattr(params, _RECORD_SHARE_CACHE, {})
+
+
+def clear_share_caches(params) -> None:
+    if hasattr(params, _FOLDER_SHARE_CACHE) and isinstance(getattr(params, _FOLDER_SHARE_CACHE), dict):
+        getattr(params, _FOLDER_SHARE_CACHE).clear()
+    if hasattr(params, _RECORD_SHARE_CACHE) and isinstance(getattr(params, _RECORD_SHARE_CACHE), dict):
+        getattr(params, _RECORD_SHARE_CACHE).clear()
+
+
+def _chunked(items: Sequence[str], size: int) -> Iterable[List[str]]:
+    for i in range(0, len(items), size):
+        yield list(items[i:i + size])
+
+
+def _warm_nsf_folder_chunk(params, cache, chunk: List[str]) -> None:
+    """Fetch one folder-UID chunk, following pagination; leave failures uncached."""
+    from .folder_api import get_folder_access_v3
+
+    accumulated: dict = {}
+    failed: Set[str] = set()
+    token = None
+    for _ in range(50):
+        info = get_folder_access_v3(
+            params, chunk, continuation_token=token, resolve_usernames=True)
+        for fr in info.get('results') or []:
+            fuid = fr.get('folder_uid')
+            if not fuid:
+                continue
+            if fr.get('success'):
+                accumulated.setdefault(fuid, []).extend(fr.get('accessors') or [])
+            else:
+                failed.add(fuid)
+                logging.debug('NSF folder ACL warm error for %s: %s', fuid, fr.get('error'))
+        if not info.get('has_more'):
+            break
+        token = info.get('continuation_token')
+        if token is None:
+            break
+
+    for fuid, accessors in accumulated.items():
+        cache[fuid] = accessors
+    for fuid in failed:
+        if fuid not in accumulated:
+            cache[fuid] = []
+
+
+def warm_nsf_folder_share_cache(params, folder_uids: Iterable[str], *, force: bool = False) -> None:
+    """Batch-load full NSF folder accessors into ``nested_share_folder_share_cache``.
+
+    On transport/API exception the UIDs are left uncached so a later warm can
+    retry (same as record ACL warm). ``success: false`` results cache as [].
+    """
+    ensure_share_caches(params)
+    cache = getattr(params, _FOLDER_SHARE_CACHE)
+    needed = []
+    seen: Set[str] = set()
+    for uid in folder_uids:
+        if not uid or uid in seen:
+            continue
+        seen.add(uid)
+        if force or uid not in cache:
+            needed.append(uid)
+    if not needed:
+        return
+
+    for chunk in _chunked(needed, _FOLDER_BATCH):
+        try:
+            _warm_nsf_folder_chunk(params, cache, chunk)
+        except Exception as exc:
+            logging.debug('NSF folder ACL warm failed for %s: %s', chunk, exc)
+
+def _store_nsf_record_accesses(cache, record_uids: Sequence[str], info: dict) -> None:
+    by_uid: dict = {}
+    for access in info.get('record_accesses', []) or []:
+        ruid = access.get('record_uid')
+        if not ruid:
+            continue
+        by_uid.setdefault(ruid, []).append(access)
+    forbidden = set(info.get('forbidden_records') or [])
+    for uid in record_uids:
+        if uid in forbidden:
+            cache[uid] = []
+        elif uid in by_uid:
+            cache[uid] = by_uid[uid]
+        else:
+            # Successful response with no rows for this UID — real empty ACL.
+            cache[uid] = []
+
+
+def _is_throttle_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return 'throttl' in text or 'too many' in text or 'rate limit' in text
+
+
+def _warm_nsf_record_chunk(params, cache, chunk: List[str], *, force: bool) -> bool:
+    """Warm one chunk. Returns False if further warming should stop (throttled)."""
+    from .record_api import get_record_accesses_v3
+
+    pending = [u for u in chunk if force or u not in cache]
+    if not pending:
+        return True
+
+    try:
+        info = get_record_accesses_v3(params, pending)
+        _store_nsf_record_accesses(cache, pending, info)
+        return True
+    except Exception as exc:
+        if _is_throttle_error(exc):
+            logging.warning(
+                'NSF record ACL warm throttled — stopping further record ACL fetches. '
+                'Records without a cached ACL will show parent-folder shares. (%s)',
+                exc)
+            return False
+
+        # Binary-split once instead of N individual calls (avoids hammering / throttle).
+        if len(pending) > _RECORD_BATCH_MIN:
+            mid = len(pending) // 2
+            logging.debug(
+                'NSF record ACL warm failed for batch of %d; splitting: %s',
+                len(pending), exc)
+            if not _warm_nsf_record_chunk(params, cache, pending[:mid], force=force):
+                return False
+            return _warm_nsf_record_chunk(params, cache, pending[mid:], force=force)
+
+        logging.warning('NSF record ACL warm failed for %s: %s', pending[0], exc)
+        # Leave uncached so folder-ACL fallback can still apply.
+        return True
+
+
+def warm_nsf_record_share_cache(params, record_uids: Iterable[str], *, force: bool = False) -> None:
+    """Batch-load full NSF record accessors into ``nested_share_record_share_cache``.
+
+    On failure, splits the batch rather than retrying every UID individually
+    (that pattern caused API floods / throttling). Throttle aborts the rest of
+    the warm for this call; uncached records fall back to parent folder ACL.
+    """
+    ensure_share_caches(params)
+    cache = getattr(params, _RECORD_SHARE_CACHE)
+    needed = []
+    seen: Set[str] = set()
+    for uid in record_uids:
+        if not uid or uid in seen:
+            continue
+        seen.add(uid)
+        if force or uid not in cache:
+            needed.append(uid)
+    if not needed:
+        return
+
+    for chunk in _chunked(needed, _RECORD_BATCH):
+        if not _warm_nsf_record_chunk(params, cache, chunk, force=force):
+            break
+
+
+def warm_classic_record_shares(params, record_uids: Iterable[str]) -> None:
+    """Ensure classic ``record_cache[uid]['shares']`` is populated (batched API)."""
+    uids = [u for u in dict.fromkeys(record_uids) if u and u in (params.record_cache or {})]
+    if not uids:
+        return
+    try:
+        api.get_record_shares(params, uids)
+    except Exception as exc:
+        logging.debug('Classic record share warm failed: %s', exc)
+
+
+def warm_for_tree(params,
+                  nsf_folder_uids: Optional[Iterable[str]] = None,
+                  classic_record_uids: Optional[Iterable[str]] = None,
+                  nsf_record_uids: Optional[Iterable[str]] = None) -> None:
+    """Warm all ACL caches needed for ``tree -s`` / ``tree -s -r``."""
+    if nsf_folder_uids:
+        warm_nsf_folder_share_cache(params, nsf_folder_uids)
+    if nsf_record_uids:
+        warm_nsf_record_share_cache(params, nsf_record_uids)
+    if classic_record_uids:
+        warm_classic_record_shares(params, classic_record_uids)
+
+
+def get_nsf_folder_share_accessors(params, folder_uid: str) -> List[dict]:
+    ensure_share_caches(params)
+    return list(getattr(params, _FOLDER_SHARE_CACHE).get(folder_uid) or [])
+
+
+def get_nsf_record_share_accessors(params, record_uid: str) -> List[dict]:
+    ensure_share_caches(params)
+    return list(getattr(params, _RECORD_SHARE_CACHE).get(record_uid) or [])

--- a/keepercommander/nested_share_folder/record_api.py
+++ b/keepercommander/nested_share_folder/record_api.py
@@ -328,23 +328,21 @@ def _try_decrypt_record_key(params, enc_rk, rk_type, uid):
     return drk
 
 
-def get_record_accesses_v3(params, record_uids):
-    if not record_uids:
-        raise ValueError("At least one record UID required")
-    rq = record_details_pb2.RecordAccessRequest()
-    for uid in record_uids:
-        rq.recordUids.append(utils.base64_url_decode(uid))
+def _access_type_name(access_type):
+    try:
+        return folder_pb2.AccessType.Name(access_type)
+    except (ValueError, TypeError):
+        return 'AT_UNKNOWN'
 
-    rs = api.communicate_rest(params, rq, 'vault/records/v3/details/access',
-                              rs_type=record_details_pb2.RecordAccessResponse)
-    result = {'record_accesses': [], 'forbidden_records': []}
+
+def _parse_record_access_response(rs, result):
     for ra in rs.recordAccesses:
         d = ra.data
         ai = ra.accessorInfo
         ao = {
             'record_uid': utils.base64_url_encode(d.recordUid),
             'accessor_name': ai.name,
-            'access_type': folder_pb2.AccessType.Name(d.accessType) if hasattr(d, 'accessType') else 'UNKNOWN',
+            'access_type': _access_type_name(d.accessType),
             'access_type_uid': utils.base64_url_encode(d.accessTypeUid),
             'owner': getattr(d, 'owner', False),
             'inherited': bool(getattr(d, 'inherited', False)),
@@ -361,7 +359,46 @@ def get_record_accesses_v3(params, record_uids):
                 getattr(d.tlaProperties, 'rotateOnExpiration', False))
         result['record_accesses'].append(ao)
     for fu in rs.forbiddenRecords:
-        result['forbidden_records'].append(utils.base64_url_encode(fu))
+        fuid = utils.base64_url_encode(fu)
+        if fuid not in result['forbidden_records']:
+            result['forbidden_records'].append(fuid)
+
+
+def get_record_accesses_v3(params, record_uids):
+    if not record_uids:
+        raise ValueError("At least one record UID required")
+    from ..proto import pagination_pb2
+
+    result = {'record_accesses': [], 'forbidden_records': []}
+    cursor = ''
+    page_number = 1
+    use_page = False
+    # Guard against runaway pagination.
+    for _ in range(50):
+        rq = record_details_pb2.RecordAccessRequest()
+        for uid in record_uids:
+            rq.recordUids.append(utils.base64_url_decode(uid))
+        # First request matches historical nsf-get behavior (no page).
+        # Only send Page on follow-ups; forcing pageSize on page 1 caused
+        # incomplete accessor lists for some vaults.
+        if use_page:
+            page = pagination_pb2.Page()
+            page.pageNumber = page_number
+            page.pageSize = 500  # server max
+            if cursor:
+                page.cursorToken = cursor
+            rq.page.CopyFrom(page)
+
+        rs = api.communicate_rest(params, rq, 'vault/records/v3/details/access',
+                                  rs_type=record_details_pb2.RecordAccessResponse)
+        _parse_record_access_response(rs, result)
+
+        page_info = rs.pageInfo if rs.HasField('pageInfo') else None
+        if not page_info or not page_info.hasMore:
+            break
+        cursor = page_info.cursorToken or ''
+        page_number = (page_info.pageNumber or page_number) + 1
+        use_page = True
     return result
 
 

--- a/keepercommander/nested_share_folder/sync.py
+++ b/keepercommander/nested_share_folder/sync.py
@@ -37,6 +37,10 @@ def _ensure_nested_share_folder_attrs(params):
         params.nested_share_record_links = {}
     if not hasattr(params, 'nested_share_raw_dag_data'):
         params.nested_share_raw_dag_data = []
+    if not hasattr(params, 'nested_share_folder_share_cache'):
+        params.nested_share_folder_share_cache = {}
+    if not hasattr(params, 'nested_share_record_share_cache'):
+        params.nested_share_record_share_cache = {}
 
 
 def create_accumulator():
@@ -78,6 +82,10 @@ def clear_caches(params):
     params.nested_share_record_sharing_states.clear()
     params.nested_share_record_links.clear()
     params.nested_share_raw_dag_data.clear()
+    if hasattr(params, 'nested_share_folder_share_cache'):
+        params.nested_share_folder_share_cache.clear()
+    if hasattr(params, 'nested_share_record_share_cache'):
+        params.nested_share_record_share_cache.clear()
     # nested_share_folder_trashed_folders is intentionally NOT cleared here.
     # The server keeps sending trashed folders in every sync_down response
     # (including full/CLEAR syncs), so the trashed-UID filter must survive

--- a/keepercommander/params.py
+++ b/keepercommander/params.py
@@ -259,6 +259,9 @@ class KeeperParams:
         self.nested_share_record_sharing_states = {}    # record_uid -> sharing state dict
         self.nested_share_record_links = {}             # record_uid -> list of record link dicts
         self.nested_share_raw_dag_data = []             # list of raw DAG entry dicts
+        # Full NSF ACL lists after warm (separate from sync self-rows above)
+        self.nested_share_folder_share_cache = {}       # folder_uid -> list of accessors
+        self.nested_share_record_share_cache = {}       # record_uid -> list of accessors
         self.__proxy = None
         self.ssh_agent = None
         self.unmask_all = False
@@ -345,6 +348,8 @@ class KeeperParams:
         self.nested_share_record_sharing_states = {}
         self.nested_share_record_links = {}
         self.nested_share_raw_dag_data = []
+        self.nested_share_folder_share_cache = {}
+        self.nested_share_record_share_cache = {}
         self.ws = None
         if self.ssh_agent:
             self.ssh_agent.close()

--- a/keepercommander/service/util/parse_keeper_response.py
+++ b/keepercommander/service/util/parse_keeper_response.py
@@ -241,26 +241,24 @@ class KeeperResponseParser:
     @staticmethod
     def _parse_tree_share_permissions(name: str) -> Optional[Dict[str, Any]]:
         """
-        Parse shared-folder permission suffix from a tree line into structured fields.
+        Parse shared-folder permission suffix from ASCII tree (service ``tree``).
 
-        CLI format (from folder.formatted_tree): (default:...; user:...; teams:...; users:...)
+        Emits ``{"default": "...", "teams"?: ..., "users"?: ...}`` — no ``user``
+        field. ``tree --format=json`` uses ``_parse_json_format_command`` instead.
         """
-        # Ordered segments from folder.py: default, user, optional teams, optional users
         m = re.search(
-            r'\(default:([^;]+); user:([^;]+)(?:; teams:([^;]+))?(?:; users:([^)]+))?\)',
+            r'\(default:([^;]+)(?:; user:([^;]+))?(?:; teams:([^;]+))?(?:; users:([^)]+))?\)',
             name,
         )
         if not m:
             return None
 
         default_val = m.group(1).strip()
-        user_val = m.group(2).strip()
         teams_seg = (m.group(3) or "").strip()
         users_seg = (m.group(4) or "").strip()
 
         share_permissions: Dict[str, Any] = {
             "default": default_val,
-            "user": user_val,
         }
         if teams_seg:
             share_permissions["teams"] = KeeperResponseParser._parse_share_bracket_list(
@@ -273,8 +271,25 @@ class KeeperResponseParser:
         return share_permissions
 
     @staticmethod
+    def _extract_tree_uid(name: str) -> Optional[str]:
+        """Return verbose-mode UID paren; ignore share-permission suffixes."""
+        share_prefixes = (
+            'default:', 'user:', 'users:', 'teams:', 'folders:',
+            'applications:', 'shared:',
+        )
+        for m in re.finditer(r'\(([^)]+)\)', name):
+            inner = m.group(1).strip()
+            if any(inner.startswith(p) for p in share_prefixes):
+                continue
+            return inner
+        return None
+
+    @staticmethod
     def _parse_tree_command(response: str) -> Dict[str, Any]:
-        """Parse 'tree' command output into structured format."""
+        """Parse ASCII ``tree`` into the legacy service-mode flat structure.
+
+        Distinct from ``tree --format=json`` (``_parse_json_format_command``).
+        """
         result = {
             "status": "success",
             "command": "tree",
@@ -349,27 +364,32 @@ class KeeperResponseParser:
             if not name:
                 continue
                 
-            is_record = "[Record]" in name
-            is_shared = "[SHARED]" in name
+            is_record = '[Record]' in name or '[Nested Record]' in name
+            is_shared = '[SHARED]' in name
             
-            # Extract UID if present (for -v flag)
-            uid = None
-            uid_match = re.search(r'\(([^)]+)\)', name)
-            if uid_match and not any(x in uid_match.group(1) for x in ["default:", "user:"]):
-                uid = uid_match.group(1)
+            uid = KeeperResponseParser._extract_tree_uid(name)
             
             # Extract share permissions if present (for -s flag)
             share_permissions = (
                 KeeperResponseParser._parse_tree_share_permissions(name) if is_shared else None
             )
             
-            # Clean the name from all indicators
+            # Clean the name from indicators / share suffixes / record type tags
             clean_name = name
-            clean_name = re.sub(r' \([^)]*\) \[SHARED\] \([^)]*\)', '', clean_name)  # Remove UID + SHARED + permissions
-            clean_name = re.sub(r' \([^)]*\) \[Record\]', '', clean_name)  # Remove UID + Record
-            clean_name = re.sub(r' \([^)]*\) \[SHARED\]', '', clean_name)  # Remove UID + SHARED
-            clean_name = re.sub(r' \([^)]*\)', '', clean_name)  # Remove just UID
-            clean_name = clean_name.replace(" [Record]", "").replace(" [SHARED]", "")
+            clean_name = re.sub(
+                r' \((?:default|user|users|teams|folders|applications|shared):[^)]*\)',
+                '',
+                clean_name,
+            )
+            clean_name = re.sub(r' \([^)]*\) \[SHARED\]', '', clean_name)
+            clean_name = re.sub(r' \([^)]*\)(?= \[)', '', clean_name)  # UID before [tag]
+            clean_name = re.sub(r' \([^)]+\)$', '', clean_name)  # trailing UID
+            for tag in (
+                ' [Nested Share Folder]', ' [Nested Record]', ' [Record]', ' [SHARED]',
+            ):
+                clean_name = clean_name.replace(tag, '')
+            clean_name = re.sub(r' \[[A-Za-z0-9_]+\]', '', clean_name)  # [login], etc.
+            clean_name = clean_name.strip()
             
             # Determine type
             item_type = "record" if is_record else "folder"
@@ -1232,6 +1252,7 @@ class KeeperResponseParser:
 
 
 def ensure_record_add_json_format(command: str) -> str:
+    """Append ``--format=json`` for record-add when missing. Not applied to tree."""
     if not command.strip().startswith('record-add'):
         return command
     if '--format=json' in command or '--format json' in command:

--- a/unit-tests/service/test_response_parser.py
+++ b/unit-tests/service/test_response_parser.py
@@ -62,14 +62,14 @@ Folder2"""
         self.assertEqual(result['data']['tree'][1]['path'], 'Folder1')
 
     def test_parse_tree_command_share_permissions_structured(self):
-        """tree -s -v: share_permissions splits default/user vs per-user list"""
+        """tree -s -v: share_permissions uses default only (all abbrevs), plus users list"""
         sample_output = """Share Permissions Key:
 ======================
 RO = Read-Only
 MU = Can Manage Users
 ======================
 My Vault
- └── Shared Folder (abc123) [SHARED] (default:CE; user:CE; users:[a@x.com:RO],[b@y.com:MU,MR])
+ └── Shared Folder (abc123) [SHARED] (default:CE; users:[a@x.com:RO],[b@y.com:MU,MR])
 """
         result = KeeperResponseParser._parse_tree_command(sample_output)
         self.assertEqual(result['data']['share_permissions_key'][:2], ['RO = Read-Only', 'MU = Can Manage Users'])
@@ -77,12 +77,55 @@ My Vault
         self.assertTrue(entry['shared'])
         sp = entry['share_permissions']
         self.assertEqual(sp['default'], 'CE')
-        self.assertEqual(sp['user'], 'CE')
+        self.assertNotIn('user', sp)
         self.assertEqual(len(sp['users']), 2)
         self.assertEqual(sp['users'][0]['username'], 'a@x.com')
         self.assertEqual(sp['users'][0]['permissions'], 'RO')
         self.assertEqual(sp['users'][1]['username'], 'b@y.com')
         self.assertEqual(sp['users'][1]['permissions'], 'MU,MR')
+
+    def test_parse_tree_share_permissions_ignores_legacy_user_segment(self):
+        """Legacy user: segment is ignored; only default is kept."""
+        line = 'Shared Folder [SHARED] (default:MU,CE; user:MU,CE; users:[a@x.com:RO])'
+        sp = KeeperResponseParser._parse_tree_share_permissions(line)
+        self.assertEqual(sp['default'], 'MU,CE')
+        self.assertNotIn('user', sp)
+        self.assertEqual(sp['users'][0]['username'], 'a@x.com')
+
+    def test_parse_tree_does_not_treat_share_suffix_as_uid(self):
+        sample = (
+            'My Vault\n'
+            ' └── Folder (abcUID12345678901234) [SHARED] '
+            '(default:RO; users:[a@x.com:RO])\n'
+            ' └── Rec [login] [Nested Record] (users:[me@x.com:OW])\n'
+        )
+        result = KeeperResponseParser._parse_tree_command(sample)
+        folder = result['data']['tree'][0]
+        self.assertEqual(folder['name'], 'Folder')
+        self.assertEqual(folder['uid'], 'abcUID12345678901234')
+        self.assertEqual(folder['share_permissions']['default'], 'RO')
+        rec = result['data']['tree'][1]
+        self.assertEqual(rec['name'], 'Rec')
+        self.assertEqual(rec['type'], 'record')
+        self.assertNotIn('uid', rec)
+
+    def test_tree_format_json_uses_native_json_parser(self):
+        """tree --format=json must not use the ASCII tree parser."""
+        self.assertEqual(
+            KeeperResponseParser._find_parser_method('tree --format=json'),
+            '_parse_json_format_command',
+        )
+        self.assertEqual(
+            KeeperResponseParser._find_parser_method('tree'),
+            '_parse_tree_command',
+        )
+        native = '{"tree": {"name": "My Vault", "kind": "folder", "children": []}}'
+        result = KeeperResponseParser._parse_json_format_command(
+            'tree --format=json', native
+        )
+        self.assertEqual(result['status'], 'success')
+        self.assertEqual(result['data']['tree']['kind'], 'folder')
+        self.assertNotIn('level', result['data']['tree'])
 
     def test_parse_mkdir_command(self):
         """Test parsing of 'mkdir' command output"""

--- a/unit-tests/test_command_enterprise.py
+++ b/unit-tests/test_command_enterprise.py
@@ -55,6 +55,29 @@ class TestEnterprise(TestCase):
             cmd = enterprise.EnterpriseInfoCommand()
             cmd.execute(params, verbose=True)
 
+    def test_enterprise_info_users_verbose_returns_ids(self):
+        """With -v, node/teams/roles columns should be IDs; without -v, names."""
+        params = get_connected_params()
+        api.query_enterprise(params)
+        cmd = enterprise.EnterpriseInfoCommand()
+        columns = 'name,node,teams,roles'
+
+        report = cmd.execute(
+            params, users=True, format='json', columns=columns, quiet=True)
+        users = json.loads(report)
+        user1 = next(u for u in users if u['user_id'] == ent_env.user1_id)
+        self.assertEqual(user1['node'], 'Enterprise 1')
+        self.assertEqual(user1['teams'], [ent_env.team1_name])
+        self.assertEqual(user1['roles'], [ent_env.role1_name])
+
+        report = cmd.execute(
+            params, users=True, format='json', columns=columns, verbose=True, quiet=True)
+        users = json.loads(report)
+        user1 = next(u for u in users if u['user_id'] == ent_env.user1_id)
+        self.assertEqual(user1['node'], str(ent_env.node1_id))
+        self.assertEqual(user1['teams'], [ent_env.team1_uid])
+        self.assertEqual(user1['roles'], [str(ent_env.role1_id)])
+
     def test_enterprise_add_user(self):
         params = get_connected_params()
         api.query_enterprise(params)

--- a/unit-tests/test_nsf_acl_cache.py
+++ b/unit-tests/test_nsf_acl_cache.py
@@ -247,6 +247,42 @@ class TestTreeShareFormatting(TestCase):
         self.assertEqual(data['user_permissions'], [])
         self.assertEqual(data['record_permissions'], ['RO'])
 
+    def test_classic_folder_share_resolves_users_and_teams(self):
+        """SF cache often has account_uid-only users; must still emit users/teams."""
+        from keepercommander.commands.folder import _classic_folder_share_data
+        self.params.user_cache = {'AU1': 'alice@x.com', 'AU2': 'me@example.com'}
+        self.params.team_cache = {'T1': {'name': 'Engineering'}}
+        sf = {
+            'shared_folder_uid': 'SF1',
+            'default_manage_users': True,
+            'default_manage_records': False,
+            'default_can_edit': False,
+            'default_can_share': True,
+            'users': [
+                {'account_uid': 'AU1', 'username': '', 'manage_users': False, 'manage_records': True},
+                {'account_uid': 'AU2', 'username': '', 'manage_users': True, 'manage_records': True},
+                {'account_uid': 'AU3', 'username': '', 'manage_users': False, 'manage_records': False},
+            ],
+            'teams': [
+                {'team_uid': 'T1', 'name': '', 'manage_users': False, 'manage_records': True},
+                {'team_uid': 'T2', 'name': '', 'manage_users': False, 'manage_records': False},
+            ],
+        }
+        data, text = _classic_folder_share_data(self.params, sf, include_uids=True)
+        self.assertEqual(data['user_permissions'], ['MU'])
+        self.assertEqual(data['record_permissions'], ['CS'])
+        emails = {u.get('email') or u.get('uid') for u in data['users']}
+        self.assertEqual(emails, {'alice@x.com', 'me@example.com', 'AU3'})
+        self.assertEqual(
+            next(u['permissions'] for u in data['users'] if u.get('email') == 'alice@x.com'),
+            ['MR'])
+        team_names = {t['name'] for t in data['teams']}
+        self.assertEqual(team_names, {'Engineering', 'T2'})
+        self.assertIn('users:', text)
+        self.assertIn('teams:', text)
+        self.assertIn('alice@x.com:MR', text)
+        self.assertIn('Engineering:MR', text)
+
     def test_format_classic_record_share_info(self):
         from keepercommander.commands.folder import _classic_record_share_data
         data, text = _classic_record_share_data(self.params, 'R1')

--- a/unit-tests/test_nsf_acl_cache.py
+++ b/unit-tests/test_nsf_acl_cache.py
@@ -1,0 +1,437 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# unit tests for NSF ACL share cache warmer
+#
+
+from unittest import TestCase, mock
+
+from keepercommander.nested_share_folder import acl_cache
+from keepercommander.params import KeeperParams
+
+
+class TestNsfAclCache(TestCase):
+    def setUp(self):
+        self.params = KeeperParams()
+        self.params.user = 'me@example.com'
+        self.params.record_cache = {
+            'R1': {'record_uid': 'R1'},
+            'R2': {'record_uid': 'R2'},
+        }
+
+    def test_warm_nsf_folder_share_cache_batches_and_stores(self):
+        fake_results = {
+            'results': [
+                {
+                    'folder_uid': 'F1',
+                    'success': True,
+                    'accessors': [
+                        {'accessor_uid': 'U1', 'username': 'a@x.com',
+                         'access_type': 'AT_USER', 'role': 'VIEWER'},
+                    ],
+                },
+                {
+                    'folder_uid': 'F2',
+                    'success': True,
+                    'accessors': [],
+                },
+            ]
+        }
+        with mock.patch(
+                'keepercommander.nested_share_folder.folder_api.get_folder_access_v3',
+                return_value=fake_results) as m:
+            acl_cache.warm_nsf_folder_share_cache(self.params, ['F1', 'F2', 'F1'])
+            m.assert_called_once()
+            args = m.call_args[0]
+            self.assertEqual(set(args[1]), {'F1', 'F2'})
+
+        self.assertEqual(
+            self.params.nested_share_folder_share_cache['F1'][0]['username'],
+            'a@x.com')
+        self.assertEqual(self.params.nested_share_folder_share_cache['F2'], [])
+
+        # Second warm is a no-op (already cached)
+        with mock.patch(
+                'keepercommander.nested_share_folder.folder_api.get_folder_access_v3') as m2:
+            acl_cache.warm_nsf_folder_share_cache(self.params, ['F1', 'F2'])
+            m2.assert_not_called()
+
+    def test_warm_nsf_folder_share_cache_does_not_poison_on_failure(self):
+        with mock.patch(
+                'keepercommander.nested_share_folder.folder_api.get_folder_access_v3',
+                side_effect=RuntimeError('boom')):
+            acl_cache.warm_nsf_folder_share_cache(self.params, ['F1'])
+        self.assertNotIn('F1', self.params.nested_share_folder_share_cache)
+
+    def test_warm_nsf_folder_share_cache_paginates(self):
+        pages = [
+            {
+                'results': [{'folder_uid': 'F1', 'success': True,
+                             'accessors': [{'username': 'a@x.com'}]}],
+                'has_more': True,
+                'continuation_token': 111,
+            },
+            {
+                'results': [{'folder_uid': 'F1', 'success': True,
+                             'accessors': [{'username': 'b@x.com'}]}],
+                'has_more': False,
+            },
+        ]
+        with mock.patch(
+                'keepercommander.nested_share_folder.folder_api.get_folder_access_v3',
+                side_effect=pages) as m:
+            acl_cache.warm_nsf_folder_share_cache(self.params, ['F1'])
+            self.assertEqual(m.call_count, 2)
+            self.assertEqual(m.call_args_list[1].kwargs.get('continuation_token'), 111)
+        names = [a['username'] for a in self.params.nested_share_folder_share_cache['F1']]
+        self.assertEqual(names, ['a@x.com', 'b@x.com'])
+
+    def test_warm_nsf_record_share_cache_groups_by_record(self):
+        fake = {
+            'record_accesses': [
+                {'record_uid': 'NR1', 'accessor_name': 'a@x.com', 'owner': False,
+                 'access_type': 'AT_USER', 'access_role_type': 2},
+                {'record_uid': 'NR1', 'accessor_name': 'me@example.com', 'owner': True,
+                 'access_type': 'AT_USER', 'access_role_type': 6},
+                {'record_uid': 'NR2', 'accessor_name': 'b@x.com', 'owner': False,
+                 'access_type': 'AT_USER', 'access_role_type': 2},
+            ],
+            'forbidden_records': [],
+        }
+        with mock.patch(
+                'keepercommander.nested_share_folder.record_api.get_record_accesses_v3',
+                return_value=fake):
+            acl_cache.warm_nsf_record_share_cache(self.params, ['NR1', 'NR2'])
+
+        self.assertEqual(len(self.params.nested_share_record_share_cache['NR1']), 2)
+        self.assertEqual(len(self.params.nested_share_record_share_cache['NR2']), 1)
+
+    def test_warm_nsf_record_share_cache_does_not_poison_on_failure(self):
+        with mock.patch(
+                'keepercommander.nested_share_folder.record_api.get_record_accesses_v3',
+                side_effect=RuntimeError('boom')):
+            acl_cache.warm_nsf_record_share_cache(self.params, ['NR1'])
+        self.assertNotIn('NR1', self.params.nested_share_record_share_cache)
+
+    def test_warm_nsf_record_share_cache_stops_on_throttle(self):
+        calls = []
+
+        def boom(params, uids):
+            calls.append(list(uids))
+            raise RuntimeError('throttled: try again in 1 minute')
+
+        with mock.patch(
+                'keepercommander.nested_share_folder.record_api.get_record_accesses_v3',
+                side_effect=boom):
+            acl_cache.warm_nsf_record_share_cache(
+                self.params, ['A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'B1'])
+        # First chunk fails with throttle → abort; do not keep calling for later chunks.
+        self.assertEqual(len(calls), 1)
+        self.assertNotIn('B1', self.params.nested_share_record_share_cache)
+
+    def test_warm_classic_record_shares_delegates(self):
+        with mock.patch('keepercommander.api.get_record_shares') as m:
+            acl_cache.warm_classic_record_shares(self.params, ['R1', 'missing', 'R1'])
+            m.assert_called_once()
+            self.assertEqual(m.call_args[0][1], ['R1'])
+
+    def test_clear_share_caches(self):
+        acl_cache.ensure_share_caches(self.params)
+        self.params.nested_share_folder_share_cache['F1'] = [{'x': 1}]
+        self.params.nested_share_record_share_cache['R1'] = [{'y': 1}]
+        acl_cache.clear_share_caches(self.params)
+        self.assertEqual(self.params.nested_share_folder_share_cache, {})
+        self.assertEqual(self.params.nested_share_record_share_cache, {})
+
+
+class TestTreeShareFormatting(TestCase):
+    def setUp(self):
+        self.params = KeeperParams()
+        self.params.user = 'me@example.com'
+        self.params.nested_share_folders = {
+            'F1': {'name': 'NSF One', 'owner_username': 'owner@x.com', 'parent_uid': None},
+        }
+        self.params.nested_share_folder_share_cache = {
+            'F1': [
+                {'access_type': 'AT_OWNER', 'username': 'owner@x.com', 'role': 'MANAGER'},
+                {'access_type': 'AT_USER', 'username': 'bob@x.com', 'role': 'VIEWER'},
+                {'access_type': 'AT_TEAM', 'accessor_uid': 'T1', 'role': 'SHARED_MANAGER'},
+            ]
+        }
+        self.params.enterprise = {
+            'teams': [{'team_uid': 'T1', 'name': 'Eng'}],
+        }
+        self.params.record_cache = {
+            'R1': {
+                'shares': {
+                    'user_permissions': [
+                        {'username': 'me@example.com', 'owner': True},
+                        {'username': 'alice@x.com', 'editable': True, 'shareable': False},
+                    ],
+                    'shared_folder_permissions': [
+                        {'shared_folder_uid': 'SF1', 'editable': False, 'reshareable': False},
+                    ],
+                }
+            }
+        }
+        self.params.shared_folder_cache = {
+            'SF1': {'shared_folder_uid': 'SF1', 'name': 'Team SF'},
+        }
+        self.params.nested_share_record_share_cache = {
+            'NR1': [
+                {'owner': True, 'accessor_name': 'owner@x.com', 'access_type': 'AT_USER',
+                 'access_role_type': 6},
+                {'owner': False, 'accessor_name': 'carol@x.com', 'access_type': 'AT_USER',
+                 'access_role_type': 2},
+            ]
+        }
+
+    def test_format_nsf_folder_share_info(self):
+        from keepercommander.commands.folder import _nsf_folder_share_data
+        data, text = _nsf_folder_share_data(self.params, 'F1')
+        self.assertNotIn('owner:', text)
+        self.assertIn('users:[owner@x.com:OW],[bob@x.com:VW]', text)
+        self.assertIn('teams:[Eng:SM]', text)
+        self.assertEqual(data['users'][0], {'email': 'owner@x.com', 'permissions': ['OW']})
+        self.assertEqual(data['users'][1]['permissions'], ['VW'])
+        self.assertNotIn('uid', data['teams'][0])
+        data_v, _ = _nsf_folder_share_data(self.params, 'F1', include_uids=True)
+        self.assertEqual(data_v['teams'][0].get('uid'), 'T1')
+
+    def test_nsf_apps_not_listed_as_user_uids(self):
+        from keepercommander.commands.folder import _nsf_folder_share_data
+        self.params.nested_share_folder_share_cache['F1'].append({
+            'access_type': 'AT_APPLICATION',
+            'accessor_uid': 'fdHf2YtMAOKsWjJATodEGw',
+            'role': 'CONTENT_MANAGER',
+        })
+        self.params.nested_share_folder_share_cache['F1'].append({
+            'access_type': 'AT_USER',
+            'accessor_uid': 'MK8op0lCPLtJyP4W2-dD1A',
+            'username': None,
+            'role': 'VIEWER',
+        })
+        data, text = _nsf_folder_share_data(self.params, 'F1')
+        self.assertNotIn('fdHf2YtMAOKsWjJATodEGw', text)
+        emails = [u.get('email') for u in data.get('users', [])]
+        self.assertNotIn('MK8op0lCPLtJyP4W2-dD1A', emails)
+        self.assertTrue(any(a.get('permissions') == ['CM'] for a in data.get('applications', [])))
+
+    def test_tree_json_compact_share_entries(self):
+        from keepercommander.commands.folder import _tree_json_dumps
+        payload = {
+            'share_permissions': {
+                'users': [{'email': 'a@x.com', 'permissions': ['OW']}],
+                'teams': [{'name': 'Eng', 'permissions': ['VW']}],
+            }
+        }
+        text = _tree_json_dumps(payload)
+        self.assertIn('{ "email": "a@x.com", "permissions": ["OW"] }', text)
+        self.assertIn('{ "name": "Eng", "permissions": ["VW"] }', text)
+        self.assertNotIn('"permissions": [\n', text)
+
+    def test_format_classic_folder_share_ro_alignment(self):
+        from keepercommander.commands.folder import _classic_folder_share_data
+        sf = {
+            'shared_folder_uid': 'SF1', 'name': 'Team SF',
+            'users': [], 'teams': [],
+            'default_manage_records': False, 'default_manage_users': False,
+            'default_can_edit': False, 'default_can_share': False,
+        }
+        data, text = _classic_folder_share_data(self.params, sf)
+        self.assertIn('default:RO', text)
+        self.assertEqual(data['user_permissions'], [])
+        self.assertEqual(data['record_permissions'], ['RO'])
+
+    def test_format_classic_record_share_info(self):
+        from keepercommander.commands.folder import _classic_record_share_data
+        data, text = _classic_record_share_data(self.params, 'R1')
+        self.assertIn('me@example.com:OW', text)
+        self.assertIn('alice@x.com:CE', text)
+        self.assertNotIn('folders:', text)
+        self.assertNotIn('folders', data)
+        self.assertEqual(data['users'][0]['permissions'], ['OW'])
+
+    def test_format_nsf_record_share_info(self):
+        from keepercommander.commands.folder import _nsf_record_share_data
+        data, text = _nsf_record_share_data(self.params, 'NR1')
+        self.assertIn('owner@x.com:OW', text)
+        self.assertIn('carol@x.com:VW', text)
+        self.assertEqual(data['users'][0]['email'], 'owner@x.com')
+        self.assertEqual(data['users'][0]['permissions'], ['OW'])
+        self.assertEqual(data['users'][1]['email'], 'carol@x.com')
+
+    def test_nsf_record_prefers_direct_over_inherited(self):
+        from keepercommander.commands.folder import _nsf_record_share_data
+        self.params.nested_share_record_share_cache['NR1'] = [
+            {'owner': True, 'accessor_name': 'owner@x.com', 'access_type': 'AT_USER',
+             'access_role_type': 6, 'inherited': False},
+            # Inherited folder role first in raw list — should lose to direct CT
+            {'owner': False, 'accessor_name': 'carol@x.com', 'access_type': 'AT_USER',
+             'access_role_type': 2, 'inherited': True},
+            {'owner': False, 'accessor_name': 'carol@x.com', 'access_type': 'AT_USER',
+             'access_role_type': 1, 'inherited': False},  # contributor
+        ]
+        data, text = _nsf_record_share_data(self.params, 'NR1')
+        self.assertIn('carol@x.com:CT', text)
+        self.assertNotIn('carol@x.com:VW', text)
+        carol = [u for u in data['users'] if u.get('email') == 'carol@x.com']
+        self.assertEqual(len(carol), 1)
+        self.assertEqual(carol[0]['permissions'], ['CT'])
+
+    def test_nsf_record_falls_back_to_folder_acl(self):
+        from keepercommander.commands.folder import _nsf_record_share_data
+        self.params.nested_share_record_share_cache = {}
+        self.params.nested_share_folder_records = {'F1': {'NR_EMPTY'}}
+        data, text = _nsf_record_share_data(self.params, 'NR_EMPTY')
+        self.assertIn('owner@x.com:OW', text)
+        self.assertIn('bob@x.com:VW', text)
+        self.assertEqual(data['users'][0]['permissions'], ['OW'])
+
+    def test_tree_json_and_ns_flag_warming(self):
+        from keepercommander.commands.folder import formatted_tree
+        from keepercommander.subfolder import UserFolderNode
+
+        def walk(node):
+            yield node
+            for child in node.get('children') or []:
+                yield from walk(child)
+
+        root = UserFolderNode()
+        root.uid = ''
+        root.name = 'Root'
+        root.type = '/'
+        root.subfolders = []
+        self.params.folder_cache = {}
+        with mock.patch('keepercommander.nested_share_folder.acl_cache.warm_for_tree') as warm:
+            formatted_tree(self.params, root, shares=True, nsf_shares=False)
+            warm.assert_not_called()
+            formatted_tree(self.params, root, shares=False, nsf_shares=True)
+            warm.assert_called_once()
+        with mock.patch('keepercommander.nested_share_folder.acl_cache.warm_for_tree'):
+            payload = formatted_tree(self.params, root, shares=False, nsf_shares=True, fmt='json')
+            payload_v = formatted_tree(
+                self.params, root, shares=False, nsf_shares=True, fmt='json', verbose=True)
+        self.assertIn('tree', payload)
+        self.assertEqual(payload['tree']['path'], '/')
+        self.assertEqual(payload['tree']['kind'], 'folder')
+        nodes = list(walk(payload['tree']))
+        self.assertTrue(any(i.get('kind') == 'nested_share_folder' for i in nodes))
+        for item in nodes:
+            self.assertIn('path', item)
+            self.assertNotIn('source', item)
+        nsf_items = [i for i in nodes if i.get('kind') == 'nested_share_folder']
+        if nsf_items:
+            self.assertNotIn('uid', nsf_items[0])
+            self.assertTrue(nsf_items[0]['path'].startswith('/'))
+            # Nested under root via children
+            self.assertTrue(any(
+                c.get('kind') == 'nested_share_folder'
+                for c in (payload['tree'].get('children') or [])
+            ))
+        nodes_v = list(walk(payload_v['tree']))
+        nsf_items_v = [i for i in nodes_v if i.get('kind') == 'nested_share_folder']
+        if nsf_items_v:
+            self.assertIn('uid', nsf_items_v[0])
+            self.assertEqual(list(nsf_items_v[0].keys())[:3], ['name', 'path', 'uid'])
+        self.assertIn('share_permissions_key', payload)
+        self.assertIn('OW', payload['share_permissions_key']['nsf'])
+
+    def test_tree_record_shares_with_s_and_ns_flags(self):
+        from keepercommander.commands.folder import formatted_tree
+        from keepercommander.record import Record
+        from keepercommander.subfolder import NestedShareFolderNode, SharedFolderNode, UserFolderNode
+        import keepercommander.nested_share_folder as nsf_mod
+
+        def walk(node):
+            yield node
+            for child in node.get('children') or []:
+                yield from walk(child)
+
+        root = UserFolderNode()
+        root.uid = ''
+        root.name = 'Root'
+        root.type = '/'
+        root.subfolders = ['SF1']
+
+        sf = SharedFolderNode()
+        sf.uid = 'SF1'
+        sf.name = 'Team SF'
+        sf.type = 'shared_folder'
+        sf.subfolders = []
+
+        nsf_folder = NestedShareFolderNode()
+        nsf_folder.uid = 'F1'
+        nsf_folder.name = 'NSF One'
+        nsf_folder.subfolders = []
+
+        classic = Record()
+        classic.record_uid = 'R1'
+        classic.title = 'Classic Login'
+        classic.record_type = 'login'
+
+        nested = Record()
+        nested.record_uid = 'NR1'
+        nested.title = 'Nested Login'
+        nested.record_type = 'login'
+
+        self.params.folder_cache = {'SF1': sf, 'F1': nsf_folder}
+        self.params.shared_folder_cache = {
+            'SF1': {
+                'shared_folder_uid': 'SF1', 'name': 'Team SF',
+                'users': [{'username': 'bob@x.com', 'manage_users': False, 'manage_records': False}],
+                'default_manage_records': False, 'default_manage_users': False,
+                'default_can_edit': False, 'default_can_share': False,
+            }
+        }
+        self.params.nested_share_records = {'NR1': {'record_uid': 'NR1'}}
+        self.params.nested_share_folder_records = {'F1': {'NR1'}}
+        self.params.subfolder_record_cache = {'SF1': {'R1'}, 'F1': set(), '': set()}
+
+        # Drop any lazily cached warmer binding so the patch is used.
+        nsf_mod.__dict__.pop('warm_for_tree', None)
+
+        with mock.patch(
+                'keepercommander.nested_share_folder.acl_cache.warm_for_tree') as warm, \
+                mock.patch('keepercommander.commands.folder.api.get_record',
+                           side_effect=lambda p, uid: {'R1': classic, 'NR1': nested}.get(uid)), \
+                mock.patch('keepercommander.commands.folder.get_contained_record_uids',
+                           side_effect=lambda p, uid, **kw: (
+                               {'SF1': {'R1'}} if uid == 'SF1' else {uid or '': set()}
+                           )):
+            payload = formatted_tree(
+                self.params, root, show_records=True, shares=True, nsf_shares=True, fmt='json')
+            warm.assert_called_once()
+            kwargs = warm.call_args.kwargs
+            self.assertIn('R1', list(kwargs.get('classic_record_uids') or []))
+            self.assertIn('NR1', list(kwargs.get('nsf_record_uids') or []))
+
+        self.assertIn('tree', payload)
+        records = [i for i in walk(payload['tree']) if i.get('kind') == 'record']
+        by_name = {i['name']: i for i in records}
+        self.assertIn('Classic Login', by_name)
+        classic_item = by_name['Classic Login']
+        self.assertEqual(classic_item.get('record_type'), 'login')
+        self.assertIn('share_permissions', classic_item)
+        self.assertEqual(classic_item['share_permissions']['users'][0]['permissions'], ['OW'])
+        self.assertNotIn('folders', classic_item['share_permissions'])
+        self.assertNotIn('children', classic_item)  # leaf: omit empty children
+
+        nested_records = [i for i in walk(payload['tree']) if i.get('kind') == 'nested_record']
+        nested_by_name = {i['name']: i for i in nested_records}
+        self.assertIn('Nested Login', nested_by_name)
+        nested_item = nested_by_name['Nested Login']
+        self.assertIn('share_permissions', nested_item)
+        self.assertEqual(nested_item['share_permissions']['users'][0]['permissions'], ['OW'])
+        self.assertEqual(nested_item['share_permissions']['users'][1]['email'], 'carol@x.com')
+        # Nested under NSF folder in the tree
+        nsf_nodes = [i for i in walk(payload['tree']) if i.get('kind') == 'nested_share_folder']
+        self.assertTrue(nsf_nodes)
+        self.assertTrue(any(
+            c.get('name') == 'Nested Login'
+            for n in nsf_nodes for c in (n.get('children') or [])
+        ))


### PR DESCRIPTION
## Summary
- Support SailPoint identity mapping by returning node/team/role IDs from `enterprise-info --users -v`.
- Add `tree --format=json` so SailPoint can consume a Commander-native nested tree response.
- Include classic and NSF folder/record share permissions in that JSON (and in text with `-s` / `-ns`).

## Changes
- **enterprise-info**
  - With `-v`, `node` / `teams` / `roles` return IDs instead of path/names; non-verbose output is unchanged.

- **tree – `--format=json` (main)**
  - Adds native nested JSON output for `tree` (name, path, kind, children, share_permissions).
  - Recommended for SailPoint / new service-mode callers: `tree --format=json`.
  - Plain service-mode `tree` (no `--format=json`) keeps the legacy flat ASCII→parser response for existing integrations.

- **tree – folders**
  - Classic (`-s`): text uses a single `default:` segment (no duplicate `user:`).
  - Classic JSON: `user_permissions` (MU/MR) and `record_permissions` (CE/CS), plus `users` / `teams`.
  - NSF (`-ns`): folder ACLs via warmed cache; JSON `kind` is `nested_share_folder`.

- **tree – records**
  - Classic (`-s -r`): direct user shares only; no inherited `folders` list on the record.
  - NSF (`-ns -r`): record ACLs with parent-folder fallback when needed.
  - JSON `kind` is `record` (classic) or `nested_record` (NSF).