### PR TITLE
Require ownership before adopting service Docker setup folders and apps

### DIFF
--- a/keepercommander/commands/ksm.py
+++ b/keepercommander/commands/ksm.py
@@ -1757,7 +1757,7 @@ class KSMCommand(Command):
         logging.debug("Creating new KSM Application named '%s'" % app_name)
 
         found_app = KSMCommand.get_app_record(params, app_name)
-        if (found_app is not None) and (found_app is not force_to_add):
+        if found_app is not None and not force_to_add:
             if format_type == 'json':
                 return json.dumps({"error": f'Application with the same name "{app_name}" already exists.'})
             else:

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -347,7 +347,9 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
         if folder_uid in params.subfolder_record_cache:
             for rec_uid in params.subfolder_record_cache[folder_uid]:
                 rec = api.get_record(params, rec_uid)
-                if rec.title == record_name:
+                if rec.title != record_name:
+                    continue
+                if self._is_owned_record(params, rec_uid):
                     return rec_uid
         return None
 
@@ -394,9 +396,11 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
             raise CommandError(self.get_command_name(), f'Failed to update record fields: {str(e)}')
 
     def _find_folder_uid_by_name(self, params, folder_name: str) -> Optional[str]:
-        # Prefer shared folders; integration setup always creates a shared folder.
+        # Prefer owned shared folders; never adopt a folder owned by another account.
         for folder_uid, folder_data in params.shared_folder_cache.items():
-            if folder_data.get('name') == folder_name:
+            if folder_data.get('name') != folder_name:
+                continue
+            if self._is_owned_shared_folder(params, folder_uid):
                 return folder_uid
         return None
 

--- a/keepercommander/service/commands/integrations/integration_setup_base.py
+++ b/keepercommander/service/commands/integrations/integration_setup_base.py
@@ -344,13 +344,10 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
         return record_uid
 
     def _find_record_in_folder(self, params, folder_uid: str, record_name: str):
-        if folder_uid in params.subfolder_record_cache:
-            for rec_uid in params.subfolder_record_cache[folder_uid]:
-                rec = api.get_record(params, rec_uid)
-                if rec.title != record_name:
-                    continue
-                if self._is_owned_record(params, rec_uid):
-                    return rec_uid
+        for rec_uid in (params.subfolder_record_cache or {}).get(folder_uid, []):
+            rec = api.get_record(params, rec_uid)
+            if rec.title == record_name and self._is_owned_record(params, rec_uid):
+                return rec_uid
         return None
 
     def _create_login_record(self, params, folder_uid: str, record_name: str) -> str:
@@ -396,11 +393,9 @@ class IntegrationSetupCommand(Command, DockerSetupBase, ABC):
             raise CommandError(self.get_command_name(), f'Failed to update record fields: {str(e)}')
 
     def _find_folder_uid_by_name(self, params, folder_name: str) -> Optional[str]:
-        # Prefer owned shared folders; never adopt a folder owned by another account.
-        for folder_uid, folder_data in params.shared_folder_cache.items():
-            if folder_data.get('name') != folder_name:
-                continue
-            if self._is_owned_shared_folder(params, folder_uid):
+        """Return an owned shared folder UID with this name, or None."""
+        for folder_uid, folder_data in (params.shared_folder_cache or {}).items():
+            if folder_data.get('name') == folder_name and self._is_owned_shared_folder(params, folder_uid):
                 return folder_uid
         return None
 

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -26,6 +26,7 @@ from typing import Dict, Any
 
 from ...commands.folder import FolderMakeCommand
 from ...commands.ksm import KSMCommand
+from ...commands.register import _is_shared_folder_owner
 from ... import api, vault, utils, attachment, record_management, loginv3
 from ...display import bcolors
 from ...error import CommandError
@@ -38,6 +39,48 @@ from ..config.record_handler import RecordHandler
 
 class DockerSetupBase:
     """Base class for Docker setup with reusable core logic"""
+
+    @staticmethod
+    def _is_owned_record(params, record_uid: str) -> bool:
+        """True when record_owner_cache marks the record as owned by this account."""
+        if not record_uid:
+            return False
+        owner = (getattr(params, 'record_owner_cache', None) or {}).get(record_uid)
+        return bool(owner and owner.owner)
+
+    @staticmethod
+    def _is_owned_shared_folder(params, folder_uid: str) -> bool:
+        """True when the shared folder is owned by the current account."""
+        if not folder_uid:
+            return False
+        shared_folder = (getattr(params, 'shared_folder_cache', None) or {}).get(folder_uid)
+        if not shared_folder:
+            return False
+        return _is_shared_folder_owner(params, shared_folder)
+
+    @staticmethod
+    def _find_owned_ksm_app_by_title(params, app_name: str):
+        """Return an owned KSM app matching title, or None.
+
+        Scans the full cache so a non-owned title squat cannot shadow an owned app.
+        """
+        if not app_name:
+            return None
+        record_cache = getattr(params, 'record_cache', None) or {}
+        for rec_cache_val in record_cache.values():
+            rec = KSMCommand._app_record_from_cache_entry(rec_cache_val)
+            if not rec:
+                continue
+            r_uid = rec.get('record_uid')
+            try:
+                title = json.loads(rec.get('data_unencrypted').decode('utf-8')).get('title')
+            except Exception:
+                continue
+            if title != app_name:
+                continue
+            if DockerSetupBase._is_owned_record(params, r_uid):
+                return rec
+        return None
 
     @staticmethod
     def resolve_commander_config_path(config_path: str = None, params=None) -> str:
@@ -164,12 +207,27 @@ class DockerSetupBase:
             raise CommandError('docker-setup', f'Device setup failed: {str(e)}')
 
     def _create_shared_folder(self, params, folder_name: str) -> str:
-        """Create shared folder or return existing one"""
-        # Check if folder exists
+        """Create shared folder or return an existing one owned by this account.
+
+        Name matches owned by another account are ignored so credentials are
+        never written into an attacker-controlled shared folder.
+        """
+        saw_non_owned = False
         for folder_uid, folder in params.folder_cache.items():
