### PR TITLE
Misc fixes with PAM Tunnel Diagnose command

### DIFF
--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -1463,7 +1463,7 @@ class PAMTunnelDiagnoseCommand(Command):
             conn.request('GET', '/', headers={'User-Agent': 'keeper-pam-diagnose/1.0'})
             resp = conn.getresponse()
             ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 399, f'HTTP {resp.status}  (reachable)', ms
+            return 100 <= resp.status < 400, f'HTTP {resp.status}  (reachable)', ms
         except Exception as exc:
             return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
         finally:
@@ -1488,7 +1488,7 @@ class PAMTunnelDiagnoseCommand(Command):
             })
             resp = conn.getresponse()
             ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 399, f'HTTP {resp.status}', ms
+            return 100 <= resp.status < 400, f'HTTP {resp.status}', ms
         except Exception as exc:
             return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
         finally:
@@ -1785,7 +1785,6 @@ class PAMTunnelDiagnoseCommand(Command):
                 )
                 if output_format == 'json':
                     print(json.dumps(rust_results, indent=2))
-                    return 0
 
                 # Fold Rust test results into the unified pass/fail accounting
                 for test in rust_results.get('test_results', []):
@@ -2619,8 +2618,6 @@ class PAMTunnelDiagnoseCommand(Command):
         print()
         print(f'  {self._dsep()}')
         print()
-
-        return 0 if passed_total == total_checks else 1
 
 
 class PAMConnectionEditCommand(Command):

--- a/keepercommander/commands/tunnel_and_connections.py
+++ b/keepercommander/commands/tunnel_and_connections.py
@@ -1463,7 +1463,7 @@ class PAMTunnelDiagnoseCommand(Command):
             conn.request('GET', '/', headers={'User-Agent': 'keeper-pam-diagnose/1.0'})
             resp = conn.getresponse()
             ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 600, f'HTTP {resp.status}  (reachable)', ms
+            return 100 <= resp.status < 399, f'HTTP {resp.status}  (reachable)', ms
         except Exception as exc:
             return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
         finally:
@@ -1488,7 +1488,7 @@ class PAMTunnelDiagnoseCommand(Command):
             })
             resp = conn.getresponse()
             ms = int((time.monotonic() - t0) * 1000)
-            return 100 <= resp.status < 600, f'HTTP {resp.status}', ms
+            return 100 <= resp.status < 399, f'HTTP {resp.status}', ms
         except Exception as exc:
             return False, str(exc)[:60], int((time.monotonic() - t0) * 1000)
         finally:
@@ -1642,7 +1642,7 @@ class PAMTunnelDiagnoseCommand(Command):
                                '--turn-test / --stun-only requires a record argument: '
                                'pam tunnel diagnose <pamMachine-or-pamDirectory-UID> --turn-test')
 
-        server = params.server  # e.g. "keepersecurity.com" or "https://qa.keepersecurity.com"
+        server = 'keepersecurity.us' if params.server == 'govcloud.keepersecurity.us' else params.server
         server_host = get_keeper_server_hostname(server)
         krelay_server = get_relay_host(params.server)
         connect_host = get_router_host(params.server)
@@ -1651,7 +1651,7 @@ class PAMTunnelDiagnoseCommand(Command):
         self._print_header()
         print()
         now = datetime.datetime.utcnow()
-        region_label = 'US' if server_host == 'keepersecurity.com' else server_host.split('.')[0].upper()
+        region_label = 'US' if server == 'keepersecurity.com' else 'GOVCLOUD' if server == 'keepersecurity.us' else server.split('.')[-1].upper()
         print(self._green(f'  Region  {region_label}  \u00b7  {server}'))
         print(self._green(f'  Date    {now.strftime("%Y-%m-%d  %H:%M")} UTC'))
         if record_name:
@@ -1736,7 +1736,7 @@ class PAMTunnelDiagnoseCommand(Command):
         print(row.rstrip())
 
         passed_ports = sum(1 for _, ok, _ in port_results if ok)
-        print(f'    {self._check()}  {self._green(str(passed_ports))}/{len(port_results)} sampled ports reachable')
+        print(f'    {self._check()}'+self._green(f'  {str(passed_ports)}/{len(port_results)} sampled ports reachable'))
         print()
 
         # ── section 4: WebRTC connectivity (Rust library) ─────────────────────


### PR DESCRIPTION
- 443 server URL tested is wrong for GOV (connect.govcloud.keepersecurity.us instead of connect.keepersecurity.us)
- Wrong region printed for non-US servers (KEEPERSECURITY instead of EU, CA, JP, AU)
- Websocket test is always passed even if response status is 400 or 500
- WebRTC sample color-coding is incomplete
- Command returns an int

> Before

<img width="1275" height="650" alt="image" src="https://github.com/user-attachments/assets/f92cb0c0-eabc-4d9f-b046-67c8b5c5100b" />


> After

<img width="1275" height="650" alt="image" src="https://github.com/user-attachments/assets/a594ee9f-d35b-4825-bf3f-01f978b3a3dd" />

