### PR TITLE
KC-1412: Fix email-config title lookup so shared-in records cannot redirect --send-email SMTP

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -3812,6 +3812,10 @@ class PAMGatewayActionRotateCommand(Command):
             # Find and load email config to validate provider and dependencies
             try:
                 config_uid = find_email_config_record(params, self.email_config)
+                if not config_uid:
+                    raise CommandError(
+                        'pam action rotate',
+                        f'Email configuration "{self.email_config}" not found')
                 email_config_obj = load_email_config_from_record(params, config_uid)
 
                 # Check if required dependencies are installed for this provider

--- a/keepercommander/commands/email_commands.py
+++ b/keepercommander/commands/email_commands.py
@@ -186,7 +186,8 @@ def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
                     owner = (params.record_owner_cache or {}).get(record_uid)
                     if not owner or not owner.owner:
                         logging.warning(
-                            'Ignoring email configuration "%s" (%s): owned by another account',
+                            'Ignoring email configuration "%s" (%s): '
+                            'not owned by the current account (or ownership unknown)',
                             name, record_uid)
                         continue
 
@@ -605,13 +606,17 @@ class EmailConfigCreateCommand(Command):
 
 
 class EmailConfigListCommand(Command):
-    """List all email configurations."""
+    """List owned email configurations."""
 
     def get_parser(self):
         return email_config_list_parser
 
     def execute(self, params: KeeperParams, **kwargs):
-        """Execute email-config list command."""
+        """Execute email-config list command.
+
+        Only configurations owned by the current account are listed, matching
+        ``find_email_config_record`` eligibility used by test/delete/--send-email.
+        """
         configs = []
 
         # Find all email config records
@@ -643,13 +648,24 @@ class EmailConfigListCommand(Command):
                         if values:
                             from_address = values[0]
 
-                if is_email_config:
-                    configs.append({
-                        'name': record.title,
-                        'record_uid': record_uid,
-                        'provider': provider or 'unknown',
-                        'from_address': from_address or ''
-                    })
+                if not is_email_config:
+                    continue
+
+                # Match find_email_config_record: only list owned configs
+                owner = (params.record_owner_cache or {}).get(record_uid)
+                if not owner or not owner.owner:
+                    logging.debug(
+                        'Skipping email configuration "%s" (%s) in list: '
+                        'not owned by the current account (or ownership unknown)',
+                        record.title, record_uid)
+                    continue
+
+                configs.append({
+                    'name': record.title,
+                    'record_uid': record_uid,
+                    'provider': provider or 'unknown',
+                    'from_address': from_address or ''
+                })
             except Exception as e:
                 logging.debug(f'Error loading record {record_uid}: {e}')
                 continue