-            if folder.name == folder_name and folder_uid in params.shared_folder_cache:
-                DockerSetupPrinter.print_success("Using existing shared folder")
+            if folder.name != folder_name or folder_uid not in params.shared_folder_cache:
+                continue
+            if self._is_owned_shared_folder(params, folder_uid):
+                DockerSetupPrinter.print_success(
+                    f"Using existing shared folder (UID: {folder_uid})"
+                )
                 return folder_uid
+            saw_non_owned = True
+
+        if saw_non_owned:
+            DockerSetupPrinter.print_warning(
+                f"Ignoring shared folder(s) named '{folder_name}' owned by another account; "
+                f"creating a new owned folder"
+            )
 
         # Create new folder
         try:
@@ -194,14 +252,23 @@ class DockerSetupBase:
             raise CommandError('docker-setup', f'Failed to create shared folder: {str(e)}')
 
     def _create_config_record(self, params, record_name: str, folder_uid: str) -> str:
-        """Create a config record or return existing one"""
-        # Check if record exists
+        """Create a config record or return an existing owned one"""
+        saw_non_owned = False
         if folder_uid in params.subfolder_record_cache:
             for rec_uid in params.subfolder_record_cache[folder_uid]:
                 rec = api.get_record(params, rec_uid)
-                if rec.title == record_name:
+                if rec.title != record_name:
+                    continue
+                if self._is_owned_record(params, rec_uid):
                     DockerSetupPrinter.print_success("Using existing record")
                     return rec_uid
+                saw_non_owned = True
+
+        if saw_non_owned:
+            DockerSetupPrinter.print_warning(
+                f"Ignoring record(s) titled '{record_name}' owned by another account; "
+                f"creating a new owned record"
+            )
 
         # Create new record
         try:
@@ -336,12 +403,21 @@ class DockerSetupBase:
             return config_path
 
     def _create_ksm_app(self, params, app_name: str) -> str:
-        """Create KSM app or return existing one"""
-        # Check if app exists
-        existing_app = KSMCommand.get_app_record(params, app_name)
+        """Create KSM app or return an existing one owned by this account."""
+        existing_app = self._find_owned_ksm_app_by_title(params, app_name)
         if existing_app:
             DockerSetupPrinter.print_success("Using existing app")
             return existing_app.get('record_uid')
+
+        # A non-owned app with the same title must not be adopted. Force-create
+        # so add_new_v5_app does not treat the squat as our existing app.
+        force_to_add = False
+        if KSMCommand.get_app_record(params, app_name):
+            DockerSetupPrinter.print_warning(
+                f"Ignoring Secrets Manager app '{app_name}' owned by another account; "
+                f"creating a new owned app"
+            )
+            force_to_add = True
 
         # Create new app
         try:
@@ -349,19 +425,25 @@ class DockerSetupBase:
             old_stdout = sys.stdout
             sys.stdout = io.StringIO()
             try:
-                KSMCommand.add_new_v5_app(params, app_name, force_to_add=False, format_type='table')
+                KSMCommand.add_new_v5_app(
+                    params, app_name, force_to_add=force_to_add, format_type='table'
+                )
             finally:
                 sys.stdout = old_stdout
             
             api.sync_down(params)
-            
-            app_rec = KSMCommand.get_app_record(params, app_name)
+
+            # Resolve by ownership after create — title lookup alone can still
+            # return a non-owned squat that shadows the newly created app.
+            app_rec = self._find_owned_ksm_app_by_title(params, app_name)
             if not app_rec:
                 raise CommandError('docker-setup', 'Failed to retrieve created app')
             
             app_uid = app_rec.get('record_uid')
             DockerSetupPrinter.print_success(f"App created successfully (UID: {app_uid})")
             return app_uid
+        except CommandError:
+            raise
         except Exception as e:
             raise CommandError('docker-setup', f'Failed to create KSM app: {str(e)}')
 

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -24,10 +24,8 @@ import sys
 import tempfile
 from typing import Dict, Any
 
-from ...commands.folder import FolderMakeCommand
 from ...commands.ksm import KSMCommand
-from ...commands.register import _is_shared_folder_owner
-from ... import api, vault, utils, attachment, record_management, loginv3
+from ... import api, vault, utils, crypto, attachment, record_management, loginv3
 from ...display import bcolors
 from ...error import CommandError
 
@@ -45,7 +43,8 @@ class DockerSetupBase:
         """True when record_owner_cache marks the record as owned by this account."""
         if not record_uid:
             return False
-        owner = (getattr(params, 'record_owner_cache', None) or {}).get(record_uid)
+        owner_cache = getattr(params, 'record_owner_cache', None) or {}
+        owner = owner_cache.get(record_uid)
         return bool(owner and owner.owner)
 
     @staticmethod
@@ -56,29 +55,31 @@ class DockerSetupBase:
         shared_folder = (getattr(params, 'shared_folder_cache', None) or {}).get(folder_uid)
         if not shared_folder:
             return False
-        return _is_shared_folder_owner(params, shared_folder)
+
+        owner_uid = shared_folder.get('owner_account_uid')
+        account_uid_bytes = getattr(params, 'account_uid_bytes', None)
+        if owner_uid and account_uid_bytes:
+            return owner_uid == utils.base64_url_encode(account_uid_bytes)
+
+        owner_username = shared_folder.get('owner_username')
+        if owner_username and getattr(params, 'user', None):
+            return owner_username.lower() == params.user.lower()
+        return False
 
     @staticmethod
     def _find_owned_ksm_app_by_title(params, app_name: str):
-        """Return an owned KSM app matching title, or None.
-
-        Scans the full cache so a non-owned title squat cannot shadow an owned app.
-        """
+        """Return an owned KSM app with this title, or None (ignores non-owned squats)."""
         if not app_name:
             return None
-        record_cache = getattr(params, 'record_cache', None) or {}
-        for rec_cache_val in record_cache.values():
+        for rec_cache_val in (getattr(params, 'record_cache', None) or {}).values():
             rec = KSMCommand._app_record_from_cache_entry(rec_cache_val)
             if not rec:
                 continue
