### PR TITLE
KC-1417, KC-1418: Handle NSF record fields the same way as classic add/update.

### DIFF
--- a/keepercommander/commands/nested_share_folder/display_commands.py
+++ b/keepercommander/commands/nested_share_folder/display_commands.py
@@ -87,7 +87,10 @@ class NestedShareRecordGetDetailsCommand(Command):
 class NestedShareGetCommand(Command):
     """Show details of a Nested Share Record or folder."""
 
-    _MASKED_TYPES = frozenset({'password', 'secret', 'pinCode', 'pin_code'})
+    _MASKED_TYPES = frozenset({
+        'password', 'secret', 'pinCode', 'pin_code', 'oneTimeCode', 'otp',
+        'note', 'json',
+    })
 
     def get_parser(self):
         return nested_share_get_parser
@@ -196,10 +199,19 @@ class NestedShareGetCommand(Command):
         if url_val:
             print('{0:>20s}: {1:<20s}'.format('URL', url_val))
 
-        shown_types = {'login', 'password', 'url'}
-        for f in meta['fields']:
+        self._print_typed_fields(meta['fields'], unmask, skip_types={'login', 'password', 'url'})
+        self._print_typed_fields(meta.get('custom') or [], unmask)
+
+        if meta['notes']:
+            for i, line in enumerate(meta['notes'].split('\n')):
+                print('{0:>21s} {1}'.format('Notes:' if i == 0 else '', line.strip()))
+
+        self._print_record_permissions(params, record_uid, verbose)
+
+    def _print_typed_fields(self, fields, unmask, skip_types=()):
+        for f in fields or []:
             ftype = f.get('type', '')
-            if ftype in shown_types:
+            if ftype in skip_types:
                 continue
             label = f.get('label') or ftype.replace('_', ' ').title()
             values = f.get('value', [])
@@ -215,12 +227,6 @@ class NestedShareGetCommand(Command):
                 else:
                     dval = str(val)
                 print('{0:>20s}: {1:<s}'.format(label, dval))
-
-        if meta['notes']:
-            for i, line in enumerate(meta['notes'].split('\n')):
-                print('{0:>21s} {1}'.format('Notes:' if i == 0 else '', line.strip()))
-
-        self._print_record_permissions(params, record_uid, verbose)
 
     @staticmethod
     def _extract_field_value(fields, field_type):
@@ -247,6 +253,8 @@ class NestedShareGetCommand(Command):
             ro['folder'] = meta['folder_location']
         if meta['fields']:
             ro['fields'] = meta['fields']
+        if meta.get('custom'):
+            ro['custom'] = meta['custom']
         if meta['notes']:
             ro['notes'] = meta['notes']
 

--- a/keepercommander/commands/nested_share_folder/helpers.py
+++ b/keepercommander/commands/nested_share_folder/helpers.py
@@ -705,7 +705,7 @@ def load_record_metadata(params, record_uid):
     """Load record metadata from cache, falling back to the v3 details API.
 
     Returns a dict with keys:
-        ``title``, ``type``, ``fields``, ``notes``,
+        ``title``, ``type``, ``fields``, ``custom``, ``notes``,
         ``revision``, ``version``, ``folder_location``
     """
     from ... import nested_share_folder as _nsf
@@ -713,6 +713,7 @@ def load_record_metadata(params, record_uid):
     title = record_uid
     rec_type = ''
     fields = []
+    custom = []
     notes = ''
     revision = 0
     version = 0
@@ -724,7 +725,12 @@ def load_record_metadata(params, record_uid):
             dj = data_obj['data_json']
             title    = dj.get('title', record_uid)
             rec_type = dj.get('type', '')
-            fields   = dj.get('fields', [])
+            fields   = dj.get('fields') or []
+            custom   = dj.get('custom') or []
+            if not isinstance(fields, list):
+                fields = []
+            if not isinstance(custom, list):
+                custom = []
             notes    = dj.get('notes', '') or ''
 
     nsf_records = getattr(params, 'nested_share_records', {})
@@ -749,6 +755,7 @@ def load_record_metadata(params, record_uid):
         'title': title,
         'type': rec_type,
         'fields': fields,
+        'custom': custom,
         'notes': notes,
         'revision': revision,
         'version': version,

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -295,11 +295,16 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     # refreshed cache and re-apply typed field matching once.
                     if (not result.get('success')
                             and result.get('status') == 'RS_OUT_OF_SYNC'):
+                        self.warnings.clear()
+                        self.errors.clear()
                         record = self._apply_update(
                             self._typed_record_from_uid(params, record_uid),
                             kwargs.get('title'), kwargs.get('notes'),
                             record_type, rt_fields, record_fields)
                         if self.abort_if_errors():
+                            continue
+                        _apply_password_policy(self, params, record, force)
+                        if _should_stop_after_warnings(self, force):
                             continue
                         result = self._send_typed_update(params, record_uid, record)
                     check_result(result, 'nsf-record-update')

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -277,15 +277,10 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                                                identifier=identifier)
                     check_record_edit_permission(params, record_uid, 'nsf-record-update')
 
-                    record = self._typed_record_from_uid(params, record_uid)
-                    title = kwargs.get('title')
-                    if title:
-                        record.title = title
-                    self._apply_notes(record, kwargs.get('notes'))
-                    if record_type:
-                        record.type_name = record_type
-                        self.adjust_typed_record_fields(record, rt_fields)
-                    self.assign_typed_fields(record, record_fields)
+                    record = self._apply_update(
+                        self._typed_record_from_uid(params, record_uid),
+                        kwargs.get('title'), kwargs.get('notes'),
+                        record_type, rt_fields, record_fields)
 
                     if self.abort_if_errors():
                         continue
@@ -294,15 +289,41 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     if _should_stop_after_warnings(self, force):
                         continue
 
-                    result = _nsf.update_record_v3(
-                        params=params, record_uid=record_uid,
-                        data=vault_extensions.extract_typed_record_data(record),
-                    )
+                    result = self._send_typed_update(params, record_uid, record)
+                    # KC-1403: update_record_v3 already synced on RS_OUT_OF_SYNC
+                    # but will not retry a full data payload. Rebuild from the
+                    # refreshed cache and re-apply typed field matching once.
+                    if (not result.get('success')
+                            and result.get('status') == 'RS_OUT_OF_SYNC'):
+                        record = self._apply_update(
+                            self._typed_record_from_uid(params, record_uid),
+                            kwargs.get('title'), kwargs.get('notes'),
+                            record_type, rt_fields, record_fields)
+                        if self.abort_if_errors():
+                            continue
+                        result = self._send_typed_update(params, record_uid, record)
                     check_result(result, 'nsf-record-update')
                     updated += 1
         finally:
             if updated:
                 params.sync_data = True