--- a/keepercommander/commands/email_commands.py
+++ b/keepercommander/commands/email_commands.py
@@ -153,7 +153,12 @@ email_config_delete_parser.add_argument(
 
 def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
     """
-    Find email config record by name.
+    Find an owned email config record by name.
+
+    Only records owned by the current account are eligible. Shared or
+    non-owned records (even with a matching title and ``__email_config__``
+    marker) are ignored so SMTP/provider settings cannot be supplied by
+    another user.
 
     Args:
         params: KeeperParams session
@@ -175,8 +180,17 @@ def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
             custom_fields = record_dict.get('custom', [])
             for field in custom_fields:
                 if field.get('type') == 'text' and field.get('label') == '__email_config__':
-                    if record.title == name:
-                        return record_uid
+                    if record.title != name:
+                        continue
+
+                    owner = (params.record_owner_cache or {}).get(record_uid)
+                    if not owner or not owner.owner:
+                        logging.warning(
+                            'Ignoring email configuration "%s" (%s): owned by another account',
+                            name, record_uid)
+                        continue
+
+                    return record_uid
         except:
             continue
 

--- a/keepercommander/commands/email_commands.py
+++ b/keepercommander/commands/email_commands.py
@@ -151,6 +151,30 @@ email_config_delete_parser.add_argument(
 # Helper Functions
 # =============================================================================
 
+def _current_account_uid(params: KeeperParams) -> Optional[str]:
+    account_uid_bytes = getattr(params, 'account_uid_bytes', None)
+    if not account_uid_bytes:
+        return None
+    return utils.base64_url_encode(account_uid_bytes)
+
+
+def _is_owned_email_config_record(params: KeeperParams, record_uid: str) -> bool:
+    """True if the current account owns this record.
+
+    Shared-folder sync can overwrite ``record_owner_cache[uid].owner`` to False
+    for a record the user still owns, so account_uid and record metadata are
+    consulted as well. Unknown ownership fails closed.
+    """
+    owner = (params.record_owner_cache or {}).get(record_uid)
+    current_uid = _current_account_uid(params)
+    if owner and current_uid and owner.account_uid == current_uid:
+        return True
+    if owner and owner.owner:
+        return True
+    meta = (getattr(params, 'meta_data_cache', None) or {}).get(record_uid) or {}
+    return bool(meta.get('owner'))
+
+
 def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
     """
     Find an owned email config record by name.
@@ -158,7 +182,8 @@ def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
     Only records owned by the current account are eligible. Shared or
     non-owned records (even with a matching title and ``__email_config__``
     marker) are ignored so SMTP/provider settings cannot be supplied by
-    another user.
+    another user. A missing or unknown ownership entry is treated the same
+    way (not owned by the current account, or ownership unknown).
 
     Args:
         params: KeeperParams session
@@ -174,25 +199,26 @@ def find_email_config_record(params: KeeperParams, name: str) -> Optional[str]:
         if record.record_type != 'login':
             continue
 
-        # Check if this is an email config by looking for custom field
         try:
             record_dict = vault_extensions.extract_typed_record_data(record)
             custom_fields = record_dict.get('custom', [])
-            for field in custom_fields:
-                if field.get('type') == 'text' and field.get('label') == '__email_config__':
-                    if record.title != name:
-                        continue
-
-                    owner = (params.record_owner_cache or {}).get(record_uid)
-                    if not owner or not owner.owner:
-                        logging.warning(
-                            'Ignoring email configuration "%s" (%s): '
-                            'not owned by the current account (or ownership unknown)',
-                            name, record_uid)
-                        continue
-
-                    return record_uid
-        except:
+            is_email_config = any(
+                field.get('type') == 'text' and field.get('label') == '__email_config__'
+                for field in custom_fields
+            )
+            if not is_email_config:
+                continue
+            if record.title != name:
+                continue
+            if not _is_owned_email_config_record(params, record_uid):
+                logging.warning(
+                    'Ignoring email configuration "%s" (%s): '
+                    'not owned by the current account (or ownership unknown)',
+                    name, record_uid)
+                continue
+            return record_uid
+        except Exception as e:
+            logging.debug('Skipping record %s: %s', record_uid, e)
             continue
 
     return None
@@ -651,9 +677,7 @@ class EmailConfigListCommand(Command):
                 if not is_email_config:
                     continue
 
-                # Match find_email_config_record: only list owned configs
-                owner = (params.record_owner_cache or {}).get(record_uid)
-                if not owner or not owner.owner:
+                if not _is_owned_email_config_record(params, record_uid):
                     logging.debug(
                         'Skipping email configuration "%s" (%s) in list: '
                         'not owned by the current account (or ownership unknown)',

--- a/keepercommander/commands/email_commands.py
+++ b/keepercommander/commands/email_commands.py
@@ -151,24 +151,13 @@ email_config_delete_parser.add_argument(
 # Helper Functions
 # =============================================================================
 
-def _current_account_uid(params: KeeperParams) -> Optional[str]:
-    account_uid_bytes = getattr(params, 'account_uid_bytes', None)
-    if not account_uid_bytes:
-        return None
-    return utils.base64_url_encode(account_uid_bytes)
-
-
 def _is_owned_email_config_record(params: KeeperParams, record_uid: str) -> bool:
     """True if the current account owns this record.
 
-    Shared-folder sync can overwrite ``record_owner_cache[uid].owner`` to False
-    for a record the user still owns, so account_uid and record metadata are
-    consulted as well. Unknown ownership fails closed.
+    Uses ``record_owner_cache`` first, then ``meta_data_cache`` from
+    recordMetaData (server-asserted). Unknown ownership fails closed.
     """
     owner = (params.record_owner_cache or {}).get(record_uid)
-    current_uid = _current_account_uid(params)
-    if owner and current_uid and owner.account_uid == current_uid:
-        return True
     if owner and owner.owner:
         return True
     meta = (getattr(params, 'meta_data_cache', None) or {}).get(record_uid) or {}

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -881,6 +881,8 @@ class RecordAddCommand(Command, RecordEditMixin):
 
                 email_config_name = kwargs.get('email_config')
                 config_uid = find_email_config_record(params, email_config_name)
+                if not config_uid:
+                    raise CommandError('record-add', f'Email configuration "{email_config_name}" not found')
                 email_config_obj = load_email_config_from_record(params, config_uid)
 
                 # Check if required dependencies are installed for this provider

--- a/keepercommander/service/README.md
+++ b/keepercommander/service/README.md
@@ -540,7 +540,8 @@ The command generates a complete `docker-compose.yml` with both Commander servic
 | `chat_approvals_space_id` | text | Google Chat space ID (`spaces/...`) |
 | `chat_command_request_record_id` | text | Slash command ID for `/keeper-request-record` |
 | `chat_command_request_folder_id` | text | Slash command ID for `/keeper-request-folder` |
-| `chat_command_one_time_share_id` | text | Slash command ID for `/keeper-one-time-share` |
+| `chat_command_external_share_id` | text | Slash command ID for `/keeper-external-share` |
+| `chat_command_create_secret_id` | text | Slash command ID for `/keeper-create-secret` |
 | `pedm_enabled` | text | `true` / `false` |
 | `pedm_polling_interval` | text | Seconds |
 | `device_approval_enabled` | text | `true` / `false` |

--- a/keepercommander/service/commands/integrations/gchat_app_setup.py
+++ b/keepercommander/service/commands/integrations/gchat_app_setup.py
@@ -100,9 +100,13 @@ class GChatAppSetupCommand(IntegrationSetupCommand):
             '/keeper-request-folder',
             GChatConstants.DEFAULT_COMMAND_REQUEST_FOLDER_ID,
         )
-        chat_command_one_time_share_id = self._prompt_command_id(
-            '/keeper-one-time-share',
-            GChatConstants.DEFAULT_COMMAND_ONE_TIME_SHARE_ID,
+        chat_command_external_share_id = self._prompt_command_id(
+            '/keeper-external-share',
+            GChatConstants.DEFAULT_COMMAND_EXTERNAL_SHARE_ID,
+        )
+        chat_command_create_secret_id = self._prompt_command_id(
+            '/keeper-create-secret',
+            GChatConstants.DEFAULT_COMMAND_CREATE_SECRET_ID,
         )
 
         pedm_enabled, pedm_interval = self._collect_pedm_config()
@@ -118,7 +122,8 @@ class GChatAppSetupCommand(IntegrationSetupCommand):
             chat_approvals_space_id=chat_approvals_space_id,
             chat_command_request_record_id=chat_command_request_record_id,
             chat_command_request_folder_id=chat_command_request_folder_id,
-            chat_command_one_time_share_id=chat_command_one_time_share_id,
+            chat_command_external_share_id=chat_command_external_share_id,
+            chat_command_create_secret_id=chat_command_create_secret_id,
             pedm_enabled=pedm_enabled,
             pedm_polling_interval=pedm_interval,
             device_approval_enabled=da_enabled,
@@ -158,8 +163,13 @@ class GChatAppSetupCommand(IntegrationSetupCommand):
             ),
             vault.TypedField.new_field(
                 'text',
-                config.chat_command_one_time_share_id,
-                GChatConstants.FIELD_COMMAND_ONE_TIME_SHARE_ID,
+                config.chat_command_external_share_id,
+                GChatConstants.FIELD_COMMAND_EXTERNAL_SHARE_ID,
+            ),
+            vault.TypedField.new_field(
+                'text',
+                config.chat_command_create_secret_id,
+                GChatConstants.FIELD_COMMAND_CREATE_SECRET_ID,
             ),
             vault.TypedField.new_field(
                 'text',
@@ -205,8 +215,12 @@ class GChatAppSetupCommand(IntegrationSetupCommand):
             f"{bcolors.OKBLUE}{config.chat_command_request_folder_id}{bcolors.ENDC}"
         )
         print(
-            f"    • /keeper-one-time-share ID: "
-            f"{bcolors.OKBLUE}{config.chat_command_one_time_share_id}{bcolors.ENDC}"
+            f"    • /keeper-external-share ID: "
+            f"{bcolors.OKBLUE}{config.chat_command_external_share_id}{bcolors.ENDC}"
+        )
+        print(
+            f"    • /keeper-create-secret ID: "
+            f"{bcolors.OKBLUE}{config.chat_command_create_secret_id}{bcolors.ENDC}"
         )
 
     def print_integration_commands(self):
@@ -214,8 +228,12 @@ class GChatAppSetupCommand(IntegrationSetupCommand):
         print(f"  {bcolors.OKGREEN}• /keeper-request-record{bcolors.ENDC} - Request access to a record")
         print(f"  {bcolors.OKGREEN}• /keeper-request-folder{bcolors.ENDC} - Request access to a folder")
         print(
-            f"  {bcolors.OKGREEN}• /keeper-one-time-share{bcolors.ENDC} "
-            f"- Request a one-time share link\n"
+            f"  {bcolors.OKGREEN}• /keeper-external-share{bcolors.ENDC} "
+            f"- Request an external share link"
+        )
+        print(
+            f"  {bcolors.OKGREEN}• /keeper-create-secret{bcolors.ENDC} "
+            f"- Request creation of a secret\n"
         )
 
     # ── Validation helpers ────────────────────────────────────────

--- a/keepercommander/service/docker/models.py
+++ b/keepercommander/service/docker/models.py
@@ -149,7 +149,8 @@ class GChatConstants:
     FIELD_APPROVALS_SPACE_ID = 'chat_approvals_space_id'
     FIELD_COMMAND_REQUEST_RECORD_ID = 'chat_command_request_record_id'
     FIELD_COMMAND_REQUEST_FOLDER_ID = 'chat_command_request_folder_id'
-    FIELD_COMMAND_ONE_TIME_SHARE_ID = 'chat_command_one_time_share_id'
+    FIELD_COMMAND_EXTERNAL_SHARE_ID = 'chat_command_external_share_id'
+    FIELD_COMMAND_CREATE_SECRET_ID = 'chat_command_create_secret_id'
     FIELD_PEDM_ENABLED = 'pedm_enabled'
     FIELD_PEDM_POLLING_INTERVAL = 'pedm_polling_interval'
     FIELD_DEVICE_APPROVAL_ENABLED = 'device_approval_enabled'
@@ -157,7 +158,8 @@ class GChatConstants:
 
     DEFAULT_COMMAND_REQUEST_RECORD_ID = '1'
     DEFAULT_COMMAND_REQUEST_FOLDER_ID = '2'
-    DEFAULT_COMMAND_ONE_TIME_SHARE_ID = '3'
+    DEFAULT_COMMAND_EXTERNAL_SHARE_ID = '3'
+    DEFAULT_COMMAND_CREATE_SECRET_ID = '4'
 
     SPACE_ID_PREFIX = 'spaces/'
     SERVICE_ACCOUNT_TYPE = 'service_account'
@@ -178,7 +180,8 @@ class GChatConfig:
     chat_approvals_space_id: str
     chat_command_request_record_id: str = GChatConstants.DEFAULT_COMMAND_REQUEST_RECORD_ID
     chat_command_request_folder_id: str = GChatConstants.DEFAULT_COMMAND_REQUEST_FOLDER_ID
-    chat_command_one_time_share_id: str = GChatConstants.DEFAULT_COMMAND_ONE_TIME_SHARE_ID
+    chat_command_external_share_id: str = GChatConstants.DEFAULT_COMMAND_EXTERNAL_SHARE_ID
+    chat_command_create_secret_id: str = GChatConstants.DEFAULT_COMMAND_CREATE_SECRET_ID
     pedm_enabled: bool = False
     pedm_polling_interval: int = 120
     device_approval_enabled: bool = False

--- a/unit-tests/service/test_gchat_app_setup.py
+++ b/unit-tests/service/test_gchat_app_setup.py
@@ -164,7 +164,8 @@ class TestGChatAppSetupValidation(unittest.TestCase):
             chat_approvals_space_id='spaces/AAAA',
             chat_command_request_record_id='1',
             chat_command_request_folder_id='2',
-            chat_command_one_time_share_id='3',
+            chat_command_external_share_id='3',
+            chat_command_create_secret_id='4',
             pedm_enabled=True,
             pedm_polling_interval=60,
             device_approval_enabled=False,
@@ -184,7 +185,8 @@ class TestGChatAppSetupValidation(unittest.TestCase):
         self.assertEqual(fields[GChatConstants.FIELD_APPROVALS_SPACE_ID], 'spaces/AAAA')
         self.assertEqual(fields[GChatConstants.FIELD_COMMAND_REQUEST_RECORD_ID], '1')
         self.assertEqual(fields[GChatConstants.FIELD_COMMAND_REQUEST_FOLDER_ID], '2')
-        self.assertEqual(fields[GChatConstants.FIELD_COMMAND_ONE_TIME_SHARE_ID], '3')
+        self.assertEqual(fields[GChatConstants.FIELD_COMMAND_EXTERNAL_SHARE_ID], '3')
+        self.assertEqual(fields[GChatConstants.FIELD_COMMAND_CREATE_SECRET_ID], '4')
         self.assertEqual(fields[GChatConstants.FIELD_PEDM_ENABLED], 'true')
         self.assertEqual(fields[GChatConstants.FIELD_PEDM_POLLING_INTERVAL], '60')
         self.assertEqual(fields[GChatConstants.FIELD_DEVICE_APPROVAL_ENABLED], 'false')

--- a/unit-tests/test_email_config_ownership.py
+++ b/unit-tests/test_email_config_ownership.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keepercommander.params import KeeperParams, RecordOwner
+
+
+class TestFindEmailConfigRecordOwnership(unittest.TestCase):
+    """Email config records must be owned by the current account."""
+
+    TITLE = 'default'
+
+    def _make_typed_record(self, uid, title=None):
+        from keepercommander import vault
+
+        record = MagicMock(spec=vault.TypedRecord)
+        record.record_uid = uid
+        record.title = title or self.TITLE
+        record.record_type = 'login'
+        return record
+
+    def _email_config_data(self):
+        return {
+            'custom': [
+                {'type': 'text', 'label': '__email_config__', 'value': ['true']},
+            ]
+        }
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_skips_non_owned_record(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        shared = self._make_typed_record('SHARED_UID')
+        owned = self._make_typed_record('OWNED_UID')
+
+        def load_side_effect(_params, uid):
+            return {'SHARED_UID': shared, 'OWNED_UID': owned}[uid]
+
+        mock_load.side_effect = load_side_effect
+        mock_extract.return_value = self._email_config_data()
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {'SHARED_UID': {}, 'OWNED_UID': {}}
+        params.record_owner_cache = {
+            'SHARED_UID': RecordOwner(False, 'attacker'),
+            'OWNED_UID': RecordOwner(True, 'operator'),
+        }
+
+        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_returns_none_when_only_shared_match(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('SHARED_UID')
+        mock_extract.return_value = self._email_config_data()
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {'SHARED_UID': {}}
+        params.record_owner_cache = {
+            'SHARED_UID': RecordOwner(False, 'attacker'),
+        }
+
+        self.assertIsNone(find_email_config_record(params, self.TITLE))
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_returns_none_when_owner_cache_missing(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('UNKNOWN_UID')
+        mock_extract.return_value = self._email_config_data()
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {'UNKNOWN_UID': {}}
+        params.record_owner_cache = {}
+
+        self.assertIsNone(find_email_config_record(params, self.TITLE))
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_returns_owned_record(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('OWNED_UID')
+        mock_extract.return_value = self._email_config_data()
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {'OWNED_UID': {}}
+        params.record_owner_cache = {
+            'OWNED_UID': RecordOwner(True, 'operator'),
+        }
+
+        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/test_email_config_ownership.py
+++ b/unit-tests/test_email_config_ownership.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from keepercommander.error import CommandError
 from keepercommander.params import KeeperParams, RecordOwner
 
 
@@ -93,6 +94,91 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         }
 
         self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+
+class TestEmailConfigListOwnership(unittest.TestCase):
+    """email-config list must only show owned configurations."""
+
+    def _make_typed_record(self, uid, title):
+        from keepercommander import vault
+
+        record = MagicMock(spec=vault.TypedRecord)
+        record.record_uid = uid
+        record.title = title
+        record.record_type = 'login'
+        return record
+
+    def _email_config_data(self, provider='smtp', from_address='it@corp.example'):
+        return {
+            'custom': [
+                {'type': 'text', 'label': '__email_config__', 'value': ['true']},
+                {'type': 'text', 'label': 'provider', 'value': [provider]},
+                {'type': 'text', 'label': 'from_address', 'value': [from_address]},
+            ]
+        }
+
+    @patch('keepercommander.commands.email_commands.dump_report_data')
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_list_skips_shared_in_config(self, mock_load, mock_extract, mock_dump):
+        from keepercommander.commands.email_commands import EmailConfigListCommand
+
+        shared = self._make_typed_record('SHARED_UID', 'default')
+        owned = self._make_typed_record('OWNED_UID', 'corp-smtp')
+
+        def load_side_effect(_params, uid):
+            return {'SHARED_UID': shared, 'OWNED_UID': owned}[uid]
+
+        mock_load.side_effect = load_side_effect
+        mock_extract.return_value = self._email_config_data()
+
+        params = MagicMock(spec=KeeperParams)
+        params.record_cache = {'SHARED_UID': {}, 'OWNED_UID': {}}
+        params.record_owner_cache = {
+            'SHARED_UID': RecordOwner(False, 'attacker'),
+            'OWNED_UID': RecordOwner(True, 'operator'),
+        }
+
+        EmailConfigListCommand().execute(params, format='table')
+
+        mock_dump.assert_called_once()
+        table = mock_dump.call_args[0][0]
+        self.assertEqual(len(table), 1)
+        self.assertEqual(table[0][0], 'corp-smtp')
+        self.assertEqual(table[0][3], 'OWNED_UID')
+
+
+class TestSendEmailValidationOwnership(unittest.TestCase):
+    """Patched validation paths must raise when only a shared-in config matches."""
+
+    @patch('keepercommander.commands.email_commands.find_email_config_record', return_value=None)
+    def test_record_add_raises_when_only_shared_config(self, _mock_find):
+        from keepercommander.commands.record_edit import RecordAddCommand
+
+        params = MagicMock(spec=KeeperParams)
+        with self.assertRaises(CommandError) as ctx:
+            RecordAddCommand().execute(
+                params,
+                send_email='newhire@corp.example',
+                email_config='default',
+            )
+        self.assertIn('Email configuration "default" not found', str(ctx.exception))
+
+    @patch('keepercommander.commands.discoveryrotation._is_rotation_allowed_by_enforcement',
+           return_value=True)
+    @patch('keepercommander.commands.discoveryrotation.find_email_config_record', return_value=None)
+    def test_pam_rotate_raises_when_only_shared_config(self, _mock_find, _mock_allowed):
+        from keepercommander.commands.discoveryrotation import PAMGatewayActionRotateCommand
+
+        params = MagicMock(spec=KeeperParams)
+        with self.assertRaises(CommandError) as ctx:
+            PAMGatewayActionRotateCommand().execute(
+                params,
+                record_uid='REC_UID',
+                send_email='newhire@corp.example',
+                email_config='default',
+            )
+        self.assertIn('Email configuration "default" not found', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/unit-tests/test_email_config_ownership.py
+++ b/unit-tests/test_email_config_ownership.py
@@ -19,12 +19,21 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         record.record_type = 'login'
         return record
 
-    def _email_config_data(self):
-        return {
-            'custom': [
-                {'type': 'text', 'label': '__email_config__', 'value': ['true']},
-            ]
-        }
+    def _email_config_data(self, extra_fields=None):
+        custom = [
+            {'type': 'text', 'label': '__email_config__', 'value': ['true']},
+        ]
+        if extra_fields:
+            custom.extend(extra_fields)
+        return {'custom': custom}
+
+    def _params(self, record_cache, record_owner_cache, account_uid_bytes=None, meta_data_cache=None):
+        params = MagicMock(spec=KeeperParams)
+        params.account_uid_bytes = account_uid_bytes
+        params.record_cache = record_cache
+        params.record_owner_cache = record_owner_cache
+        params.meta_data_cache = meta_data_cache or {}
+        return params
 
     @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
     @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
@@ -40,12 +49,13 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         mock_load.side_effect = load_side_effect
         mock_extract.return_value = self._email_config_data()
 
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {'SHARED_UID': {}, 'OWNED_UID': {}}
-        params.record_owner_cache = {
-            'SHARED_UID': RecordOwner(False, 'attacker'),
-            'OWNED_UID': RecordOwner(True, 'operator'),
-        }
+        params = self._params(
+            {'SHARED_UID': {}, 'OWNED_UID': {}},
+            {
+                'SHARED_UID': RecordOwner(False, 'attacker'),
+                'OWNED_UID': RecordOwner(True, 'operator'),
+            },
+        )
 
         self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
 
@@ -57,11 +67,10 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         mock_load.return_value = self._make_typed_record('SHARED_UID')
         mock_extract.return_value = self._email_config_data()
 
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {'SHARED_UID': {}}
-        params.record_owner_cache = {
-            'SHARED_UID': RecordOwner(False, 'attacker'),
-        }
+        params = self._params(
+            {'SHARED_UID': {}},
+            {'SHARED_UID': RecordOwner(False, 'attacker')},
+        )
 
         self.assertIsNone(find_email_config_record(params, self.TITLE))
 
@@ -73,9 +82,7 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         mock_load.return_value = self._make_typed_record('UNKNOWN_UID')
         mock_extract.return_value = self._email_config_data()
 
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {'UNKNOWN_UID': {}}
-        params.record_owner_cache = {}
+        params = self._params({'UNKNOWN_UID': {}}, {})
 
         self.assertIsNone(find_email_config_record(params, self.TITLE))
 
@@ -87,11 +94,63 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
         mock_load.return_value = self._make_typed_record('OWNED_UID')
         mock_extract.return_value = self._email_config_data()
 
-        params = MagicMock(spec=KeeperParams)
-        params.record_cache = {'OWNED_UID': {}}
-        params.record_owner_cache = {
-            'OWNED_UID': RecordOwner(True, 'operator'),
-        }
+        params = self._params(
+            {'OWNED_UID': {}},
+            {'OWNED_UID': RecordOwner(True, 'operator')},
+        )
+
+        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_accepts_owned_record_when_owner_flag_overwritten(self, mock_load, mock_extract):
+        from keepercommander import utils
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('OWNED_UID')
+        mock_extract.return_value = self._email_config_data()
+
+        account_uid_bytes = b'current-account'
+        current_uid = utils.base64_url_encode(account_uid_bytes)
+        params = self._params(
+            {'OWNED_UID': {}},
+            {'OWNED_UID': RecordOwner(False, current_uid)},
+            account_uid_bytes=account_uid_bytes,
+        )
+
+        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_accepts_owned_record_from_metadata_when_owner_cache_wrong(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('OWNED_UID')
+        mock_extract.return_value = self._email_config_data()
+
+        params = self._params(
+            {'OWNED_UID': {}},
+            {'OWNED_UID': RecordOwner(False, 'attacker')},
+            meta_data_cache={'OWNED_UID': {'owner': True}},
+        )
+
+        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+
+    @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
+    @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
+    def test_matches_when_marker_is_not_last_custom_field(self, mock_load, mock_extract):
+        from keepercommander.commands.email_commands import find_email_config_record
+
+        mock_load.return_value = self._make_typed_record('OWNED_UID')
+        mock_extract.return_value = self._email_config_data(
+            extra_fields=[
+                {'type': 'text', 'label': 'smtp_host', 'value': ['smtp.example.com']},
+            ]
+        )
+        params = self._params(
+            {'OWNED_UID': {}},
+            {'OWNED_UID': RecordOwner(True, 'operator')},
+        )
 
         self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
 
@@ -133,11 +192,13 @@ class TestEmailConfigListOwnership(unittest.TestCase):
         mock_extract.return_value = self._email_config_data()
 
         params = MagicMock(spec=KeeperParams)
+        params.account_uid_bytes = None
         params.record_cache = {'SHARED_UID': {}, 'OWNED_UID': {}}
         params.record_owner_cache = {
             'SHARED_UID': RecordOwner(False, 'attacker'),
             'OWNED_UID': RecordOwner(True, 'operator'),
         }
+        params.meta_data_cache = {}
 
         EmailConfigListCommand().execute(params, format='table')
 

--- a/unit-tests/test_email_config_ownership.py
+++ b/unit-tests/test_email_config_ownership.py
@@ -103,22 +103,23 @@ class TestFindEmailConfigRecordOwnership(unittest.TestCase):
 
     @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
     @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')
-    def test_accepts_owned_record_when_owner_flag_overwritten(self, mock_load, mock_extract):
+    def test_rejects_shared_record_with_current_account_uid_fallback(self, mock_load, mock_extract):
+        """Shared-in records must not match via ownerAccountUid display fallback."""
         from keepercommander import utils
         from keepercommander.commands.email_commands import find_email_config_record
 
-        mock_load.return_value = self._make_typed_record('OWNED_UID')
+        mock_load.return_value = self._make_typed_record('SHARED_UID')
         mock_extract.return_value = self._email_config_data()
 
         account_uid_bytes = b'current-account'
         current_uid = utils.base64_url_encode(account_uid_bytes)
         params = self._params(
-            {'OWNED_UID': {}},
-            {'OWNED_UID': RecordOwner(False, current_uid)},
+            {'SHARED_UID': {}},
+            {'SHARED_UID': RecordOwner(False, current_uid)},
             account_uid_bytes=account_uid_bytes,
         )
 
-        self.assertEqual(find_email_config_record(params, self.TITLE), 'OWNED_UID')
+        self.assertIsNone(find_email_config_record(params, self.TITLE))
 
     @patch('keepercommander.commands.email_commands.vault_extensions.extract_typed_record_data')
     @patch('keepercommander.commands.email_commands.vault.KeeperRecord.load')


### PR DESCRIPTION
## Summary

- Fixed `record-add --send-email` so email configuration is resolved only from records owned by the current account. Config lookup matched on title across the visible record cache, so a shared-in login titled like an email config (with `__email_config__` and attacker SMTP settings) could send the onboarding mail and share URL through an attacker-controlled server.
- Also updated Google Chat app setup to rename the one-time-share slash command to external share and add a create-secret command ID for vault config and setup prompts.

## Changes
- `email_commands.py`: Restrict `find_email_config_record()` and `email-config list` to owned configs; clarify non-owned warning text; narrow exception handling; add `_is_owned_email_config_record()` using `owner.owner` and `meta_data_cache` only (no `account_uid` fallback)
- `record_edit.py`: Fail early in `record-add` validation with `Email configuration "..." not found` when no owned config exists
- `discoveryrotation.py`: Same clear not-found error on the `pam action rotate` email-config validation path
- `test_email_config_ownership.py`: Ownership, list, validation-path, metadata-fallback, and shared-in rejection tests (including `RecordOwner(False, current_uid)` attack shape)

### Gchat changes
- `models.py`: Rename GChat one-time-share constants/fields to external share; add create-secret command ID defaults
- `gchat_app_setup.py`: Prompt for `/keeper-external-share` and `/keeper-create-secret`; persist and display updated command IDs in vault custom fields
- `service/README.md`: Document `chat_command_external_share_id` and `chat_command_create_secret_id` vault fields
- `test_gchat_app_setup.py`: Assert external-share and create-secret custom fields in GChat setup