-            r_uid = rec.get('record_uid')
             try:
-                title = json.loads(rec.get('data_unencrypted').decode('utf-8')).get('title')
+                title = json.loads(rec['data_unencrypted'].decode('utf-8')).get('title')
             except Exception:
                 continue
-            if title != app_name:
-                continue
-            if DockerSetupBase._is_owned_record(params, r_uid):
+            if title == app_name and DockerSetupBase._is_owned_record(params, rec.get('record_uid')):
                 return rec
         return None
 
@@ -206,20 +207,47 @@ class DockerSetupBase:
         except Exception as e:
             raise CommandError('docker-setup', f'Device setup failed: {str(e)}')
 
-    def _create_shared_folder(self, params, folder_name: str) -> str:
-        """Create shared folder or return an existing one owned by this account.
+    @staticmethod
+    def _add_owned_shared_folder(params, folder_name: str) -> str:
+        """Create a root-level shared folder via folder_add (allows duplicate display names).
 
-        Name matches owned by another account are ignored so credentials are
-        never written into an attacker-controlled shared folder.
+        Bypasses FolderMakeCommand/mkdir, which refuses to create when any visible
+        folder already has the same name — including a non-owned squat.
         """
+        name = (folder_name or '').strip()
+        if not name:
+            raise CommandError('docker-setup', 'Shared folder name is required')
+        if not getattr(params, 'data_key', None):
+            raise CommandError('docker-setup', 'Not logged in (missing data key)')
+
+        folder_uid = api.generate_record_uid()
+        folder_key = utils.generate_aes_key()
+        request = {
+            'command': 'folder_add',
+            'folder_type': 'shared_folder',
+            'folder_uid': folder_uid,
+            'key': utils.base64_url_encode(crypto.encrypt_aes_v1(folder_key, params.data_key)),
+            'name': utils.base64_url_encode(crypto.encrypt_aes_v1(name.encode('utf-8'), folder_key)),
+            'data': utils.base64_url_encode(
+                crypto.encrypt_aes_v1(json.dumps({'name': name}).encode('utf-8'), folder_key)
+            ),
+            'manage_users': True,
+            'manage_records': True,
+            'can_share': True,
+            'can_edit': True,
+        }
+        api.communicate(params, request)
+        params.sync_data = True
+        return folder_uid
+
+    def _create_shared_folder(self, params, folder_name: str) -> str:
+        """Create a shared folder, or reuse one owned by this account with the same name."""
         saw_non_owned = False
-        for folder_uid, folder in params.folder_cache.items():
-            if folder.name != folder_name or folder_uid not in params.shared_folder_cache:
+        for folder_uid, folder in (params.folder_cache or {}).items():
+            if folder.name != folder_name or folder_uid not in (params.shared_folder_cache or {}):
                 continue
             if self._is_owned_shared_folder(params, folder_uid):
-                DockerSetupPrinter.print_success(
-                    f"Using existing shared folder (UID: {folder_uid})"
-                )
+                DockerSetupPrinter.print_success(f"Using existing shared folder (UID: {folder_uid})")
                 return folder_uid
             saw_non_owned = True
 
@@ -229,40 +257,27 @@ class DockerSetupBase:
                 f"creating a new owned folder"
             )
 
-        # Create new folder
         try:
-            old_stdout = sys.stdout
-            sys.stdout = io.StringIO()
-            try:
-                folder_uid = FolderMakeCommand().execute(
-                    params,
-                    folder=folder_name,
-                    shared_folder=True,
-                    manage_users=True,
-                    manage_records=True,
-                    can_edit=True,
-                    can_share=True
-                )
-            finally:
-                sys.stdout = old_stdout
+            folder_uid = self._add_owned_shared_folder(params, folder_name)
             api.sync_down(params)
             DockerSetupPrinter.print_success(f"Shared folder created successfully (UID: {folder_uid})")
             return folder_uid
+        except CommandError:
+            raise
         except Exception as e:
             raise CommandError('docker-setup', f'Failed to create shared folder: {str(e)}')
 
     def _create_config_record(self, params, record_name: str, folder_uid: str) -> str:
-        """Create a config record or return an existing owned one"""
+        """Create a config record, or reuse an owned one with the same title in the folder."""
         saw_non_owned = False
-        if folder_uid in params.subfolder_record_cache:
-            for rec_uid in params.subfolder_record_cache[folder_uid]:
-                rec = api.get_record(params, rec_uid)
-                if rec.title != record_name:
-                    continue
-                if self._is_owned_record(params, rec_uid):
-                    DockerSetupPrinter.print_success("Using existing record")
-                    return rec_uid
-                saw_non_owned = True
+        for rec_uid in (params.subfolder_record_cache or {}).get(folder_uid, []):
+            rec = api.get_record(params, rec_uid)
+            if rec.title != record_name:
+                continue
+            if self._is_owned_record(params, rec_uid):
+                DockerSetupPrinter.print_success("Using existing record")
+                return rec_uid
+            saw_non_owned = True
 
         if saw_non_owned:
             DockerSetupPrinter.print_warning(
@@ -270,17 +285,16 @@ class DockerSetupBase:
                 f"creating a new owned record"
             )
 
-        # Create new record
         try:
             record = vault.KeeperRecord.create(params, 'login')
             record.record_uid = utils.generate_uid()
             record.record_key = utils.generate_aes_key()
             record.title = record_name
             record.type_name = 'login'
-            
+
             record_management.add_record_to_folder(params, record, folder_uid)
             api.sync_down(params)
-            
+
             DockerSetupPrinter.print_success(f"Record created successfully (UID: {record.record_uid})")
             return record.record_uid
         except Exception as e:
@@ -403,25 +417,26 @@ class DockerSetupBase:
             return config_path
 
     def _create_ksm_app(self, params, app_name: str) -> str:
-        """Create KSM app or return an existing one owned by this account."""
+        """Create a KSM app, or reuse an owned app with the same title."""
         existing_app = self._find_owned_ksm_app_by_title(params, app_name)
         if existing_app:
             DockerSetupPrinter.print_success("Using existing app")
             return existing_app.get('record_uid')
 
-        # A non-owned app with the same title must not be adopted. Force-create
-        # so add_new_v5_app does not treat the squat as our existing app.
+        existing_any = KSMCommand.get_app_record(params, app_name)
         force_to_add = False
-        if KSMCommand.get_app_record(params, app_name):
+        if existing_any:
+            existing_uid = existing_any.get('record_uid')
+            if self._is_owned_record(params, existing_uid):
+                DockerSetupPrinter.print_success("Using existing app")
+                return existing_uid
+            force_to_add = True
             DockerSetupPrinter.print_warning(
                 f"Ignoring Secrets Manager app '{app_name}' owned by another account; "
                 f"creating a new owned app"
             )
-            force_to_add = True
 
-        # Create new app
         try:
-            # Suppress KSM command output
             old_stdout = sys.stdout
             sys.stdout = io.StringIO()
             try:
@@ -430,15 +445,13 @@ class DockerSetupBase:
                 )
             finally:
                 sys.stdout = old_stdout
-            
+
             api.sync_down(params)
 
-            # Resolve by ownership after create — title lookup alone can still
-            # return a non-owned squat that shadows the newly created app.
             app_rec = self._find_owned_ksm_app_by_title(params, app_name)
             if not app_rec:
                 raise CommandError('docker-setup', 'Failed to retrieve created app')
-            
+
             app_uid = app_rec.get('record_uid')
             DockerSetupPrinter.print_success(f"App created successfully (UID: {app_uid})")
             return app_uid

--- a/unit-tests/service/test_docker_setup_ownership.py
+++ b/unit-tests/service/test_docker_setup_ownership.py
@@ -1,0 +1,240 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Contact: ops@keepersecurity.com
+#
+
+"""Service Docker / integration setup must only adopt owned folders, apps, and records."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keepercommander.params import KeeperParams, RecordOwner
+from keepercommander.service.docker.setup_base import DockerSetupBase
+
+
+FOLDER_NAME = 'Commander Service Mode - Docker'
+APP_NAME = 'Commander Service Mode - KSM App'
+RECORD_NAME = 'Commander Service Mode Docker Config'
+
+
+class TestDockerSetupOwnershipHelpers(unittest.TestCase):
+    def test_is_owned_record(self):
+        params = MagicMock(spec=KeeperParams)
+        params.record_owner_cache = {
+            'OWNED': RecordOwner(True, 'operator'),
+            'SHARED': RecordOwner(False, 'attacker'),
+        }
+        self.assertTrue(DockerSetupBase._is_owned_record(params, 'OWNED'))
+        self.assertFalse(DockerSetupBase._is_owned_record(params, 'SHARED'))
+        self.assertFalse(DockerSetupBase._is_owned_record(params, 'MISSING'))
+        self.assertFalse(DockerSetupBase._is_owned_record(params, ''))
+
+    def test_is_owned_shared_folder(self):
+        params = MagicMock(spec=KeeperParams)
+        params.user = 'operator@corp.example'
+        params.account_uid_bytes = b'op-uid'
+        params.shared_folder_cache = {
+            'OWNED_SF': {'owner_username': 'operator@corp.example'},
+            'SHARED_SF': {'owner_username': 'mallory@corp.example'},
+        }
+        self.assertTrue(DockerSetupBase._is_owned_shared_folder(params, 'OWNED_SF'))
+        self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'SHARED_SF'))
+        self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'MISSING'))
+
+
+class TestCreateSharedFolderOwnership(unittest.TestCase):
+    def _folder(self, name):
+        folder = MagicMock()
+        folder.name = name
+        return folder
+
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_reuses_owned_folder_when_squat_also_present(self, _printer):
+        params = MagicMock(spec=KeeperParams)
+        params.user = 'operator@corp.example'
+        params.folder_cache = {
+            'ATTACKER_SF': self._folder(FOLDER_NAME),
+            'OWNED_SF': self._folder(FOLDER_NAME),
+        }
+        params.shared_folder_cache = {
+            'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
+            'OWNED_SF': {'owner_username': 'operator@corp.example'},
+        }
+
+        uid = DockerSetupBase()._create_shared_folder(params, FOLDER_NAME)
+        self.assertEqual(uid, 'OWNED_SF')
+
+    @patch('keepercommander.service.docker.setup_base.api.sync_down')
+    @patch('keepercommander.service.docker.setup_base.FolderMakeCommand')
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_creates_when_only_non_owned_match(self, printer, mock_mkdir, _sync):
+        params = MagicMock(spec=KeeperParams)
+        params.user = 'operator@corp.example'
+        params.folder_cache = {'ATTACKER_SF': self._folder(FOLDER_NAME)}
+        params.shared_folder_cache = {
+            'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
+        }
+        mock_mkdir.return_value.execute.return_value = 'NEW_OWNED_SF'
+
+        uid = DockerSetupBase()._create_shared_folder(params, FOLDER_NAME)
+
+        self.assertEqual(uid, 'NEW_OWNED_SF')
+        mock_mkdir.return_value.execute.assert_called_once()
+        printer.print_warning.assert_called()
+
+
+class TestCreateConfigRecordOwnership(unittest.TestCase):
+    @patch('keepercommander.service.docker.setup_base.api.get_record')
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_reuses_owned_record(self, _printer, mock_get):
+        owned = MagicMock()
+        owned.title = RECORD_NAME
+        shared = MagicMock()
+        shared.title = RECORD_NAME
+        mock_get.side_effect = lambda _p, uid: shared if uid == 'SHARED_REC' else owned
+
+        params = MagicMock(spec=KeeperParams)
+        params.subfolder_record_cache = {'FOLDER': ['SHARED_REC', 'OWNED_REC']}
+        params.record_owner_cache = {
+            'SHARED_REC': RecordOwner(False, 'attacker'),
+            'OWNED_REC': RecordOwner(True, 'operator'),
+        }
+
+        uid = DockerSetupBase()._create_config_record(params, RECORD_NAME, 'FOLDER')
+        self.assertEqual(uid, 'OWNED_REC')
+
+    @patch('keepercommander.service.docker.setup_base.api.sync_down')
+    @patch('keepercommander.service.docker.setup_base.record_management.add_record_to_folder')
+    @patch('keepercommander.service.docker.setup_base.vault.KeeperRecord.create')
+    @patch('keepercommander.service.docker.setup_base.utils.generate_aes_key', return_value=b'k' * 32)
+    @patch('keepercommander.service.docker.setup_base.utils.generate_uid', return_value='NEW_REC')
+    @patch('keepercommander.service.docker.setup_base.api.get_record')
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_creates_when_only_non_owned_match(
+        self, printer, mock_get, _uid, _key, mock_create, _add, _sync
+    ):
+        shared = MagicMock()
+        shared.title = RECORD_NAME
+        mock_get.return_value = shared
+
+        created = MagicMock()
+        created.record_uid = 'NEW_REC'
+        mock_create.return_value = created
+
+        params = MagicMock(spec=KeeperParams)
+        params.subfolder_record_cache = {'FOLDER': ['SHARED_REC']}
+        params.record_owner_cache = {'SHARED_REC': RecordOwner(False, 'attacker')}
+
+        uid = DockerSetupBase()._create_config_record(params, RECORD_NAME, 'FOLDER')
+        self.assertEqual(uid, 'NEW_REC')
+        printer.print_warning.assert_called()
+
+
+class TestFindOwnedKsmApp(unittest.TestCase):
+    def _app_entry(self, uid, title):
+        return {
+            'record_uid': uid,
+            'version': 5,
+            'data_unencrypted': json.dumps({'title': title, 'type': 'app'}).encode('utf-8'),
+        }
+
+    @patch('keepercommander.commands.ksm.KSMCommand._app_record_from_cache_entry', side_effect=lambda r: r)
+    def test_prefers_owned_when_squat_present(self, _from_cache):
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {
+            'ATTACKER_APP': self._app_entry('ATTACKER_APP', APP_NAME),
+            'OWNED_APP': self._app_entry('OWNED_APP', APP_NAME),
+        }
+        params.record_owner_cache = {
+            'ATTACKER_APP': RecordOwner(False, 'attacker'),
+            'OWNED_APP': RecordOwner(True, 'operator'),
+        }
+
+        rec = DockerSetupBase._find_owned_ksm_app_by_title(params, APP_NAME)
+        self.assertEqual(rec['record_uid'], 'OWNED_APP')
+
+    @patch('keepercommander.commands.ksm.KSMCommand._app_record_from_cache_entry', side_effect=lambda r: r)
+    def test_returns_none_for_non_owned_only(self, _from_cache):
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {
+            'ATTACKER_APP': self._app_entry('ATTACKER_APP', APP_NAME),
+        }
+        params.record_owner_cache = {
+            'ATTACKER_APP': RecordOwner(False, 'attacker'),
+        }
+
+        self.assertIsNone(DockerSetupBase._find_owned_ksm_app_by_title(params, APP_NAME))
+
+
+class TestCreateKsmAppOwnership(unittest.TestCase):
+    @patch('keepercommander.service.docker.setup_base.api.sync_down')
+    @patch('keepercommander.service.docker.setup_base.KSMCommand.add_new_v5_app')
+    @patch('keepercommander.service.docker.setup_base.KSMCommand.get_app_record')
+    @patch.object(DockerSetupBase, '_find_owned_ksm_app_by_title')
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_force_creates_when_squat_present(
+        self, printer, mock_find_owned, mock_get_app, mock_add, _sync
+    ):
+        owned_after_create = {'record_uid': 'NEW_OWNED_APP'}
+        mock_find_owned.side_effect = [None, owned_after_create]
+        mock_get_app.return_value = {'record_uid': 'ATTACKER_APP'}
+
+        uid = DockerSetupBase()._create_ksm_app(MagicMock(spec=KeeperParams), APP_NAME)
+
+        self.assertEqual(uid, 'NEW_OWNED_APP')
+        mock_add.assert_called_once()
+        self.assertTrue(mock_add.call_args.kwargs.get('force_to_add'))
+        printer.print_warning.assert_called()
+
+
+class TestIntegrationFolderLookupOwnership(unittest.TestCase):
+    def test_find_folder_uid_by_name_skips_non_owned(self):
+        from keepercommander.service.commands.integrations.slack_app_setup import (
+            SlackAppSetupCommand,
+        )
+
+        params = MagicMock(spec=KeeperParams)
+        params.user = 'operator@corp.example'
+        params.shared_folder_cache = {
+            'ATTACKER_SF': {
+                'name': FOLDER_NAME,
+                'owner_username': 'mallory@corp.example',
+            },
+            'OWNED_SF': {
+                'name': FOLDER_NAME,
+                'owner_username': 'operator@corp.example',
+            },
+        }
+
+        self.assertEqual(
+            SlackAppSetupCommand()._find_folder_uid_by_name(params, FOLDER_NAME),
+            'OWNED_SF',
+        )
+
+    def test_find_folder_uid_by_name_returns_none_for_squat_only(self):
+        from keepercommander.service.commands.integrations.slack_app_setup import (
+            SlackAppSetupCommand,
+        )
+
+        params = MagicMock(spec=KeeperParams)
+        params.user = 'operator@corp.example'
+        params.shared_folder_cache = {
+            'ATTACKER_SF': {
+                'name': FOLDER_NAME,
+                'owner_username': 'mallory@corp.example',
+            },
+        }
+
+        self.assertIsNone(
+            SlackAppSetupCommand()._find_folder_uid_by_name(params, FOLDER_NAME)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_docker_setup_ownership.py
+++ b/unit-tests/service/test_docker_setup_ownership.py
@@ -14,6 +14,7 @@ import json
 import unittest
 from unittest.mock import MagicMock, patch
 
+from keepercommander import utils
 from keepercommander.params import KeeperParams, RecordOwner
 from keepercommander.service.docker.setup_base import DockerSetupBase
 
@@ -23,91 +24,155 @@ APP_NAME = 'Commander Service Mode - KSM App'
 RECORD_NAME = 'Commander Service Mode Docker Config'
 
 
-class TestDockerSetupOwnershipHelpers(unittest.TestCase):
+def _params(**kwargs):
+    params = MagicMock(spec=KeeperParams)
+    params.user = kwargs.get('user', 'operator@corp.example')
+    params.account_uid_bytes = kwargs.get('account_uid_bytes', b'op-uid')
+    params.folder_cache = kwargs.get('folder_cache', {})
+    params.shared_folder_cache = kwargs.get('shared_folder_cache', {})
+    params.record_cache = kwargs.get('record_cache', {})
+    params.record_owner_cache = kwargs.get('record_owner_cache', {})
+    params.subfolder_record_cache = kwargs.get('subfolder_record_cache', {})
+    return params
+
+
+def _folder(name):
+    folder = MagicMock()
+    folder.name = name
+    return folder
+
+
+def _app_entry(uid, title):
+    return {
+        'record_uid': uid,
+        'version': 5,
+        'data_unencrypted': json.dumps({'title': title, 'type': 'app'}).encode('utf-8'),
+    }
+
+
+class TestOwnershipHelpers(unittest.TestCase):
     def test_is_owned_record(self):
-        params = MagicMock(spec=KeeperParams)
-        params.record_owner_cache = {
+        params = _params(record_owner_cache={
             'OWNED': RecordOwner(True, 'operator'),
             'SHARED': RecordOwner(False, 'attacker'),
-        }
+        })
         self.assertTrue(DockerSetupBase._is_owned_record(params, 'OWNED'))
         self.assertFalse(DockerSetupBase._is_owned_record(params, 'SHARED'))
         self.assertFalse(DockerSetupBase._is_owned_record(params, 'MISSING'))
         self.assertFalse(DockerSetupBase._is_owned_record(params, ''))
 
-    def test_is_owned_shared_folder(self):
-        params = MagicMock(spec=KeeperParams)
-        params.user = 'operator@corp.example'
-        params.account_uid_bytes = b'op-uid'
-        params.shared_folder_cache = {
+    def test_is_owned_shared_folder_by_username(self):
+        params = _params(shared_folder_cache={
             'OWNED_SF': {'owner_username': 'operator@corp.example'},
             'SHARED_SF': {'owner_username': 'mallory@corp.example'},
-        }
+        })
         self.assertTrue(DockerSetupBase._is_owned_shared_folder(params, 'OWNED_SF'))
         self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'SHARED_SF'))
         self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'MISSING'))
 