+
+    def _apply_update(self, record, title, notes, record_type, rt_fields, record_fields):
+        if title:
+            record.title = title
+        self._apply_notes(record, notes)
+        if record_type:
+            record.type_name = record_type
+            self.adjust_typed_record_fields(record, rt_fields)
+        self.assign_typed_fields(record, record_fields)
+        return record
+
+    @staticmethod
+    def _send_typed_update(params, record_uid, record):
+        return _nsf.update_record_v3(
+            params=params, record_uid=record_uid,
+            data=vault_extensions.extract_typed_record_data(record),
+        )
 
     def _apply_notes(self, record, notes):
         if not isinstance(notes, str):

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -54,6 +54,7 @@ def _parse_field_specs(raw_fields, cmd_name):
 
 
 def _apply_password_policy(editor, params, source, force):
+    # Keep parity with record-update: source can be TypedRecord (update) or dict (add).
     pw_failures = PasswordComplexityEnforcer.validate_record(params, source)
     for failure in pw_failures:
         editor.on_warning(failure)

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -21,10 +21,10 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from ..base import Command, GroupCommand
-from ..record_edit import RecordEditMixin, record_fields_description, ParsedFieldValue
+from ..record_edit import RecordEditMixin, record_fields_description
 from ...enforcement import PasswordComplexityEnforcer, RecordTypeEnforcer
 from ...error import CommandError
