### PR TITLE
KC-1408: Treat first-time share invitations as success in Service Mode

### DIFF
--- a/keepercommander/commands/nested_share_folder/folder_commands.py
+++ b/keepercommander/commands/nested_share_folder/folder_commands.py
@@ -530,7 +530,7 @@ class NestedShareFolderShareCommand(Command):
                     logging.info("%s share '%s' %s", kind, recipient, verb)
             else:
                 logging.warning("%s share '%s' failed", kind, recipient)
-        except ValueError as e:
+        except _nsf.ShareInviteSentError as e:
             logging.warning("nsf-share-folder: %s", e)
         except Exception as e:
             raise CommandError('nsf-share-folder', str(e))

--- a/keepercommander/commands/nested_share_folder/sharing_commands.py
+++ b/keepercommander/commands/nested_share_folder/sharing_commands.py
@@ -110,11 +110,10 @@ class NestedShareRecordShareCommand(Command):
                         result, effective_action = self._dispatch(
                             params, action, record_uid, email, access_role_type, expiration,
                             rotate_on_expiration)
-                        self._log_results(result, effective_action, email)
-                    except ValueError as e:
-                        # handle_share_invite raises ValueError after sending an
-                        # invitation; treat as success (same as nsf-share-folder).
+                    except _nsf.ShareInviteSentError as e:
                         logging.warning('nsf-share-record: %s', e)
+                        continue
+                    self._log_results(result, effective_action, email)
 
     # Strategy dispatch — returns (result, effective_action)
     @staticmethod

--- a/keepercommander/commands/nested_share_folder/sharing_commands.py
+++ b/keepercommander/commands/nested_share_folder/sharing_commands.py
@@ -106,10 +106,15 @@ class NestedShareRecordShareCommand(Command):
                     raise_if_record_share_target_is_owner(
                         params, record_uid, email, 'nsf-share-record',
                         is_ownership_transfer=(action == 'owner'))
-                    result, effective_action = self._dispatch(
-                        params, action, record_uid, email, access_role_type, expiration,
-                        rotate_on_expiration)
-                    self._log_results(result, effective_action, email)
+                    try:
+                        result, effective_action = self._dispatch(
+                            params, action, record_uid, email, access_role_type, expiration,
+                            rotate_on_expiration)
+                        self._log_results(result, effective_action, email)
+                    except ValueError as e:
+                        # handle_share_invite raises ValueError after sending an
+                        # invitation; treat as success (same as nsf-share-folder).
+                        logging.warning('nsf-share-record: %s', e)
 
     # Strategy dispatch — returns (result, effective_action)
     @staticmethod

--- a/keepercommander/commands/register.py
+++ b/keepercommander/commands/register.py
@@ -807,7 +807,9 @@ class ShareFolderCommand(Command):
                                 uo.typedSharedFolderKey.encryptedKeyType = folder_pb2.encrypted_by_public_key
 
                         rq.sharedFolderAddUser.append(uo)
-                    else:
+                    elif not invited:
+                        # After a successful invite, keys are unavailable until accepted.
+                        # Do not emit "User not found" — Service Mode treats that as failure.
                         logging.warning('User %s not found', email)
 
         if len(teams) > 0:

--- a/keepercommander/nested_share_folder/__init__.py
+++ b/keepercommander/nested_share_folder/__init__.py
@@ -21,7 +21,7 @@ _SUBMODULE_MAP = {
         'get_folder_key', 'get_record_key', 'get_user_public_key',
         'get_record_from_cache', 'parse_sharing_status', 'get_record_key_type',
         'encrypt_record_key_for_folder', 'encrypt_for_recipient',
-        'handle_share_invite', 'resolve_user_uid_bytes',
+        'handle_share_invite', 'ShareInviteSentError', 'resolve_user_uid_bytes',
         'load_user_public_key', 'parse_folder_access_result',
         'resolve_team_uid_bytes', 'resolve_team_identifier',
         'get_team_keys', 'encrypt_for_team', 'is_keeper_uid',

--- a/keepercommander/nested_share_folder/common.py
+++ b/keepercommander/nested_share_folder/common.py
@@ -484,8 +484,16 @@ def _retry_with_canonical_email(params, recipient_email, _load_pk,
 # Share invite helper  (previously duplicated in share + update_share)
 # ═══════════════════════════════════════════════════════════════════════════
 
+class ShareInviteSentError(ValueError):
+    """Invite was sent; caller should treat as success-with-notice."""
+
+
 def handle_share_invite(params, recipient_email, needs_invite):
-    """Send a share invite if *needs_invite* is True; raise ValueError."""
+    """Send a share invite if *needs_invite* is True.
+
+    Raises ShareInviteSentError after a successful invite (subclass of ValueError).
+    Raises ValueError when the invite could not be sent.
+    """
     if not needs_invite:
         return
     try:
@@ -493,10 +501,10 @@ def handle_share_invite(params, recipient_email, needs_invite):
         rq = APIRequest_pb2.SendShareInviteRequest()
         rq.email = recipient_email
         api.communicate_rest(params, rq, 'vault/send_share_invite')
-        raise ValueError(
+        raise ShareInviteSentError(
             f"Share invitation has been sent to '{recipient_email}'. "
             f"Please repeat this command once the invitation is accepted.")
-    except ValueError:
+    except ShareInviteSentError:
         raise
     except Exception:
         raise ValueError(

--- a/keepercommander/service/util/parse_keeper_response.py
+++ b/keepercommander/service/util/parse_keeper_response.py
@@ -1077,23 +1077,6 @@ class KeeperResponseParser:
         
         has_success_indicator = any(indicator in response_lower for indicator in success_indicators)
 
-        # Share invitation is a successful outcome for first-time share targets.
-        # Commands may also emit trailing "User ... not found" after inviting;
-        # treat the invitation itself as success for Service Mode / Chat.
-        invitation_patterns = [
-            "share invitation has been sent",
-            "invitation has been sent",
-        ]
-        has_invitation = any(pattern in response_lower for pattern in invitation_patterns)
-        if has_invitation:
-            formatted_message = KeeperResponseParser._format_multiline_message(response_str)
-            return {
-                "status": "success",
-                "command": command.split()[0] if command.split() else command,
-                "message": formatted_message,
-                "data": None,
-            }
-
         if is_throttle_text(response_str):
             return {
                 "status": "error",
@@ -1165,6 +1148,19 @@ class KeeperResponseParser:
         has_bad_request = any(pattern in response_lower for pattern in bad_request_patterns)
         has_error = any(pattern in response_lower for pattern in error_patterns)
         has_warning = any(pattern in response_lower for pattern in warning_patterns)
+
+        # First-time share invite is success. Mixed multi-recipient output is
+        # only partially represented: throttle (above) and forbidden keep
+        # precedence over this short-circuit.
+        has_invitation = 'share invitation has been sent to' in response_lower
+        if has_invitation and not has_forbidden:
+            formatted_message = KeeperResponseParser._format_multiline_message(response_str)
+            return {
+                "status": "success",
+                "command": command.split()[0] if command.split() else command,
+                "message": formatted_message,
+                "data": None,
+            }
         
         if has_success_indicator and (has_not_found or has_bad_request or has_error):
             return {

--- a/keepercommander/service/util/parse_keeper_response.py
+++ b/keepercommander/service/util/parse_keeper_response.py
@@ -1077,6 +1077,23 @@ class KeeperResponseParser:
         
         has_success_indicator = any(indicator in response_lower for indicator in success_indicators)
 
+        # Share invitation is a successful outcome for first-time share targets.
+        # Commands may also emit trailing "User ... not found" after inviting;
+        # treat the invitation itself as success for Service Mode / Chat.
+        invitation_patterns = [
+            "share invitation has been sent",
+            "invitation has been sent",
+        ]
+        has_invitation = any(pattern in response_lower for pattern in invitation_patterns)
+        if has_invitation:
+            formatted_message = KeeperResponseParser._format_multiline_message(response_str)
+            return {
+                "status": "success",
+                "command": command.split()[0] if command.split() else command,
+                "message": formatted_message,
+                "data": None,
+            }
+
         if is_throttle_text(response_str):
             return {
                 "status": "error",

--- a/unit-tests/service/test_throttle_response.py
+++ b/unit-tests/service/test_throttle_response.py
@@ -78,6 +78,26 @@ class TestThrottleResponse(unittest.TestCase):
             'Due to repeated attempts, your request has been throttled.',
         )
 
+    def test_parser_treats_share_invitation_as_success(self):
+        result = KeeperResponseParser._parse_logging_based_command(
+            'share-folder',
+            "Share invitation has been sent to 'user@example.com'\n"
+            "Please repeat this command when invitation is accepted.\n"
+            "User user@example.com not found",
+        )
+        self.assertEqual(result['status'], 'success')
+        self.assertNotIn('error', result)
+        self.assertIn('Share invitation has been sent', str(result['message']))
+
+    def test_parser_treats_nsf_share_record_invitation_as_success(self):
+        result = KeeperResponseParser._parse_logging_based_command(
+            'nsf-share-record',
+            "nsf-share-record: Share invitation has been sent to 'user@example.com'. "
+            "Please repeat this command once the invitation is accepted.",
+        )
+        self.assertEqual(result['status'], 'success')
+        self.assertIn('Share invitation has been sent', str(result['message']))
+
     def test_parser_does_not_treat_rate_limit_config_text_as_throttle(self):
         result = KeeperResponseParser._parse_logging_based_command(
             'help',

--- a/unit-tests/service/test_throttle_response.py
+++ b/unit-tests/service/test_throttle_response.py
@@ -98,6 +98,24 @@ class TestThrottleResponse(unittest.TestCase):
         self.assertEqual(result['status'], 'success')
         self.assertIn('Share invitation has been sent', str(result['message']))
 
+    def test_parser_keeps_throttle_precedence_over_invitation(self):
+        result = KeeperResponseParser._parse_logging_based_command(
+            'share-folder',
+            "Share invitation has been sent to 'user@example.com'\n"
+            "throttled: Due to repeated attempts, your request has been throttled.",
+        )
+        self.assertEqual(result['status_code'], 429)
+        self.assertEqual(result['result_code'], RESULT_THROTTLED)
+
+    def test_parser_keeps_forbidden_precedence_over_invitation(self):
+        result = KeeperResponseParser._parse_logging_based_command(
+            'share-record',
+            "Share invitation has been sent to 'user@example.com'\n"
+            "Permission denied",
+        )
+        self.assertEqual(result['status'], 'error')
+        self.assertEqual(result.get('status_code'), 403)
+
     def test_parser_does_not_treat_rate_limit_config_text_as_throttle(self):
         result = KeeperResponseParser._parse_logging_based_command(
             'help',

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -956,6 +956,28 @@ class TestNestedShareFolderSharingCommands(TestCase):
         self.assertIn('nsf-share-folder: Share invitation has been sent', output)
         self.assertNotIn("User '", output)
 
+    @patch('keepercommander.nested_share_folder.record_api.share_record_v3')
+    def test_share_record_invite_message_logged_as_warning(self, mock_share):
+        import keepercommander.nested_share_folder as nsf
+        from keepercommander.commands.nested_share_folder import NestedShareRecordShareCommand
+
+        nsf.__dict__.pop('share_record_v3', None)
+        ruid, robj = _make_record()
+        email = 'user@example.com'
+        mock_share.side_effect = ValueError(
+            f"Share invitation has been sent to '{email}'. "
+            "Please repeat this command once the invitation is accepted.")
+
+        cmd = NestedShareRecordShareCommand()
+        with self.assertLogs(level='WARNING') as logs, \
+                mock.patch.object(NestedShareRecordShareCommand, '_get_direct_user_share',
+                                  return_value=None):
+            cmd.execute(_make_params(nested_share_records={ruid: robj}),
+                        record=ruid, email=[email], action='grant', role='viewer')
+
+        output = '\n'.join(logs.output)
+        self.assertIn('nsf-share-record: Share invitation has been sent', output)
+
     def test_share_record_roe_rejects_non_grant(self):
         from keepercommander.commands.nested_share_folder import NestedShareRecordShareCommand
         ruid, robj = _make_record()

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -939,11 +939,14 @@ class TestNestedShareFolderSharingCommands(TestCase):
 
     @patch('keepercommander.nested_share_folder.folder_api.grant_folder_access_v3')
     def test_share_folder_invite_message_uses_command_prefix(self, mock_grant):
+        import keepercommander.nested_share_folder as nsf
         from keepercommander.commands.nested_share_folder import NestedShareFolderShareCommand
+        from keepercommander.nested_share_folder.common import ShareInviteSentError
 
+        nsf.__dict__.pop('grant_folder_access_v3', None)
         fuid, fobj = _make_folder()
         email = 'user@example.com'
-        mock_grant.side_effect = ValueError(
+        mock_grant.side_effect = ShareInviteSentError(
             f"Share invitation has been sent to '{email}'. "
             "Please repeat this command once the invitation is accepted.")
 
@@ -956,15 +959,33 @@ class TestNestedShareFolderSharingCommands(TestCase):
         self.assertIn('nsf-share-folder: Share invitation has been sent', output)
         self.assertNotIn("User '", output)
 
+    @patch('keepercommander.nested_share_folder.folder_api.grant_folder_access_v3')
+    def test_share_folder_no_relationship_still_fails(self, mock_grant):
+        import keepercommander.nested_share_folder as nsf
+        from keepercommander.commands.nested_share_folder import NestedShareFolderShareCommand
+
+        nsf.__dict__.pop('grant_folder_access_v3', None)
+        fuid, fobj = _make_folder()
+        mock_grant.side_effect = ValueError(
+            "No sharing relationship with 'user@example.com'. "
+            "Please invite them to share first, then repeat this command.")
+
+        cmd = NestedShareFolderShareCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.execute(_make_params(nested_share_folders={fuid: fobj}),
+                        folder=[fuid], user=['user@example.com'], action='grant', role='viewer')
+        self.assertIn('No sharing relationship', str(ctx.exception))
+
     @patch('keepercommander.nested_share_folder.record_api.share_record_v3')
     def test_share_record_invite_message_logged_as_warning(self, mock_share):
         import keepercommander.nested_share_folder as nsf
         from keepercommander.commands.nested_share_folder import NestedShareRecordShareCommand
+        from keepercommander.nested_share_folder.common import ShareInviteSentError
 
         nsf.__dict__.pop('share_record_v3', None)
         ruid, robj = _make_record()
         email = 'user@example.com'
-        mock_share.side_effect = ValueError(
+        mock_share.side_effect = ShareInviteSentError(
             f"Share invitation has been sent to '{email}'. "
             "Please repeat this command once the invitation is accepted.")
 
@@ -977,6 +998,25 @@ class TestNestedShareFolderSharingCommands(TestCase):
 
         output = '\n'.join(logs.output)
         self.assertIn('nsf-share-record: Share invitation has been sent', output)
+
+    @patch('keepercommander.nested_share_folder.record_api.share_record_v3')
+    def test_share_record_no_relationship_still_fails(self, mock_share):
+        import keepercommander.nested_share_folder as nsf
+        from keepercommander.commands.nested_share_folder import NestedShareRecordShareCommand
+
+        nsf.__dict__.pop('share_record_v3', None)
+        ruid, robj = _make_record()
+        mock_share.side_effect = ValueError(
+            "No sharing relationship with 'user@example.com'. "
+            "Please invite them to share first, then repeat this command.")
+
+        cmd = NestedShareRecordShareCommand()
+        with mock.patch.object(NestedShareRecordShareCommand, '_get_direct_user_share',
+                               return_value=None):
+            with self.assertRaises(CommandError) as ctx:
+                cmd.execute(_make_params(nested_share_records={ruid: robj}),
+                            record=ruid, email=['user@example.com'], action='grant', role='viewer')
+        self.assertIn('No sharing relationship', str(ctx.exception))
 
     def test_share_record_roe_rejects_non_grant(self):
         from keepercommander.commands.nested_share_folder import NestedShareRecordShareCommand


### PR DESCRIPTION
## Summary
Fixed Service Mode so first-time shares to users with no existing relationship return success after sending an invitation, instead of HTTP 500. The invite itself was working; `nsf-share-record` treated the invitation notice as a hard error, and `share-folder` also logged `User not found`, which the Service Mode parser treated as failure. Invite success is now signaled with a distinct `ShareInviteSentError` so genuine share failures are not masked.

## Changes
- `common.py` / `__init__.py`: Added `ShareInviteSentError` and raised it from `handle_share_invite` on successful invite send
- `sharing_commands.py`: Caught `ShareInviteSentError` for `nsf-share-record` and logged it as a warning
- `folder_commands.py`: Narrowed the `nsf-share-folder` catch from broad `ValueError` to `ShareInviteSentError`
- `register.py`: Stopped `share-folder` from logging `User not found` after a successful invite
- `parse_keeper_response.py`: Treated “share invitation has been sent to” as success, with throttle and forbidden keeping precedence
- `test_nested_share_folder.py`: Added invite-success and genuine-failure tests for `nsf-share-record` / `nsf-share-folder`
- `test_throttle_response.py`: Added parser tests for invitation success and throttle/forbidden precedence