+    def test_is_owned_shared_folder_by_account_uid(self):
+        account_uid = utils.base64_url_encode(b'op-uid')
+        params = _params(
+            account_uid_bytes=b'op-uid',
+            shared_folder_cache={
+                'OWNED_SF': {'owner_account_uid': account_uid},
+                'SHARED_SF': {'owner_account_uid': utils.base64_url_encode(b'other')},
+            },
+        )
+        self.assertTrue(DockerSetupBase._is_owned_shared_folder(params, 'OWNED_SF'))
+        self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'SHARED_SF'))
+
+    def test_is_owned_shared_folder_requires_account_uid_bytes(self):
+        params = _params(
+            account_uid_bytes=None,
+            shared_folder_cache={
+                'SF': {'owner_account_uid': utils.base64_url_encode(b'op-uid')},
+            },
+        )
+        # Without session account_uid_bytes, do not guess ownership from uid alone.
+        self.assertFalse(DockerSetupBase._is_owned_shared_folder(params, 'SF'))
+
 
 class TestCreateSharedFolderOwnership(unittest.TestCase):
-    def _folder(self, name):
-        folder = MagicMock()
-        folder.name = name
-        return folder
-
     @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
     def test_reuses_owned_folder_when_squat_also_present(self, _printer):
-        params = MagicMock(spec=KeeperParams)
-        params.user = 'operator@corp.example'
-        params.folder_cache = {
-            'ATTACKER_SF': self._folder(FOLDER_NAME),
-            'OWNED_SF': self._folder(FOLDER_NAME),
-        }
-        params.shared_folder_cache = {
-            'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
-            'OWNED_SF': {'owner_username': 'operator@corp.example'},
-        }
-
-        uid = DockerSetupBase()._create_shared_folder(params, FOLDER_NAME)
-        self.assertEqual(uid, 'OWNED_SF')
+        params = _params(
+            folder_cache={
+                'ATTACKER_SF': _folder(FOLDER_NAME),
+                'OWNED_SF': _folder(FOLDER_NAME),
+            },
+            shared_folder_cache={
+                'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
+                'OWNED_SF': {'owner_username': 'operator@corp.example'},
+            },
+        )
+        self.assertEqual(DockerSetupBase()._create_shared_folder(params, FOLDER_NAME), 'OWNED_SF')
 
     @patch('keepercommander.service.docker.setup_base.api.sync_down')