-from ... import nested_share_folder as _nsf, vault
+from ... import nested_share_folder as _nsf, vault, vault_extensions
 from .helpers import (
     resolve_folder_uid, command_error_handler, check_result,
     check_record_edit_permission, check_record_delete_permission,
@@ -39,6 +39,37 @@ from .parsers import (
     nested_share_record_shortcut_keep_parser,
     nested_share_record_rm_parser,
 )
+
+
+def _parse_field_specs(raw_fields, cmd_name):
+    record_fields = []
+    attachments = []
+    for spec in [f.strip() for f in (raw_fields or []) if f.strip()]:
+        try:
+            parsed = RecordEditMixin.parse_field(spec)
+        except ValueError as e:
+            raise CommandError(cmd_name, f'Invalid field specification: {e}')
+        (attachments if parsed.type == 'file' else record_fields).append(parsed)
+    return record_fields, attachments
+
+
+def _apply_password_policy(editor, params, source, force):
+    pw_failures = PasswordComplexityEnforcer.validate_record(params, source)
+    for failure in pw_failures:
+        editor.on_warning(failure)
+    if pw_failures and not force:
+        editor.on_warning('Use --force to bypass password policy warnings.')
+
+
+def _should_stop_after_warnings(editor, force):
+    if not editor.warnings:
+        return False
+    for w in editor.warnings:
+        logging.warning(w)
+    if not force:
+        return True
+    editor.warnings.clear()
+    return False
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -73,22 +104,15 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         notes = kwargs.get('notes')
-        record_fields, add_attachments = self._parse_fields(kwargs.get('fields', []))
+        record_fields, add_attachments = _parse_field_specs(kwargs.get('fields', []), 'nsf-record-add')
         folder_uid = self._resolve_folder(params, kwargs.get('folder_uid'))
 
         data = self._build_record_data(params, record_type, title, notes, record_fields)
         if self.abort_if_errors():
             return
-        self._check_password_policy(params, data, **kwargs)
-
-        if self.abort_if_errors():
+        _apply_password_policy(self, params, data, kwargs.get('force'))
+        if _should_stop_after_warnings(self, kwargs.get('force')):
             return
-
-        if self.warnings:
-            for w in self.warnings:
-                logging.warning(w)
-            if not kwargs.get('force'):
-                return
 
         if add_attachments:
             logging.warning('File attachments are not yet supported in nsf-record-add. '
@@ -106,15 +130,6 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
             check_result(result, 'nsf-record-add')
             params.sync_data = True
             return result['record_uid']
-
-    def _parse_fields(self, raw_fields):
-        fields = [f.strip() for f in raw_fields if f.strip()]
-        record_fields = []
-        attachments = []
-        for field in fields:
-            parsed = RecordEditMixin.parse_field(field)
-            (attachments if parsed.type == 'file' else record_fields).append(parsed)
-        return record_fields, attachments
 
     @staticmethod
     def _resolve_folder(params, folder_input):
@@ -183,20 +198,13 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
             data['notes'] = notes
         return data
 
-    def _check_password_policy(self, params, data, **kwargs):
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        for failure in pw_failures:
-            self.on_warning(failure)
-        if pw_failures and not kwargs.get('force'):
-            self.on_warning('Use --force to bypass password policy warnings.')
-
 
 # ══════════════════════════════════════════════════════════════════════════
 # nsf-record-update
 # ══════════════════════════════════════════════════════════════════════════
 
 class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
-    """Update a Nested Share Record."""
+    """Update a Nested Share Record, matching ``record-update`` field handling."""
 
     def __init__(self):
         super().__init__()
@@ -204,32 +212,6 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
 
     def get_parser(self):
         return nested_share_record_update_parser
-
-    def _resolve_field_value(self, parsed):
-        raw = parsed.value
-        if not raw:
-            return raw
-
-        action_params = []
-        if self.is_json_value(raw, action_params):
-            return action_params[0] if action_params else None
-        action_params.clear()
-        if self.is_generate_value(raw, action_params):
-            if self.warn_wrong_password_gen_field(parsed):
-                return None
-            if parsed.type == 'password':
-                password, gen_error = self.generate_password(action_params, policy=self._password_policy)
-                if gen_error:
-                    self.on_error(gen_error)
-                    return None
-                return password
-            if parsed.type in ('oneTimeCode', 'otp'):
-                return self.generate_totp_url()
-            return raw
-        action_params.clear()
-        if self.is_base64_value(raw, action_params):
-            return action_params[0] if action_params else None
-        return raw
 
     def execute(self, params, **kwargs):
         if kwargs.get('syntax_help'):
@@ -244,39 +226,23 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         record_type = kwargs.get('record_type')
+        rt_fields = None
         if record_type and record_type not in ('legacy', 'general'):
             RecordTypeEnforcer.enforce(params, record_type, 'nsf-record-update')
             rt_fields = self.get_record_type_fields(params, record_type)
             if not rt_fields:
-                raise CommandError('nsf-record-update', f'Record type "{record_type}" cannot be found.')
+                raise CommandError('nsf-record-update',
+                                   f'Record type "{record_type}" cannot be found.')
 
-        fields = {}
-        for spec in [f.strip() for f in kwargs.get('fields', []) if f.strip()]:
-            try:
-                parsed = RecordEditMixin.parse_field(spec)
-                if self.warn_wrong_password_gen_field(parsed):
-                    continue
-                value = self._resolve_field_value(parsed)
-                if value is None:
-                    continue
-                if parsed.type in fields:
-                    existing = fields[parsed.type]
-                    fields[parsed.type] = ([existing] if not isinstance(existing, list)
-                                           else existing) + [value]
-                else:
-                    fields[parsed.type] = value
-            except ValueError as e:
-                raise CommandError('nsf-record-update', f'Invalid field specification: {e}')
+        record_fields, attachments = _parse_field_specs(kwargs.get('fields', []), 'nsf-record-update')
 
-        if self.abort_if_errors():
-            return
-
-        if self.warnings:
-            for w in self.warnings:
-                logging.warning(w)
+        if attachments:
+            logging.warning('File attachments are not yet supported in nsf-record-update. '
+                            'Use record-update for attachment support.')
             if not kwargs.get('force'):
                 return
 
+        force = kwargs.get('force')
         with command_error_handler('nsf-record-update'):
             for identifier in record_uids:
                 record_uid = _nsf.resolve_nested_share_record_uid(params, identifier)
@@ -286,37 +252,52 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                 ensure_nested_share_record(params, record_uid, 'nsf-record-update',
                                            identifier=identifier)
                 check_record_edit_permission(params, record_uid, 'nsf-record-update')
-                merged = self._merge_update_data(
-                    params, record_uid,
-                    title=kwargs.get('title'),
-                    record_type=record_type,
-                    fields=fields or None,
-                    notes=kwargs.get('notes'),
-                )
-                self._check_password_policy(params, merged, **kwargs)
-                if self.warnings:
-                    for w in self.warnings:
-                        logging.warning(w)
-                    if not kwargs.get('force'):
-                        return
-                    self.warnings.clear()
+
+                record = self._typed_record_from_uid(params, record_uid)
+                title = kwargs.get('title')
+                if title is not None:
+                    record.title = title
+                self._apply_notes(record, kwargs.get('notes'))
+                if record_type:
+                    record.type_name = record_type
+                    if rt_fields:
+                        self.adjust_typed_record_fields(record, rt_fields)
+                self.assign_typed_fields(record, record_fields)
+
+                if self.abort_if_errors():
+                    return
+
+                _apply_password_policy(self, params, record, force)
+                if _should_stop_after_warnings(self, force):
+                    return
+
                 result = _nsf.update_record_v3(
-                    params=params,
-                    record_uid=record_uid,
-                    title=kwargs.get('title'),
-                    record_type=record_type,
-                    fields=fields or None,
-                    notes=kwargs.get('notes'),
+                    params=params, record_uid=record_uid,
+                    data=vault_extensions.extract_typed_record_data(record),
                 )
                 check_result(result, 'nsf-record-update')
             params.sync_data = True
 
-    def _check_password_policy(self, params, data, **kwargs):
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        for failure in pw_failures:
-            self.on_warning(failure)
-        if pw_failures and not kwargs.get('force'):
-            self.on_warning('Use --force to bypass password policy warnings.')
+    def _apply_notes(self, record, notes):
+        if not isinstance(notes, str):
+            return
+        notes = self.validate_notes(notes)
+        if notes.startswith('+'):
+            notes = notes[1:].strip()
+            if record.notes:
+                record.notes += '\n'
+            record.notes += notes
+            return
+        record.notes = notes
+
+    def _typed_record_from_uid(self, params, record_uid):
+        existing = self._load_record_data(params, record_uid)
+        if not existing:
+            raise CommandError('nsf-record-update',
+                               f"Record data for '{record_uid}' is not available in the local cache")
+        record = vault.TypedRecord()
+        record.load_record_data(existing)
+        return record
 
     @staticmethod
     def _load_record_data(params, record_uid):   # type: (Any, str) -> Optional[Dict]
@@ -327,35 +308,21 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             raw = nsf_data.get('data_json')
         if raw is None:
             return None
-        if isinstance(raw, bytes):
-            return json.loads(raw.decode('utf-8'))
-        if isinstance(raw, str):
-            return json.loads(raw)
-        if isinstance(raw, dict):
-            return raw.copy()
-        return None
-
-    @classmethod
-    def _merge_update_data(cls, params, record_uid, title=None, record_type=None,
-                           fields=None, notes=None):   # type: (...) -> Dict
-        existing = cls._load_record_data(params, record_uid)
-        data = existing.copy() if existing else {'fields': []}
-        if title is not None:
-            data['title'] = title
-        if record_type is not None:
-            data['type'] = record_type
-        if fields is not None:
-            by_type = {}
-            for ef in data.get('fields', []):
-                by_type.setdefault(ef.get('type'), []).append(ef)
-            for ft, fv in fields.items():
-                fv = fv if isinstance(fv, list) else [fv]
-                if ft in by_type and by_type[ft]:
-                    by_type[ft][0]['value'] = fv
-                else:
-                    data.setdefault('fields', []).append({'type': ft, 'value': fv})
-        if notes is not None:
-            data['notes'] = notes
+        try:
+            if isinstance(raw, bytes):
+                data = json.loads(raw.decode('utf-8'))
+            elif isinstance(raw, str):
+                data = json.loads(raw)
+            elif isinstance(raw, dict):
+                data = raw.copy()
+            else:
+                return None
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError, ValueError):
+            raise CommandError('nsf-record-update',
+                               f"Record data for '{record_uid}' could not be decoded")
+        if not isinstance(data, dict):
+            raise CommandError('nsf-record-update',
+                               f"Record data for '{record_uid}' could not be decoded")
         return data
 
 

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -248,7 +248,8 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
         if record_type:
             if record_type in ('legacy', 'general'):
                 raise CommandError('nsf-record-update',
-                                   f'Record type "{record_type}" cannot be found.')
+                                   'Record type not valid for NSF records; '
+                                   'use login or a typed record type.')
             RecordTypeEnforcer.enforce(params, record_type, 'nsf-record-update')
             rt_fields = self.get_record_type_fields(params, record_type)
             if not rt_fields:
