### PR TITLE
Correct library name for Azure import

### DIFF
--- a/keepercommander/commands/azure_import.py
+++ b/keepercommander/commands/azure_import.py
@@ -75,7 +75,7 @@ class AzureSecretsImportCommand(Command, CloudImportMixin):
         except ImportError:
             raise CommandError(
                 'azure-secrets-import',
-                'azure-identity is required. Install it with: pip install keeper-commander[azure]'
+                'azure-identity is required. Install it with: pip install keepercommander[azure]'
             )
 
         if tenant_id and client_id and client_secret:
@@ -110,7 +110,7 @@ class AzureSecretsImportCommand(Command, CloudImportMixin):
         except ImportError:
             raise CommandError(
                 'azure-secrets-import',
-                'azure-keyvault-secrets is required. Install it with: pip install keeper-commander[azure]'
+                'azure-keyvault-secrets is required. Install it with: pip install keepercommander[azure]'
             )
         vault_url = f'https://{vault_name}.vault.azure.net/'
         return SecretClient(vault_url=vault_url, credential=credential)


### PR DESCRIPTION
If azure modules are not loaded, we incorrectly suggest running:  
`pip install keeper-commander[azure]`  
But the correct library name is `keepercommander[azure]`