-    @patch('keepercommander.service.docker.setup_base.FolderMakeCommand')
+    @patch.object(DockerSetupBase, '_add_owned_shared_folder', return_value='NEW_OWNED_SF')
     @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
-    def test_creates_when_only_non_owned_match(self, printer, mock_mkdir, _sync):
-        params = MagicMock(spec=KeeperParams)
-        params.user = 'operator@corp.example'
-        params.folder_cache = {'ATTACKER_SF': self._folder(FOLDER_NAME)}
-        params.shared_folder_cache = {
-            'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
-        }
-        mock_mkdir.return_value.execute.return_value = 'NEW_OWNED_SF'
+    def test_creates_owned_folder_despite_squat_same_name(self, printer, mock_add, _sync):
+        params = _params(
+            folder_cache={'ATTACKER_SF': _folder(FOLDER_NAME)},
+            shared_folder_cache={
+                'ATTACKER_SF': {'owner_username': 'mallory@corp.example'},
+            },
+        )
 
         uid = DockerSetupBase()._create_shared_folder(params, FOLDER_NAME)
 
         self.assertEqual(uid, 'NEW_OWNED_SF')
-        mock_mkdir.return_value.execute.assert_called_once()
+        mock_add.assert_called_once_with(params, FOLDER_NAME)
         printer.print_warning.assert_called()
