### PR TITLE
Correct supported time definitions for self-destruct flags

### DIFF
--- a/RECORD_ADD_DOCUMENTATION.md
+++ b/RECORD_ADD_DOCUMENTATION.md
@@ -403,13 +403,15 @@ The `--self-destruct` option creates temporary records that automatically delete
 ### Syntax
 
 ```bash
---self-destruct <NUMBER>[(m)inutes|(h)ours|(d)ays]
+--self-destruct <NUMBER>[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]
 ```
 
 **Time Units:**
-- `m` or `minutes` - Minutes (default if no unit specified)
+- `mi` or `minutes` - Minutes (default if no unit specified)
 - `h` or `hours` - Hours  
 - `d` or `days` - Days
+- `mo` or `months` - Months
+- `y` or `years` - Years
 
 ### Examples
 
@@ -428,7 +430,7 @@ record-add -t "Temporary Server Access" -rt login \
 record-add -t "Guest WiFi Access" -rt wifiCredentials \
   text.ssid="Company-Guest" \
   password=TempPass123 \
-  --self-destruct 30m \
+  --self-destruct 30mi \
   --notes "Visitor access for meeting"
 ```
 

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -3701,7 +3701,7 @@ class PAMGatewayActionRotateCommand(Command):
 
     # Email and share link arguments
     parser.add_argument('--self-destruct', dest='self_destruct', action='store',
-                        metavar='<NUMBER>[(m)inutes|(h)ours|(d)ays]',
+                        metavar='<NUMBER>[(mi)inutes|(h)ours|(d)ays|(mo)nths|(y)ears]',
                         help='Create one-time share link that expires after duration')
     parser.add_argument('--email-config', dest='email_config', action='store',
                         help='Email configuration name to use for sending (required with --send-email)')

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -50,7 +50,7 @@ record_add_parser.add_argument('-n', '--notes', dest='notes', action='store', he
 record_add_parser.add_argument('--folder', dest='folder', action='store',
                                help='folder name or UID to store record')
 record_add_parser.add_argument('--self-destruct', dest='self_destruct', action='store',
-                               metavar='<NUMBER>[(m)inutes|(h)ours|(d)ays]',
+                               metavar='<NUMBER>[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]',
                                help='Time period record share URL is valid. The record will be deleted in your vault in 5 minutes since open')
 record_add_parser.add_argument('--pam-config', dest='pam_config', action='store',
                                help='PAM configuration UID or name to sync password to cloud provider (Azure AD, AWS IAM)')


### PR DESCRIPTION
In `record-add` and `pam action rotate`, the help menu gives incorrect time definitions for `--self-destruct`:
`[(m)inutes|(h)ours|(d)ays]`

Changed to:
`[(mi)nutes|(h)ours|(d)ays|(mo)nths|(y)ears]`