### PR TITLE
KC-1378: Implement Ownership check for "Commander Service Mode Config" record

### DIFF
--- a/keepercommander/service/config/cli_handler.py
+++ b/keepercommander/service/config/cli_handler.py
@@ -41,21 +41,35 @@ class CommandHandler:
 
     @debug_decorator
     def find_config_record(self, params: KeeperParams, title: str) -> Optional[str]:
-        """Find existing config record by exact title match using vault search."""
+        """Find owned config record by exact title match using vault search.
+
+        Only records owned by the current account are eligible. Shared or
+        non-owned records (even with a matching title) are ignored so that
+        service configuration cannot be supplied or overwritten by another user.
+        """
         try:
             from ... import vault_extensions
             
             logger.debug(f"Searching for record with exact title: '{title}'")
             records = list(vault_extensions.find_records(params, title))
             
-            # Filter to exact title match only
             for record in records:
                 logger.debug(f"Checking record: '{record.title}' (UID: {record.record_uid})")
-                if record.title == title:
-                    logger.debug(f"✓ Found exact title match: '{title}' (UID: {record.record_uid})")
-                    return record.record_uid
+                if record.title != title:
+                    continue
+
+                owner = (params.record_owner_cache or {}).get(record.record_uid)
+                if not owner or not owner.owner:
+                    logger.debug(
+                        f"Skipping non-owned config record '{title}' "
+                        f"(UID: {record.record_uid})"
+                    )
+                    continue
+
+                logger.debug(f"✓ Found owned exact title match: '{title}' (UID: {record.record_uid})")
+                return record.record_uid
             
-            logger.debug(f"✗ No record found with exact title: '{title}'")
+            logger.debug(f"✗ No owned record found with exact title: '{title}'")
             return None
             
         except Exception as e:

--- a/unit-tests/service/test_service_config.py
+++ b/unit-tests/service/test_service_config.py
@@ -161,3 +161,55 @@ class TestServiceConfig(unittest.TestCase):
         mock_record_handler.update_or_add_record.assert_called_once_with(
             params, self.service_config.title, self.service_config.config_path
         )
+
+
+class TestFindConfigRecordOwnership(unittest.TestCase):
+    """Service config records must be owned by the current account."""
+
+    TITLE = 'Commander Service Mode Config'
+
+    def _make_record(self, uid, title=None):
+        record = MagicMock()
+        record.record_uid = uid
+        record.title = title or self.TITLE
+        return record
+
+    @patch('keepercommander.vault_extensions.find_records')
+    def test_skips_non_owned_record(self, mock_find):
+        from keepercommander.params import RecordOwner
+        from keepercommander.service.config.cli_handler import CommandHandler
+
+        shared = self._make_record('SHARED_UID')
+        owned = self._make_record('OWNED_UID')
+        mock_find.return_value = [shared, owned]
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_owner_cache = {
+            'SHARED_UID': RecordOwner(False, 'attacker'),
+            'OWNED_UID': RecordOwner(True, 'operator'),
+        }
+
+        self.assertEqual(CommandHandler().find_config_record(params, self.TITLE), 'OWNED_UID')
+
+    @patch('keepercommander.vault_extensions.find_records')
+    def test_returns_none_when_only_shared_match(self, mock_find):
+        from keepercommander.params import RecordOwner
+        from keepercommander.service.config.cli_handler import CommandHandler
+
+        mock_find.return_value = [self._make_record('SHARED_UID')]
+        params = MagicMock(spec=KeeperParams)
+        params.record_owner_cache = {
+            'SHARED_UID': RecordOwner(False, 'attacker'),
+        }
+
+        self.assertIsNone(CommandHandler().find_config_record(params, self.TITLE))
+
+    @patch('keepercommander.vault_extensions.find_records')
+    def test_returns_none_when_owner_cache_missing(self, mock_find):
+        from keepercommander.service.config.cli_handler import CommandHandler
+
+        mock_find.return_value = [self._make_record('UNKNOWN_UID')]
+        params = MagicMock(spec=KeeperParams)
+        params.record_owner_cache = {}
+
+        self.assertIsNone(CommandHandler().find_config_record(params, self.TITLE))


### PR DESCRIPTION
## Summary
- Prevent Service Mode from adopting or writing configuration from vault records the current account does not own.
- Title-based lookup still works for owned records and integrations; shared or attacker-planted config records are ignored.

## Changes
- Require `record_owner_cache` ownership when resolving the Service Mode config record by title.
- Add unit tests covering shared-only, shared-then-owned, and missing ownership-cache cases.