+
+    @patch('keepercommander.service.docker.setup_base.api.communicate')
+    @patch('keepercommander.service.docker.setup_base.api.generate_record_uid', return_value='DIRECT_SF')
+    def test_add_owned_shared_folder_sends_folder_add(self, _uid, mock_communicate):
+        params = _params()
+        params.data_key = b'd' * 32
+
+        uid = DockerSetupBase._add_owned_shared_folder(params, FOLDER_NAME)
+
+        self.assertEqual(uid, 'DIRECT_SF')
+        mock_communicate.assert_called_once()
+        request = mock_communicate.call_args[0][1]
+        self.assertEqual(request['command'], 'folder_add')
+        self.assertEqual(request['folder_type'], 'shared_folder')
+        self.assertEqual(request['folder_uid'], 'DIRECT_SF')
+        self.assertTrue(request['manage_users'])
+        self.assertTrue(request['manage_records'])
+
+    def test_add_owned_shared_folder_requires_name_and_data_key(self):
+        from keepercommander.error import CommandError
+
+        with self.assertRaises(CommandError):
+            DockerSetupBase._add_owned_shared_folder(_params(), '  ')
+
+        params = _params()
+        params.data_key = None
+        with self.assertRaises(CommandError):
+            DockerSetupBase._add_owned_shared_folder(params, FOLDER_NAME)
 
 
 class TestCreateConfigRecordOwnership(unittest.TestCase):
     @patch('keepercommander.service.docker.setup_base.api.get_record')
     @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
     def test_reuses_owned_record(self, _printer, mock_get):
