### PR TITLE
Output full record contents for record-history -a view --format=json

### DIFF
--- a/keepercommander/commands/record.py
+++ b/keepercommander/commands/record.py
@@ -2736,6 +2736,62 @@ class RecordHistoryCommand(Command, RecordMixin):
             if action == 'view':
                 rev = history[index]
                 record = vault.KeeperRecord.load(params, rev)
+                fmt = kwargs.get('format') or ''
+
+                if fmt == 'json':
+                    version = rev.get('version') or 0
+                    ro = {
+                        'record_uid': record.record_uid
+                    }
+                    if version < 3:
+                        ro['title'] = record.title
+                        if isinstance(record, vault.PasswordRecord):
+                            if record.login:
+                                ro['login'] = record.login
+                            if record.password:
+                                ro['password'] = record.password
+                            if record.link:
+                                ro['login_url'] = record.link
+                            if record.custom:
+                                ro['custom_fields'] = [{
+                                    'name': x.name,
+                                    'value': x.value,
+                                    'type': x.type
+                                } for x in record.custom]
+                            if record.totp:
+                                ro['totp'] = record.totp
+                            if record.attachments:
+                                ro['attachments'] = [{
+                                    'id': a.id,
+                                    'name': a.name,
+                                    'size': a.size
+                                } for a in record.attachments]
+                            if record.notes:
+                                ro['notes'] = record.notes
+                    else:
+                        data = rev['data_unencrypted'] if 'data_unencrypted' in rev else b'{}'
+                        data = json.loads(data.decode())
+                        ro.update(data)
+                    ro['version'] = version
+                    ro['revision'] = record.revision
+                    if 'user_name' in rev:
+                        ro['modified_by'] = rev['user_name']
+                    if 'client_modified_time' in rev:
+                        cmt = rev['client_modified_time']
+                        if isinstance(cmt, (int, float)):
+                            dt = datetime.datetime.fromtimestamp(int(cmt / 1000))
+                            ro['client_modified_time'] = dt.isoformat()
+
+                    output = kwargs.get('output')
+                    if output:
+                        _, ext = os.path.splitext(output)
+                        if not ext:
+                            output += '.json'
+                        with open(output, 'w') as f:
+                            json.dump(ro, f, indent=2)
+                    else:
+                        print(json.dumps(ro, indent=2))
+                    return
 
                 rows = []
                 for name, value in record.enumerate_fields():
@@ -2747,7 +2803,6 @@ class RecordHistoryCommand(Command, RecordMixin):
                         rows.append([name, value])
                 modified = datetime.datetime.fromtimestamp(int(rev['client_modified_time'] / 1000.0))
                 rows.append(['Modified', modified])
-                fmt = kwargs.get('format') or ''
                 return base.dump_report_data(rows, headers=['Name', 'Value'],
                                  title=f'Record Revision V.{revision}', no_header=True, right_align=(0,),
                                  fmt=fmt, filename=kwargs.get('output'))


### PR DESCRIPTION
## Summary
- `record-history -a view --format=json` previously emitted the same flattened Name/Value rows as the table view, exposing fewer fields than `get --format=json`.
- The view action now emits the complete record contents in the same JSON structure as the `get` command, so raw history differences between revisions can be compared directly.

## Details
- **Typed records (v3+):** the revision's decrypted record data JSON is merged in raw (`title`, `type`, `fields`, `custom`, `notes`), matching `get`.
- **Legacy records (v2):** mapped to the same field names `get` uses (`title`, `login`, `password`, `login_url`, `custom_fields`, `totp`, `attachments`, `notes`).
- **Revision metadata appended:** `version`, `revision`, `modified_by`, and `client_modified_time` (ISO format).
- `--output <file>` writes the JSON to a file (appending `.json` if no extension), consistent with other JSON report handling.
- Table/detail output for non-JSON formats is unchanged.

## Testing
- Verified with mocked history revisions: v3 typed record dumps its full raw data JSON, v2 legacy record maps to `get`-style fields, and the default table view renders exactly as before.
- `python -m py_compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)