### PR TITLE
KC-1407: Add terraform-app-setup with Min-Commander-Version gate

### DIFF
--- a/keepercommander/command_categories.py
+++ b/keepercommander/command_categories.py
@@ -83,7 +83,8 @@ COMMAND_CATEGORIES = {
     # Service Mode REST API
     'Service Mode REST API': {
         'service-create', 'service-add-config', 'service-start', 'service-stop', 'service-status',
-        'service-config-add', 'service-docker-setup', 'slack-app-setup', 'teams-app-setup',
+        'service-config-add', 'service-docker-setup', 'terraform-app-setup',
+        'slack-app-setup', 'teams-app-setup',
         'sailpoint-app-setup', 'gchat-app-setup'
     },
 

--- a/keepercommander/commands/start_service.py
+++ b/keepercommander/commands/start_service.py
@@ -13,6 +13,7 @@ from ..service.commands.create_service import CreateService
 from ..service.commands.config_operation import AddConfigService
 from ..service.commands.handle_service import StartService, StopService, ServiceStatus
 from ..service.commands.service_docker_setup import ServiceDockerSetupCommand
+from ..service.commands.terraform_app_setup import TerraformAppSetupCommand
 from ..service.commands.integrations import (
     GChatAppSetupCommand,
     SlackAppSetupCommand,
@@ -27,6 +28,7 @@ def register_commands(commands):
     commands['service-stop'] = StopService()
     commands['service-status'] = ServiceStatus()
     commands['service-docker-setup'] = ServiceDockerSetupCommand()
+    commands['terraform-app-setup'] = TerraformAppSetupCommand()
     commands['slack-app-setup'] = SlackAppSetupCommand()
     commands['teams-app-setup'] = TeamsAppSetupCommand()
     commands['sailpoint-app-setup'] = SailPointAppSetupCommand()
@@ -40,6 +42,7 @@ def register_command_info(aliases, command_info):
         StopService,
         ServiceStatus,
         ServiceDockerSetupCommand,
+        TerraformAppSetupCommand,
         SlackAppSetupCommand,
         TeamsAppSetupCommand,
         SailPointAppSetupCommand,

--- a/keepercommander/service/commands/service_docker_setup.py
+++ b/keepercommander/service/commands/service_docker_setup.py
@@ -16,11 +16,9 @@ Standalone Docker service mode setup command.
 import argparse
 import os
 from dataclasses import asdict
-from typing import Dict, Any
 
 from ...commands.base import Command, raise_parse_exception, suppress_exit
 from ...display import bcolors
-from ...error import CommandError
 from ..config.config_validation import ConfigValidator, ValidationError
 from ..docker import (
     DockerSetupBase, DockerSetupConstants, DockerSetupPrinter,
@@ -69,19 +67,17 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
 
     def execute(self, params, **kwargs):
         """Main execution flow for standalone command"""
-        self._require_file_based_config(params, 'service-docker-setup')
+        command_name = self.get_parser().prog
+        self._require_file_based_config(params, command_name)
 
-        # Parse arguments
         config_path = self._require_commander_config_file(
-            'service-docker-setup',
+            command_name,
             kwargs.get('config_path'),
             params,
         )
-        
-        # Print header
+
         DockerSetupPrinter.print_header("Docker Setup")
-        
-        # Run core setup steps (inherited from DockerSetupBase)
+
         setup_result = self.run_setup_steps(
             params=params,
             folder_name=kwargs.get('folder_name', DockerSetupConstants.DEFAULT_FOLDER_NAME),
@@ -91,19 +87,13 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
             timeout=kwargs.get('timeout', DockerSetupConstants.DEFAULT_TIMEOUT),
             skip_device_setup=kwargs.get('skip_device_setup', False)
         )
-        
-        # Get service configuration
+
         DockerSetupPrinter.print_completion("Docker Setup Complete!")
         service_config = self.get_service_configuration(params)
-        
-        # Generate docker-compose.yml
+
         self.generate_and_save_docker_compose(setup_result, service_config)
         DockerSetupPrinter.print_completion("Service Mode Configuration Complete!")
-        
-        # Print success message
         self.print_standalone_success_message(setup_result, service_config, config_path)
-        
-        return
 
     def get_service_configuration(self, params) -> ServiceConfig:
         """Interactively get service configuration from user"""
@@ -221,134 +211,3 @@ class ServiceDockerSetupCommand(Command, DockerSetupBase):
         print(f"  Queue mode enables async API (v2) for better performance")
         queue_input = input(f"{bcolors.OKBLUE}Enable queue mode? [Press Enter for Yes] (y/n):{bcolors.ENDC} ").strip().lower()
         return queue_input != 'n'
-
-
-    def _get_advanced_security_config(self) -> Dict[str, Any]:
-        """Get advanced security configuration"""
-        print(f"\n{bcolors.BOLD}Advanced Security (optional):{bcolors.ENDC}")
-        print(f"  Configure IP filtering, rate limiting, and response encryption")
-        enable_advanced = input(f"{bcolors.OKBLUE}Enable advanced security? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
-        
-        config = {
-            'allowed_ip': '0.0.0.0/0,::/0',
-            'denied_ip': '',
-            'rate_limit': '',
-            'encryption_enabled': False,
-            'encryption_key': '',
-            'token_expiration': ''
-        }
-        
-        if enable_advanced:
-            # IP Allowed List
-            config.update(self._get_ip_allowed_config())
-            
-            # IP Denied List
-            config.update(self._get_ip_denied_config())
-            
-            # Rate Limiting
-            config.update(self._get_rate_limit_config())
-            
-            # Encryption
-            config.update(self._get_encryption_config())
-            
-            # Token Expiration
-            config.update(self._get_token_expiration_config())
-        
-        return config
-
-    def _get_ip_allowed_config(self) -> Dict[str, str]:
-        """Get allowed IP configuration"""
-        print(f"\n{bcolors.BOLD}IP Allowed List:{bcolors.ENDC}")
-        print(f"  Comma-separated IPs or CIDR ranges (e.g., 192.168.1.0/24,10.0.0.1)")
-        
-        ip_list = input(f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} ").strip()
-        
-        if ip_list:
-            while True:
-                try:
-                    return {'allowed_ip': ConfigValidator.validate_ip_list(ip_list)}
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                    ip_list = input(f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} ").strip()
-                    if not ip_list:
-                        break
-        
-        return {'allowed_ip': '0.0.0.0/0,::/0'}
-
-    def _get_ip_denied_config(self) -> Dict[str, str]:
-        """Get denied IP configuration"""
-        print(f"\n{bcolors.BOLD}IP Denied List:{bcolors.ENDC}")
-        print(f"  Comma-separated IPs or CIDR ranges to block")
-        
-        ip_list = input(f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} ").strip()
-        
-        if ip_list:
-            while True:
-                try:
-                    return {'denied_ip': ConfigValidator.validate_ip_list(ip_list)}
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                    ip_list = input(f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} ").strip()
-                    if not ip_list:
-                        break
-        
-        return {'denied_ip': ''}
-
-    def _get_rate_limit_config(self) -> Dict[str, str]:
-        """Get rate limiting configuration"""
-        print(f"\n{bcolors.BOLD}Rate Limiting:{bcolors.ENDC}")
-        print(f"  Format: <number>/<period> (e.g., 10/minute, 100/hour, 1000/day)")
-        
-        rate_limit = input(f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} ").strip()
-        
-        if rate_limit:
-            while True:
-                try:
-                    return {'rate_limit': ConfigValidator.validate_rate_limit(rate_limit)}
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                    rate_limit = input(f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} ").strip()
-                    if not rate_limit:
-                        break
-        
-        return {'rate_limit': ''}
-
-    def _get_encryption_config(self) -> Dict[str, Any]:
-        """Get encryption configuration"""
-        print(f"\n{bcolors.BOLD}Response Encryption:{bcolors.ENDC}")
-        print(f"  Enable AES-256 encryption for API responses")
-        enable_encryption = input(f"{bcolors.OKBLUE}Enable encryption? [Press Enter for No] (y/n):{bcolors.ENDC} ").strip().lower() == 'y'
-        
-        config = {'encryption_enabled': enable_encryption, 'encryption_key': ''}
-        
-        if enable_encryption:
-            print(f"  Encryption key must be exactly 32 alphanumeric characters")
-            while True:
-                key = input(f"{bcolors.OKBLUE}Encryption key (32 chars):{bcolors.ENDC} ").strip()
-                try:
-                    config['encryption_key'] = ConfigValidator.validate_encryption_key(key)
-                    break
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-        
-        return config
-
-    def _get_token_expiration_config(self) -> Dict[str, str]:
-        """Get token expiration configuration"""
-        print(f"\n{bcolors.BOLD}API Token Expiration:{bcolors.ENDC}")
-        print(f"  Format: Xm (minutes), Xh (hours), Xd (days) - e.g., 30m, 24h, 7d")
-        
-        expiration = input(f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} ").strip()
-        
-        if expiration:
-            while True:
-                try:
-                    ConfigValidator.parse_expiration_time(expiration)
-                    return {'token_expiration': expiration}
-                except ValidationError as e:
-                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
-                    expiration = input(f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} ").strip()
-                    if not expiration:
-                        break
-        
-        return {'token_expiration': ''}

--- a/keepercommander/service/commands/terraform_app_setup.py
+++ b/keepercommander/service/commands/terraform_app_setup.py
@@ -1,0 +1,112 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Terraform provider Docker service mode setup command."""
+
+import argparse
+
+from ...commands.base import raise_parse_exception, suppress_exit
+from ...error import CommandError
+from ..config.service_config import ServiceConfig as RuntimeServiceConfig
+from ..docker import DockerSetupConstants
+from ..util.exceptions import ValidationError
+from .service_docker_setup import ServiceDockerSetupCommand
+
+
+class TerraformSetupConstants:
+    """Defaults and allowlist for terraform-app-setup."""
+    DEFAULT_FOLDER_NAME = 'Commander Service Mode - Terraform'
+    DEFAULT_APP_NAME = 'Commander Service Mode - Terraform KSM App'
+    DEFAULT_RECORD_NAME = 'Commander Service Mode Terraform Config'
+    DEFAULT_TIMEOUT = DockerSetupConstants.DEFAULT_TIMEOUT
+
+    SERVICE_COMMANDS = (
+        'this-device,sync-down,switch-to-mc,switch-to-msp,'
+        'msp-add,msp-down,msp-info,msp-remove,msp-update,'
+        'enterprise-info,enterprise-node,enterprise-user,enterprise-role,'
+        'enterprise-team,enterprise-down,enterprise-push,team-approve,'
+        'record-add,record-update,rm,get,list,record-type-info,'
+        'share-folder,rmdir,rndir,mkdir,epm,scim,mv,pam,secrets-manager,'
+        'ln,share-record,'
+        'nsf-mkdir,nsf-get,nsf-rmdir,nsf-record-add,nsf-record-update,'
+        'nsf-rm,nsf-rndir,nsf-share-folder,nsf-share-record,nsf-ln'
+    )
+
+
+terraform_app_setup_parser = argparse.ArgumentParser(
+    prog='terraform-app-setup',
+    description=(
+        'Automate Docker service mode setup for the Terraform provider '
+        '(API v2 queue always enabled)'
+    ),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+terraform_app_setup_parser.add_argument(
+    '--folder-name', dest='folder_name', type=str,
+    default=TerraformSetupConstants.DEFAULT_FOLDER_NAME,
+    help=f'Name for the shared folder '
+         f'(default: "{TerraformSetupConstants.DEFAULT_FOLDER_NAME}")',
+)
+terraform_app_setup_parser.add_argument(
+    '--app-name', dest='app_name', type=str,
+    default=TerraformSetupConstants.DEFAULT_APP_NAME,
+    help=f'Name for the secrets manager app '
+         f'(default: "{TerraformSetupConstants.DEFAULT_APP_NAME}")',
+)
+terraform_app_setup_parser.add_argument(
+    '--record-name', dest='record_name', type=str,
+    default=TerraformSetupConstants.DEFAULT_RECORD_NAME,
+    help=f'Name for the config record '
+         f'(default: "{TerraformSetupConstants.DEFAULT_RECORD_NAME}")',
+)
+terraform_app_setup_parser.add_argument(
+    '--config-path', dest='config_path', type=str,
+    help='Path to config.json file (default: active session config file)',
+)
+terraform_app_setup_parser.add_argument(
+    '--timeout', dest='timeout', type=str,
+    default=TerraformSetupConstants.DEFAULT_TIMEOUT,
+    help=f'Device timeout setting (default: {TerraformSetupConstants.DEFAULT_TIMEOUT})',
+)
+terraform_app_setup_parser.add_argument(
+    '--skip-device-setup', dest='skip_device_setup', action='store_true',
+    help='Skip device registration and setup if already configured',
+)
+terraform_app_setup_parser.error = raise_parse_exception
+terraform_app_setup_parser.exit = suppress_exit
+
+
+class TerraformAppSetupCommand(ServiceDockerSetupCommand):
+    """service-docker-setup flow with Terraform defaults: always queue, fixed allowlist."""
+
+    def get_parser(self):
+        return terraform_app_setup_parser
+
+    def execute(self, params, **kwargs):
+        kwargs.setdefault('folder_name', TerraformSetupConstants.DEFAULT_FOLDER_NAME)
+        kwargs.setdefault('app_name', TerraformSetupConstants.DEFAULT_APP_NAME)
+        kwargs.setdefault('record_name', TerraformSetupConstants.DEFAULT_RECORD_NAME)
+        kwargs.setdefault('timeout', TerraformSetupConstants.DEFAULT_TIMEOUT)
+        return super().execute(params, **kwargs)
+
+    def _get_commands_config(self, params) -> str:
+        try:
+            return RuntimeServiceConfig().validate_command_list(
+                TerraformSetupConstants.SERVICE_COMMANDS, params
+            )
+        except ValidationError as e:
+            raise CommandError(
+                self.get_parser().prog,
+                f'Terraform command allowlist validation failed: {e}',
+            )
+
+    def _get_queue_config(self) -> bool:
+        return True

--- a/keepercommander/service/commands/terraform_app_setup.py
+++ b/keepercommander/service/commands/terraform_app_setup.py
@@ -12,11 +12,18 @@
 """Terraform provider Docker service mode setup command."""
 
 import argparse
+from dataclasses import asdict
 
 from ...commands.base import raise_parse_exception, suppress_exit
 from ...error import CommandError
 from ..config.service_config import ServiceConfig as RuntimeServiceConfig
-from ..docker import DockerSetupConstants
+from ..docker import (
+    DockerComposeBuilder,
+    DockerSetupConstants,
+    DockerSetupPrinter,
+    ServiceConfig,
+    SetupResult,
+)
 from ..util.exceptions import ValidationError
 from .service_docker_setup import ServiceDockerSetupCommand
 
@@ -27,6 +34,8 @@ class TerraformSetupConstants:
     DEFAULT_APP_NAME = 'Commander Service Mode - Terraform KSM App'
     DEFAULT_RECORD_NAME = 'Commander Service Mode Terraform Config'
     DEFAULT_TIMEOUT = DockerSetupConstants.DEFAULT_TIMEOUT
+    COMMANDER_SERVICE_NAME = 'commander-terraform'
+    COMMANDER_CONTAINER_NAME = 'keeper-service-terraform'
 
     SERVICE_COMMANDS_LIST = (
         'this-device', 'sync-down', 'switch-to-mc', 'switch-to-msp',
@@ -122,3 +131,20 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
 
     def _get_queue_config(self) -> bool:
         return True
+
+    def generate_docker_compose_yaml(self, setup_result: SetupResult, config: ServiceConfig) -> str:
+        builder = DockerComposeBuilder(
+            setup_result,
+            asdict(config),
+            commander_service_name=TerraformSetupConstants.COMMANDER_SERVICE_NAME,
+            commander_container_name=TerraformSetupConstants.COMMANDER_CONTAINER_NAME,
+        )
+        return builder.build()
+
+    def _print_next_steps(self, config: ServiceConfig, config_path: str) -> None:
+        DockerSetupPrinter.print_common_deployment_steps(
+            str(config.port),
+            config_path,
+            container_name=TerraformSetupConstants.COMMANDER_CONTAINER_NAME,
+        )
+        print()

--- a/keepercommander/service/commands/terraform_app_setup.py
+++ b/keepercommander/service/commands/terraform_app_setup.py
@@ -21,7 +21,7 @@ from ..docker import (
     DockerComposeBuilder,
     DockerSetupConstants,
     DockerSetupPrinter,
-    ServiceConfig,
+    ServiceConfig as DockerServiceConfig,
     SetupResult,
 )
 from ..util.exceptions import ValidationError
@@ -106,11 +106,9 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
         kwargs.setdefault('app_name', TerraformSetupConstants.DEFAULT_APP_NAME)
         kwargs.setdefault('record_name', TerraformSetupConstants.DEFAULT_RECORD_NAME)
         kwargs.setdefault('timeout', TerraformSetupConstants.DEFAULT_TIMEOUT)
-        self._validated_commands = self._validate_terraform_commands(params)
-        try:
-            return super().execute(params, **kwargs)
-        finally:
-            self._validated_commands = None
+        # Fail closed before any setup; _get_commands_config re-validates locally.
+        self._validate_terraform_commands(params)
+        return super().execute(params, **kwargs)
 
     def _validate_terraform_commands(self, params) -> str:
         try:
@@ -124,15 +122,12 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
             )
 
     def _get_commands_config(self, params) -> str:
-        cached = getattr(self, '_validated_commands', None)
-        if cached is not None:
-            return cached
         return self._validate_terraform_commands(params)
 
     def _get_queue_config(self) -> bool:
         return True
 
-    def generate_docker_compose_yaml(self, setup_result: SetupResult, config: ServiceConfig) -> str:
+    def generate_docker_compose_yaml(self, setup_result: SetupResult, config: DockerServiceConfig) -> str:
         builder = DockerComposeBuilder(
             setup_result,
             asdict(config),
@@ -141,7 +136,7 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
         )
         return builder.build()
 
-    def _print_next_steps(self, config: ServiceConfig, config_path: str) -> None:
+    def _print_next_steps(self, config: DockerServiceConfig, config_path: str) -> None:
         DockerSetupPrinter.print_common_deployment_steps(
             str(config.port),
             config_path,

--- a/keepercommander/service/commands/terraform_app_setup.py
+++ b/keepercommander/service/commands/terraform_app_setup.py
@@ -28,17 +28,18 @@ class TerraformSetupConstants:
     DEFAULT_RECORD_NAME = 'Commander Service Mode Terraform Config'
     DEFAULT_TIMEOUT = DockerSetupConstants.DEFAULT_TIMEOUT
 
-    SERVICE_COMMANDS = (
-        'this-device,sync-down,switch-to-mc,switch-to-msp,'
-        'msp-add,msp-down,msp-info,msp-remove,msp-update,'
-        'enterprise-info,enterprise-node,enterprise-user,enterprise-role,'
-        'enterprise-team,enterprise-down,enterprise-push,team-approve,'
-        'record-add,record-update,rm,get,list,record-type-info,'
-        'share-folder,rmdir,rndir,mkdir,epm,scim,mv,pam,secrets-manager,'
-        'ln,share-record,'
-        'nsf-mkdir,nsf-get,nsf-rmdir,nsf-record-add,nsf-record-update,'
-        'nsf-rm,nsf-rndir,nsf-share-folder,nsf-share-record,nsf-ln'
+    SERVICE_COMMANDS_LIST = (
+        'this-device', 'sync-down', 'switch-to-mc', 'switch-to-msp',
+        'msp-add', 'msp-down', 'msp-info', 'msp-remove', 'msp-update',
+        'enterprise-info', 'enterprise-node', 'enterprise-user', 'enterprise-role',
+        'enterprise-team', 'enterprise-down', 'enterprise-push', 'team-approve',
+        'record-add', 'record-update', 'rm', 'get', 'list', 'record-type-info',
+        'share-folder', 'rmdir', 'rndir', 'mkdir', 'epm', 'scim', 'mv', 'pam',
+        'secrets-manager', 'ln', 'share-record',
+        'nsf-mkdir', 'nsf-get', 'nsf-rmdir', 'nsf-record-add', 'nsf-record-update',
+        'nsf-rm', 'nsf-rndir', 'nsf-share-folder', 'nsf-share-record', 'nsf-ln',
     )
+    SERVICE_COMMANDS = ','.join(SERVICE_COMMANDS_LIST)
 
 
 terraform_app_setup_parser = argparse.ArgumentParser(
@@ -91,13 +92,18 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
         return terraform_app_setup_parser
 
     def execute(self, params, **kwargs):
+        # setdefault covers programmatic execute() without argparse defaults.
         kwargs.setdefault('folder_name', TerraformSetupConstants.DEFAULT_FOLDER_NAME)
         kwargs.setdefault('app_name', TerraformSetupConstants.DEFAULT_APP_NAME)
         kwargs.setdefault('record_name', TerraformSetupConstants.DEFAULT_RECORD_NAME)
         kwargs.setdefault('timeout', TerraformSetupConstants.DEFAULT_TIMEOUT)
-        return super().execute(params, **kwargs)
+        self._validated_commands = self._validate_terraform_commands(params)
+        try:
+            return super().execute(params, **kwargs)
+        finally:
+            self._validated_commands = None
 
-    def _get_commands_config(self, params) -> str:
+    def _validate_terraform_commands(self, params) -> str:
         try:
             return RuntimeServiceConfig().validate_command_list(
                 TerraformSetupConstants.SERVICE_COMMANDS, params
@@ -107,6 +113,12 @@ class TerraformAppSetupCommand(ServiceDockerSetupCommand):
                 self.get_parser().prog,
                 f'Terraform command allowlist validation failed: {e}',
             )
+
+    def _get_commands_config(self, params) -> str:
+        cached = getattr(self, '_validated_commands', None)
+        if cached is not None:
+            return cached
+        return self._validate_terraform_commands(params)
 
     def _get_queue_config(self) -> bool:
         return True

--- a/keepercommander/service/decorators/min_commander_version.py
+++ b/keepercommander/service/decorators/min_commander_version.py
@@ -77,7 +77,7 @@ def check_min_commander_version() -> Optional[Tuple[dict, int]]:
 
     message = (
         f'Commander version {current_raw} is below the required minimum {required_raw}. '
-        f'Please update Keeper Commander and re-run terraform-app-setup.'
+        f'Please update Keeper Commander to >= {required_raw} and retry.'
     )
     logger.info(message)
     return {'status': 'error', 'error': message}, 426

--- a/keepercommander/service/decorators/min_commander_version.py
+++ b/keepercommander/service/decorators/min_commander_version.py
@@ -1,0 +1,96 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Enforce Min-Commander-Version header against the running Commander."""
+
+from functools import wraps
+from typing import Optional, Tuple
+
+from flask import request
+from packaging.version import InvalidVersion, Version
+
+from ... import __version__ as commander_version
+from .logging import logger
+
+# Hyphenated only: Werkzeug/WSGI silently drops headers that contain underscores.
+MIN_COMMANDER_VERSION_HEADER = 'Min-Commander-Version'
+
+
+def _read_min_commander_version_header() -> Optional[str]:
+    value = request.headers.get(MIN_COMMANDER_VERSION_HEADER)
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def _parse_version(version_str: str) -> Optional[Version]:
+    if not version_str or len(version_str) > 64:
+        return None
+    try:
+        return Version(version_str.lstrip('vV'))
+    except InvalidVersion:
+        return None
+
+
+def check_min_commander_version() -> Optional[Tuple[dict, int]]:
+    """
+    If Min-Commander-Version is present, require running Commander >= that version.
+
+    Missing header: no-op.
+    Invalid header: 400.
+    Too old: 426 with upgrade guidance.
+    """
+    required_raw = _read_min_commander_version_header()
+    if required_raw is None:
+        return None
+
+    required = _parse_version(required_raw)
+    if required is None:
+        return {
+            'status': 'error',
+            'error': (
+                f'Invalid {MIN_COMMANDER_VERSION_HEADER} header. '
+                'Expected a dotted version such as 18.1.0.'
+            ),
+        }, 400
+
+    current_raw = str(commander_version).strip()
+    current = _parse_version(current_raw)
+    if current is None:
+        logger.error('Unable to parse running Commander version')
+        return {
+            'status': 'error',
+            'error': 'Unable to determine running Commander version.',
+        }, 500
+
+    if current >= required:
+        return None
+
+    message = (
+        f'Commander version {current_raw} is below the required minimum {required_raw}. '
+        f'Please update Keeper Commander and re-run terraform-app-setup.'
+    )
+    logger.info(message)
+    return {'status': 'error', 'error': message}, 426
+
+
+def min_commander_version_check(fn):
+    """Run after auth: enforce Min-Commander-Version when the header is present."""
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        version_error = check_min_commander_version()
+        if version_error:
+            return version_error
+        return fn(*args, **kwargs)
+
+    return wrapper

--- a/keepercommander/service/decorators/min_commander_version.py
+++ b/keepercommander/service/decorators/min_commander_version.py
@@ -24,14 +24,6 @@ from .logging import logger
 MIN_COMMANDER_VERSION_HEADER = 'Min-Commander-Version'
 
 
-def _read_min_commander_version_header() -> Optional[str]:
-    value = request.headers.get(MIN_COMMANDER_VERSION_HEADER)
-    if value is None:
-        return None
-    value = str(value).strip()
-    return value or None
-
-
 def _parse_version(version_str: str) -> Optional[Version]:
     if not version_str or len(version_str) > 64:
         return None
@@ -39,6 +31,18 @@ def _parse_version(version_str: str) -> Optional[Version]:
         return Version(version_str.lstrip('vV'))
     except InvalidVersion:
         return None
+
+
+_RUNNING_VERSION_RAW = str(commander_version).strip()
+_RUNNING_VERSION = _parse_version(_RUNNING_VERSION_RAW)
+
+
+def _read_min_commander_version_header() -> Optional[str]:
+    value = request.headers.get(MIN_COMMANDER_VERSION_HEADER)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
 
 
 def check_min_commander_version() -> Optional[Tuple[dict, int]]:
@@ -63,20 +67,18 @@ def check_min_commander_version() -> Optional[Tuple[dict, int]]:
             ),
         }, 400
 
-    current_raw = str(commander_version).strip()
-    current = _parse_version(current_raw)
-    if current is None:
+    if _RUNNING_VERSION is None:
         logger.error('Unable to parse running Commander version')
         return {
             'status': 'error',
             'error': 'Unable to determine running Commander version.',
         }, 500
 
-    if current >= required:
+    if _RUNNING_VERSION >= required:
         return None
 
     message = (
-        f'Commander version {current_raw} is below the required minimum {required_raw}. '
+        f'Commander version {_RUNNING_VERSION_RAW} is below the required minimum {required_raw}. '
         f'Please update Keeper Commander to >= {required_raw} and retry.'
     )
     logger.info(message)

--- a/keepercommander/service/decorators/unified.py
+++ b/keepercommander/service/decorators/unified.py
@@ -15,6 +15,7 @@ from .logging import debug_decorator, catch_all
 from .api_logging import api_log_handler
 from .security import security_check
 from .auth import auth_check, policy_check
+from .min_commander_version import min_commander_version_check
 
 def unified_api_decorator() -> Callable:
     def decorator(f: Callable) -> Callable:
@@ -22,6 +23,7 @@ def unified_api_decorator() -> Callable:
         @api_log_handler
         @security_check
         @auth_check
+        @min_commander_version_check
         @policy_check
         @catch_all
         @debug_decorator

--- a/keepercommander/service/docker/__init__.py
+++ b/keepercommander/service/docker/__init__.py
@@ -20,8 +20,9 @@ This module provides reusable components for Docker-based integrations:
 """
 
 from .models import (
-    DockerSetupConstants, SetupResult, ServiceConfig, SlackConfig, TeamsConfig,
-    SailPointConfig, GChatConfig, GChatConstants, SetupStep, ApproverTeam, ApprovalsConfig,
+    DockerSetupConstants, SetupResult, ServiceConfig,
+    SlackConfig, TeamsConfig, SailPointConfig, GChatConfig, GChatConstants,
+    SetupStep, ApproverTeam, ApprovalsConfig,
 )
 from .printer import DockerSetupPrinter
 from .setup_base import DockerSetupBase

--- a/keepercommander/service/docker/printer.py
+++ b/keepercommander/service/docker/printer.py
@@ -61,7 +61,8 @@ class DockerSetupPrinter:
         print(f"{indent}• KSM Base64 Config: {bcolors.OKGREEN}✓ Generated{bcolors.ENDC}")
     
     @staticmethod
-    def print_common_deployment_steps(port: str, config_path: str = None) -> None:
+    def print_common_deployment_steps(port: str, config_path: str = None,
+                                      container_name: str = 'keeper-service') -> None:
         """Print common deployment steps (header + steps 1-5)"""
         DockerSetupPrinter.print_header("Next Steps to Deploy")
         
@@ -82,6 +83,6 @@ class DockerSetupPrinter:
         
         print(f"\n{bcolors.BOLD}Step 5: Check services health{bcolors.ENDC}")
         print(f"  {bcolors.OKGREEN}docker ps{bcolors.ENDC} - View container status")
-        print(f"  {bcolors.OKGREEN}docker logs keeper-service{bcolors.ENDC} - View Commander logs")
+        print(f"  {bcolors.OKGREEN}docker logs {container_name}{bcolors.ENDC} - View Commander logs")
         print(f"  {bcolors.OKGREEN}curl http://localhost:{port}/health{bcolors.ENDC} - Test health endpoint")
 

--- a/keepercommander/service/docker/setup_base.py
+++ b/keepercommander/service/docker/setup_base.py
@@ -584,3 +584,138 @@ class DockerSetupBase:
                     print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
         
         return config
+
+    def _get_advanced_security_config(self) -> Dict[str, Any]:
+        """Get advanced security configuration (IP filter, rate limit, encryption, token expiry)."""
+        print(f"\n{bcolors.BOLD}Advanced Security (optional):{bcolors.ENDC}")
+        print(f"  Configure IP filtering, rate limiting, and response encryption")
+        enable_advanced = input(
+            f"{bcolors.OKBLUE}Enable advanced security? [Press Enter for No] (y/n):{bcolors.ENDC} "
+        ).strip().lower() == 'y'
+
+        config = {
+            'allowed_ip': '0.0.0.0/0,::/0',
+            'denied_ip': '',
+            'rate_limit': '',
+            'encryption_enabled': False,
+            'encryption_key': '',
+            'token_expiration': ''
+        }
+
+        if enable_advanced:
+            config.update(self._get_ip_allowed_config())
+            config.update(self._get_ip_denied_config())
+            config.update(self._get_rate_limit_config())
+            config.update(self._get_encryption_config())
+            config.update(self._get_token_expiration_config())
+
+        return config
+
+    def _get_ip_allowed_config(self) -> Dict[str, str]:
+        """Get allowed IP configuration"""
+        print(f"\n{bcolors.BOLD}IP Allowed List:{bcolors.ENDC}")
+        print(f"  Comma-separated IPs or CIDR ranges (e.g., 192.168.1.0/24,10.0.0.1)")
+
+        ip_list = input(f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} ").strip()
+
+        if ip_list:
+            while True:
+                try:
+                    return {'allowed_ip': ConfigValidator.validate_ip_list(ip_list)}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    ip_list = input(
+                        f"{bcolors.OKBLUE}Allowed IPs [Press Enter for all]:{bcolors.ENDC} "
+                    ).strip()
+                    if not ip_list:
+                        break
+
+        return {'allowed_ip': '0.0.0.0/0,::/0'}
+
+    def _get_ip_denied_config(self) -> Dict[str, str]:
+        """Get denied IP configuration"""
+        print(f"\n{bcolors.BOLD}IP Denied List:{bcolors.ENDC}")
+        print(f"  Comma-separated IPs or CIDR ranges to block")
+
+        ip_list = input(f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} ").strip()
+
+        if ip_list:
+            while True:
+                try:
+                    return {'denied_ip': ConfigValidator.validate_ip_list(ip_list)}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    ip_list = input(
+                        f"{bcolors.OKBLUE}Denied IPs [Press Enter to skip]:{bcolors.ENDC} "
+                    ).strip()
+                    if not ip_list:
+                        break
+
+        return {'denied_ip': ''}
+
+    def _get_rate_limit_config(self) -> Dict[str, str]:
+        """Get rate limiting configuration"""
+        print(f"\n{bcolors.BOLD}Rate Limiting:{bcolors.ENDC}")
+        print(f"  Format: <number>/<period> (e.g., 10/minute, 100/hour, 1000/day)")
+
+        rate_limit = input(f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} ").strip()
+
+        if rate_limit:
+            while True:
+                try:
+                    return {'rate_limit': ConfigValidator.validate_rate_limit(rate_limit)}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    rate_limit = input(
+                        f"{bcolors.OKBLUE}Rate limit [Press Enter to skip]:{bcolors.ENDC} "
+                    ).strip()
+                    if not rate_limit:
+                        break
+
+        return {'rate_limit': ''}
+
+    def _get_encryption_config(self) -> Dict[str, Any]:
+        """Get encryption configuration"""
+        print(f"\n{bcolors.BOLD}Response Encryption:{bcolors.ENDC}")
+        print(f"  Enable AES-256 encryption for API responses")
+        enable_encryption = input(
+            f"{bcolors.OKBLUE}Enable encryption? [Press Enter for No] (y/n):{bcolors.ENDC} "
+        ).strip().lower() == 'y'
+
+        config = {'encryption_enabled': enable_encryption, 'encryption_key': ''}
+
+        if enable_encryption:
+            print(f"  Encryption key must be exactly 32 alphanumeric characters")
+            while True:
+                key = input(f"{bcolors.OKBLUE}Encryption key (32 chars):{bcolors.ENDC} ").strip()
+                try:
+                    config['encryption_key'] = ConfigValidator.validate_encryption_key(key)
+                    break
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+
+        return config
+
+    def _get_token_expiration_config(self) -> Dict[str, str]:
+        """Get token expiration configuration"""
+        print(f"\n{bcolors.BOLD}API Token Expiration:{bcolors.ENDC}")
+        print(f"  Format: Xm (minutes), Xh (hours), Xd (days) - e.g., 30m, 24h, 7d")
+
+        expiration = input(
+            f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} "
+        ).strip()
+
+        if expiration:
+            while True:
+                try:
+                    ConfigValidator.parse_expiration_time(expiration)
+                    return {'token_expiration': expiration}
+                except ValidationError as e:
+                    print(f"{bcolors.FAIL}Error: {str(e)}{bcolors.ENDC}")
+                    expiration = input(
+                        f"{bcolors.OKBLUE}Token expiration [Press Enter for never]:{bcolors.ENDC} "
+                    ).strip()
+                    if not expiration:
+                        break
+
+        return {'token_expiration': ''}

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     prompt_toolkit
     protobuf>=5.29.6,<6
     googleapis-common-protos
+    packaging
     psutil
     pycryptodomex>=3.20.0
     pyngrok

--- a/unit-tests/service/test_min_commander_version.py
+++ b/unit-tests/service/test_min_commander_version.py
@@ -98,7 +98,8 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertEqual(body['status'], 'error')
             self.assertIn('17.0.0', body['error'])
             self.assertIn('18.1.0', body['error'])
-            self.assertIn('terraform-app-setup', body['error'])
+            self.assertIn('Please update Keeper Commander to >= 18.1.0 and retry.', body['error'])
+            self.assertNotIn('terraform-app-setup', body['error'])
 
     @mock.patch(
         'keepercommander.service.decorators.min_commander_version.commander_version',
@@ -114,6 +115,21 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertEqual(status, 400)
             self.assertEqual(body['status'], 'error')
             self.assertIn('Invalid', body['error'])
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'not-a-version',
+    )
+    def test_rejects_when_running_version_unparseable(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: '18.1.0'},
+        ):
+            body, status = check_min_commander_version()
+            self.assertEqual(status, 500)
+            self.assertEqual(body['status'], 'error')
+            self.assertIn('Unable to determine running Commander version', body['error'])
 
     @mock.patch(
         'keepercommander.service.decorators.min_commander_version.commander_version',

--- a/unit-tests/service/test_min_commander_version.py
+++ b/unit-tests/service/test_min_commander_version.py
@@ -48,7 +48,11 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIsNone(check_min_commander_version())
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('18.1.0'),
+    )
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION_RAW',
         '18.1.0',
     )
     def test_accepts_when_current_meets_minimum(self):
@@ -60,7 +64,11 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIsNone(check_min_commander_version())
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('18.1.0'),
+    )
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION_RAW',
         '18.1.0',
     )
     def test_accepts_case_insensitive_header(self):
@@ -72,7 +80,11 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIsNone(check_min_commander_version())
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('18.1.0'),
+    )
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION_RAW',
         '18.1.0',
     )
     def test_accepts_partial_required_version(self):
@@ -84,7 +96,11 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIsNone(check_min_commander_version())
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('17.0.0'),
+    )
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION_RAW',
         '17.0.0',
     )
     def test_rejects_when_current_too_old(self):
@@ -99,11 +115,10 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIn('17.0.0', body['error'])
             self.assertIn('18.1.0', body['error'])
             self.assertIn('Please update Keeper Commander to >= 18.1.0 and retry.', body['error'])
-            self.assertNotIn('terraform-app-setup', body['error'])
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
-        '18.1.0',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('18.1.0'),
     )
     def test_rejects_invalid_header(self):
         with self.app.test_request_context(
@@ -117,8 +132,8 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIn('Invalid', body['error'])
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
-        'not-a-version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        None,
     )
     def test_rejects_when_running_version_unparseable(self):
         with self.app.test_request_context(
@@ -132,7 +147,11 @@ class TestMinCommanderVersionCheck(TestCase):
             self.assertIn('Unable to determine running Commander version', body['error'])
 
     @mock.patch(
-        'keepercommander.service.decorators.min_commander_version.commander_version',
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION',
+        Version('17.0.0'),
+    )
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version._RUNNING_VERSION_RAW',
         '17.0.0',
     )
     def test_decorator_blocks_handler(self):

--- a/unit-tests/service/test_min_commander_version.py
+++ b/unit-tests/service/test_min_commander_version.py
@@ -1,0 +1,138 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+from unittest import TestCase, mock
+
+from flask import Flask
+from packaging.version import Version
+
+from keepercommander.service.decorators.min_commander_version import (
+    MIN_COMMANDER_VERSION_HEADER,
+    check_min_commander_version,
+    min_commander_version_check,
+    _parse_version,
+)
+
+
+class TestParseVersion(TestCase):
+    def test_parses_simple_semver(self):
+        self.assertEqual(_parse_version('18.1.0'), Version('18.1.0'))
+
+    def test_strips_v_prefix(self):
+        self.assertEqual(_parse_version('v18.2.1'), Version('18.2.1'))
+
+    def test_normalizes_partial_versions(self):
+        self.assertEqual(_parse_version('18.1'), Version('18.1.0'))
+
+    def test_rejects_invalid(self):
+        self.assertIsNone(_parse_version(''))
+        self.assertIsNone(_parse_version('abc'))
+        self.assertIsNone(_parse_version('1.2.x'))
+        self.assertIsNone(_parse_version('x' * 65))
+
+
+class TestMinCommanderVersionCheck(TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+
+    def test_missing_header_is_noop(self):
+        with self.app.test_request_context('/api/v2/executecommand-async', method='POST'):
+            self.assertIsNone(check_min_commander_version())
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '18.1.0',
+    )
+    def test_accepts_when_current_meets_minimum(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: '18.0.0'},
+        ):
+            self.assertIsNone(check_min_commander_version())
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '18.1.0',
+    )
+    def test_accepts_case_insensitive_header(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={'min-commander-version': '18.1.0'},
+        ):
+            self.assertIsNone(check_min_commander_version())
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '18.1.0',
+    )
+    def test_accepts_partial_required_version(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: '18.1'},
+        ):
+            self.assertIsNone(check_min_commander_version())
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '17.0.0',
+    )
+    def test_rejects_when_current_too_old(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: '18.1.0'},
+        ):
+            body, status = check_min_commander_version()
+            self.assertEqual(status, 426)
+            self.assertEqual(body['status'], 'error')
+            self.assertIn('17.0.0', body['error'])
+            self.assertIn('18.1.0', body['error'])
+            self.assertIn('terraform-app-setup', body['error'])
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '18.1.0',
+    )
+    def test_rejects_invalid_header(self):
+        with self.app.test_request_context(
+            '/api/v2/executecommand-async',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: 'not-a-version'},
+        ):
+            body, status = check_min_commander_version()
+            self.assertEqual(status, 400)
+            self.assertEqual(body['status'], 'error')
+            self.assertIn('Invalid', body['error'])
+
+    @mock.patch(
+        'keepercommander.service.decorators.min_commander_version.commander_version',
+        '17.0.0',
+    )
+    def test_decorator_blocks_handler(self):
+        called = {'value': False}
+
+        @min_commander_version_check
+        def handler():
+            called['value'] = True
+            return {'status': 'success'}, 200
+
+        with self.app.test_request_context(
+            '/test',
+            method='POST',
+            headers={MIN_COMMANDER_VERSION_HEADER: '99.0.0'},
+        ):
+            body, status = handler()
+            self.assertEqual(status, 426)
+            self.assertFalse(called['value'])
+            self.assertEqual(body['status'], 'error')

--- a/unit-tests/service/test_terraform_app_setup.py
+++ b/unit-tests/service/test_terraform_app_setup.py
@@ -11,11 +11,14 @@
 
 from unittest import TestCase, mock
 
+from keepercommander.cli import aliases, commands, enterprise_commands, msp_commands
+from keepercommander.error import CommandError
 from keepercommander.service.commands.terraform_app_setup import (
     TerraformAppSetupCommand,
     TerraformSetupConstants,
 )
 from keepercommander.service.docker.models import ServiceConfig
+from keepercommander.service.util.exceptions import ValidationError
 
 
 class TestTerraformAppSetupCommand(TestCase):
@@ -45,6 +48,29 @@ class TestTerraformAppSetupCommand(TestCase):
         mock_runtime_config.return_value.validate_command_list.assert_called_once_with(
             TerraformSetupConstants.SERVICE_COMMANDS, params
         )
+
+    @mock.patch(
+        'keepercommander.service.commands.terraform_app_setup.RuntimeServiceConfig'
+    )
+    def test_commands_config_wraps_validation_error(self, mock_runtime_config):
+        mock_runtime_config.return_value.validate_command_list.side_effect = ValidationError(
+            'bad command'
+        )
+        with self.assertRaises(CommandError) as ctx:
+            TerraformAppSetupCommand()._get_commands_config(mock.Mock())
+        self.assertEqual(ctx.exception.command, 'terraform-app-setup')
+        self.assertIn('bad command', ctx.exception.message)
+
+    @mock.patch.object(TerraformAppSetupCommand, 'run_setup_steps')
+    @mock.patch.object(
+        TerraformAppSetupCommand,
+        '_validate_terraform_commands',
+        side_effect=CommandError('terraform-app-setup', 'bad allowlist'),
+    )
+    def test_execute_validates_allowlist_before_setup(self, _mock_validate, mock_setup):
+        with self.assertRaises(CommandError):
+            TerraformAppSetupCommand().execute(mock.Mock())
+        mock_setup.assert_not_called()
 
     @mock.patch.object(TerraformAppSetupCommand, '_get_advanced_security_config')
     @mock.patch.object(TerraformAppSetupCommand, '_get_cloudflare_config')
@@ -95,27 +121,18 @@ class TestTerraformAppSetupCommand(TestCase):
 
 
 class TestTerraformSetupConstants(TestCase):
-    def test_allowlist_includes_core_commands(self):
-        commands = {
-            c.strip()
-            for c in TerraformSetupConstants.SERVICE_COMMANDS.split(',')
-            if c.strip()
-        }
-        for expected in (
-            'this-device',
-            'sync-down',
-            'enterprise-user',
-            'record-add',
-            'nsf-share-record',
-            'pam',
-            'secrets-manager',
-        ):
-            self.assertIn(expected, commands)
+    def test_allowlist_entries_are_registered_commands(self):
+        known = set(commands) | set(enterprise_commands) | set(msp_commands) | set(aliases)
+        missing = [
+            name for name in TerraformSetupConstants.SERVICE_COMMANDS_LIST
+            if name not in known
+        ]
+        self.assertEqual(missing, [])
 
     def test_allowlist_has_no_duplicate_entries(self):
-        parts = [
-            c.strip()
-            for c in TerraformSetupConstants.SERVICE_COMMANDS.split(',')
-            if c.strip()
-        ]
+        parts = TerraformSetupConstants.SERVICE_COMMANDS_LIST
         self.assertEqual(len(parts), len(set(parts)))
+        self.assertEqual(
+            TerraformSetupConstants.SERVICE_COMMANDS,
+            ','.join(TerraformSetupConstants.SERVICE_COMMANDS_LIST),
+        )

--- a/unit-tests/service/test_terraform_app_setup.py
+++ b/unit-tests/service/test_terraform_app_setup.py
@@ -1,0 +1,121 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+from unittest import TestCase, mock
+
+from keepercommander.service.commands.terraform_app_setup import (
+    TerraformAppSetupCommand,
+    TerraformSetupConstants,
+)
+from keepercommander.service.docker.models import ServiceConfig
+
+
+class TestTerraformAppSetupCommand(TestCase):
+    def test_parser_prog_and_defaults(self):
+        cmd = TerraformAppSetupCommand()
+        parser = cmd.get_parser()
+        self.assertEqual(parser.prog, 'terraform-app-setup')
+        args = parser.parse_args([])
+        self.assertEqual(args.folder_name, TerraformSetupConstants.DEFAULT_FOLDER_NAME)
+        self.assertEqual(args.app_name, TerraformSetupConstants.DEFAULT_APP_NAME)
+        self.assertEqual(args.record_name, TerraformSetupConstants.DEFAULT_RECORD_NAME)
+
+    def test_queue_config_always_enabled(self):
+        self.assertTrue(TerraformAppSetupCommand()._get_queue_config())
+
+    @mock.patch(
+        'keepercommander.service.commands.terraform_app_setup.RuntimeServiceConfig'
+    )
+    def test_commands_config_uses_fixed_allowlist(self, mock_runtime_config):
+        mock_runtime_config.return_value.validate_command_list.return_value = (
+            TerraformSetupConstants.SERVICE_COMMANDS
+        )
+        cmd = TerraformAppSetupCommand()
+        params = mock.Mock()
+        result = cmd._get_commands_config(params)
+        self.assertEqual(result, TerraformSetupConstants.SERVICE_COMMANDS)
+        mock_runtime_config.return_value.validate_command_list.assert_called_once_with(
+            TerraformSetupConstants.SERVICE_COMMANDS, params
+        )
+
+    @mock.patch.object(TerraformAppSetupCommand, '_get_advanced_security_config')
+    @mock.patch.object(TerraformAppSetupCommand, '_get_cloudflare_config')
+    @mock.patch.object(TerraformAppSetupCommand, '_get_ngrok_config')
+    @mock.patch.object(TerraformAppSetupCommand, '_get_port_config', return_value=8900)
+    @mock.patch.object(
+        TerraformAppSetupCommand,
+        '_get_commands_config',
+        return_value=TerraformSetupConstants.SERVICE_COMMANDS,
+    )
+    def test_service_configuration_always_enables_queue(
+        self,
+        _mock_commands,
+        _mock_port,
+        mock_ngrok,
+        mock_cf,
+        mock_security,
+    ):
+        mock_ngrok.return_value = {
+            'ngrok_enabled': False,
+            'ngrok_auth_token': '',
+            'ngrok_custom_domain': '',
+            'ngrok_public_url': '',
+        }
+        mock_cf.return_value = {
+            'cloudflare_enabled': False,
+            'cloudflare_tunnel_token': '',
+            'cloudflare_custom_domain': '',
+            'cloudflare_public_url': '',
+        }
+        mock_security.return_value = {
+            'allowed_ip': '0.0.0.0/0,::/0',
+            'denied_ip': '',
+            'rate_limit': '',
+            'encryption_enabled': False,
+            'encryption_key': '',
+            'token_expiration': '',
+        }
+
+        cmd = TerraformAppSetupCommand()
+        config = cmd.get_service_configuration(params=mock.Mock())
+
+        self.assertIsInstance(config, ServiceConfig)
+        self.assertTrue(config.queue_enabled)
+        self.assertEqual(config.commands, TerraformSetupConstants.SERVICE_COMMANDS)
+        self.assertEqual(config.port, 8900)
+        mock_security.assert_called_once()
+
+
+class TestTerraformSetupConstants(TestCase):
+    def test_allowlist_includes_core_commands(self):
+        commands = {
+            c.strip()
+            for c in TerraformSetupConstants.SERVICE_COMMANDS.split(',')
+            if c.strip()
+        }
+        for expected in (
+            'this-device',
+            'sync-down',
+            'enterprise-user',
+            'record-add',
+            'nsf-share-record',
+            'pam',
+            'secrets-manager',
+        ):
+            self.assertIn(expected, commands)
+
+    def test_allowlist_has_no_duplicate_entries(self):
+        parts = [
+            c.strip()
+            for c in TerraformSetupConstants.SERVICE_COMMANDS.split(',')
+            if c.strip()
+        ]
+        self.assertEqual(len(parts), len(set(parts)))

--- a/unit-tests/service/test_terraform_app_setup.py
+++ b/unit-tests/service/test_terraform_app_setup.py
@@ -34,6 +34,29 @@ class TestTerraformAppSetupCommand(TestCase):
     def test_queue_config_always_enabled(self):
         self.assertTrue(TerraformAppSetupCommand()._get_queue_config())
 
+    def test_compose_uses_terraform_service_and_container_names(self):
+        setup_result = mock.Mock(
+            folder_uid='f', folder_name='folder', app_uid='a', app_name='app',
+            record_uid='r', b64_config='cfg',
+        )
+        config = ServiceConfig(
+            port=8900,
+            commands=TerraformSetupConstants.SERVICE_COMMANDS,
+            queue_enabled=True,
+            ngrok_enabled=False,
+            ngrok_auth_token='',
+            ngrok_custom_domain='',
+            cloudflare_enabled=False,
+            cloudflare_tunnel_token='',
+            cloudflare_custom_domain='',
+        )
+        yaml_content = TerraformAppSetupCommand().generate_docker_compose_yaml(
+            setup_result, config
+        )
+        self.assertIn('commander-terraform:', yaml_content)
+        self.assertIn('container_name: keeper-service-terraform', yaml_content)
+        self.assertNotIn('container_name: keeper-service\n', yaml_content)
+
     @mock.patch(
         'keepercommander.service.commands.terraform_app_setup.RuntimeServiceConfig'
     )


### PR DESCRIPTION
## Summary
- Adds `terraform-app-setup` to provision Commander Service Mode for the Terraform provider (always queue/API v2, fixed command allowlist, tunnel + advanced security prompts).
- Enforces `Min-Commander-Version` on authenticated service requests so Terraform can fail fast when Commander is too old.

## Changes
- New `terraform-app-setup` command based on `service-docker-setup` (no Phase 2).
- Moved advanced-security prompts onto shared Docker setup base for reuse.
- Added post-auth version check for hyphenated `Min-Commander-Version` header (426 when below minimum).
- Unit tests for setup defaults and version-gate behavior.