-        owned = MagicMock()
-        owned.title = RECORD_NAME
-        shared = MagicMock()
-        shared.title = RECORD_NAME
+        owned = MagicMock(title=RECORD_NAME)
+        shared = MagicMock(title=RECORD_NAME)
         mock_get.side_effect = lambda _p, uid: shared if uid == 'SHARED_REC' else owned
 
-        params = MagicMock(spec=KeeperParams)
-        params.subfolder_record_cache = {'FOLDER': ['SHARED_REC', 'OWNED_REC']}
-        params.record_owner_cache = {
-            'SHARED_REC': RecordOwner(False, 'attacker'),
-            'OWNED_REC': RecordOwner(True, 'operator'),
-        }
-
-        uid = DockerSetupBase()._create_config_record(params, RECORD_NAME, 'FOLDER')
-        self.assertEqual(uid, 'OWNED_REC')
+        params = _params(
+            subfolder_record_cache={'FOLDER': ['SHARED_REC', 'OWNED_REC']},
+            record_owner_cache={
+                'SHARED_REC': RecordOwner(False, 'attacker'),
+                'OWNED_REC': RecordOwner(True, 'operator'),
+            },
+        )
+        self.assertEqual(
+            DockerSetupBase()._create_config_record(params, RECORD_NAME, 'FOLDER'),
+            'OWNED_REC',
+        )
 
     @patch('keepercommander.service.docker.setup_base.api.sync_down')
     @patch('keepercommander.service.docker.setup_base.record_management.add_record_to_folder')
@@ -119,17 +184,14 @@ class TestCreateConfigRecordOwnership(unittest.TestCase):
     def test_creates_when_only_non_owned_match(
         self, printer, mock_get, _uid, _key, mock_create, _add, _sync
     ):
-        shared = MagicMock()
-        shared.title = RECORD_NAME
-        mock_get.return_value = shared
-
-        created = MagicMock()
-        created.record_uid = 'NEW_REC'
+        mock_get.return_value = MagicMock(title=RECORD_NAME)
+        created = MagicMock(record_uid='NEW_REC')
         mock_create.return_value = created
 
-        params = MagicMock(spec=KeeperParams)
-        params.subfolder_record_cache = {'FOLDER': ['SHARED_REC']}
-        params.record_owner_cache = {'SHARED_REC': RecordOwner(False, 'attacker')}
+        params = _params(
+            subfolder_record_cache={'FOLDER': ['SHARED_REC']},
+            record_owner_cache={'SHARED_REC': RecordOwner(False, 'attacker')},
+        )
 
         uid = DockerSetupBase()._create_config_record(params, RECORD_NAME, 'FOLDER')
         self.assertEqual(uid, 'NEW_REC')
@@ -137,38 +199,25 @@ class TestCreateConfigRecordOwnership(unittest.TestCase):
 
 
 class TestFindOwnedKsmApp(unittest.TestCase):
-    def _app_entry(self, uid, title):
-        return {
-            'record_uid': uid,
-            'version': 5,
-            'data_unencrypted': json.dumps({'title': title, 'type': 'app'}).encode('utf-8'),
-        }
-
-    @patch('keepercommander.commands.ksm.KSMCommand._app_record_from_cache_entry', side_effect=lambda r: r)
-    def test_prefers_owned_when_squat_present(self, _from_cache):
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {
-            'ATTACKER_APP': self._app_entry('ATTACKER_APP', APP_NAME),
-            'OWNED_APP': self._app_entry('OWNED_APP', APP_NAME),
-        }
-        params.record_owner_cache = {
-            'ATTACKER_APP': RecordOwner(False, 'attacker'),
-            'OWNED_APP': RecordOwner(True, 'operator'),
-        }
-
+    def test_prefers_owned_when_squat_present(self):
+        params = _params(
+            record_cache={
+                'ATTACKER_APP': _app_entry('ATTACKER_APP', APP_NAME),
+                'OWNED_APP': _app_entry('OWNED_APP', APP_NAME),
+            },
+            record_owner_cache={
+                'ATTACKER_APP': RecordOwner(False, 'attacker'),
+                'OWNED_APP': RecordOwner(True, 'operator'),
+            },
+        )
         rec = DockerSetupBase._find_owned_ksm_app_by_title(params, APP_NAME)
         self.assertEqual(rec['record_uid'], 'OWNED_APP')
 
