### PR TITLE
Add support for Key Files in Keepass export

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -97,6 +97,8 @@ export_parser.add_argument('--max-size', dest='max_size',
                            help='Maximum file attachment file. Example: 100K, 50M, 2G. Default: 10M')
 export_parser.add_argument('-kp', '--keepass-file-password', dest='file_password', action='store',
                            help='Password for the exported file')
+export_parser.add_argument('-kkf', '--keepass-key-file', dest='kbdx_key_file', action='store',
+                           help='Keepass key file for the exported file')
 export_parser.add_argument('--zip', dest='zip_archive', action='store_true',
                            help='Create ZIP archive for file attachments. JSON only')
 export_parser.add_argument('--save-in-vault', dest='save_in_vault', action='store_true',

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -431,6 +431,8 @@ def export(params, file_format, filename, **kwargs):
     file_password = kwargs.get('file_password')
     if file_password:
         args['file_password'] = file_password
+    if kwargs.get('kbdx_key_file'):
+        args['kbdx_key_file'] = kwargs.get('kbdx_key_file')
     zip_archive = kwargs.get('zip_archive') is True
     if zip_archive:
         args['zip_archive'] = zip_archive

--- a/keepercommander/importer/keepass/keepass.py
+++ b/keepercommander/importer/keepass/keepass.py
@@ -284,18 +284,15 @@ class KeepassExporter(BaseExporter, XmlUtils):
         else:
             return XmlUtils.sanitize_xml_text(keeper_value)
 
-    def do_export(self, filename, records, file_password=None, **kwargs):
-        master_password = file_password
-        confirmed = True
-        while not master_password or not confirmed:
-            print('Choose password for your Keepass file')
-            master_password = getpass.getpass(prompt='...' + 'Keepass Password'.rjust(20) + ': ', stream=None)
-            print('\nRe-enter password for your Keepass file')
-            confirmation = getpass.getpass(prompt='...' + 'Keepass Password'.rjust(20) + ': ', stream=None)
-            confirmed = master_password == confirmation
-            retry_msg = 'The passwords you entered do not match.\nPlease try again.\n'
-            fail_msg = bcolors.FAIL + bcolors.BOLD + '\nALERT!\n' + retry_msg + bcolors.ENDC
-            not confirmed and print(fail_msg)
+    def do_export(self, filename, records, file_password=None, kbdx_key_file=None, **kwargs):
+        password = file_password or getpass.getpass(prompt='...' + 'Keepass Password'.rjust(20) + ': ', stream=None) or None
+        if not kbdx_key_file:
+            print('Press Enter if your Keepass file is not protected with a key file')
+        keyfile = kbdx_key_file or input('...' + 'Path to Key file'.rjust(20) + ': ') or None
+        if keyfile:
+            keyfile = os.path.expanduser(keyfile.strip("\"'"))
+        else:
+            keyfile = None
 
         sfs = []  # type: list[SharedFolder]
         rs = []   # type: list[Record]
@@ -308,7 +305,8 @@ class KeepassExporter(BaseExporter, XmlUtils):
         template_file = os.path.join(os.path.dirname(__file__), 'template.kdbx')
 
         with PyKeePass(template_file, password='111111') as kdb:
-            kdb.password = master_password
+            kdb.password = password
+            kdb.keyfile = keyfile
             root = kdb.root_group
 
             for r in rs:


### PR DESCRIPTION

Keepass export changes:
- You can now pass the key file path as command arg keepass-key-file
- If none set, you will be prompted for a file path (same as password)
- If one set, the keepass exporter now handles Key File encryption of kbdx file.
- Also since the password can be empty now, made it so that it will be null if none is set (otherwise you have to explicitly set a password in Keepass with empty value)