### PR TITLE
KC-1357 : Add Nested Share Folder (NSF) support for import

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -169,7 +169,7 @@ To load the sample data:
 import --format=csv sample_data/import.csv
 
 Nested Share Folders (NSF):
-import --format=csv --nsf --permissions=a sample_data/import_nsf.csv
+import --format=csv --nsf sample_data/import_nsf.csv
 '''
 
 json_instructions = '''JSON Import Instructions
@@ -184,11 +184,20 @@ To load the sample file into your vault, run this command:
 import --format=json sample_data/import.json.txt
 
 Nested Share Folders (NSF) — works with any --format (json, csv, keepass, …):
-import --format=json --nsf --permissions=a sample_data/import_nsf.json.txt
-import --format=json --nsf sample_data/import_nsf.json
+import --format=json --nsf sample_data/import_nsf.json.txt
 
-With --nsf, shared_folders[].permissions (users/teams) from JSON are granted
-on the Nested Share Folders after folders and records are created.
+With --nsf, shared_folders[].permissions from JSON are granted on Nested
+Share Folders after folders and records are created. Prefer NSF roles:
+
+  "permissions": [
+    { "name": "user@company.com", "role": "viewer" },
+    { "name": "lead@company.com", "role": "content-manager" },
+    { "name": "admin@company.com", "role": "full-manager" }
+  ]
+
+Accepted roles: requestor, viewer, share-manager, content-manager,
+content-share-manager, full-manager.
+Sample: sample_data/import_nsf_permissions.json.txt
 Use --users --nsf to update NSF permissions only (no record import).
 '''
 
@@ -231,7 +240,9 @@ class RecordImportCommand(ImporterCommand):
             permissions = kwargs.get('permissions') or ''
             del kwargs['permissions']
 
-        if (kwargs.get('shared') is True or kwargs.get('use_nsf') is True) and not permissions:
+        # Classic --shared prompts for default U/R/E/S permissions.
+        # NSF uses roles from the import file (and optional -p); do not prompt.
+        if kwargs.get('shared') is True and not kwargs.get('use_nsf') and not permissions:
             permissions = user_choice('Default shared folder permissions: manage (U)sers, manage (R)ecords, can (E)dit, can (S)hare, or (A)ll, (N)one', 'uresan', show_choice=False, multi_choice=True)
         if permissions:
             chars = set()

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -61,6 +61,8 @@ import_parser.add_argument('--dry-run', dest='dry_run', action='store_true',
                            help='display records to be imported without importing them')
 import_parser.add_argument('-s', '--shared', dest='shared', action='store_true',
                            help='import folders as Keeper shared folders')
+import_parser.add_argument('--nsf', dest='use_nsf', action='store_true',
+                           help='import folders and records into Nested Share Folders (works with any --format)')
 import_parser.add_argument('-p', '--permissions', dest='permissions', action='store',
                            help='default shared folder permissions: manage (U)sers, manage (R)ecords, can (E)dit, can (S)hare, or (A)ll, (N)one')
 import_parser.add_argument('--update',  dest='update_flag',  action='store_true',
@@ -68,7 +70,7 @@ import_parser.add_argument('--update',  dest='update_flag',  action='store_true'
 import_parser.add_argument('--no-shortcuts',  dest='no_shortcuts',  action='store_true',
                            help='disable shortcut handling (only new records)')
 import_parser.add_argument('--users',  dest='users_only',  action='store_true',
-                           help='update shared folder user permissions only')
+                           help='update shared folder / NSF user permissions only')
 import_parser.add_argument('--record-type', dest='record_type', action='store',
                            help='Import legacy records as record type')
 import_parser.add_argument('--login-type', '-l', dest='login_type', action='store_true',
@@ -84,7 +86,9 @@ import_parser.add_argument('--show-skipped', dest='show_skipped', action='store_
 import_parser.add_argument('--secret-ids', dest='secret_ids', action='store',
                            help='Comma separated list of secret IDs to fetch (Thycotic)')
 import_parser.add_argument(
-    'name', type=str, help='file name (json, csv, keepass, 1password), account name (lastpass), or URL (ManageEngine, Thycotic)'
+    'name', type=str,
+    help='file name (json/csv/keepass/1password/…), account name (lastpass), or URL (ManageEngine, Thycotic). '
+         'JSON samples may use .json or .json.txt'
 )
 import_parser.error = raise_parse_exception
 import_parser.exit = suppress_exit
@@ -163,6 +167,9 @@ Personal,Twitter,craig@gmail.com,123456,https://twitter.com,,Social Media#edit#r
 
 To load the sample data:
 import --format=csv sample_data/import.csv
+
+Nested Share Folders (NSF):
+import --format=csv --nsf --permissions=a sample_data/import_nsf.csv
 '''
 
 json_instructions = '''JSON Import Instructions
@@ -175,6 +182,14 @@ Within shared folders, you can also automatically assign user or team permission
 
 To load the sample file into your vault, run this command:
 import --format=json sample_data/import.json.txt
+
+Nested Share Folders (NSF) — works with any --format (json, csv, keepass, …):
+import --format=json --nsf --permissions=a sample_data/import_nsf.json.txt
+import --format=json --nsf sample_data/import_nsf.json
+
+With --nsf, shared_folders[].permissions (users/teams) from JSON are granted
+on the Nested Share Folders after folders and records are created.
+Use --users --nsf to update NSF permissions only (no record import).
 '''
 
 
@@ -216,7 +231,7 @@ class RecordImportCommand(ImporterCommand):
             permissions = kwargs.get('permissions') or ''
             del kwargs['permissions']
 
-        if kwargs.get('shared') is True and not permissions:
+        if (kwargs.get('shared') is True or kwargs.get('use_nsf') is True) and not permissions:
             permissions = user_choice('Default shared folder permissions: manage (U)sers, manage (R)ecords, can (E)dit, can (S)hare, or (A)ll, (N)one', 'uresan', show_choice=False, multi_choice=True)
         if permissions:
             chars = set()

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -87,8 +87,7 @@ import_parser.add_argument('--secret-ids', dest='secret_ids', action='store',
                            help='Comma separated list of secret IDs to fetch (Thycotic)')
 import_parser.add_argument(
     'name', type=str,
-    help='file name (json/csv/keepass/1password/…), account name (lastpass), or URL (ManageEngine, Thycotic). '
-         'JSON samples may use .json or .json.txt'
+    help='file name (json, csv , keepass, 1password), account name (lastpass), or URL (ManageEngine, Thycotic). '
 )
 import_parser.error = raise_parse_exception
 import_parser.exit = suppress_exit
@@ -184,7 +183,7 @@ To load the sample file into your vault, run this command:
 import --format=json sample_data/import.json.txt
 
 Nested Share Folders (NSF) — works with any --format (json, csv, keepass, …):
-import --format=json --nsf sample_data/import_nsf.json.txt
+import --format=json --nsf sample_data/import_nsf.txt
 
 With --nsf, shared_folders[].permissions from JSON are granted on Nested
 Share Folders after folders and records are created. Prefer NSF roles:
@@ -197,7 +196,7 @@ Share Folders after folders and records are created. Prefer NSF roles:
 
 Accepted roles: requestor, viewer, share-manager, content-manager,
 content-share-manager, full-manager.