@@ -290,9 +291,8 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                         continue
 
                     result = self._send_typed_update(params, record_uid, record)
-                    # KC-1403: update_record_v3 already synced on RS_OUT_OF_SYNC
-                    # but will not retry a full data payload. Rebuild from the
-                    # refreshed cache and re-apply typed field matching once.
+                    # API syncs on RS_OUT_OF_SYNC but does not retry a full data
+                    # payload; rebuild from refreshed cache and re-apply once.
                     if (not result.get('success')
                             and result.get('status') == 'RS_OUT_OF_SYNC'):
                         self.warnings.clear()

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -16,6 +16,7 @@ Single Responsibility: every class here deals with record lifecycle
 (create, update, link/unlink, shortcut management, delete).
 """
 
+import copy
 import json
 import logging
 from typing import Any, Dict, List, Optional
@@ -54,7 +55,7 @@ def _parse_field_specs(raw_fields, cmd_name):
 
 
 def _apply_password_policy(editor, params, source, force):
-    # Keep parity with record-update: source can be TypedRecord (update) or dict (add).
+    # TypedRecord (typed add/update) or v3 dict (legacy add). validate_record accepts both.
     pw_failures = PasswordComplexityEnforcer.validate_record(params, source)
     for failure in pw_failures:
         editor.on_warning(failure)
@@ -71,6 +72,20 @@ def _should_stop_after_warnings(editor, force):
         return True
     editor.warnings.clear()
     return False
+
+
+def _unsupported_attachment_warning(attachments, cmd_name):
+    if not attachments:
+        return
+    classic = 'record-add' if cmd_name == 'nsf-record-add' else 'record-update'
+    if any(not a.value for a in attachments):
+        logging.warning(
+            'Attachment removal (file= with an empty value) is not supported in %s. '
+            'Use record-update to remove attachments.', cmd_name)
+    if any(a.value for a in attachments):
+        logging.warning(
+            'File attachments are not yet supported in %s. '
+            'Use %s for attachment support.', cmd_name, classic)
 
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -108,16 +123,15 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         record_fields, add_attachments = _parse_field_specs(kwargs.get('fields', []), 'nsf-record-add')
         folder_uid = self._resolve_folder(params, kwargs.get('folder_uid'))
 
-        data = self._build_record_data(params, record_type, title, notes, record_fields)
+        data = self._build_record_data(
+            params, record_type, title, notes, record_fields, kwargs.get('force'))
         if self.abort_if_errors():
             return
-        _apply_password_policy(self, params, data, kwargs.get('force'))
         if _should_stop_after_warnings(self, kwargs.get('force')):
             return
 
         if add_attachments:
-            logging.warning('File attachments are not yet supported in nsf-record-add. '
-                            'Use record-add for attachment support.')
+            _unsupported_attachment_warning(add_attachments, 'nsf-record-add')
             if not kwargs.get('force'):
                 return
 
@@ -142,13 +156,15 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         ensure_nested_share_folder(params, uid, 'nsf-record-add', identifier=folder_input)
         return uid
 
-    def _build_record_data(self, params, record_type, title, notes, record_fields):
+    def _build_record_data(self, params, record_type, title, notes, record_fields, force=False):
         if record_type in ('legacy', 'general'):
             record = vault.PasswordRecord()
             self.assign_legacy_fields(record, record_fields)
             record.title = title
             record.notes = self.validate_notes(notes or '')
-            return self._legacy_to_data(record, title, notes)
+            data = self._legacy_to_data(record, title)
+            _apply_password_policy(self, params, data, force)
+            return data
 
         rt_fields = self.get_record_type_fields(params, record_type)
         if not rt_fields:
@@ -167,10 +183,11 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         self.assign_typed_fields(record, record_fields)
         record.title = title
         record.notes = self.validate_notes(notes or '')
-        return self._typed_to_data(record, title, notes)
+        _apply_password_policy(self, params, record, force)
+        return self._typed_to_data(record, title)
 
     @staticmethod
-    def _typed_to_data(record, title, notes=None):
+    def _typed_to_data(record, title):
         data = {
             'type': record.type_name, 'title': title,
             'fields': [{'type': f.type, 'label': f.label or '', 'value': list(f.value)}
@@ -178,12 +195,12 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
             'custom': [{'type': f.type, 'label': f.label or '', 'value': list(f.value)}
                         for f in record.custom],
         }
-        if notes:
-            data['notes'] = notes
+        if record.notes:
+            data['notes'] = record.notes
         return data
 
     @staticmethod
-    def _legacy_to_data(record, title, notes=None):
+    def _legacy_to_data(record, title):
         data = {'type': record.get_record_type(), 'title': title, 'fields': []}
         for ftype, val in [('login', record.login), ('password', record.password),
                            ('url', record.link), ('oneTimeCode', record.totp)]:
@@ -195,8 +212,8 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
                 'label': cf.name if hasattr(cf, 'name') else '',
                 'value': [cf.value if hasattr(cf, 'value') else str(cf)],
             })
-        if notes:
-            data['notes'] = notes
+        if record.notes:
+            data['notes'] = record.notes
         return data
 
 
@@ -228,7 +245,10 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
 
         record_type = kwargs.get('record_type')
         rt_fields = None
-        if record_type and record_type not in ('legacy', 'general'):
+        if record_type:
+            if record_type in ('legacy', 'general'):
+                raise CommandError('nsf-record-update',
+                                   f'Record type "{record_type}" cannot be found.')
             RecordTypeEnforcer.enforce(params, record_type, 'nsf-record-update')
             rt_fields = self.get_record_type_fields(params, record_type)
             if not rt_fields:
@@ -238,46 +258,51 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
         record_fields, attachments = _parse_field_specs(kwargs.get('fields', []), 'nsf-record-update')
 
         if attachments:
-            logging.warning('File attachments are not yet supported in nsf-record-update. '
-                            'Use record-update for attachment support.')
+            _unsupported_attachment_warning(attachments, 'nsf-record-update')
             if not kwargs.get('force'):
                 return
 
         force = kwargs.get('force')
-        with command_error_handler('nsf-record-update'):
-            for identifier in record_uids:
-                record_uid = _nsf.resolve_nested_share_record_uid(params, identifier)
-                if not record_uid:
-                    raise CommandError('nsf-record-update',
-                                       f"Record '{identifier}' not found")
-                ensure_nested_share_record(params, record_uid, 'nsf-record-update',
-                                           identifier=identifier)
-                check_record_edit_permission(params, record_uid, 'nsf-record-update')
+        updated = 0
+        try:
+            with command_error_handler('nsf-record-update'):
+                for identifier in record_uids:
+                    self.warnings.clear()
+                    self.errors.clear()
+                    record_uid = _nsf.resolve_nested_share_record_uid(params, identifier)
+                    if not record_uid:
+                        raise CommandError('nsf-record-update',
+                                           f"Record '{identifier}' not found")
+                    ensure_nested_share_record(params, record_uid, 'nsf-record-update',
+                                               identifier=identifier)
+                    check_record_edit_permission(params, record_uid, 'nsf-record-update')
 
-                record = self._typed_record_from_uid(params, record_uid)
-                title = kwargs.get('title')
-                if title is not None:
-                    record.title = title
-                self._apply_notes(record, kwargs.get('notes'))
-                if record_type:
-                    record.type_name = record_type
-                    if rt_fields:
+                    record = self._typed_record_from_uid(params, record_uid)
+                    title = kwargs.get('title')
+                    if title:
+                        record.title = title
+                    self._apply_notes(record, kwargs.get('notes'))
+                    if record_type:
+                        record.type_name = record_type
                         self.adjust_typed_record_fields(record, rt_fields)
-                self.assign_typed_fields(record, record_fields)
+                    self.assign_typed_fields(record, record_fields)
 
-                if self.abort_if_errors():
-                    return
+                    if self.abort_if_errors():
+                        continue
 
-                _apply_password_policy(self, params, record, force)
-                if _should_stop_after_warnings(self, force):
-                    return
+                    _apply_password_policy(self, params, record, force)
+                    if _should_stop_after_warnings(self, force):
+                        continue
 
-                result = _nsf.update_record_v3(
-                    params=params, record_uid=record_uid,
-                    data=vault_extensions.extract_typed_record_data(record),
-                )
-                check_result(result, 'nsf-record-update')
-            params.sync_data = True
+                    result = _nsf.update_record_v3(
+                        params=params, record_uid=record_uid,
+                        data=vault_extensions.extract_typed_record_data(record),
+                    )
+                    check_result(result, 'nsf-record-update')
+                    updated += 1
+        finally:
+            if updated:
+                params.sync_data = True
 
     def _apply_notes(self, record, notes):
         if not isinstance(notes, str):
@@ -315,7 +340,7 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             elif isinstance(raw, str):
                 data = json.loads(raw)
             elif isinstance(raw, dict):
-                data = raw.copy()
+                data = copy.deepcopy(raw)
             else:
                 return None
         except (json.JSONDecodeError, UnicodeDecodeError, TypeError, ValueError):

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -586,7 +586,7 @@ class PasswordComplexityEnforcer:
                 return []
         if not isinstance(data, dict):
             return []
-        for fld in data.get('fields') or []:
+        for fld in itertools.chain(data.get('fields') or [], data.get('custom') or []):
             if isinstance(fld, dict) and fld.get('type') == 'password':
                 val = fld.get('value')
                 if isinstance(val, list):

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -235,6 +235,24 @@ class TestCommandHelpers(TestCase):
         result = load_record_metadata(params, ruid)
         self.assertEqual(result['title'], 'Cached')
         self.assertEqual(result['revision'], 5)
+        self.assertEqual(result['custom'], [])
+
+    def test_load_record_metadata_includes_custom(self):
+        from keepercommander.commands.nested_share_folder.helpers import load_record_metadata
+        ruid = utils.generate_uid()
+        custom = [{'type': 'text', 'label': 'AppName', 'value': ['Example']}]
+        params = _make_params(
+            nested_share_record_data={ruid: {
+                'data_json': {
+                    'title': 'SaaS', 'type': 'saasConfiguration',
+                    'fields': [{'type': 'fileRef', 'value': []}],
+                    'custom': custom,
+                }
+            }},
+            nested_share_records={ruid: {'revision': 1, 'version': 3}},
+        )
+        result = load_record_metadata(params, ruid)
+        self.assertEqual(result['custom'], custom)
 
 
 class TestSync(TestCase):
@@ -601,6 +619,194 @@ class TestNestedShareFolderRecordCommands(TestCase):
         cmd = NestedShareRecordUpdateCommand()
         cmd.execute(params, record_uids=[ruid], fields=['password=abc'], force=False)
         mock_update.assert_not_called()
+
+    def _nsf_update_params(self, data):
+        ruid, robj = _make_record()
+        payload = json.dumps(data)
+        params = _make_params(
+            nested_share_records={ruid: robj},
+            record_cache={ruid: {
+                'revision': 1,
+                'data_unencrypted': payload,
+            }},
+            nested_share_record_data={ruid: {'data_json': data}},
+        )
+        return ruid, params
+
+    @staticmethod
+    def _stub_update(mock_update, ruid):
+        mock_update.return_value = {
+            'record_uid': ruid, 'status': 'SUCCESS', 'message': '', 'success': True,
+        }
+
+    @staticmethod
+    def _updated_data(mock_update):
+        return mock_update.call_args.kwargs['data']
+
+    @staticmethod
+    def _by_label(fields):
+        return {(f.get('type'), f.get('label') or ''): f for f in fields}
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_matches_labeled_fields_without_merging(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'pamDatabase',
+            'title': 'DB',
+            'fields': [
+                {'type': 'checkbox', 'label': 'useSSL', 'value': [True]},
+                {'type': 'text', 'label': 'databaseId', 'value': []},
+                {'type': 'text', 'label': 'providerGroup', 'value': []},
+                {'type': 'text', 'label': 'providerRegion', 'value': []},
+            ],
+            'custom': [],
+        })
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], force=True, fields=[
+            'f.checkbox.useSSL=false',
+            'f.text.databaseId=abc',
+            'f.text.providerGroup=AWS',
+            'f.text.providerRegion=us-east-1',
+        ])
+        data = self._updated_data(mock_update)
+        by_label = self._by_label(data['fields'])
+        self.assertEqual(by_label[('checkbox', 'useSSL')]['value'], [False])
+        self.assertEqual(by_label[('text', 'databaseId')]['value'], ['abc'])
+        self.assertEqual(by_label[('text', 'providerGroup')]['value'], ['AWS'])
+        self.assertEqual(by_label[('text', 'providerRegion')]['value'], ['us-east-1'])
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_writes_custom_fields_in_place(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'saasConfiguration',
+            'title': 'SaaS',
+            'fields': [{'type': 'fileRef', 'value': []}],
+            'custom': [
+                {'type': 'text', 'label': 'SaaS Type', 'value': ['Okta']},
+                {'type': 'text', 'label': 'AppName', 'value': ['Example']},
+            ],
+        })
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], force=True, fields=[
+            'c.text.SaaS Type=Okta updated',
+            'c.text.AppName=Example SaaS App updated',
+        ])
+        data = self._updated_data(mock_update)
+        custom = self._by_label(data.get('custom') or [])
+        self.assertEqual(custom[('text', 'SaaS Type')]['value'], ['Okta updated'])
+        self.assertEqual(custom[('text', 'AppName')]['value'], ['Example SaaS App updated'])
+        field_types = [f.get('type') for f in data['fields']]
+        self.assertNotIn('text', field_types)
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_converts_pam_hostname(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'pamMachine',
+            'title': 'Host',
+            'fields': [{
+                'type': 'pamHostname',
+                'value': [{'hostName': 'db.example.com', 'port': '5432'}],
+            }],
+            'custom': [],
+        })
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], force=True,
+                    fields=['f.pamHostname=other.example.com:22'])
+        data = self._updated_data(mock_update)
+        host = next(f for f in data['fields'] if f.get('type') == 'pamHostname')
+        self.assertEqual(host['value'], [{'hostName': 'other.example.com', 'port': '22'}])
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_clears_login_and_removes_custom(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login',
+            'title': 'Clear',
+            'fields': [
+                {'type': 'login', 'value': ['alice']},
+                {'type': 'password', 'value': ['Secret123']},
+            ],
+            'custom': [{'type': 'text', 'label': 'AppName', 'value': ['KeepMe']}],
+        })
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], force=True,
+                    fields=['login=', 'c.text.AppName='])
+        data = self._updated_data(mock_update)
+        login = next(f for f in data['fields'] if f.get('type') == 'login')
+        self.assertEqual(login['value'], [])
+        self.assertFalse(data.get('custom'))
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_appends_and_unescapes_notes(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login',
+            'title': 'Notes',
+            'notes': 'Original notes',
+            'fields': [{'type': 'login', 'value': ['user']}],
+            'custom': [],
+        })
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], force=True, fields=[],
+                    notes='+Rotated 2026-08-18')
+        data = self._updated_data(mock_update)
+        self.assertEqual(data['notes'], 'Original notes\nRotated 2026-08-18')
+
+        mock_update.reset_mock()
+        self._stub_update(mock_update, ruid)
+        cmd.execute(params, record_uids=[ruid], force=True, fields=[],
+                    notes='line1\\nline2')
+        data = self._updated_data(mock_update)
+        self.assertEqual(data['notes'], 'line1\nline2')
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_rejects_missing_record_data(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, robj = _make_record()
+        params = _make_params(nested_share_records={ruid: robj})
+        cmd = NestedShareRecordUpdateCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.execute(params, record_uids=[ruid], title='X', fields=[])
+        self.assertIn('not available', str(ctx.exception).lower())
+        mock_update.assert_not_called()
+
+    def test_update_rejects_invalid_field_spec(self):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        cmd = NestedShareRecordUpdateCommand()
+        with self.assertRaises(CommandError) as ctx:
+            cmd.execute(_make_params(), record_uids=['x'], fields=['nocolon'])
+        self.assertIn('invalid field specification', str(ctx.exception).lower())
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_title_only_preserves_custom(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login',
+            'title': 'Old',
+            'fields': [{'type': 'login', 'value': ['alice']}],
+            'custom': [{'type': 'text', 'label': 'AppName', 'value': ['KeepMe']}],
+        })
+        self._stub_update(mock_update, ruid)
+        NestedShareRecordUpdateCommand().execute(
+            params, record_uids=[ruid], title='New', fields=[], force=True)
+        data = self._updated_data(mock_update)
+        self.assertEqual(data['title'], 'New')
+        custom = self._by_label(data.get('custom') or [])
+        self.assertEqual(custom[('text', 'AppName')]['value'], ['KeepMe'])
 
     @patch('keepercommander.nested_share_folder.folder_record_api.add_record_to_folder_v3')
     def test_add_record_to_folder(self, mock_add):
@@ -2026,6 +2232,57 @@ class TestNestedShareFolderDisplayCommands(TestCase):
 
         payload = json.loads(captured[-1])
         self.assertEqual(payload['team_permissions'][0]['accessor'], 'Engineering Team')
+
+    @patch('keepercommander.commands.nested_share_folder.display_commands._nsf.get_record_accesses_v3')
+    def test_record_json_includes_custom_fields(self, mock_access):
+        from keepercommander.commands.nested_share_folder.display_commands import NestedShareGetCommand
+        mock_access.return_value = {'record_accesses': []}
+        ruid, robj = _make_record()
+        custom = [
+            {'type': 'text', 'label': 'SaaS Type', 'value': ['Okta']},
+            {'type': 'text', 'label': 'AppName', 'value': ['Example SaaS App']},
+        ]
+        params = _make_params(
+            nested_share_records={ruid: robj},
+            nested_share_record_data={ruid: {
+                'data_json': {
+                    'title': 'SaaS',
+                    'type': 'saasConfiguration',
+                    'fields': [{'type': 'fileRef', 'label': '', 'value': []}],
+                    'custom': custom,
+                }
+            }},
+        )
+        captured = []
+        with mock.patch('builtins.print', side_effect=lambda *a, **k: captured.append(a[0] if a else '')):
+            NestedShareGetCommand()._record_json(params, ruid, verbose=False)
+        payload = json.loads(captured[-1])
+        self.assertEqual(payload['custom'], custom)
+
+    @patch('keepercommander.commands.nested_share_folder.display_commands._nsf.get_record_accesses_v3')
+    def test_record_detail_prints_custom_and_masks_totp(self, mock_access):
+        from keepercommander.commands.nested_share_folder.display_commands import NestedShareGetCommand
+        mock_access.return_value = {'record_accesses': []}
+        ruid, robj = _make_record()
+        params = _make_params(
+            nested_share_records={ruid: robj},
+            nested_share_record_data={ruid: {
+                'data_json': {
+                    'title': 'TOTP',
+                    'type': 'login',
+                    'fields': [{'type': 'oneTimeCode', 'value': ['otpauth://totp/secret']}],
+                    'custom': [{'type': 'text', 'label': 'AppName', 'value': ['Example']}],
+                }
+            }},
+        )
+        captured = []
+        with mock.patch('builtins.print', side_effect=lambda *a, **k: captured.append(a[0] if a else '')):
+            NestedShareGetCommand()._record_detail(params, ruid, verbose=False, unmask=False)
+        text = '\n'.join(str(x) for x in captured)
+        self.assertIn('AppName', text)
+        self.assertIn('Example', text)
+        self.assertIn('********', text)
+        self.assertNotIn('otpauth://', text)
 
 
 class TestCommandRegistration(TestCase):

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -858,7 +858,7 @@ class TestNestedShareFolderRecordCommands(TestCase):
         for record_type in ('legacy', 'general'):
             with self.assertRaises(CommandError) as ctx:
                 cmd.execute(params, record_uids=[ruid], record_type=record_type, fields=[])
-            self.assertIn('cannot be found', str(ctx.exception).lower())
+            self.assertIn('not valid for nsf', str(ctx.exception).lower())
         mock_update.assert_not_called()
 
     @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -847,6 +847,172 @@ class TestNestedShareFolderRecordCommands(TestCase):
         custom = self._by_label(data.get('custom') or [])
         self.assertEqual(custom[('text', 'AppName')]['value'], ['KeepMe'])
 
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_rejects_legacy_and_general_record_type(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login', 'title': 'Typed', 'fields': [], 'custom': [],
+        })
+        cmd = NestedShareRecordUpdateCommand()
+        for record_type in ('legacy', 'general'):
+            with self.assertRaises(CommandError) as ctx:
+                cmd.execute(params, record_uids=[ruid], record_type=record_type, fields=[])
+            self.assertIn('cannot be found', str(ctx.exception).lower())
+        mock_update.assert_not_called()
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_failed_request_does_not_mutate_cache(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, robj = _make_record()
+        cache_data = {
+            'type': 'login',
+            'title': 'Old',
+            'fields': [{'type': 'login', 'value': ['alice']}],
+            'custom': [],
+        }
+        params = _make_params(
+            nested_share_records={ruid: robj},
+            record_cache={ruid: {'revision': 1}},
+            nested_share_record_data={ruid: {'data_json': cache_data}},
+        )
+        mock_update.return_value = {
+            'success': False, 'status': 'RS_ACCESS_DENIED', 'message': 'denied',
+        }
+        with self.assertRaises(CommandError):
+            NestedShareRecordUpdateCommand().execute(
+                params, record_uids=[ruid], fields=['login=bob'], force=True)
+        self.assertEqual(cache_data['fields'][0]['value'], ['alice'])
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_sets_sync_data_after_partial_batch_failure(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid1, params = self._nsf_update_params({
+            'type': 'login', 'title': 'One',
+            'fields': [{'type': 'login', 'value': ['alice']}], 'custom': [],
+        })
+        ruid2, robj2 = _make_record()
+        params.nested_share_records[ruid2] = robj2
+        params.record_cache[ruid2] = {
+            'revision': 1,
+            'data_unencrypted': json.dumps({
+                'type': 'login', 'title': 'Two',
+                'fields': [{'type': 'login', 'value': ['bob']}], 'custom': [],
+            }),
+        }
+        mock_update.side_effect = [
+            {'record_uid': ruid1, 'status': 'SUCCESS', 'message': '', 'success': True},
+            {'success': False, 'status': 'RS_ACCESS_DENIED', 'message': 'denied'},
+        ]
+        with self.assertRaises(CommandError):
+            NestedShareRecordUpdateCommand().execute(
+                params, record_uids=[ruid1, ruid2], title='Updated', fields=[], force=True)
+        self.assertEqual(mock_update.call_count, 2)
+        self.assertTrue(params.sync_data)
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_skips_warned_record_and_continues_batch(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        policy = json.dumps([{
+            'length': 12,
+            'lower-use': True, 'lower-min': 1,
+            'upper-use': True, 'upper-min': 1,
+            'digit-use': True, 'digit-min': 1,
+        }])
+        ruid1, params = self._nsf_update_params({
+            'type': 'login', 'title': 'Weak',
+            'fields': [{'type': 'password', 'value': ['abc']}], 'custom': [],
+        })
+        ruid2, robj2 = _make_record()
+        params.nested_share_records[ruid2] = robj2
+        params.record_cache[ruid2] = {
+            'revision': 1,
+            'data_unencrypted': json.dumps({
+                'type': 'login', 'title': 'Strong',
+                'fields': [{'type': 'password', 'value': ['ExistingPass123']}],
+                'custom': [],
+            }),
+        }
+        params.enforcements = {'jsons': [{'key': 'generated_password_complexity', 'value': policy}]}
+        self._stub_update(mock_update, ruid2)
+        NestedShareRecordUpdateCommand().execute(
+            params, record_uids=[ruid1, ruid2], title='Updated', fields=[], force=False)
+        self.assertEqual(mock_update.call_count, 1)
+        self.assertEqual(mock_update.call_args.kwargs['record_uid'], ruid2)
+        self.assertTrue(params.sync_data)
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_empty_title_does_not_clear_existing(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login', 'title': 'Keep Me',
+            'fields': [{'type': 'login', 'value': ['alice']}], 'custom': [],
+        })
+        self._stub_update(mock_update, ruid)
+        NestedShareRecordUpdateCommand().execute(
+            params, record_uids=[ruid], title='', fields=['login=bob'], force=True)
+        data = self._updated_data(mock_update)
+        self.assertEqual(data['title'], 'Keep Me')
+        login = next(f for f in data['fields'] if f.get('type') == 'login')
+        self.assertEqual(login['value'], ['bob'])
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_empty_file_spec_warns_as_removal(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'login', 'title': 'Files', 'fields': [], 'custom': [],
+        })
+        with self.assertLogs() as cm:
+            NestedShareRecordUpdateCommand().execute(
+                params, record_uids=[ruid], fields=['file='], force=False)
+        self.assertTrue(any('Attachment removal' in line for line in cm.output))
+        mock_update.assert_not_called()
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.create_record_v3')
+    def test_add_rejects_weak_custom_password_without_force(self, mock_create):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordAddCommand
+        fuid, fobj = _make_folder()
+        params = _make_params(
+            nested_share_folders={fuid: fobj},
+            enforcements={
+                'jsons': [{
+                    'key': 'generated_password_complexity',
+                    'value': json.dumps([{
+                        'length': 12,
+                        'lower-use': True, 'lower-min': 1,
+                        'upper-use': True, 'upper-min': 1,
+                        'digit-use': True, 'digit-min': 1,
+                    }]),
+                }],
+            },
+        )
+        cmd = NestedShareRecordAddCommand()
+        with mock.patch.object(cmd, 'get_record_type_fields',
+                               return_value=[{'$ref': 'login'}, {'$ref': 'password'}]):
+            cmd.execute(params, title='Weak custom', record_type='login',
+                        fields=['c.password.AppSecret=abc'], force=False)
+        mock_create.assert_not_called()
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.create_record_v3')
+    def test_add_unescapes_notes(self, mock_create):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordAddCommand
+        mock_create.return_value = {
+            'record_uid': utils.generate_uid(), 'status': 'SUCCESS',
+            'message': '', 'success': True, 'revision': 1,
+        }
+        fuid, fobj = _make_folder()
+        cmd = NestedShareRecordAddCommand()
+        cmd.execute(_make_params(nested_share_folders={fuid: fobj}),
+                    title='Notes', record_type='general', fields=[], force=True,
+                    notes='line1\\nline2')
+        record_data = mock_create.call_args.kwargs['record_data']
+        self.assertEqual(record_data['notes'], 'line1\nline2')
+
     @patch('keepercommander.nested_share_folder.folder_record_api.add_record_to_folder_v3')
     def test_add_record_to_folder(self, mock_add):
         pass

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -620,6 +620,45 @@ class TestNestedShareFolderRecordCommands(TestCase):
         cmd.execute(params, record_uids=[ruid], fields=['password=abc'], force=False)
         mock_update.assert_not_called()
 
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_record_gen_password_uses_password_policy(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, robj = _make_record()
+        params = _make_params(
+            nested_share_records={ruid: robj},
+            record_cache={ruid: {'revision': 1, 'data_unencrypted': json.dumps({
+                'type': 'login', 'title': 'Old',
+                'fields': [{'type': 'password', 'value': ['ExistingPass123']}],
+            })}},
+            enforcements={
+                'jsons': [{
+                    'key': 'generated_password_complexity',
+                    'value': json.dumps([{
+                        'length': 16,
+                        'lower-use': True, 'lower-min': 2,
+                        'upper-use': True, 'upper-min': 2,
+                        'digit-use': True, 'digit-min': 2,
+                        'special-use': True, 'special-min': 1,
+                        'special': '!@#$',
+                    }]),
+                }],
+            },
+        )
+        self._stub_update(mock_update, ruid)
+        cmd = NestedShareRecordUpdateCommand()
+        cmd.execute(params, record_uids=[ruid], fields=['password=$GEN'], force=True)
+        data = self._updated_data(mock_update)
+        password = next(
+            v[0] for f in data['fields']
+            if f.get('type') == 'password' for v in [f.get('value', [])] if v
+        )
+        self.assertGreaterEqual(len(password), 16)
+        self.assertGreaterEqual(sum(1 for c in password if c.islower()), 2)
+        self.assertGreaterEqual(sum(1 for c in password if c.isupper()), 2)
+        self.assertGreaterEqual(sum(1 for c in password if c.isdigit()), 2)
+        self.assertGreaterEqual(sum(1 for c in password if c in '!@#$'), 1)
+
     def _nsf_update_params(self, data):
         ruid, robj = _make_record()
         payload = json.dumps(data)

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -887,6 +887,49 @@ class TestNestedShareFolderRecordCommands(TestCase):
 
     @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
     @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
+    def test_update_retries_out_of_sync_with_typed_fields(self, mock_perm, mock_update):
+        from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        ruid, params = self._nsf_update_params({
+            'type': 'pamDatabase',
+            'title': 'DB',
+            'fields': [
+                {'type': 'checkbox', 'label': 'useSSL', 'value': [True]},
+                {'type': 'text', 'label': 'databaseId', 'value': []},
+            ],
+            'custom': [],
+        })
+
+        def _side_effect(**kwargs):
+            if mock_update.call_count == 1:
+                params.record_cache[ruid]['data_unencrypted'] = json.dumps({
+                    'type': 'pamDatabase',
+                    'title': 'DB',
+                    'fields': [
+                        {'type': 'checkbox', 'label': 'useSSL', 'value': [True]},
+                        {'type': 'text', 'label': 'databaseId', 'value': ['from-sync']},
+                    ],
+                    'custom': [],
+                })
+                return {
+                    'success': False, 'status': 'RS_OUT_OF_SYNC',
+                    'message': 'This object no longer exists.',
+                }
+            return {
+                'record_uid': ruid, 'status': 'SUCCESS', 'message': '', 'success': True,
+            }
+
+        mock_update.side_effect = _side_effect
+        NestedShareRecordUpdateCommand().execute(
+            params, record_uids=[ruid], force=True,
+            fields=['f.checkbox.useSSL=false'])
+        self.assertEqual(mock_update.call_count, 2)
+        data = self._updated_data(mock_update)
+        by_label = self._by_label(data['fields'])
+        self.assertEqual(by_label[('checkbox', 'useSSL')]['value'], [False])
+        self.assertEqual(by_label[('text', 'databaseId')]['value'], ['from-sync'])
+
+    @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
+    @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
     def test_update_sets_sync_data_after_partial_batch_failure(self, mock_perm, mock_update):
         from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
         ruid1, params = self._nsf_update_params({


### PR DESCRIPTION
## Summary
- `nsf-record-update` now matches and writes fields the same way as `nsf-record-add` / `record-update` (section + type + label, including `custom`).
- `nsf-get` now returns those custom fields in JSON and detail output.

## Changes
- Match update specs by `f`/`c` + type + label instead of type only, so labeled fields are updated in place and not merged into one value list.
- Write `c.*` specs under `custom` instead of `fields`.
- Store checkbox `true`/`false` as booleans instead of dropping or storing string values.
- Include `custom` in `nsf-get` JSON and detail (it was omitted even when add had written it).