### PR TITLE
Add support for exporting only owned records

### DIFF
--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -104,6 +104,8 @@ export_parser.add_argument('-kkf', '--keepass-key-file', dest='kbdx_key_file', a
                            help='Keepass key file for the exported file')
 export_parser.add_argument('--zip', dest='zip_archive', action='store_true',
                            help='Create ZIP archive for file attachments. JSON only')
+export_parser.add_argument('--owned-only', dest='owned_only', action='store_true',
+                           help='Only export owned records')                           
 export_parser.add_argument('--save-in-vault', dest='save_in_vault', action='store_true',
                            help='Stores exports file as a record attachment. KeePass only')
 export_parser.add_argument('--force', dest='force', action='store_true', help='Suppress user interaction. Assume "yes"')

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -331,12 +331,13 @@ def export(params, file_format, filename, **kwargs):
     # for record_uid in params.record_cache.keys():
     #     ext_id += 1
     #     external_ids[record_uid] = ext_id
-    for record_uid in params.record_cache:
+    record_list = params.record_cache if not kwargs.get('owned_only') else {uid:params.record_cache[uid] for uid in params.record_owner_cache if params.record_owner_cache[uid].owner is True}
+    for record_uid in record_list:
         if record_filter or folder_path:
             if record_uid not in record_filter:
                 continue
 
-        record = params.record_cache[record_uid]
+        record = record_list[record_uid]
         record_version = record.get('version') or 0
         if record_version == 2 or record_version == 3:
             try:


### PR DESCRIPTION
The Vault UI allows you to export owned or owned+shared records. The Commander `export` only allows you to export owned+shared records.
Adding support for `--owned-only` flag, which provides parity between Vault and Commander