### PR TITLE
KC-1372: Return separate name and ID fields in enterprise-info --users --verbose

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -797,17 +797,24 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                         elif column == 'transfer_status':
                             row.append(user_status_dict['acct_transfer_status'])
                         elif column == 'node':
+                            node_path = self.get_node_path(params, u['node_id'])
                             if is_verbose:
-                                row.append(str(u['node_id']))
+                                row.append({
+                                    'node_id': str(u['node_id']),
+                                    'node_name': node_path,
+                                })
                             else:
-                                row.append(self.get_node_path(params, u['node_id']))
+                                row.append(node_path)
                         elif column == 'team_count':
                             row.append(len([1 for t in teams.values() if t['users'] and user_id in t['users']]))
                         elif column == 'teams':
                             user_team_list = [t for t in teams.values()
                                               if t['users'] and user_id in t['users']]
                             if is_verbose:
-                                row.append([t['id'] for t in user_team_list])
+                                row.append([
+                                    {'team_uid': t['id'], 'team_name': t['name']}
+                                    for t in user_team_list
+                                ])
                             else:
                                 row.append([t['name'] for t in user_team_list])
                         elif column == 'role_count' or column == 'roles':
@@ -822,7 +829,13 @@ class EnterpriseInfoCommand(EnterpriseCommand):
                                 row.append(len(role_ids))
                             else:
                                 if is_verbose:
-                                    row.append([str(role_id) for role_id in role_ids if role_id in roles])
+                                    row.append([
+                                        {
+                                            'role_id': str(role_id),
+                                            'role_name': roles[role_id]['name'],
+                                        }
+                                        for role_id in role_ids if role_id in roles
+                                    ])
                                 else:
                                     role_names = [roles[role_id]['name'] for role_id in role_ids if role_id in roles]
                                     row.append(role_names)

--- a/unit-tests/test_command_enterprise.py
+++ b/unit-tests/test_command_enterprise.py
@@ -56,7 +56,7 @@ class TestEnterprise(TestCase):
             cmd.execute(params, verbose=True)
 
     def test_enterprise_info_users_verbose_returns_ids(self):
-        """With -v, node/teams/roles columns should be IDs; without -v, names."""
+        """With -v, node/teams/roles include separate name and ID fields; without -v, names only."""
         params = get_connected_params()
         api.query_enterprise(params)
         cmd = enterprise.EnterpriseInfoCommand()
@@ -74,9 +74,18 @@ class TestEnterprise(TestCase):
             params, users=True, format='json', columns=columns, verbose=True, quiet=True)
         users = json.loads(report)
         user1 = next(u for u in users if u['user_id'] == ent_env.user1_id)
-        self.assertEqual(user1['node'], str(ent_env.node1_id))
-        self.assertEqual(user1['teams'], [ent_env.team1_uid])
-        self.assertEqual(user1['roles'], [str(ent_env.role1_id)])
+        self.assertEqual(user1['node'], {
+            'node_id': str(ent_env.node1_id),
+            'node_name': 'Enterprise 1',
+        })
+        self.assertEqual(user1['teams'], [{
+            'team_uid': ent_env.team1_uid,
+            'team_name': ent_env.team1_name,
+        }])
+        self.assertEqual(user1['roles'], [{
+            'role_id': str(ent_env.role1_id),
+            'role_name': ent_env.role1_name,
+        }])
 
     def test_enterprise_add_user(self):
         params = get_connected_params()


### PR DESCRIPTION
### Summary

`enterprise-info --users --verbose` now returns IDs for `node`, `teams`, and `roles`, but as separate id/name fields rather than names only or combined strings. Without `--verbose`, output stays name-based. Verbose shape matches the records object style (`*_id` / `*_name` or `team_uid` / `team_name`).

### Changes

- `enterprise.py` — with `--verbose`, `node` / `teams` / `roles` return objects with separate id and name fields; without `--verbose`, names only
- `test_command_enterprise.py` — added test covering name-only vs verbose object output for those columns