-    @patch('keepercommander.commands.ksm.KSMCommand._app_record_from_cache_entry', side_effect=lambda r: r)
-    def test_returns_none_for_non_owned_only(self, _from_cache):
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {
-            'ATTACKER_APP': self._app_entry('ATTACKER_APP', APP_NAME),
-        }
-        params.record_owner_cache = {
-            'ATTACKER_APP': RecordOwner(False, 'attacker'),
-        }
-
+    def test_returns_none_for_non_owned_only(self):
+        params = _params(
+            record_cache={'ATTACKER_APP': _app_entry('ATTACKER_APP', APP_NAME)},
+            record_owner_cache={'ATTACKER_APP': RecordOwner(False, 'attacker')},
+        )
         self.assertIsNone(DockerSetupBase._find_owned_ksm_app_by_title(params, APP_NAME))
 
 
@@ -181,27 +230,37 @@ class TestCreateKsmAppOwnership(unittest.TestCase):
     def test_force_creates_when_squat_present(
         self, printer, mock_find_owned, mock_get_app, mock_add, _sync
     ):
-        owned_after_create = {'record_uid': 'NEW_OWNED_APP'}
-        mock_find_owned.side_effect = [None, owned_after_create]
+        mock_find_owned.side_effect = [None, {'record_uid': 'NEW_OWNED_APP'}]
         mock_get_app.return_value = {'record_uid': 'ATTACKER_APP'}
 
-        uid = DockerSetupBase()._create_ksm_app(MagicMock(spec=KeeperParams), APP_NAME)
+        uid = DockerSetupBase()._create_ksm_app(_params(), APP_NAME)
 
         self.assertEqual(uid, 'NEW_OWNED_APP')
-        mock_add.assert_called_once()
         self.assertTrue(mock_add.call_args.kwargs.get('force_to_add'))
         printer.print_warning.assert_called()
 
+    @patch('keepercommander.service.docker.setup_base.KSMCommand.get_app_record')
+    @patch.object(DockerSetupBase, '_find_owned_ksm_app_by_title', return_value=None)
+    @patch('keepercommander.service.docker.setup_base.DockerSetupPrinter')
+    def test_reuses_owned_app_from_get_app_record_fallback(
+        self, _printer, _find_owned, mock_get_app
+    ):
+        mock_get_app.return_value = {'record_uid': 'OWNED_NSF_APP'}
+        params = _params(record_owner_cache={
+            'OWNED_NSF_APP': RecordOwner(True, 'operator'),
+        })
 
-class TestIntegrationFolderLookupOwnership(unittest.TestCase):
+        uid = DockerSetupBase()._create_ksm_app(params, APP_NAME)
+        self.assertEqual(uid, 'OWNED_NSF_APP')
+
+
+class TestIntegrationLookupOwnership(unittest.TestCase):
     def test_find_folder_uid_by_name_skips_non_owned(self):
         from keepercommander.service.commands.integrations.slack_app_setup import (
             SlackAppSetupCommand,
         )
 
-        params = MagicMock(spec=KeeperParams)
-        params.user = 'operator@corp.example'
-        params.shared_folder_cache = {
+        params = _params(shared_folder_cache={
             'ATTACKER_SF': {
                 'name': FOLDER_NAME,
                 'owner_username': 'mallory@corp.example',
@@ -210,8 +269,7 @@ class TestIntegrationFolderLookupOwnership(unittest.TestCase):
                 'name': FOLDER_NAME,
                 'owner_username': 'operator@corp.example',
             },
-        }
-
+        })
         self.assertEqual(
             SlackAppSetupCommand()._find_folder_uid_by_name(params, FOLDER_NAME),
             'OWNED_SF',
@@ -222,17 +280,36 @@ class TestIntegrationFolderLookupOwnership(unittest.TestCase):
             SlackAppSetupCommand,
         )
 
-        params = MagicMock(spec=KeeperParams)
-        params.user = 'operator@corp.example'
-        params.shared_folder_cache = {
+        params = _params(shared_folder_cache={
             'ATTACKER_SF': {
                 'name': FOLDER_NAME,
                 'owner_username': 'mallory@corp.example',
             },
-        }
-
+        })
         self.assertIsNone(
             SlackAppSetupCommand()._find_folder_uid_by_name(params, FOLDER_NAME)
+        )
+
+    @patch('keepercommander.service.commands.integrations.integration_setup_base.api.get_record')
+    def test_find_record_in_folder_skips_non_owned(self, mock_get):
+        from keepercommander.service.commands.integrations.slack_app_setup import (
+            SlackAppSetupCommand,
+        )
+
+        owned = MagicMock(title=RECORD_NAME)
+        shared = MagicMock(title=RECORD_NAME)
+        mock_get.side_effect = lambda _p, uid: shared if uid == 'SHARED_REC' else owned
+
+        params = _params(
+            subfolder_record_cache={'FOLDER': ['SHARED_REC', 'OWNED_REC']},
+            record_owner_cache={
+                'SHARED_REC': RecordOwner(False, 'attacker'),
+                'OWNED_REC': RecordOwner(True, 'operator'),
+            },
+        )
+        self.assertEqual(
+            SlackAppSetupCommand()._find_record_in_folder(params, 'FOLDER', RECORD_NAME),
+            'OWNED_REC',
         )
 
 


### PR DESCRIPTION
## Summary
- Service Docker and integration setup adopted shared folders, KSM apps, and config records by hardcoded name with no ownership check, so a shared same-name folder could receive the operator’s credentials.
- Setup now only reuses objects owned by the current account; non-owned name matches are skipped and a new owned object is created.

## Changes
- Gate folder, KSM app, and config-record adoption in the shared Docker setup base on ownership.
- Apply the same ownership checks to integration folder/record lookup on re-run.
- Allow forced KSM app create when a non-owned same-title app would otherwise block setup.
- Add unit tests for squat skip, owned preference, and create fallback.