-Sample: sample_data/import_nsf_permissions.json.txt
+Sample: sample_data/import_nsf_permissions.txt
 Use --users --nsf to update NSF permissions only (no record import).
 '''
 

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -706,9 +706,41 @@ def import_user_permissions(params,
                 logging.info("%d user(s) removed from shared folders", users_removed)
 
 
+def _strip_path_prefix(records, folders, prefix):
+    # type: (List[ImportRecord], List[ImportSharedFolder], str) -> None
+    """Remove an import --folder prefix from record/shared-folder paths."""
+    if not prefix:
+        return
+    prefix_l = prefix.lower()
+    delim = PathDelimiter
+
+    def strip_one(path):
+        if not path:
+            return path
+        path_l = path.lower()
+        if path_l == prefix_l:
+            return ''
+        if path_l.startswith(prefix_l + delim):
+            return path[len(prefix) + len(delim):]
+        return path
+
+    for rec in records or []:
+        if not rec.folders:
+            continue
+        for fol in rec.folders:
+            if fol.domain:
+                fol.domain = strip_one(fol.domain)
+            if fol.path:
+                fol.path = strip_one(fol.path)
+    for fol in folders or []:
+        if fol.path:
+            fol.path = strip_one(fol.path)
+
+
 def _import(params, file_format, filename, **kwargs):
     """Import records from one of a variety of sources."""
     shared = kwargs.get('shared') or False
+    use_nsf = kwargs.get('use_nsf') or False
     import_users = kwargs.get('users_only') or False
     old_domain = kwargs.get('old_domain')
     new_domain = kwargs.get('new_domain')
@@ -735,6 +767,9 @@ def _import(params, file_format, filename, **kwargs):
 
     filter_folder_lower = filter_folder.lower() if isinstance(filter_folder, str) else ''
 
+    # When --nsf is set, skip classic shared-folder domain splitting.
+    classic_shared = shared and not use_nsf
+
     for x in importer.execute(filename, params=params, users_only=import_users, filter_folder=filter_folder,
                               old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids, dry_run=dry_run):
         if isinstance(x, ImportRecord):
@@ -759,11 +794,11 @@ def _import(params, file_format, filename, **kwargs):
                 else:
                     continue
 
-            if shared or import_into:
+            if classic_shared or import_into or use_nsf:
                 if not x.folders:
                     x.folders = [ImportFolder()]
                 for f in x.folders:
-                    if shared:
+                    if classic_shared:
                         d_comps = list(path_components(f.domain)) if f.domain else []
                         p_comps = list(path_components(f.path)) if f.path else []
                         if len(d_comps) > 0:
@@ -789,7 +824,7 @@ def _import(params, file_format, filename, **kwargs):
                 logging.info(ce.message)
             records.append(x)
         elif isinstance(x, ImportSharedFolder):
-            if shared:
+            if classic_shared:
                 continue
             if filter_folder and not importer.support_folder_filter():
                 name = x.path.lower().lstrip('\\')
@@ -803,18 +838,40 @@ def _import(params, file_format, filename, **kwargs):
 
             folders.append(x)
 
-    if import_users:
-        import_user_permissions(params, folders)
-        return
-
-    sync_down.sync_down(params)
-
     manage_users = kwargs.get('manage_users') or False
     manage_records = kwargs.get('manage_records') or False
     can_edit = kwargs.get('can_edit') or False
     can_share = kwargs.get('can_share') or False
 
-    if shared:
+    if import_users:
+        if use_nsf:
+            from .nsf_import import apply_nsf_folder_permissions, prepare_nsf_folders
+            sync_down.sync_down(params)
+            prepare_nsf_folders(params, folders, [], '')
+            apply_nsf_folder_permissions(
+                params, folders, manage_users, manage_records, can_edit, can_share)
+        else:
+            import_user_permissions(params, folders)
+        return
+
+    sync_down.sync_down(params)
+
+    nsf_base_parent = ''
+    if import_into:
+        from .nsf_import import resolve_nsf_folder
+        resolved_nsf = resolve_nsf_folder(params, import_into)
+        if resolved_nsf:
+            use_nsf = True
+            # If --folder was an NSF UID, treat it as parent and strip the UID prefix.
+            if import_into == resolved_nsf:
+                nsf_base_parent = resolved_nsf
+                _strip_path_prefix(records, folders, import_into)
+
+    if use_nsf:
+        from .nsf_import import flatten_record_folder_paths
+        flatten_record_folder_paths(records)
+
+    if classic_shared:
         sfol = set()
         for r in records:
             if r.folders:
@@ -830,52 +887,58 @@ def _import(params, file_format, filename, **kwargs):
             sf.can_share = can_share
             folders.append(sf)
 
-    # shared folder mapping
+    # shared folder mapping (classic only)
     sf_map = {}     # type: Dict[str, str]
-    for shared_folder_uid in params.shared_folder_cache:
-        folder = params.folder_cache.get(shared_folder_uid)
-        if not folder:
-            continue
-        if folder.parent_uid:
-            sf_path = get_folder_path(params, folder.parent_uid)
-            sf_path.strip(PathDelimiter)
-        else:
-            sf_path = ''
-        sf_name = folder.name.strip()
-        if ' - ' in sf_name:
-            sf_from_name = sf_name.replace(' - ', PathDelimiter)
-            sf_to_name = folder.name
-            if sf_path:
-                sf_from_name = sf_path + PathDelimiter + sf_from_name
-                sf_to_name = sf_path + PathDelimiter + sf_to_name
-            sf_map[sf_from_name.lower()] = sf_to_name
-    if len(sf_map) > 0:
-        sf_keys = list(sf_map.keys())
-        sf_keys.sort()
-        for record in records:
-            if isinstance(record.folders, list) and len(record.folders) > 0:
-                for fol in record.folders:
-                    path = fol.domain or ''
-                    if fol.path:
-                        if path:
-                            path += PathDelimiter
-                        path += fol.path
-                    path_l = path.lower()
-                    idx = bisect.bisect_right(sf_keys, path_l)
-                    if 0 <= idx < len(sf_map) and path_l == sf_keys[idx]:
-                        fol.domain = sf_map[path_l]
-                        fol.path = ''
-                    elif 0 < idx <= len(sf_map) and path_l.startswith(sf_keys[idx - 1]):
-                        sf_name = sf_keys[idx - 1]
-                        fol.domain = sf_map[sf_name]
-                        fol.path = (path[len(sf_name):]).strip(PathDelimiter)
+    if not use_nsf:
+        for shared_folder_uid in params.shared_folder_cache:
+            folder = params.folder_cache.get(shared_folder_uid)
+            if not folder:
+                continue
+            if folder.parent_uid:
+                sf_path = get_folder_path(params, folder.parent_uid)
+                sf_path.strip(PathDelimiter)
+            else:
+                sf_path = ''
+            sf_name = folder.name.strip()
+            if ' - ' in sf_name:
+                sf_from_name = sf_name.replace(' - ', PathDelimiter)
+                sf_to_name = folder.name
+                if sf_path:
+                    sf_from_name = sf_path + PathDelimiter + sf_from_name
+                    sf_to_name = sf_path + PathDelimiter + sf_to_name
+                sf_map[sf_from_name.lower()] = sf_to_name
+        if len(sf_map) > 0:
+            sf_keys = list(sf_map.keys())
+            sf_keys.sort()
+            for record in records:
+                if isinstance(record.folders, list) and len(record.folders) > 0:
+                    for fol in record.folders:
+                        path = fol.domain or ''
+                        if fol.path:
+                            if path:
+                                path += PathDelimiter
+                            path += fol.path
+                        path_l = path.lower()
+                        idx = bisect.bisect_right(sf_keys, path_l)
+                        if 0 <= idx < len(sf_map) and path_l == sf_keys[idx]:
+                            fol.domain = sf_map[path_l]
+                            fol.path = ''
+                        elif 0 < idx <= len(sf_map) and path_l.startswith(sf_keys[idx - 1]):
+                            sf_name = sf_keys[idx - 1]
+                            fol.domain = sf_map[sf_name]
+                            fol.path = (path[len(sf_name):]).strip(PathDelimiter)
 
-    folder_add = prepare_folder_add(params, folders, records, manage_users, manage_records, can_edit, can_share)
-    if folder_add:
+    if use_nsf:
+        from .nsf_import import prepare_nsf_folders
         if not dry_run:
-            fol_rs, _ = execute_import_folder_record(params, folder_add, None)
-            _ = fol_rs
-            sync_down.sync_down(params)
+            prepare_nsf_folders(params, folders, records, nsf_base_parent)
+    else:
+        folder_add = prepare_folder_add(params, folders, records, manage_users, manage_records, can_edit, can_share)
+        if folder_add:
+            if not dry_run:
+                fol_rs, _ = execute_import_folder_record(params, folder_add, None)
+                _ = fol_rs
+                sync_down.sync_down(params)
 
     record_keys = {}
     audit_uids = []
@@ -884,6 +947,7 @@ def _import(params, file_format, filename, **kwargs):
         records_v2_to_update = []   # type: List[dict]
         records_v3_to_add = []      # type: List[record_pb2.RecordAdd]
         records_v3_to_update = []   # type: List[record_pb2.RecordUpdate]
+        nsf_records_to_add = []     # NSF vault/records/v3/add payloads
         import_uids = {}
 
         records_to_import, record_exists, external_lookup = prepare_record_add_or_update(update_flag, no_shortcuts, params, records)
@@ -1028,6 +1092,23 @@ def _import(params, file_format, filename, **kwargs):
                         if folder.type == BaseFolderNode.RootFolderType:
                             folder_uid = ''
 
+                from .nsf_import import is_nsf_folder
+                if folder_uid and is_nsf_folder(params, folder_uid):
+                    data = _construct_record_v3_data(import_record)
+                    data_bytes = api.get_record_data_json_bytes(data)
+                    if len(data_bytes) > RECORD_MAX_DATA_LEN:
+                        logging.warning(RECORD_MAX_DATA_WARN.format(data['title'], len(data_bytes), RECORD_MAX_DATA_LEN))
+                        continue
+                    from .nsf_import import build_nsf_record_add
+                    try:
+                        nsf_add = build_nsf_record_add(params, import_record, record_key, data)
+                    except Exception as exc:
+                        logging.warning('Skipping NSF record "%s": %s', import_record.title, exc)
+                        continue
+                    import_uids[import_record.uid] = {'ver': 'nsf', 'op': 'add'}
+                    nsf_records_to_add.append(nsf_add)
+                    continue
+
                 v3_add_rq = record_pb2.RecordAdd()
                 v3_add_rq.record_uid = utils.base64_url_decode(import_record.uid)
                 import_uids[import_record.uid] = {'ver': 'v3', 'op': 'add'}
@@ -1088,6 +1169,9 @@ def _import(params, file_format, filename, **kwargs):
                 if record_key and link_key:
                     link.record_key = crypto.encrypt_aes_v2(link_key, record_key)
 
+        if nsf_records_to_add:
+            from .nsf_import import execute_nsf_records_add
+            execute_nsf_records_add(params, nsf_records_to_add)
         if records_v3_to_add:
             rec_rs = execute_records_add(params, records_v3_to_add)
         if records_v2_to_update:
@@ -1095,7 +1179,11 @@ def _import(params, file_format, filename, **kwargs):
         if records_v3_to_update:
             rec_rs = execute_records_update(params, records_v3_to_update)
 
-        sync_down.sync_down(params)
+        if use_nsf or nsf_records_to_add:
+            from ..commands.pam_import.nsf_helpers import sync_down_preserving_nsf_keys
+            sync_down_preserving_nsf_keys(params)
+        else:
+            sync_down.sync_down(params)
 
         # update audit data
         if audit_uids and params.enterprise_ec_key:
@@ -1161,7 +1249,7 @@ def _import(params, file_format, filename, **kwargs):
             if r.attachments:
                 if r.uid in import_uids:
                     ver = import_uids[r.uid]['ver']
-                    if ver == 'v3':
+                    if ver == 'v3' or ver == 'nsf':
                         v3_atts.append(r)
                     else:
                         for a in r.attachments:
@@ -1206,6 +1294,11 @@ def _import(params, file_format, filename, **kwargs):
             upload_attachment(params, v2_atts)
         if len(v3_atts) > 0:
             upload_v3_attachments(params, v3_atts)
+
+    if use_nsf and folders and not dry_run:
+        from .nsf_import import apply_nsf_folder_permissions
+        apply_nsf_folder_permissions(
+            params, folders, manage_users, manage_records, can_edit, can_share)
 
     if hasattr(importer, 'cleanup') and callable(importer.cleanup):
         importer.cleanup()
@@ -2223,6 +2316,10 @@ def prepare_record_link(params, records):
                 for fol in rec.folders or [None]:
                     folder_uid = fol.uid if fol else ''
                     if folder_uid and folder_uid not in params.folder_cache:
+                        continue
+                    from .nsf_import import is_nsf_folder
+                    if folder_uid and is_nsf_folder(params, folder_uid):
+                        # NSF multi-folder links use a different API; skip classic move/link.
                         continue
                     if folder_uid in folder_ids:
                         continue

--- a/keepercommander/importer/importer.py
+++ b/keepercommander/importer/importer.py
@@ -103,6 +103,7 @@ class Permission:
         self.name = None
         self.manage_users = None
         self.manage_records = None
+        self.role = None  # NSF role name: viewer, content-manager, full-manager, …
 
 
 class SharedFolder:

--- a/keepercommander/importer/importer.py
+++ b/keepercommander/importer/importer.py
@@ -398,21 +398,57 @@ class BaseFileImporter(BaseImporter, abc.ABC):
     def __init__(self):
         super(BaseFileImporter, self).__init__()
 
-    def execute(self, name, **kwargs):
-        # type: (str, ...) -> Iterable[Union[Record, SharedFolder, File]]
+    def _path_candidates(self, name):
+        # type: (str) -> List[str]
+        """Yield existing-path candidates for *name* (exact, +ext, sample .ext.txt)."""
+        path = os.path.expanduser(name)
+        candidates = [path]
+        ext = (self.extension() or '').lstrip('.')
+        if ext:
+            lower = path.lower()
+            ext_suffix = '.' + ext.lower()
+            ext_txt_suffix = ext_suffix + '.txt'
+            if lower.endswith(ext_txt_suffix):
+                pass
+            elif lower.endswith(ext_suffix):
+                # foo.json → also try foo.json.txt (sample_data convention)
+                candidates.append(path + '.txt')
+            else:
+                # foo → foo.json, foo.json.txt, foo.txt
+                candidates.append(path + '.' + ext)
+                candidates.append(path + '.' + ext + '.txt')
+                candidates.append(path + '.txt')
+        # Deduplicate while preserving order
+        seen = set()
+        for candidate in candidates:
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            yield candidate
+
+    def resolve_file_path(self, name):
+        # type: (str) -> str
+        """Resolve an import file path, trying common extensions and sample suffixes."""
         try:
             json.loads(name)
-            path = name
-        except ValueError as e:    
-            path = os.path.expanduser(name)
-            if not os.path.isfile(path):
-                ext = self.extension()
-                if ext:
-                    path = path + '.' + ext
+            return name
+        except ValueError:
+            pass
 
-            if not os.path.isfile(path):
-                raise CommandError('import', f'File \'{name}\' does not exist')
+        tried = []
+        for candidate in self._path_candidates(name):
+            tried.append(candidate)
+            if os.path.isfile(candidate):
+                return candidate
+        hint = ''
+        ext = (self.extension() or '').lstrip('.')
+        if ext:
+            hint = f' (tried: {", ".join(tried[:4])}{"…" if len(tried) > 4 else ""})'
+        raise CommandError('import', f'File \'{name}\' does not exist{hint}')
 
+    def execute(self, name, **kwargs):
+        # type: (str, ...) -> Iterable[Union[Record, SharedFolder, File]]
+        path = self.resolve_file_path(name)
         yield from self.do_import(path, **kwargs)
 
 

--- a/keepercommander/importer/json/json.py
+++ b/keepercommander/importer/json/json.py
@@ -203,7 +203,9 @@ class KeeperJsonImporter(BaseFileImporter, KeeperJsonMixin):
                 fol.manage_users = shf.get('manage_users') or False
                 fol.can_edit = shf.get('can_edit') or False
                 fol.can_share = shf.get('can_share') or False
-                if users_only and 'permissions' in shf:
+                # Always parse user/team permissions. Classic shared folders apply
+                # them with --users; NSF applies them during --nsf import.
+                if 'permissions' in shf:
                     fol.permissions = []
                     permissions = shf['permissions']
                     if not isinstance(permissions, list):

--- a/keepercommander/importer/json/json.py
+++ b/keepercommander/importer/json/json.py
@@ -218,6 +218,9 @@ class KeeperJsonImporter(BaseFileImporter, KeeperJsonMixin):
                             if p.uid or p.name:
                                 p.manage_records = perm.get('manage_records') or False
                                 p.manage_users = perm.get('manage_users') or False
+                                role = perm.get('role')
+                                if isinstance(role, str) and role.strip():
+                                    p.role = role.strip()
                                 fol.permissions.append(p)
 
                 yield fol

--- a/keepercommander/importer/nsf_import.py
+++ b/keepercommander/importer/nsf_import.py
@@ -358,8 +358,14 @@ def execute_nsf_records_add(params, record_adds):
 def apply_nsf_folder_permissions(params, folders, manage_users=False, manage_records=False,
                                  can_edit=False, can_share=False):
     # type: (KeeperParams, List[ImportSharedFolder], bool, bool, bool, bool) -> None
-    """Grant NSF folder access from ImportSharedFolder.permissions."""
+    """Grant NSF folder access from ImportSharedFolder.permissions.
+
+    Each permission may specify an NSF ``role`` (viewer, content-manager,
+    full-manager, …). When ``role`` is absent, classic manage_users /
+    manage_records flags are mapped via ``classic_perms_to_nsf_role``.
+    """
     from ..nested_share_folder.folder_api import grant_folder_access_v3
+    from ..nested_share_folder.permissions import resolve_role_name
 
     default_role = classic_perms_to_nsf_role(
         manage_users, manage_records, can_edit, can_share)
@@ -386,12 +392,27 @@ def apply_nsf_folder_permissions(params, folders, manage_users=False, manage_rec
         )
 
         for perm in fol.permissions or []:  # type: ImportPermission
-            role = classic_perms_to_nsf_role(
-                perm.manage_users if perm.manage_users is not None else False,
-                perm.manage_records if perm.manage_records is not None else False,
-            )
-            if role == 'viewer' and (manage_users or manage_records or can_edit or can_share):
-                role = folder_role if folder_role != 'viewer' else default_role
+            explicit_role = (getattr(perm, 'role', None) or '').strip()
+            if explicit_role:
+                try:
+                    resolve_role_name(explicit_role)
+                except ValueError as exc:
+                    logging.warning(
+                        'NSF permission for "%s" on "%s": %s',
+                        perm.name or perm.uid, fol.path or fol.uid, exc)
+                    continue
+                role = explicit_role.strip().lower().replace('_', '-')
+                if role == 'shared-manager':
+                    role = 'share-manager'
+                elif role == 'contributor':
+                    role = 'requestor'
+            else:
+                role = classic_perms_to_nsf_role(
+                    perm.manage_users if perm.manage_users is not None else False,
+                    perm.manage_records if perm.manage_records is not None else False,
+                )
+                if role == 'viewer' and (manage_users or manage_records or can_edit or can_share):
+                    role = folder_role if folder_role != 'viewer' else default_role
 
             name = perm.name or ''
             uid = perm.uid or ''

--- a/keepercommander/importer/nsf_import.py
+++ b/keepercommander/importer/nsf_import.py
@@ -1,0 +1,431 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+"""Nested Share Folder helpers for the general vault import pipeline."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .importer import (
+    PathDelimiter,
+    Permission as ImportPermission,
+    Record as ImportRecord,
+    SharedFolder as ImportSharedFolder,
+    path_components,
+)
+from .. import utils
+from ..error import CommandError, KeeperApiError
+from ..params import KeeperParams
+from ..subfolder import BaseFolderNode
+
+
+NSF_RECORD_BATCH = 1000
+NSF_FOLDER_BATCH = 100
+_THROTTLE_BASE_WAIT = 10.0
+_THROTTLE_MULTIPLIER = 1.5
+_THROTTLE_MAX_RETRIES = 5
+
+
+def is_nsf_folder(params, folder_uid):  # type: (KeeperParams, Optional[str]) -> bool
+    """Return True when *folder_uid* is a Nested Share Folder."""
+    if not folder_uid:
+        return False
+    if folder_uid in (getattr(params, 'nested_share_folders', None) or {}):
+        return True
+    subfolder = (getattr(params, 'subfolder_cache', None) or {}).get(folder_uid) or {}
+    if subfolder.get('source') == 'nested_share_folder':
+        return True
+    folder = (getattr(params, 'folder_cache', None) or {}).get(folder_uid)
+    return bool(folder and getattr(folder, 'type', None) == BaseFolderNode.NestedShareFolderType)
+
+
+def resolve_nsf_folder(params, identifier):  # type: (KeeperParams, Optional[str]) -> Optional[str]
+    """Resolve a folder name, path, or UID to an NSF folder UID."""
+    if not identifier:
+        return None
+    from ..nested_share_folder.folder_api import resolve_folder_identifier
+
+    for candidate in (identifier, identifier.replace('\\', '/')):
+        uid = resolve_folder_identifier(params, candidate)
+        if uid and is_nsf_folder(params, uid):
+            return uid
+    return None
+
+
+def classic_perms_to_nsf_role(manage_users=False, manage_records=False,
+                              can_edit=False, can_share=False):
+    """Map classic shared-folder booleans to an NSF role name."""
+    if manage_users and manage_records:
+        return 'full-manager'
+    if manage_records and can_share:
+        return 'content-share-manager'
+    if manage_records or can_edit:
+        return 'content-manager'
+    if can_share:
+        return 'share-manager'
+    return 'viewer'
+
+
+def flatten_record_folder_paths(records):  # type: (List[ImportRecord]) -> None
+    """Collapse domain + path into a single NSF path on each record folder."""
+    for record in records:
+        if not record.folders:
+            continue
+        for folder in record.folders:
+            comps = []
+            if folder.domain:
+                comps.extend(path_components(folder.domain))
+            if folder.path:
+                comps.extend(path_components(folder.path))
+            folder.domain = ''
+            folder.path = PathDelimiter.join(
+                [c.replace(PathDelimiter, 2 * PathDelimiter) for c in comps]
+            ) if comps else ''
+
+
+def find_nsf_child(params, folder_name, parent_uid):
+    # type: (KeeperParams, str, Optional[str]) -> Optional[str]
+    """Find an NSF child named *folder_name* under *parent_uid* (or vault root)."""
+    from ..commands.nested_share_folder.helpers import normalize_parent_uid
+
+    nsf_folders = getattr(params, 'nested_share_folders', None) or {}
+    name_lower = (folder_name or '').lower()
+    looking_for_root = not parent_uid
+    for fuid, fobj in nsf_folders.items():
+        if (fobj.get('name') or '').lower() != name_lower:
+            continue
+        raw_parent = fobj.get('parent_uid') or ''
+        normalized = normalize_parent_uid(raw_parent)
+        is_root_child = (
+            normalized in ('', 'root')
+            or (raw_parent and raw_parent not in nsf_folders)
+        )
+        if looking_for_root:
+            if is_root_child:
+                return fuid
+        elif raw_parent == parent_uid:
+            return fuid
+    return None
+
+
+def _is_throttle_error(exc):  # type: (BaseException) -> bool
+    if isinstance(exc, KeeperApiError) and str(getattr(exc, 'result_code', '')).lower() in (
+            'throttled', '429', 'too_many_requests'):
+        return True
+    text = str(getattr(exc, 'message', None) or exc).lower()
+    return 'throttl' in text or 'too many' in text or 'rate limit' in text
+
+
+def _call_with_throttle_retry(description, fn, *args, **kwargs):
+    """Retry *fn* with progressive backoff when the API returns throttled."""
+    wait = _THROTTLE_BASE_WAIT
+    for attempt in range(1, _THROTTLE_MAX_RETRIES + 1):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if not _is_throttle_error(exc) or attempt >= _THROTTLE_MAX_RETRIES:
+                raise
+            logging.warning(
+                '%s throttled (attempt %d/%d); waiting %.0fs before retry',
+                description, attempt, _THROTTLE_MAX_RETRIES, wait,
+            )
+            time.sleep(wait)
+            wait *= _THROTTLE_MULTIPLIER
+
+
+def create_nsf_folder(params, name, parent_uid=''):
+    # type: (KeeperParams, str, Optional[str]) -> str
+    """Create one NSF folder and seed local caches. Returns folder UID."""
+    results = create_nsf_folders_batch(params, [(name, parent_uid or '')])
+    if not results:
+        raise CommandError('import', f'Failed to create NSF folder "{name}"')
+    return results[0]
+
+
+def create_nsf_folders_batch(params, folders):
+    # type: (KeeperParams, List[Tuple[str, str]]) -> List[str]
+    """Create many NSF folders that share the same depth (parents already exist).
+
+    *folders* is a list of ``(name, parent_uid)`` pairs. Returns UIDs in the
+    same order. Uses ``vault/folders/v3/add`` batches of up to 100 with
+    throttle retries.
+    """
+    from ..nested_share_folder.folder_api import create_folders_batch_v3
+    from ..commands.pam_import.nsf_helpers import seed_nsf_folder_cache
+
+    if not folders:
+        return []
+
+    created_uids = []  # type: List[str]
+    for start in range(0, len(folders), NSF_FOLDER_BATCH):
+        chunk = folders[start:start + NSF_FOLDER_BATCH]
+        specs = [
+            {
+                'name': name,
+                'parent_uid': parent_uid or None,
+                'inherit_permissions': True,
+            }
+            for name, parent_uid in chunk
+        ]
+        results = _call_with_throttle_retry(
+            'NSF folder create',
+            create_folders_batch_v3,
+            params,
+            specs,
+        )
+        if len(results) != len(chunk):
+            raise CommandError(
+                'import',
+                f'NSF folder batch returned {len(results)} results for {len(chunk)} folders',
+            )
+        for (name, parent_uid), result in zip(chunk, results):
+            if not isinstance(result, dict) or result.get('success') is False:
+                message = (result or {}).get('message') if isinstance(result, dict) else None
+                raise CommandError(
+                    'import',
+                    message or f'Failed to create NSF folder "{name}"',
+                )
+            folder_uid = result['folder_uid']
+            seed_nsf_folder_cache(
+                params, folder_uid, name, parent_uid or None,
+                result.get('folder_key_unencrypted'),
+            )
+            created_uids.append(folder_uid)
+    return created_uids
+
+
+def ensure_nsf_path(params, comps, parent_uid=''):
+    # type: (KeeperParams, Iterable[str], Optional[str]) -> str
+    """Ensure path components exist under *parent_uid*; return leaf folder UID."""
+    current = parent_uid or ''
+    for comp in comps:
+        if not comp:
+            continue
+        existing = find_nsf_child(params, comp, current)
+        if existing:
+            current = existing
+            continue
+        current = create_nsf_folder(params, comp, current)
+    return current
+
+
+def _folder_comp_lists(folders, records):
+    # type: (List[ImportSharedFolder], List[ImportRecord]) -> List[Tuple[object, List[str]]]
+    """Return ``(target, component_list)`` pairs for every folder to resolve."""
+    targets = []  # type: List[Tuple[object, List[str]]]
+    for fol in folders or []:
+        comps = [c for c in path_components(fol.path or '') if c]
+        if comps:
+            targets.append((fol, comps))
+    for rec in records or []:
+        if not rec.folders:
+            continue
+        for fol in rec.folders:
+            comps = []
+            if fol.domain:
+                comps.extend(path_components(fol.domain))
+            if fol.path:
+                comps.extend(path_components(fol.path))
+            comps = [c for c in comps if c]
+            targets.append((fol, comps))
+    return targets
+
+
+def prepare_nsf_folders(params, folders, records, base_parent_uid=''):
+    # type: (KeeperParams, List[ImportSharedFolder], List[ImportRecord], str) -> int
+    """Create NSF folder trees for import shared folders and record folders.
+
+    Builds the full tree first, then creates missing folders **by depth** in
+    batches of up to 100 (``vault/folders/v3/add``), with throttle retries.
+    Sets ``uid`` on each resolved ``ImportSharedFolder`` / ``ImportFolder``.
+    Returns the number of folders created.
+    """
+    before = set((getattr(params, 'nested_share_folders', None) or {}).keys())
+    targets = _folder_comp_lists(folders, records)
+
+    # path_tuple -> folder_uid
+    uid_by_path = {}  # type: Dict[Tuple[str, ...], str]
+    if base_parent_uid:
+        uid_by_path[()] = base_parent_uid
+
+    # Resolve / create level by level so parent keys exist for children.
+    max_depth = max((len(comps) for _, comps in targets), default=0)
+    for depth in range(1, max_depth + 1):
+        pending = []  # type: List[Tuple[Tuple[str, ...], str, str]]
+        seen = set()  # type: set
+        for _, comps in targets:
+            if len(comps) < depth:
+                continue
+            path_tuple = tuple(comps[:depth])
+            if path_tuple in uid_by_path or path_tuple in seen:
+                continue
+            parent_tuple = path_tuple[:-1]
+            if parent_tuple not in uid_by_path and parent_tuple != ():
+                # Parent should have been resolved at previous depth.
+                continue
+            parent_uid = uid_by_path.get(parent_tuple, base_parent_uid or '')
+            name = path_tuple[-1]
+            existing = find_nsf_child(params, name, parent_uid)
+            if existing:
+                uid_by_path[path_tuple] = existing
+                continue
+            seen.add(path_tuple)
+            pending.append((path_tuple, name, parent_uid))
+
+        if not pending:
+            continue
+
+        batch_input = [(name, parent_uid) for _, name, parent_uid in pending]
+        created_uids = create_nsf_folders_batch(params, batch_input)
+        for (path_tuple, _name, _parent_uid), folder_uid in zip(pending, created_uids):
+            uid_by_path[path_tuple] = folder_uid
+
+    # Assign leaf UIDs back onto import objects.
+    for target, comps in targets:
+        if not comps:
+            if base_parent_uid:
+                target.uid = base_parent_uid
+            else:
+                target.uid = ''
+            continue
+        path_tuple = tuple(comps)
+        target.uid = uid_by_path.get(path_tuple, '')
+
+    after = set((getattr(params, 'nested_share_folders', None) or {}).keys())
+    created = len(after - before)
+    if created:
+        logging.info('Created %d Nested Share Folder(s)', created)
+    return created
+
+
+def build_nsf_record_add(params, import_record, record_key, data):
+    """Build a ``vault/records/v3/add`` RecordAdd for an NSF folder."""
+    from ..nested_share_folder.common import get_folder_key
+    from ..nested_share_folder.record_api import create_record_data_v3
+
+    folder_uid = ''
+    if import_record.folders:
+        folder_uid = import_record.folders[0].uid or ''
+    if not folder_uid or not is_nsf_folder(params, folder_uid):
+        raise CommandError('import', f'NSF folder not found for record "{import_record.title}"')
+
+    folder_key = get_folder_key(params, folder_uid, raise_on_missing=True)
+    return create_record_data_v3(
+        record_uid=import_record.uid,
+        record_key=record_key,
+        data=data,
+        folder_uid=folder_uid,
+        folder_key=folder_key,
+        data_key=params.data_key,
+        client_modified_time=utils.current_milli_time(),
+    )
+
+
+def execute_nsf_records_add(params, record_adds):
+    # type: (KeeperParams, list) -> list
+    """Submit NSF record adds in batches of up to 1000 with throttle retries."""
+    from ..nested_share_folder.record_api import record_add_v3
+
+    results = []
+    for start in range(0, len(record_adds), NSF_RECORD_BATCH):
+        batch = record_adds[start:start + NSF_RECORD_BATCH]
+        try:
+            rs = _call_with_throttle_retry(
+                'NSF record add',
+                record_add_v3,
+                params,
+                batch,
+            )
+            results.extend(list(rs.records))
+        except Exception as exc:
+            logging.warning('NSF record add batch failed: %s', exc)
+            for ra in batch:
+                uid = utils.base64_url_encode(ra.recordUid)
+                logging.warning('Failed to create NSF record %s', uid)
+    return results
+
+
+def apply_nsf_folder_permissions(params, folders, manage_users=False, manage_records=False,
+                                 can_edit=False, can_share=False):
+    # type: (KeeperParams, List[ImportSharedFolder], bool, bool, bool, bool) -> None
+    """Grant NSF folder access from ImportSharedFolder.permissions."""
+    from ..nested_share_folder.folder_api import grant_folder_access_v3
+
+    default_role = classic_perms_to_nsf_role(
+        manage_users, manage_records, can_edit, can_share)
+
+    granted = 0
+    for fol in folders or []:
+        if not fol.uid or not is_nsf_folder(params, fol.uid):
+            if not fol.uid and fol.path:
+                comps = list(path_components(fol.path))
+                parent = ''
+                for comp in comps:
+                    parent = find_nsf_child(params, comp, parent) or ''
+                    if not parent:
+                        break
+                fol.uid = parent
+            if not fol.uid or not is_nsf_folder(params, fol.uid):
+                continue
+
+        folder_role = classic_perms_to_nsf_role(
+            fol.manage_users if fol.manage_users is not None else manage_users,
+            fol.manage_records if fol.manage_records is not None else manage_records,
+            fol.can_edit if fol.can_edit is not None else can_edit,
+            fol.can_share if fol.can_share is not None else can_share,
+        )
+
+        for perm in fol.permissions or []:  # type: ImportPermission
+            role = classic_perms_to_nsf_role(
+                perm.manage_users if perm.manage_users is not None else False,
+                perm.manage_records if perm.manage_records is not None else False,
+            )
+            if role == 'viewer' and (manage_users or manage_records or can_edit or can_share):
+                role = folder_role if folder_role != 'viewer' else default_role
+
+            name = perm.name or ''
+            uid = perm.uid or ''
+            recipient = name or uid
+            if not recipient:
+                continue
+            if uid and '@' not in uid and (not name or '@' not in name):
+                as_team = True
+                recipient = uid
+            elif name and '@' in name:
+                as_team = False
+                recipient = name
+            elif name:
+                as_team = False
+                recipient = name
+            else:
+                as_team = False
+
+            try:
+                result = _call_with_throttle_retry(
+                    'NSF folder permission',
+                    grant_folder_access_v3,
+                    params, fol.uid, recipient, role=role, as_team=as_team,
+                )
+                if result.get('success'):
+                    granted += 1
+                else:
+                    logging.warning(
+                        'NSF permission for "%s" on "%s": %s',
+                        recipient, fol.path or fol.uid, result.get('message'))
+            except Exception as exc:
+                logging.warning(
+                    'NSF permission for "%s" on "%s" failed: %s',
+                    recipient, fol.path or fol.uid, exc)
+
+    if granted:
+        logging.info('Granted %d Nested Share Folder permission(s)', granted)

--- a/sample_data/import_nsf.txt
+++ b/sample_data/import_nsf.txt
@@ -1,0 +1,499 @@
+{
+  "shared_folders": [
+    {
+      "path": "NSF All Types\\Credentials",
+      "manage_users": true,
+      "manage_records": true,
+      "can_edit": true,
+      "can_share": true,
+      "permissions": [
+        {
+          "name": "user@mycompany.com",
+          "manage_users": false,
+          "manage_records": true
+        },
+        {
+          "name": "admin@mycompany.com",
+          "manage_users": true,
+          "manage_records": true
+        }
+      ]
+    },
+    {
+      "path": "NSF All Types\\Personal",
+      "manage_users": false,
+      "manage_records": true,
+      "can_edit": true,
+      "can_share": false,
+      "permissions": [
+        {
+          "name": "user@mycompany.com",
+          "manage_users": false,
+          "manage_records": false
+        }
+      ]
+    },
+    {
+      "path": "NSF All Types\\Infrastructure\\Servers",
+      "manage_users": true,
+      "manage_records": true,
+      "can_edit": true,
+      "can_share": true
+    },
+    {
+      "path": "NSF All Types\\Infrastructure\\Databases",
+      "manage_users": true,
+      "manage_records": true,
+      "can_edit": true,
+      "can_share": false
+    }
+  ],
+  "records": [
+    {
+      "uid": "AddrRec00000000000001",
+      "title": "Sample - Address",
+      "$type": "address",
+      "notes": "Home address sample",
+      "custom_fields": {
+        "$address": {
+          "street1": "100 Main Street",
+          "street2": "Apt 4B",
+          "city": "San Francisco",
+          "state": "CA",
+          "zip": "94105",
+          "country": "US"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Identity"
+        }
+      ]
+    },
+    {
+      "uid": "CardRec00000000000001",
+      "title": "Sample - Payment Card",
+      "$type": "bankCard",
+      "notes": "Visa demo card",
+      "custom_fields": {
+        "$paymentCard": {
+          "cardNumber": "4111111111111111",
+          "cardExpirationDate": "12/2030",
+          "cardSecurityCode": "123"
+        },
+        "$text:cardholderName": "Jane Doe",
+        "$pinCode": "4321",
+        "$addressRef": "AddrRec00000000000001"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Finance"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Bank Account",
+      "$type": "bankAccount",
+      "login": "jdoe",
+      "password": "BankPass!234",
+      "login_url": "https://bank.example.com",
+      "notes": "Checking account sample",
+      "custom_fields": {
+        "$bankAccount": {
+          "accountType": "Checking",
+          "routingNumber": "021000021",
+          "accountNumber": "1234567890",
+          "otherType": ""
+        },
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        },
+        "$cardRef": "CardRec00000000000001"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Finance"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Login",
+      "$type": "login",
+      "login": "jane.doe@example.com",
+      "password": "LoginPass!234",
+      "login_url": "https://accounts.example.com",
+      "notes": "Standard login with TOTP and security question",
+      "custom_fields": {
+        "$oneTimeCode": "otpauth://totp/Example:jane.doe@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA1&digits=6&period=30",
+        "$securityQuestion": [
+          {
+            "question": "What is your favorite color?",
+            "answer": "Blue"
+          },
+          {
+            "question": "Pet name?",
+            "answer": "Fluffy"
+          }
+        ],
+        "Department": "Engineering",
+        "Employee ID": "E-10042"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Credentials",
+          "folder": "Websites",
+          "can_edit": true,
+          "can_share": true
+        }
+      ]
+    },
+    {
+      "title": "Sample - General",
+      "$type": "general",
+      "login": "general-user",
+      "password": "GeneralPass!234",
+      "login_url": "https://general.example.com",
+      "notes": "Catch-all / general purpose record",
+      "custom_fields": {
+        "$text:label": "Misc info",
+        "Freeform Field": "Any custom value"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Credentials",
+          "folder": "Misc"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Encrypted Notes",
+      "$type": "encryptedNotes",
+      "notes": "Visible notes field",
+      "custom_fields": {
+        "$note": "This is a secured / masked note body.\nLine 2 of the secure note.",
+        "$date": 1719792000000
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Notes"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Contact",
+      "$type": "contact",
+      "notes": "Business contact",
+      "custom_fields": {
+        "$name": {
+          "first": "John",
+          "middle": "A",
+          "last": "Smith"
+        },
+        "$text:company": "Acme Corp",
+        "$email": "john.smith@acme.example.com",
+        "$phone": [
+          {
+            "region": "+1",
+            "number": "415-555-0100",
+            "ext": "200",
+            "type": "Work"
+          },
+          {
+            "region": "+1",
+            "number": "415-555-0199",
+            "type": "Mobile"
+          }
+        ],
+        "$addressRef": "AddrRec00000000000001"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Contacts"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Birth Certificate",
+      "$type": "birthCertificate",
+      "notes": "Birth certificate sample",
+      "custom_fields": {
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        },
+        "$birthDate": 631152000000
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Identity"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Driver License",
+      "$type": "driverLicense",
+      "notes": "Driver license sample",
+      "custom_fields": {
+        "$accountNumber": "D1234567",
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        },
+        "$birthDate": 631152000000,
+        "$expirationDate": 1893456000000,
+        "$addressRef": "AddrRec00000000000001"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Identity"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Passport",
+      "$type": "passport",
+      "password": "PassportPin!99",
+      "notes": "Passport sample",
+      "custom_fields": {
+        "$accountNumber": "P123456789",
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        },
+        "$birthDate": 631152000000,
+        "$expirationDate": 1924905600000,
+        "$date:dateIssued": 1609459200000,
+        "$addressRef": "AddrRec00000000000001"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Identity"
+        }
+      ]
+    },
+    {
+      "title": "Sample - SSN / Identity Card",
+      "$type": "ssnCard",
+      "notes": "Identity card sample",
+      "custom_fields": {
+        "$accountNumber": "123-45-6789",
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Identity"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Health Insurance",
+      "$type": "healthInsurance",
+      "login": "member123",
+      "password": "HealthPass!234",
+      "login_url": "https://health.example.com",
+      "notes": "Health insurance sample",
+      "custom_fields": {
+        "$accountNumber": "HIN-998877",
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Insurance"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Membership",
+      "$type": "membership",
+      "password": "MemberPass!234",
+      "notes": "Gym / club membership",
+      "custom_fields": {
+        "$accountNumber": "MEM-554433",
+        "$name": {
+          "first": "Jane",
+          "middle": "Q",
+          "last": "Doe"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Memberships"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Software License",
+      "$type": "softwareLicense",
+      "notes": "Software license key sample",
+      "custom_fields": {
+        "$licenseNumber": "AAAA-BBBB-CCCC-DDDD-EEEE",
+        "$expirationDate": 1893456000000,
+        "$date:dateActive": 1704067200000,
+        "$text:product": "Example Pro Suite",
+        "$text:seats": "10"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Credentials",
+          "folder": "Licenses"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Server Credentials",
+      "$type": "serverCredentials",
+      "login": "root",
+      "password": "ServerPass!234",
+      "notes": "Linux / Windows server",
+      "custom_fields": {
+        "$host": {
+          "hostName": "10.0.1.30",
+          "port": "22"
+        },
+        "$text:platformId": "UnixSSH",
+        "$oneTimeCode": "otpauth://totp/Server:root?secret=JBSWY3DPEHPK3PXP&issuer=Server&algorithm=SHA1&digits=6&period=30"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Infrastructure\\Servers",
+          "folder": "Unix",
+          "can_edit": true,
+          "can_share": false
+        }
+      ]
+    },
+    {
+      "title": "Sample - Database Credentials",
+      "$type": "databaseCredentials",
+      "login": "dbadmin",
+      "password": "DbPass!234",
+      "notes": "PostgreSQL sample",
+      "custom_fields": {
+        "$text:type": "postgresql",
+        "$host": {
+          "hostName": "db.example.com",
+          "port": "5432"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Infrastructure\\Databases",
+          "can_edit": true,
+          "can_share": false
+        }
+      ]
+    },
+    {
+      "title": "Sample - SSH Keys",
+      "$type": "sshKeys",
+      "login": "deploy",
+      "password": "KeyPassphrase!234",
+      "notes": "SSH key pair sample",
+      "custom_fields": {
+        "$host": {
+          "hostName": "git.example.com",
+          "port": "22"
+        },
+        "$keyPair": {
+          "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExamplePublicKeyOnlyNotReal deploy@example.com",
+          "privateKey": "-----BEGIN OPENSSH PRIVATE KEY-----\nEXAMPLE_PRIVATE_KEY_PLACEHOLDER_NOT_REAL\n-----END OPENSSH PRIVATE KEY-----"
+        }
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Infrastructure\\Servers",
+          "folder": "SSH Keys",
+          "can_edit": true,
+          "can_share": false
+        }
+      ]
+    },
+    {
+      "title": "Sample - WiFi Credentials",
+      "$type": "wifiCredentials",
+      "password": "WifiPass!234",
+      "notes": "Office WiFi",
+      "custom_fields": {
+        "$text:ssid": "Office-Guest",
+        "$text:networkSecurityType": "WPA2",
+        "$text:hiddenNetwork": "false"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Credentials",
+          "folder": "Networks"
+        }
+      ]
+    },
+    {
+      "title": "Sample - File Attachment Placeholder",
+      "$type": "file",
+      "notes": "File records are normally created when uploading attachments. This is a placeholder title/notes-only sample.",
+      "custom_fields": {},
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Files"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Photo Placeholder",
+      "$type": "photo",
+      "notes": "Photo records are normally created when uploading images. Placeholder sample only.",
+      "custom_fields": {},
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Personal",
+          "folder": "Photos"
+        }
+      ]
+    },
+    {
+      "title": "Sample - Multi Folder Placement",
+      "$type": "login",
+      "login": "shared.user",
+      "password": "MultiFolder!234",
+      "login_url": "https://shared.example.com",
+      "notes": "Same record path appears under Credentials with NSF nesting from shared_folder + folder",
+      "custom_fields": {
+        "Owner Team": "Platform"
+      },
+      "folders": [
+        {
+          "shared_folder": "NSF All Types\\Credentials",
+          "folder": "Shared Apps",
+          "can_edit": true,
+          "can_share": true
+        },
+        {
+          "folder": "NSF All Types\\Personal\\Bookmarks"
+        }
+      ]
+    }
+  ]
+}

--- a/sample_data/import_nsf_permissions.txt
+++ b/sample_data/import_nsf_permissions.txt
@@ -1,0 +1,102 @@
+{
+  "shared_folders": [
+    {
+      "path": "NSF Roles Demo\\Engineering",
+      "permissions": [
+        {
+          "name": "user@mycompany.com",
+          "role": "viewer"
+        },
+        {
+          "name": "user1@mycompany.com",
+          "role": "share-manager"
+        },
+        {
+          "name": "user2@mycompany.com",
+          "role": "share-manager"
+        },
+        {
+          "name": "user3@mycompany.com",
+          "role": "content-manager"
+        },
+        {
+          "name": "user4@mycompany.com",
+          "role": "content-share-manager"
+        },
+        {
+          "name": "user5@mycompany.com",
+          "role": "full-manager"
+        },
+        {
+          "uid": "REPLACE_WITH_TEAM_UID",
+          "name": "Engineering Team",
+          "role": "content-manager"
+        }
+      ]
+    },
+    {
+      "path": "NSF Roles Demo\\Finance",
+      "permissions": [
+        {
+          "name": "user6@mycompany.com",
+          "role": "viewer"
+        },
+        {
+          "name": "user7@mycompany.com",
+          "role": "full-manager"
+        }
+      ]
+    },
+    {
+      "path": "NSF Roles Demo\\Contractors",
+      "permissions": [
+        {
+          "name": "user8@mycompany.com",
+          "role": "requestor"
+        },
+        {
+          "name": "user9@mycompany.com",
+          "role": "share-manager"
+        }
+      ]
+    }
+  ],
+  "records": [
+    {
+      "title": "GitHub — Engineering",
+      "login": "eng-bot@mycompany.com",
+      "password": "EngSamp1e!Pass",
+      "login_url": "https://github.com/mycompany",
+      "notes": "Shared engineering org credentials",
+      "folders": [
+        {
+          "folder": "NSF Roles Demo\\Engineering"
+        }
+      ]
+    },
+    {
+      "title": "AWS Console — Finance",
+      "login": "finance-ops@mycompany.com",
+      "password": "FinSamp1e!Pass",
+      "login_url": "https://console.aws.amazon.com",
+      "notes": "Finance AWS account",
+      "folders": [
+        {
+          "folder": "NSF Roles Demo\\Finance"
+        }
+      ]
+    },
+    {
+      "title": "Partner Portal",
+      "login": "contractor@partner.com",
+      "password": "PartnerSamp1e!Pass",
+      "login_url": "https://partners.example.com",
+      "notes": "Limited contractor access folder",
+      "folders": [
+        {
+          "folder": "NSF Roles Demo\\Contractors"
+        }
+      ]
+    }
+  ]
+}

--- a/unit-tests/test_nsf_import.py
+++ b/unit-tests/test_nsf_import.py
@@ -1,0 +1,339 @@
+from unittest import TestCase, mock
+import json
+import os
+import tempfile
+
+from keepercommander.importer import nsf_import
+from keepercommander.importer.importer import Folder, Record, SharedFolder, Permission
+from keepercommander.importer.json.json import KeeperJsonImporter
+from keepercommander.subfolder import NestedShareFolderNode
+
+
+class TestNsfImportHelpers(TestCase):
+    def test_classic_perms_to_nsf_role(self):
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(True, True), 'full-manager')
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, True, can_share=True),
+                         'content-share-manager')
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, True), 'content-manager')
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, False, can_edit=True),
+                         'content-manager')
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, False, can_share=True),
+                         'share-manager')
+        self.assertEqual(nsf_import.classic_perms_to_nsf_role(), 'viewer')
+
+    def test_flatten_record_folder_paths(self):
+        rec = Record()
+        fol = Folder()
+        fol.domain = 'Shared'
+        fol.path = 'Team\\Apps'
+        rec.folders = [fol]
+        nsf_import.flatten_record_folder_paths([rec])
+        self.assertEqual(fol.domain, '')
+        self.assertEqual(fol.path, 'Shared\\Team\\Apps')
+
+    def test_is_nsf_folder(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {'nsf1': {'name': 'Root'}}
+        params.subfolder_cache = {
+            'nsf2': {'source': 'nested_share_folder', 'name': 'Child'},
+        }
+        node = NestedShareFolderNode()
+        node.uid = 'nsf3'
+        params.folder_cache = {'nsf3': node}
+
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf1'))
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf2'))
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf3'))
+        self.assertFalse(nsf_import.is_nsf_folder(params, ''))
+        self.assertFalse(nsf_import.is_nsf_folder(params, 'missing'))
+
+    def test_find_nsf_child(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'root1': {'name': 'Migration', 'parent_uid': ''},
+            'child1': {'name': 'Apps', 'parent_uid': 'root1'},
+        }
+        self.assertEqual(nsf_import.find_nsf_child(params, 'Migration', ''), 'root1')
+        self.assertEqual(nsf_import.find_nsf_child(params, 'Apps', 'root1'), 'child1')
+        self.assertIsNone(nsf_import.find_nsf_child(params, 'Missing', 'root1'))
+
+    def test_prepare_nsf_folders_reuses_existing(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'root1': {'name': 'Migration', 'parent_uid': ''},
+            'child1': {'name': 'Apps', 'parent_uid': 'root1'},
+        }
+        params.subfolder_cache = {}
+        params.folder_cache = {}
+
+        rec = Record()
+        fol = Folder()
+        fol.path = 'Migration\\Apps'
+        rec.folders = [fol]
+
+        created = nsf_import.prepare_nsf_folders(params, [], [rec], '')
+        self.assertEqual(created, 0)
+        self.assertEqual(fol.uid, 'child1')
+
+    def test_prepare_nsf_folders_creates_missing(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'root1': {'name': 'Migration', 'parent_uid': ''},
+        }
+        params.subfolder_cache = {}
+        params.folder_cache = {}
+
+        rec = Record()
+        fol = Folder()
+        fol.path = 'Migration\\NewChild'
+        rec.folders = [fol]
+
+        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
+                        return_value=['new1']) as create_mock:
+            nsf_import.prepare_nsf_folders(params, [], [rec], '')
+            create_mock.assert_called_once_with(params, [('NewChild', 'root1')])
+            self.assertEqual(fol.uid, 'new1')
+
+    def test_prepare_nsf_folders_with_base_parent(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'base': {'name': 'Base', 'parent_uid': ''},
+        }
+        params.subfolder_cache = {}
+        params.folder_cache = {}
+
+        sf = SharedFolder()
+        sf.path = 'ProjectA'
+
+        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
+                        return_value=['proj1']) as create_mock:
+            nsf_import.prepare_nsf_folders(params, [sf], [], 'base')
+            create_mock.assert_called_once_with(params, [('ProjectA', 'base')])
+            self.assertEqual(sf.uid, 'proj1')
+
+    def test_prepare_nsf_folders_batches_same_depth(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'root': {'name': 'Root', 'parent_uid': ''},
+        }
+        params.subfolder_cache = {}
+        params.folder_cache = {}
+
+        rec1 = Record()
+        fol1 = Folder()
+        fol1.path = 'Root\\A'
+        rec1.folders = [fol1]
+        rec2 = Record()
+        fol2 = Folder()
+        fol2.path = 'Root\\B'
+        rec2.folders = [fol2]
+
+        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
+                        return_value=['uidA', 'uidB']) as create_mock:
+            nsf_import.prepare_nsf_folders(params, [], [rec1, rec2], '')
+            create_mock.assert_called_once_with(
+                params, [('A', 'root'), ('B', 'root')])
+            self.assertEqual(fol1.uid, 'uidA')
+            self.assertEqual(fol2.uid, 'uidB')
+
+    def test_throttle_retry_retries_then_succeeds(self):
+        from keepercommander.error import KeeperApiError
+
+        calls = {'n': 0}
+
+        def flaky():
+            calls['n'] += 1
+            if calls['n'] < 3:
+                raise KeeperApiError('throttled', 'Due to repeated attempts, your request has been throttled')
+            return 'ok'
+
+        with mock.patch('keepercommander.importer.nsf_import.time.sleep') as sleep_mock:
+            result = nsf_import._call_with_throttle_retry('test', flaky)
+        self.assertEqual(result, 'ok')
+        self.assertEqual(calls['n'], 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+
+    def test_apply_nsf_folder_permissions(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'f1': {'name': 'Team', 'parent_uid': ''},
+        }
+
+        sf = SharedFolder()
+        sf.uid = 'f1'
+        sf.path = 'Team'
+        perm = Permission()
+        perm.name = 'user@example.com'
+        perm.manage_records = True
+        sf.permissions = [perm]
+
+        with mock.patch(
+            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
+            return_value={'success': True},
+        ) as grant_mock:
+            nsf_import.apply_nsf_folder_permissions(params, [sf])
+            grant_mock.assert_called_once()
+            args, kwargs = grant_mock.call_args
+            self.assertEqual(args[1], 'f1')
+            self.assertEqual(args[2], 'user@example.com')
+            self.assertEqual(kwargs.get('role'), 'content-manager')
+            self.assertFalse(kwargs.get('as_team'))
+
+    def test_apply_nsf_folder_permissions_multiple_users_and_roles(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'f1': {'name': 'Team', 'parent_uid': ''},
+        }
+
+        sf = SharedFolder()
+        sf.uid = 'f1'
+        sf.path = 'Team'
+        sf.manage_users = True
+        sf.manage_records = True
+
+        viewer = Permission()
+        viewer.name = 'viewer@example.com'
+        viewer.manage_users = False
+        viewer.manage_records = False
+
+        manager = Permission()
+        manager.name = 'manager@example.com'
+        manager.manage_users = True
+        manager.manage_records = True
+
+        team = Permission()
+        team.uid = 'teamUid12345678901234'
+        team.manage_records = True
+        team.manage_users = False
+
+        sf.permissions = [viewer, manager, team]
+
+        with mock.patch(
+            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
+            return_value={'success': True},
+        ) as grant_mock:
+            nsf_import.apply_nsf_folder_permissions(
+                params, [sf], manage_users=True, manage_records=True)
+            self.assertEqual(grant_mock.call_count, 3)
+            calls = grant_mock.call_args_list
+            # viewer with CLI defaults elevates to folder/default role
+            self.assertEqual(calls[0].args[2], 'viewer@example.com')
+            self.assertEqual(calls[0].kwargs.get('role'), 'full-manager')
+            self.assertFalse(calls[0].kwargs.get('as_team'))
+            # explicit full manager
+            self.assertEqual(calls[1].args[2], 'manager@example.com')
+            self.assertEqual(calls[1].kwargs.get('role'), 'full-manager')
+            # team UID treated as team
+            self.assertEqual(calls[2].args[2], 'teamUid12345678901234')
+            self.assertEqual(calls[2].kwargs.get('role'), 'content-manager')
+            self.assertTrue(calls[2].kwargs.get('as_team'))
+
+
+class TestJsonNsfPermissions(TestCase):
+    def test_json_loads_permissions_without_users_only(self):
+        """NSF import needs permissions on shared folders even without --users."""
+        payload = {
+            'shared_folders': [
+                {
+                    'path': 'NSF Demo\\Partners',
+                    'manage_users': True,
+                    'manage_records': True,
+                    'can_edit': True,
+                    'can_share': True,
+                    'permissions': [
+                        {
+                            'name': 'partner@example.com',
+                            'manage_users': False,
+                            'manage_records': True,
+                        },
+                        {
+                            'uid': 'teamUidABCDEFG0123456',
+                            'name': 'Engineering',
+                            'manage_users': True,
+                            'manage_records': True,
+                        },
+                    ],
+                }
+            ],
+            'records': [
+                {
+                    'title': 'Portal',
+                    'login': 'admin',
+                    'password': 'secret',
+                    'folders': [{'shared_folder': 'NSF Demo\\Partners'}],
+                }
+            ],
+        }
+        with tempfile.NamedTemporaryFile('w', suffix='.json', delete=False, encoding='utf-8') as tf:
+            json.dump(payload, tf)
+            path = tf.name
+        try:
+            importer = KeeperJsonImporter()
+            items = list(importer.do_import(path, users_only=False))
+        finally:
+            os.unlink(path)
+
+        folders = [x for x in items if isinstance(x, SharedFolder)]
+        records = [x for x in items if isinstance(x, Record)]
+        self.assertEqual(len(folders), 1)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(folders[0].path, 'NSF Demo\\Partners')
+        self.assertIsNotNone(folders[0].permissions)
+        self.assertEqual(len(folders[0].permissions), 2)
+        self.assertEqual(folders[0].permissions[0].name, 'partner@example.com')
+        self.assertTrue(folders[0].permissions[0].manage_records)
+        self.assertFalse(folders[0].permissions[0].manage_users)
+        self.assertEqual(folders[0].permissions[1].uid, 'teamUidABCDEFG0123456')
+        self.assertTrue(folders[0].permissions[1].manage_users)
+
+    def test_sample_nsf_json_includes_permissions(self):
+        sample = os.path.join(
+            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.json.txt')
+        if not os.path.isfile(sample):
+            self.skipTest('sample_data/import_nsf.json.txt missing')
+        importer = KeeperJsonImporter()
+        folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
+        with_perms = [f for f in folders if f.permissions]
+        self.assertGreaterEqual(len(with_perms), 1)
+        names = {p.name for f in with_perms for p in f.permissions if p.name}
+        self.assertIn('user@mycompany.com', names)
+
+
+class TestImportNsfCliFlag(TestCase):
+    def test_import_parser_has_nsf_flag(self):
+        from keepercommander.importer import commands
+        action = None
+        for a in commands.import_parser._actions:
+            if '--nsf' in (a.option_strings or []):
+                action = a
+                break
+        self.assertIsNotNone(action)
+        self.assertEqual(action.dest, 'use_nsf')
+
+
+class TestFilePathResolution(TestCase):
+    def test_resolves_json_txt_sample_from_stem(self):
+        importer = KeeperJsonImporter()
+        # sample_data/import.json.txt exists in the repo
+        resolved = importer.resolve_file_path(
+            os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'import'))
+        self.assertTrue(resolved.endswith('import.json.txt'))
+        self.assertTrue(os.path.isfile(resolved))
+
+    def test_resolves_json_txt_when_json_requested(self):
+        importer = KeeperJsonImporter()
+        sample_json = os.path.join(
+            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.json')
+        # File is stored as import_nsf.json.txt; requesting .json should find it
+        if not os.path.isfile(sample_json):
+            resolved = importer.resolve_file_path(sample_json)
+            self.assertTrue(resolved.endswith('import_nsf.json.txt'))
+            self.assertTrue(os.path.isfile(resolved))
+
+    def test_resolves_csv_exactly(self):
+        from keepercommander.importer.csv.csv import KeeperCsvImporter
+        importer = KeeperCsvImporter()
+        csv_path = os.path.join(
+            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.csv')
+        resolved = importer.resolve_file_path(csv_path)
+        self.assertEqual(os.path.abspath(resolved), os.path.abspath(csv_path))

--- a/unit-tests/test_nsf_import.py
+++ b/unit-tests/test_nsf_import.py
@@ -294,9 +294,9 @@ class TestJsonNsfPermissions(TestCase):
     def test_json_loads_nsf_role_permissions(self):
         sample = os.path.join(
             os.path.dirname(__file__), '..', 'sample_data',
-            'import_nsf_permissions.json.txt')
+            'import_nsf_permissions.txt')
         if not os.path.isfile(sample):
-            self.skipTest('sample_data/import_nsf_permissions.json.txt missing')
+            self.skipTest('sample_data/import_nsf_permissions.txt missing')
         importer = KeeperJsonImporter()
         folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
         self.assertGreaterEqual(len(folders), 1)
@@ -314,9 +314,9 @@ class TestJsonNsfPermissions(TestCase):
 
     def test_sample_nsf_json_includes_permissions(self):
         sample = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.json.txt')
+            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.txt')
         if not os.path.isfile(sample):
-            self.skipTest('sample_data/import_nsf.json.txt missing')
+            self.skipTest('sample_data/import_nsf.txt missing')
         importer = KeeperJsonImporter()
         folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
         with_perms = [f for f in folders if f.permissions]
@@ -347,7 +347,7 @@ class TestImportNsfCliFlag(TestCase):
             cmd.execute(
                 params,
                 format='json',
-                name='sample_data/import_nsf.json.txt',
+                name='sample_data/import_nsf.txt',
                 use_nsf=True,
                 users_only=True,
             )
@@ -391,15 +391,16 @@ class TestFilePathResolution(TestCase):
         self.assertTrue(resolved.endswith('import.json.txt'))
         self.assertTrue(os.path.isfile(resolved))
 
-    def test_resolves_json_txt_when_json_requested(self):
+    def test_resolves_txt_when_stem_requested(self):
         importer = KeeperJsonImporter()
-        sample_json = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.json')
-        # File is stored as import_nsf.json.txt; requesting .json should find it
-        if not os.path.isfile(sample_json):
-            resolved = importer.resolve_file_path(sample_json)
-            self.assertTrue(resolved.endswith('import_nsf.json.txt'))
-            self.assertTrue(os.path.isfile(resolved))
+        # sample_data/import_nsf.txt — resolve from stem without extension
+        stem = os.path.join(
+            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf')
+        if not os.path.isfile(stem + '.txt'):
+            self.skipTest('sample_data/import_nsf.txt missing')
+        resolved = importer.resolve_file_path(stem)
+        self.assertTrue(resolved.endswith('import_nsf.txt'))
+        self.assertTrue(os.path.isfile(resolved))
 
     def test_resolves_csv_exactly(self):
         from keepercommander.importer.csv.csv import KeeperCsvImporter

--- a/unit-tests/test_nsf_import.py
+++ b/unit-tests/test_nsf_import.py
@@ -1,411 +1,233 @@
-from unittest import TestCase, mock
 import json
 import os
 import tempfile
+from unittest import TestCase, mock
 
+from keepercommander.error import KeeperApiError
 from keepercommander.importer import nsf_import
+from keepercommander.importer.commands import RecordImportCommand, import_parser
+from keepercommander.importer.csv.csv import KeeperCsvImporter
 from keepercommander.importer.importer import Folder, Record, SharedFolder, Permission
 from keepercommander.importer.json.json import KeeperJsonImporter
 from keepercommander.subfolder import NestedShareFolderNode
 
+SAMPLE = os.path.join(os.path.dirname(__file__), '..', 'sample_data')
+GRANT = 'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3'
+CREATE = 'keepercommander.importer.nsf_import.create_nsf_folders_batch'
 
-class TestNsfImportHelpers(TestCase):
+
+def _params(folders=None):
+    p = mock.MagicMock()
+    p.nested_share_folders = folders or {}
+    p.subfolder_cache = {}
+    p.folder_cache = {}
+    p.enforcements = None
+    return p
+
+
+def _record(path):
+    rec = Record()
+    fol = Folder()
+    fol.path = path
+    rec.folders = [fol]
+    return rec, fol
+
+
+def _perm(name=None, uid=None, role=None, manage_records=False, manage_users=False):
+    p = Permission()
+    p.name = name
+    p.uid = uid
+    p.role = role
+    p.manage_records = manage_records
+    p.manage_users = manage_users
+    return p
+
+
+class TestNsfImport(TestCase):
     def test_classic_perms_to_nsf_role(self):
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(True, True), 'full-manager')
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, True, can_share=True),
-                         'content-share-manager')
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, True), 'content-manager')
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, False, can_edit=True),
-                         'content-manager')
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(False, False, can_share=True),
-                         'share-manager')
-        self.assertEqual(nsf_import.classic_perms_to_nsf_role(), 'viewer')
+        cases = [
+            ((True, True), 'full-manager'),
+            ((False, True), 'content-manager'),
+            ((False, False), 'viewer'),
+        ]
+        for args, role in cases:
+            self.assertEqual(nsf_import.classic_perms_to_nsf_role(*args), role)
+        self.assertEqual(
+            nsf_import.classic_perms_to_nsf_role(False, True, can_share=True),
+            'content-share-manager')
+        self.assertEqual(
+            nsf_import.classic_perms_to_nsf_role(False, False, can_share=True),
+            'share-manager')
 
-    def test_flatten_record_folder_paths(self):
-        rec = Record()
-        fol = Folder()
+    def test_flatten_and_find(self):
+        rec, fol = _record('')
         fol.domain = 'Shared'
         fol.path = 'Team\\Apps'
-        rec.folders = [fol]
         nsf_import.flatten_record_folder_paths([rec])
-        self.assertEqual(fol.domain, '')
-        self.assertEqual(fol.path, 'Shared\\Team\\Apps')
+        self.assertEqual((fol.domain, fol.path), ('', 'Shared\\Team\\Apps'))
 
-    def test_is_nsf_folder(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {'nsf1': {'name': 'Root'}}
-        params.subfolder_cache = {
-            'nsf2': {'source': 'nested_share_folder', 'name': 'Child'},
-        }
-        node = NestedShareFolderNode()
-        node.uid = 'nsf3'
-        params.folder_cache = {'nsf3': node}
-
-        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf1'))
-        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf2'))
-        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf3'))
-        self.assertFalse(nsf_import.is_nsf_folder(params, ''))
-        self.assertFalse(nsf_import.is_nsf_folder(params, 'missing'))
-
-    def test_find_nsf_child(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
+        params = _params({
             'root1': {'name': 'Migration', 'parent_uid': ''},
             'child1': {'name': 'Apps', 'parent_uid': 'root1'},
-        }
+        })
         self.assertEqual(nsf_import.find_nsf_child(params, 'Migration', ''), 'root1')
         self.assertEqual(nsf_import.find_nsf_child(params, 'Apps', 'root1'), 'child1')
         self.assertIsNone(nsf_import.find_nsf_child(params, 'Missing', 'root1'))
 
-    def test_prepare_nsf_folders_reuses_existing(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
+    def test_is_nsf_folder(self):
+        params = _params({'nsf1': {'name': 'Root'}})
+        params.subfolder_cache = {'nsf2': {'source': 'nested_share_folder'}}
+        node = NestedShareFolderNode()
+        node.uid = 'nsf3'
+        params.folder_cache = {'nsf3': node}
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf1'))
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf2'))
+        self.assertTrue(nsf_import.is_nsf_folder(params, 'nsf3'))
+        self.assertFalse(nsf_import.is_nsf_folder(params, 'missing'))
+
+    def test_prepare_nsf_folders(self):
+        params = _params({
             'root1': {'name': 'Migration', 'parent_uid': ''},
             'child1': {'name': 'Apps', 'parent_uid': 'root1'},
-        }
-        params.subfolder_cache = {}
-        params.folder_cache = {}
-
-        rec = Record()
-        fol = Folder()
-        fol.path = 'Migration\\Apps'
-        rec.folders = [fol]
-
-        created = nsf_import.prepare_nsf_folders(params, [], [rec], '')
-        self.assertEqual(created, 0)
+        })
+        rec, fol = _record('Migration\\Apps')
+        self.assertEqual(nsf_import.prepare_nsf_folders(params, [], [rec]), 0)
         self.assertEqual(fol.uid, 'child1')
 
-    def test_prepare_nsf_folders_creates_missing(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'root1': {'name': 'Migration', 'parent_uid': ''},
-        }
-        params.subfolder_cache = {}
-        params.folder_cache = {}
-
-        rec = Record()
-        fol = Folder()
-        fol.path = 'Migration\\NewChild'
-        rec.folders = [fol]
-
-        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
-                        return_value=['new1']) as create_mock:
-            nsf_import.prepare_nsf_folders(params, [], [rec], '')
-            create_mock.assert_called_once_with(params, [('NewChild', 'root1')])
+        rec, fol = _record('Migration\\New')
+        with mock.patch(CREATE, return_value=['new1']) as m:
+            nsf_import.prepare_nsf_folders(params, [], [rec])
+            m.assert_called_once_with(params, [('New', 'root1')])
             self.assertEqual(fol.uid, 'new1')
-
-    def test_prepare_nsf_folders_with_base_parent(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'base': {'name': 'Base', 'parent_uid': ''},
-        }
-        params.subfolder_cache = {}
-        params.folder_cache = {}
 
         sf = SharedFolder()
         sf.path = 'ProjectA'
-
-        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
-                        return_value=['proj1']) as create_mock:
-            nsf_import.prepare_nsf_folders(params, [sf], [], 'base')
-            create_mock.assert_called_once_with(params, [('ProjectA', 'base')])
+        with mock.patch(CREATE, return_value=['proj1']) as m:
+            nsf_import.prepare_nsf_folders(_params({'base': {'name': 'Base', 'parent_uid': ''}}),
+                                          [sf], [], 'base')
+            m.assert_called_once_with(mock.ANY, [('ProjectA', 'base')])
             self.assertEqual(sf.uid, 'proj1')
 
     def test_prepare_nsf_folders_batches_same_depth(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'root': {'name': 'Root', 'parent_uid': ''},
-        }
-        params.subfolder_cache = {}
-        params.folder_cache = {}
+        params = _params({'root': {'name': 'Root', 'parent_uid': ''}})
+        rec_a, fol_a = _record('Root\\A')
+        rec_b, fol_b = _record('Root\\B')
+        with mock.patch(CREATE, return_value=['uidA', 'uidB']) as m:
+            nsf_import.prepare_nsf_folders(params, [], [rec_a, rec_b])
+            m.assert_called_once_with(params, [('A', 'root'), ('B', 'root')])
+            self.assertEqual((fol_a.uid, fol_b.uid), ('uidA', 'uidB'))
 
-        rec1 = Record()
-        fol1 = Folder()
-        fol1.path = 'Root\\A'
-        rec1.folders = [fol1]
-        rec2 = Record()
-        fol2 = Folder()
-        fol2.path = 'Root\\B'
-        rec2.folders = [fol2]
-
-        with mock.patch('keepercommander.importer.nsf_import.create_nsf_folders_batch',
-                        return_value=['uidA', 'uidB']) as create_mock:
-            nsf_import.prepare_nsf_folders(params, [], [rec1, rec2], '')
-            create_mock.assert_called_once_with(
-                params, [('A', 'root'), ('B', 'root')])
-            self.assertEqual(fol1.uid, 'uidA')
-            self.assertEqual(fol2.uid, 'uidB')
-
-    def test_throttle_retry_retries_then_succeeds(self):
-        from keepercommander.error import KeeperApiError
-
-        calls = {'n': 0}
+    def test_throttle_retry(self):
+        n = {'c': 0}
 
         def flaky():
-            calls['n'] += 1
-            if calls['n'] < 3:
-                raise KeeperApiError('throttled', 'Due to repeated attempts, your request has been throttled')
+            n['c'] += 1
+            if n['c'] < 3:
+                raise KeeperApiError('throttled', 'throttled')
             return 'ok'
 
-        with mock.patch('keepercommander.importer.nsf_import.time.sleep') as sleep_mock:
-            result = nsf_import._call_with_throttle_retry('test', flaky)
-        self.assertEqual(result, 'ok')
-        self.assertEqual(calls['n'], 3)
-        self.assertEqual(sleep_mock.call_count, 2)
+        with mock.patch('keepercommander.importer.nsf_import.time.sleep') as sleep:
+            self.assertEqual(nsf_import._call_with_throttle_retry('t', flaky), 'ok')
+        self.assertEqual((n['c'], sleep.call_count), (3, 2))
 
-    def test_apply_nsf_folder_permissions(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'f1': {'name': 'Team', 'parent_uid': ''},
-        }
-
+    def test_apply_permissions_classic_and_role(self):
+        params = _params({'f1': {'name': 'Team', 'parent_uid': ''}})
         sf = SharedFolder()
         sf.uid = 'f1'
         sf.path = 'Team'
-        perm = Permission()
-        perm.name = 'user@example.com'
-        perm.manage_records = True
-        sf.permissions = [perm]
-
-        with mock.patch(
-            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
-            return_value={'success': True},
-        ) as grant_mock:
+        sf.permissions = [
+            _perm(name='user@example.com', manage_records=True),
+            _perm(name='viewer@example.com', role='viewer'),
+            _perm(name='admin@example.com', role='full-manager'),
+            _perm(name='editor@example.com', role='content_manager'),
+            _perm(name='bad@example.com', role='superuser'),
+        ]
+        with mock.patch(GRANT, return_value={'success': True}) as grant:
             nsf_import.apply_nsf_folder_permissions(params, [sf])
-            grant_mock.assert_called_once()
-            args, kwargs = grant_mock.call_args
-            self.assertEqual(args[1], 'f1')
-            self.assertEqual(args[2], 'user@example.com')
-            self.assertEqual(kwargs.get('role'), 'content-manager')
-            self.assertFalse(kwargs.get('as_team'))
+            roles = [c.kwargs.get('role') for c in grant.call_args_list]
+            self.assertEqual(roles, ['content-manager', 'viewer', 'full-manager', 'content-manager'])
+            self.assertEqual(grant.call_args_list[0].args[2], 'user@example.com')
 
-    def test_apply_nsf_folder_permissions_explicit_role(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'f1': {'name': 'Team', 'parent_uid': ''},
-        }
-
-        sf = SharedFolder()
-        sf.uid = 'f1'
-        sf.path = 'Team'
-
-        viewer = Permission()
-        viewer.name = 'viewer@example.com'
-        viewer.role = 'viewer'
-
-        manager = Permission()
-        manager.name = 'admin@example.com'
-        manager.role = 'full-manager'
-
-        alias = Permission()
-        alias.name = 'editor@example.com'
-        alias.role = 'content_manager'  # underscore alias
-
-        sf.permissions = [viewer, manager, alias]
-
-        with mock.patch(
-            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
-            return_value={'success': True},
-        ) as grant_mock:
-            nsf_import.apply_nsf_folder_permissions(params, [sf])
-            self.assertEqual(grant_mock.call_count, 3)
-            roles = [c.kwargs.get('role') for c in grant_mock.call_args_list]
-            self.assertEqual(roles, ['viewer', 'full-manager', 'content-manager'])
-
-    def test_apply_nsf_folder_permissions_rejects_invalid_role(self):
-        params = mock.MagicMock()
-        params.nested_share_folders = {
-            'f1': {'name': 'Team', 'parent_uid': ''},
-        }
-
-        sf = SharedFolder()
-        sf.uid = 'f1'
-        sf.path = 'Team'
-        bad = Permission()
-        bad.name = 'user@example.com'
-        bad.role = 'superuser'
-        sf.permissions = [bad]
-
-        with mock.patch(
-            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
-            return_value={'success': True},
-        ) as grant_mock:
-            nsf_import.apply_nsf_folder_permissions(params, [sf])
-            grant_mock.assert_not_called()
-
-
-class TestJsonNsfPermissions(TestCase):
-    def test_json_loads_permissions_without_users_only(self):
-        """NSF import needs permissions on shared folders even without --users."""
+    def test_json_loads_permissions_and_roles(self):
         payload = {
-            'shared_folders': [
-                {
-                    'path': 'NSF Demo\\Partners',
-                    'manage_users': True,
-                    'manage_records': True,
-                    'can_edit': True,
-                    'can_share': True,
-                    'permissions': [
-                        {
-                            'name': 'partner@example.com',
-                            'manage_users': False,
-                            'manage_records': True,
-                        },
-                        {
-                            'uid': 'teamUidABCDEFG0123456',
-                            'name': 'Engineering',
-                            'manage_users': True,
-                            'manage_records': True,
-                        },
-                    ],
-                }
-            ],
-            'records': [
-                {
-                    'title': 'Portal',
-                    'login': 'admin',
-                    'password': 'secret',
-                    'folders': [{'shared_folder': 'NSF Demo\\Partners'}],
-                }
-            ],
+            'shared_folders': [{
+                'path': 'NSF\\Team',
+                'permissions': [
+                    {'name': 'u@ex.com', 'manage_records': True},
+                    {'name': 'a@ex.com', 'role': 'full-manager'},
+                    {'uid': 'teamUid12345678901234', 'role': 'viewer'},
+                ],
+            }],
+            'records': [{'title': 'R', 'login': 'u', 'password': 'p',
+                         'folders': [{'folder': 'NSF\\Team'}]}],
         }
-        with tempfile.NamedTemporaryFile('w', suffix='.json', delete=False, encoding='utf-8') as tf:
+        with tempfile.NamedTemporaryFile('w', suffix='.txt', delete=False, encoding='utf-8') as tf:
             json.dump(payload, tf)
             path = tf.name
         try:
-            importer = KeeperJsonImporter()
-            items = list(importer.do_import(path, users_only=False))
+            items = list(KeeperJsonImporter().do_import(path))
         finally:
             os.unlink(path)
 
         folders = [x for x in items if isinstance(x, SharedFolder)]
-        records = [x for x in items if isinstance(x, Record)]
         self.assertEqual(len(folders), 1)
-        self.assertEqual(len(records), 1)
-        self.assertEqual(folders[0].path, 'NSF Demo\\Partners')
-        self.assertIsNotNone(folders[0].permissions)
-        self.assertEqual(len(folders[0].permissions), 2)
-        self.assertEqual(folders[0].permissions[0].name, 'partner@example.com')
-        self.assertTrue(folders[0].permissions[0].manage_records)
-        self.assertFalse(folders[0].permissions[0].manage_users)
-        self.assertEqual(folders[0].permissions[1].uid, 'teamUidABCDEFG0123456')
-        self.assertTrue(folders[0].permissions[1].manage_users)
+        perms = folders[0].permissions
+        self.assertEqual(len(perms), 3)
+        self.assertEqual(perms[0].name, 'u@ex.com')
+        self.assertTrue(perms[0].manage_records)
+        self.assertEqual(perms[1].role, 'full-manager')
+        self.assertEqual(perms[2].uid, 'teamUid12345678901234')
 
-    def test_json_loads_nsf_role_permissions(self):
-        sample = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data',
-            'import_nsf_permissions.txt')
-        if not os.path.isfile(sample):
-            self.skipTest('sample_data/import_nsf_permissions.txt missing')
-        importer = KeeperJsonImporter()
-        folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
-        self.assertGreaterEqual(len(folders), 1)
-        roles = []
-        for f in folders:
-            for p in f.permissions or []:
-                if p.role:
-                    roles.append(p.role)
-        self.assertIn('viewer', roles)
-        self.assertIn('full-manager', roles)
-        self.assertIn('content-manager', roles)
-        self.assertIn('share-manager', roles)
-        self.assertIn('content-share-manager', roles)
-        self.assertIn('requestor', roles)
+    def test_sample_files(self):
+        for name, check in (
+            ('import_nsf.txt', lambda fs: any(p.name == 'user@mycompany.com'
+                                             for f in fs for p in (f.permissions or []))),
+            ('import_nsf_permissions.txt', lambda fs: {
+                p.role for f in fs for p in (f.permissions or []) if p.role
+            } >= {'viewer', 'full-manager', 'content-manager'}),
+        ):
+            path = os.path.join(SAMPLE, name)
+            if not os.path.isfile(path):
+                self.skipTest(f'{name} missing')
+            folders = [x for x in KeeperJsonImporter().do_import(path) if isinstance(x, SharedFolder)]
+            self.assertTrue(check(folders), name)
 
-    def test_sample_nsf_json_includes_permissions(self):
-        sample = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.txt')
-        if not os.path.isfile(sample):
-            self.skipTest('sample_data/import_nsf.txt missing')
-        importer = KeeperJsonImporter()
-        folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
-        with_perms = [f for f in folders if f.permissions]
-        self.assertGreaterEqual(len(with_perms), 1)
-        names = {p.name for f in with_perms for p in f.permissions if p.name}
-        self.assertIn('user@mycompany.com', names)
-
-
-class TestImportNsfCliFlag(TestCase):
-    def test_import_parser_has_nsf_flag(self):
-        from keepercommander.importer import commands
-        action = None
-        for a in commands.import_parser._actions:
-            if '--nsf' in (a.option_strings or []):
-                action = a
-                break
-        self.assertIsNotNone(action)
-        self.assertEqual(action.dest, 'use_nsf')
-
-    def test_nsf_does_not_prompt_for_classic_permissions(self):
-        from keepercommander.importer.commands import RecordImportCommand
-
-        params = mock.MagicMock()
-        params.enforcements = None
+    def test_cli_nsf_skips_classic_prompt(self):
         cmd = RecordImportCommand()
-        with mock.patch('keepercommander.importer.commands.user_choice') as choice_mock, \
-             mock.patch('keepercommander.importer.commands.imp_exp._import') as import_mock:
-            cmd.execute(
-                params,
-                format='json',
-                name='sample_data/import_nsf.txt',
-                use_nsf=True,
-                users_only=True,
-            )
-            choice_mock.assert_not_called()
-            import_mock.assert_called_once()
-            kwargs = import_mock.call_args.kwargs
-            self.assertFalse(kwargs.get('manage_users'))
-            self.assertFalse(kwargs.get('manage_records'))
-            self.assertFalse(kwargs.get('can_edit'))
-            self.assertFalse(kwargs.get('can_share'))
+        with mock.patch('keepercommander.importer.commands.user_choice') as choice, \
+             mock.patch('keepercommander.importer.commands.imp_exp._import') as imp:
+            cmd.execute(_params(), format='json', name='sample_data/import_nsf.txt',
+                        use_nsf=True, users_only=True)
+            choice.assert_not_called()
+            self.assertTrue(all(not imp.call_args.kwargs.get(k)
+                                for k in ('manage_users', 'manage_records', 'can_edit', 'can_share')))
 
-    def test_classic_shared_still_prompts_for_permissions(self):
-        from keepercommander.importer.commands import RecordImportCommand
+            # classic --shared still prompts (name is unused; import is mocked)
+            choice.reset_mock()
+            choice.return_value = 'a'
+            cmd.execute(_params(), format='json', name='sample_data/import_nsf.txt', shared=True)
+            choice.assert_called_once()
+            self.assertTrue(all(imp.call_args.kwargs.get(k)
+                                for k in ('manage_users', 'manage_records', 'can_edit', 'can_share')))
 
-        params = mock.MagicMock()
-        params.enforcements = None
-        cmd = RecordImportCommand()
-        with mock.patch('keepercommander.importer.commands.user_choice',
-                        return_value='a') as choice_mock, \
-             mock.patch('keepercommander.importer.commands.imp_exp._import') as import_mock:
-            cmd.execute(
-                params,
-                format='json',
-                name='sample_data/import.json.txt',
-                shared=True,
-            )
-            choice_mock.assert_called_once()
-            kwargs = import_mock.call_args.kwargs
-            self.assertTrue(kwargs.get('manage_users'))
-            self.assertTrue(kwargs.get('manage_records'))
-            self.assertTrue(kwargs.get('can_edit'))
-            self.assertTrue(kwargs.get('can_share'))
+    def test_parser_and_path_resolve(self):
+        self.assertTrue(any('--nsf' in (a.option_strings or []) for a in import_parser._actions))
 
-
-class TestFilePathResolution(TestCase):
-    def test_resolves_json_txt_sample_from_stem(self):
-        importer = KeeperJsonImporter()
-        # sample_data/import.json.txt exists in the repo
-        resolved = importer.resolve_file_path(
-            os.path.join(os.path.dirname(__file__), '..', 'sample_data', 'import'))
-        self.assertTrue(resolved.endswith('import.json.txt'))
-        self.assertTrue(os.path.isfile(resolved))
-
-    def test_resolves_txt_when_stem_requested(self):
-        importer = KeeperJsonImporter()
-        # sample_data/import_nsf.txt — resolve from stem without extension
-        stem = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf')
-        if not os.path.isfile(stem + '.txt'):
+        nsf_txt = os.path.join(SAMPLE, 'import_nsf.txt')
+        if not os.path.isfile(nsf_txt):
             self.skipTest('sample_data/import_nsf.txt missing')
-        resolved = importer.resolve_file_path(stem)
-        self.assertTrue(resolved.endswith('import_nsf.txt'))
-        self.assertTrue(os.path.isfile(resolved))
 
-    def test_resolves_csv_exactly(self):
-        from keepercommander.importer.csv.csv import KeeperCsvImporter
-        importer = KeeperCsvImporter()
-        csv_path = os.path.join(
-            os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.csv')
-        resolved = importer.resolve_file_path(csv_path)
-        self.assertEqual(os.path.abspath(resolved), os.path.abspath(csv_path))
+        json_imp = KeeperJsonImporter()
+        # stem → import_nsf.txt
+        self.assertTrue(
+            json_imp.resolve_file_path(os.path.join(SAMPLE, 'import_nsf')).endswith('import_nsf.txt'))
+        # exact .txt path
+        self.assertEqual(
+            os.path.abspath(json_imp.resolve_file_path(nsf_txt)),
+            os.path.abspath(nsf_txt))
+
+        csv_path = os.path.join(SAMPLE, 'import_nsf.csv')
+        if os.path.isfile(csv_path):
+            self.assertEqual(
+                os.path.abspath(KeeperCsvImporter().resolve_file_path(csv_path)),
+                os.path.abspath(csv_path))

--- a/unit-tests/test_nsf_import.py
+++ b/unit-tests/test_nsf_import.py
@@ -179,7 +179,7 @@ class TestNsfImportHelpers(TestCase):
             self.assertEqual(kwargs.get('role'), 'content-manager')
             self.assertFalse(kwargs.get('as_team'))
 
-    def test_apply_nsf_folder_permissions_multiple_users_and_roles(self):
+    def test_apply_nsf_folder_permissions_explicit_role(self):
         params = mock.MagicMock()
         params.nested_share_folders = {
             'f1': {'name': 'Team', 'parent_uid': ''},
@@ -188,45 +188,50 @@ class TestNsfImportHelpers(TestCase):
         sf = SharedFolder()
         sf.uid = 'f1'
         sf.path = 'Team'
-        sf.manage_users = True
-        sf.manage_records = True
 
         viewer = Permission()
         viewer.name = 'viewer@example.com'
-        viewer.manage_users = False
-        viewer.manage_records = False
+        viewer.role = 'viewer'
 
         manager = Permission()
-        manager.name = 'manager@example.com'
-        manager.manage_users = True
-        manager.manage_records = True
+        manager.name = 'admin@example.com'
+        manager.role = 'full-manager'
 
-        team = Permission()
-        team.uid = 'teamUid12345678901234'
-        team.manage_records = True
-        team.manage_users = False
+        alias = Permission()
+        alias.name = 'editor@example.com'
+        alias.role = 'content_manager'  # underscore alias
 
-        sf.permissions = [viewer, manager, team]
+        sf.permissions = [viewer, manager, alias]
 
         with mock.patch(
             'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
             return_value={'success': True},
         ) as grant_mock:
-            nsf_import.apply_nsf_folder_permissions(
-                params, [sf], manage_users=True, manage_records=True)
+            nsf_import.apply_nsf_folder_permissions(params, [sf])
             self.assertEqual(grant_mock.call_count, 3)
-            calls = grant_mock.call_args_list
-            # viewer with CLI defaults elevates to folder/default role
-            self.assertEqual(calls[0].args[2], 'viewer@example.com')
-            self.assertEqual(calls[0].kwargs.get('role'), 'full-manager')
-            self.assertFalse(calls[0].kwargs.get('as_team'))
-            # explicit full manager
-            self.assertEqual(calls[1].args[2], 'manager@example.com')
-            self.assertEqual(calls[1].kwargs.get('role'), 'full-manager')
-            # team UID treated as team
-            self.assertEqual(calls[2].args[2], 'teamUid12345678901234')
-            self.assertEqual(calls[2].kwargs.get('role'), 'content-manager')
-            self.assertTrue(calls[2].kwargs.get('as_team'))
+            roles = [c.kwargs.get('role') for c in grant_mock.call_args_list]
+            self.assertEqual(roles, ['viewer', 'full-manager', 'content-manager'])
+
+    def test_apply_nsf_folder_permissions_rejects_invalid_role(self):
+        params = mock.MagicMock()
+        params.nested_share_folders = {
+            'f1': {'name': 'Team', 'parent_uid': ''},
+        }
+
+        sf = SharedFolder()
+        sf.uid = 'f1'
+        sf.path = 'Team'
+        bad = Permission()
+        bad.name = 'user@example.com'
+        bad.role = 'superuser'
+        sf.permissions = [bad]
+
+        with mock.patch(
+            'keepercommander.nested_share_folder.folder_api.grant_folder_access_v3',
+            return_value={'success': True},
+        ) as grant_mock:
+            nsf_import.apply_nsf_folder_permissions(params, [sf])
+            grant_mock.assert_not_called()
 
 
 class TestJsonNsfPermissions(TestCase):
@@ -286,6 +291,27 @@ class TestJsonNsfPermissions(TestCase):
         self.assertEqual(folders[0].permissions[1].uid, 'teamUidABCDEFG0123456')
         self.assertTrue(folders[0].permissions[1].manage_users)
 
+    def test_json_loads_nsf_role_permissions(self):
+        sample = os.path.join(
+            os.path.dirname(__file__), '..', 'sample_data',
+            'import_nsf_permissions.json.txt')
+        if not os.path.isfile(sample):
+            self.skipTest('sample_data/import_nsf_permissions.json.txt missing')
+        importer = KeeperJsonImporter()
+        folders = [x for x in importer.do_import(sample) if isinstance(x, SharedFolder)]
+        self.assertGreaterEqual(len(folders), 1)
+        roles = []
+        for f in folders:
+            for p in f.permissions or []:
+                if p.role:
+                    roles.append(p.role)
+        self.assertIn('viewer', roles)
+        self.assertIn('full-manager', roles)
+        self.assertIn('content-manager', roles)
+        self.assertIn('share-manager', roles)
+        self.assertIn('content-share-manager', roles)
+        self.assertIn('requestor', roles)
+
     def test_sample_nsf_json_includes_permissions(self):
         sample = os.path.join(
             os.path.dirname(__file__), '..', 'sample_data', 'import_nsf.json.txt')
@@ -309,6 +335,51 @@ class TestImportNsfCliFlag(TestCase):
                 break
         self.assertIsNotNone(action)
         self.assertEqual(action.dest, 'use_nsf')
+
+    def test_nsf_does_not_prompt_for_classic_permissions(self):
+        from keepercommander.importer.commands import RecordImportCommand
+
+        params = mock.MagicMock()
+        params.enforcements = None
+        cmd = RecordImportCommand()
+        with mock.patch('keepercommander.importer.commands.user_choice') as choice_mock, \
+             mock.patch('keepercommander.importer.commands.imp_exp._import') as import_mock:
+            cmd.execute(
+                params,
+                format='json',
+                name='sample_data/import_nsf.json.txt',
+                use_nsf=True,
+                users_only=True,
+            )
+            choice_mock.assert_not_called()
+            import_mock.assert_called_once()
+            kwargs = import_mock.call_args.kwargs
+            self.assertFalse(kwargs.get('manage_users'))
+            self.assertFalse(kwargs.get('manage_records'))
+            self.assertFalse(kwargs.get('can_edit'))
+            self.assertFalse(kwargs.get('can_share'))
+
+    def test_classic_shared_still_prompts_for_permissions(self):
+        from keepercommander.importer.commands import RecordImportCommand
+
+        params = mock.MagicMock()
+        params.enforcements = None
+        cmd = RecordImportCommand()
+        with mock.patch('keepercommander.importer.commands.user_choice',
+                        return_value='a') as choice_mock, \
+             mock.patch('keepercommander.importer.commands.imp_exp._import') as import_mock:
+            cmd.execute(
+                params,
+                format='json',
+                name='sample_data/import.json.txt',
+                shared=True,
+            )
+            choice_mock.assert_called_once()
+            kwargs = import_mock.call_args.kwargs
+            self.assertTrue(kwargs.get('manage_users'))
+            self.assertTrue(kwargs.get('manage_records'))
+            self.assertTrue(kwargs.get('can_edit'))
+            self.assertTrue(kwargs.get('can_share'))
 
 
 class TestFilePathResolution(TestCase):


### PR DESCRIPTION
- Added Nested Shared Folder (`--nsf`) support to Vault Import for creating NSF folders and records. 
- Added support for importing NSF user and team permissions from JSON, including explicit roles: - `viewer` - `content-manager` - `full-manager` - `share-manager` - `content-share-manager`