### PR TITLE
KC-1392: Block PAM workflow admin commands after workflow policy is revoked

### DIFF
--- a/keepercommander/commands/pam_import/workflow_apply.py
+++ b/keepercommander/commands/pam_import/workflow_apply.py
@@ -19,6 +19,7 @@ from ..workflow.helpers import (
     RecordResolver,
     WorkflowFormatter,
     sanitize_router_error,
+    ensure_can_configure_workflow_settings,
 )
 from ...error import CommandError, KeeperApiError
 from ...params import KeeperParams
@@ -192,6 +193,8 @@ def apply_workflow(
     opts: PamWorkflowOptions,
 ) -> None:
     """Create or update workflow config via Krouter. Raises CommandError on failure."""
+    ensure_can_configure_workflow_settings(params, refresh=True, action='apply')
+
     record_uid_bytes = utils.base64_url_decode(record_uid)
     ref = ProtobufRefBuilder.record_ref(record_uid_bytes, record_title)
 

--- a/keepercommander/commands/workflow/config_commands.py
+++ b/keepercommander/commands/workflow/config_commands.py
@@ -22,7 +22,13 @@ from ...params import KeeperParams
 from ...proto import workflow_pb2
 from ... import utils
 
-from .helpers import RecordResolver, ProtobufRefBuilder, WorkflowFormatter, sanitize_router_error
+from .helpers import (
+    RecordResolver,
+    ProtobufRefBuilder,
+    WorkflowFormatter,
+    sanitize_router_error,
+    ensure_can_configure_workflow_settings,
+)
 
 
 def _add_approvers_to_workflow(params, record_uid, record_name,
@@ -89,6 +95,10 @@ class WorkflowCreateCommand(Command):
         return WorkflowCreateCommand.parser
 
     def execute(self, params: KeeperParams, **kwargs):
+        # Defense in depth: registry also gates admin verbs after refreshing
+        # enforcements. Re-check here so direct execute() cannot skip the policy.
+        ensure_can_configure_workflow_settings(params, refresh=True, action='create')
+
         record_uid, record = RecordResolver.resolve(params, kwargs.get('record'))
         RecordResolver.validate_workflow_record_type(record)
         record_uid_bytes = utils.base64_url_decode(record_uid)
@@ -376,6 +386,8 @@ class WorkflowUpdateCommand(Command):
         return WorkflowUpdateCommand.parser
 
     def execute(self, params: KeeperParams, **kwargs):
+        ensure_can_configure_workflow_settings(params, refresh=True, action='update')
+
         record_uid, record = RecordResolver.resolve(params, kwargs.get('record'))
         record_uid_bytes = utils.base64_url_decode(record_uid)
 
@@ -456,6 +468,8 @@ class WorkflowDeleteCommand(Command):
         return WorkflowDeleteCommand.parser
 
     def execute(self, params: KeeperParams, **kwargs):
+        ensure_can_configure_workflow_settings(params, refresh=True, action='delete')
+
         record_uid, record = RecordResolver.resolve(params, kwargs.get('record'))
         record_uid_bytes = utils.base64_url_decode(record_uid)
         ref = ProtobufRefBuilder.record_ref(record_uid_bytes, record.title)
@@ -511,6 +525,8 @@ class WorkflowAddApproversCommand(Command):
         return WorkflowAddApproversCommand.parser
 
     def execute(self, params: KeeperParams, **kwargs):
+        ensure_can_configure_workflow_settings(params, refresh=True, action='add-approver')
+
         users = list(dict.fromkeys(
             u.strip() for u in (kwargs.get('user') or []) if u and u.strip()
         ))
@@ -582,6 +598,8 @@ class WorkflowDeleteApproversCommand(Command):
         return WorkflowDeleteApproversCommand.parser
 
     def execute(self, params: KeeperParams, **kwargs):
+        ensure_can_configure_workflow_settings(params, refresh=True, action='remove-approver')
+
         users = kwargs.get('user') or []
         teams = kwargs.get('team') or []
 

--- a/keepercommander/commands/workflow/helpers.py
+++ b/keepercommander/commands/workflow/helpers.py
@@ -9,8 +9,10 @@
 # Contact: ops@keepersecurity.com
 #
 
+import logging
 import re
 import shlex
+import time
 from typing import List, Optional, Tuple
 
 from ...error import CommandError
@@ -23,6 +25,68 @@ _PROTO_DUMP_RE = re.compile(
     r'\s*(?:type|value|name|stage|conditions|flowUid|resource)\s*:\s*(?:"[^"]*"|\S+)\s*',
 )
 _RESPONSE_CODE_RE = re.compile(r'\s*[Rr]esponse\s+code:\s*\S+\s*$')
+
+# Enterprise role enforcement: "Can manage workflow settings"
+WORKFLOW_SETTINGS_ENFORCEMENT_KEY = 'allow_configure_workflow_settings'
+
+# Avoid duplicate account-summary calls when registry + command both refresh.
+_ENFORCEMENT_REFRESH_TTL_SEC = 2.0
+_ENFORCEMENT_REFRESH_ATTR = '_workflow_enforcement_refreshed_at'
+
+
+def refresh_enforcements(params: KeeperParams) -> None:
+    """Reload account summary so revoked role enforcements take effect without re-login."""
+    now = time.monotonic()
+    last = getattr(params, _ENFORCEMENT_REFRESH_ATTR, 0.0)
+    if not isinstance(last, (int, float)):
+        last = 0.0
+    if now - last < _ENFORCEMENT_REFRESH_TTL_SEC:
+        return
+    try:
+        from ...loginv3 import LoginV3Flow
+        LoginV3Flow.populateAccountSummary(params)
+        setattr(params, _ENFORCEMENT_REFRESH_ATTR, now)
+    except Exception as e:
+        logging.error('Failed to refresh enforcements: %s', e, exc_info=True)
+
+
+def can_configure_workflow_settings(params: KeeperParams, *, refresh: bool = False) -> bool:
+    """True when the user currently has allow_configure_workflow_settings.
+
+    When refresh=True, reloads account summary first so a mid-session policy revoke
+    is visible (plain sync-down does not refresh enforcements).
+    """
+    if refresh:
+        refresh_enforcements(params)
+    enforcements = getattr(params, 'enforcements', None)
+    if not enforcements or 'booleans' not in enforcements:
+        return False
+    booleans = enforcements.get('booleans') or []
+    if not isinstance(booleans, list):
+        return False
+    return any(
+        bool(b.get('value'))
+        for b in booleans
+        if isinstance(b, dict) and b.get('key') == WORKFLOW_SETTINGS_ENFORCEMENT_KEY
+    )
+
+
+def ensure_can_configure_workflow_settings(
+    params: KeeperParams,
+    *,
+    refresh: bool = True,
+    action: str = 'manage',
+) -> None:
+    """Raise CommandError unless the user may configure workflow settings."""
+    if can_configure_workflow_settings(params, refresh=refresh):
+        return
+    raise CommandError(
+        '',
+        f'You do not have permission to manage workflow settings. '
+        f'The "{action}" command requires the "Can manage workflow settings" '
+        f'enforcement policy. Contact your Keeper administrator to enable this '
+        f'for your role.',
+    )
 
 
 class DashUidArgsMixin:

--- a/keepercommander/commands/workflow/registry.py
+++ b/keepercommander/commands/workflow/registry.py
@@ -12,8 +12,7 @@
 from ..base import GroupCommand, dump_report_data
 from ...display import bcolors
 
-_ENFORCEMENT_KEY = 'allow_configure_workflow_settings'
-
+from .helpers import can_configure_workflow_settings
 from .config_commands import (
     WorkflowCreateCommand,
     WorkflowReadCommand,
@@ -43,14 +42,8 @@ class PAMWorkflowCommand(GroupCommand):
     _ADMIN_VERBS = frozenset({'create', 'update', 'delete', 'add-approver', 'remove-approver'})
 
     @staticmethod
-    def _can_manage_workflows(params):
-        enforcements = getattr(params, 'enforcements', None)
-        if not enforcements or 'booleans' not in enforcements:
-            return False
-        return any(
-            b.get('value') for b in enforcements['booleans']
-            if b.get('key') == _ENFORCEMENT_KEY
-        )
+    def _can_manage_workflows(params, *, refresh=False):
+        return can_configure_workflow_settings(params, refresh=refresh)
 
     def execute_args(self, params, args, **kwargs):
         self._current_params = params
@@ -59,7 +52,10 @@ class PAMWorkflowCommand(GroupCommand):
         verb = (args[:pos].strip() if pos > 0 else args.strip()).lower() if args else ''
         resolved_verb = self._aliases.get(verb, verb)
 
-        if resolved_verb in self._ADMIN_VERBS and not self._can_manage_workflows(params):
+        # Refresh enforcements before admin verbs so a mid-session revoke of
+        # "Can manage workflow settings" blocks create/update/delete equally.
+        # (Plain sync-down does not reload account enforcements.)
+        if resolved_verb in self._ADMIN_VERBS and not self._can_manage_workflows(params, refresh=True):
             print(
                 f"\n{bcolors.WARNING}You do not have permission to manage workflow settings.{bcolors.ENDC}\n"
                 f"The '{bcolors.BOLD}{resolved_verb}{bcolors.ENDC}' command requires the "

--- a/unit-tests/pam/test_workflow_enforcement_gate.py
+++ b/unit-tests/pam/test_workflow_enforcement_gate.py
@@ -1,0 +1,108 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Tests for PAM workflow settings enforcement gating."""
+
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keepercommander.error import CommandError
+from keepercommander.commands.workflow.helpers import (
+    WORKFLOW_SETTINGS_ENFORCEMENT_KEY,
+    can_configure_workflow_settings,
+    ensure_can_configure_workflow_settings,
+)
+from keepercommander.commands.workflow.registry import PAMWorkflowCommand
+from keepercommander.commands.workflow.config_commands import WorkflowDeleteCommand
+
+
+def _params_with_enforcement(allowed):
+    params = MagicMock()
+    if allowed is None:
+        params.enforcements = None
+        return params
+    params.enforcements = {
+        'booleans': (
+            [{'key': WORKFLOW_SETTINGS_ENFORCEMENT_KEY, 'value': True}]
+            if allowed else
+            [{'key': 'some_other_key', 'value': True}]
+        )
+    }
+    return params
+
+
+class TestCanConfigureWorkflowSettings(unittest.TestCase):
+
+    def test_allowed_when_enforcement_true(self):
+        self.assertTrue(can_configure_workflow_settings(_params_with_enforcement(True)))
+
+    def test_denied_when_enforcement_absent(self):
+        # Revoke removes the key from booleans (Commander parser drops :false).
+        self.assertFalse(can_configure_workflow_settings(_params_with_enforcement(False)))
+
+    def test_denied_when_no_enforcements(self):
+        self.assertFalse(can_configure_workflow_settings(_params_with_enforcement(None)))
+
+    def test_refresh_reloads_revoked_policy(self):
+        params = _params_with_enforcement(True)
+
+        def _revoke(_params):
+            _params.enforcements = {'booleans': []}
+
+        with patch(
+            'keepercommander.loginv3.LoginV3Flow.populateAccountSummary',
+            side_effect=_revoke,
+        ) as mock_refresh:
+            self.assertFalse(can_configure_workflow_settings(params, refresh=True))
+            mock_refresh.assert_called_once_with(params)
+
+    def test_ensure_raises_when_denied(self):
+        with self.assertRaises(CommandError) as ctx:
+            ensure_can_configure_workflow_settings(
+                _params_with_enforcement(False), refresh=False, action='delete',
+            )
+        self.assertIn('workflow settings', str(ctx.exception).lower())
+        self.assertIn('delete', str(ctx.exception).lower())
+
+
+class TestWorkflowAdminGateRefresh(unittest.TestCase):
+
+    def test_delete_blocked_after_refresh_shows_revoke(self):
+        """Repro: stale allow in session, revoke mid-session — delete must not reach Router."""
+        params = _params_with_enforcement(True)
+
+        def _revoke(_params):
+            _params.enforcements = {'booleans': []}
+
+        cmd = PAMWorkflowCommand()
+        with patch(
+            'keepercommander.loginv3.LoginV3Flow.populateAccountSummary',
+            side_effect=_revoke,
+        ), patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            result = cmd.execute_args(params, 'delete qWRT4eqVWubL9xJbub4rfA')
+
+        self.assertIsNone(result)
+        out = stdout.getvalue()
+        self.assertIn('do not have permission', out.lower())
+        self.assertIn('delete', out.lower())
+
+    def test_delete_command_raises_when_policy_revoked(self):
+        params = _params_with_enforcement(False)
+        with patch(
+            'keepercommander.loginv3.LoginV3Flow.populateAccountSummary',
+        ), self.assertRaises(CommandError) as ctx:
+            WorkflowDeleteCommand().execute(params, record='qWRT4eqVWubL9xJbub4rfA')
+        self.assertIn('workflow settings', str(ctx.exception).lower())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Stops users from creating, updating, or deleting PAM workflows in Commander after “Can manage workflow settings” is revoked mid-session.
- Aligns Commander with Vault and other clients that already enforce this policy client-side.

## Changes
- Refresh role enforcements before workflow admin commands so a revoke takes effect without re-login.
- Apply the same gate on workflow create/update/delete, approver changes, and PAM import workflow apply.
- Add unit coverage for the revoke-then-delete case.