### PR TITLE
KC-1385, KC-1405: Add Range Support to CyberArk PAM Import and --target-node to import --format=cyberark command

### DIFF
--- a/keepercommander/commands/pam_import/cyberark_import.py
+++ b/keepercommander/commands/pam_import/cyberark_import.py
@@ -47,6 +47,7 @@ from ...importer.cyberark.cyberark_pam import (
     exclude_system_safes,
     resolve_account_dependents,
     resolve_linked_accounts,
+    PAM_SERVICE_ADD_TYPES,
     pick_admin_credentials,
     pick_launch_credentials,
     detect_dual_account,
@@ -376,7 +377,9 @@ class CyberArkImportOrchestrator:
         selected = self._cmd._interactive_safe_picker(safes)
         if selected is None:
             return safes
-        selected_set = {n.strip() for n in selected.split(',')}
+        if not selected:
+            return []
+        selected_set = set(selected)
         picked = [s for s in safes if s.get("safeName", "") in selected_set]
         if not picked:
             print_formatted_text(HTML("<ansiyellow>No safes selected</ansiyellow>"))
@@ -705,7 +708,7 @@ class CyberArkImportOrchestrator:
                 f"  • <b>{_esc(dep.get('service_name', '') or '?')}</b> "
                 f"({_esc(dep.get('raw_type', '') or 'unknown')}) "
                 f"on <b>{_esc(dep.get('machine_address', '') or '?')}</b> "
-                f"→ pam action service <b>{_esc(mapped_to)}</b>"))
+                f"→ pam action service add --type <b>{_esc(mapped_to)}</b>"))
 
     def _apply_folder_paths(self, record: dict, safe_name: str,
                             folder_mapper: SafeFolderMapper):
@@ -1504,17 +1507,7 @@ class CyberArkImportOrchestrator:
         self, mapped: MappedImportResult, project_result: dict,
         unmapped_items: list[dict],
     ) -> Optional[dict]:
-        """Replay CyberArk dependents as KeeperPAM service-account mappings.
-
-        Iterates over ``mapped.dependents`` collected during the mapping phase
-        and invokes ``PAMActionServiceAddCommand`` once per (machine, user, type)
-        tuple that resolves to imported records. Categories with no Keeper
-        equivalent, missing host machines, and non-Windows OS hosts are all
-        skipped silently and accounted for in the returned summary so the
-        import report can surface them.
-
-        Returns a summary dict, or ``None`` when nothing to do.
-        """
+        """Replay CyberArk dependents as KeeperPAM service-account mappings."""
         opts = self.options
         if opts.skip_dependents or not mapped.dependents:
             return None
@@ -1595,9 +1588,26 @@ class CyberArkImportOrchestrator:
         add_cmd = PAMActionServiceAddCommand()
 
         for dep in mapped.dependents:
+            # Match pam action service add --type {service,task,iis_pool}
             service_type = dep.get("service_type")
-            if service_type not in ("service", "task", "iis"):
+            # Legacy persisted project state stored CyberArk IIS dependents as
+            # "iis". Fresh imports emit "iis_pool" via _DEPENDENT_TYPE_ALIASES.
+            if service_type == "iis":
+                service_type = "iis_pool"
+            if service_type not in PAM_SERVICE_ADD_TYPES:
                 summary["skipped_unsupported"] += 1
+                continue
+
+            service_name = (dep.get("service_name") or "").strip()
+            if not service_name:
+                summary["skipped_other"] += 1
+                summary["details"].append({
+                    "service": "",
+                    "host": dep.get("machine_address", ""),
+                    "type": dep.get("raw_type", ""),
+                    "reason": "pam action service add requires --name "
+                              "(Windows service / task / IIS pool name)",
+                })
                 continue
 
             machine_record = self._find_machine_record(
@@ -1606,7 +1616,7 @@ class CyberArkImportOrchestrator:
             if machine_record is None:
                 summary["skipped_missing_machine"] += 1
                 summary["details"].append({
-                    "service": dep.get("service_name", ""),
+                    "service": service_name,
                     "host": dep.get("machine_address", ""),
                     "type": dep.get("raw_type", ""),
                     "reason": "no PAM Machine record imported for this host",
@@ -1617,18 +1627,20 @@ class CyberArkImportOrchestrator:
                 summary["skipped_non_windows"] += 1
                 unmapped_items.append({
                     "category": "CyberArk dependent",
-                    "item": (f"{dep.get('service_name') or dep.get('raw_type')} "
+                    "item": (f"{service_name or dep.get('raw_type')} "
                              f"on {dep.get('machine_address')}"),
                     "action": "Host is not Windows — Keeper PAM can only rotate "
                               "Windows service / task / IIS credentials",
                 })
                 continue
 
-            user_record = user_index.get(dep.get("master_user_title", ""))
+            user_record = user_index.get(
+                (dep.get("master_user_title") or "").casefold(),
+            )
             if user_record is None:
                 summary["skipped_missing_user"] += 1
                 summary["details"].append({
-                    "service": dep.get("service_name", ""),
+                    "service": service_name,
                     "host": dep.get("machine_address", ""),
                     "type": dep.get("raw_type", ""),
                     "reason": "PAM User record not found in vault after import",
@@ -1636,27 +1648,49 @@ class CyberArkImportOrchestrator:
                 continue
 
             try:
+                # execute() reads argparse dest names, not CLI flag names:
+                # --type → service_type, --name → name, --machine-uid → machine_uid
                 add_cmd.execute(
                     self.params,
                     gateway=gateway_uid,
                     configuration_uid=gateway_context.configuration.record_uid,
                     machine_uid=machine_record.record_uid,
                     user_uid=user_record.record_uid,
-                    type=service_type,
+                    service_type=service_type,
+                    name=service_name,
                 )
                 summary["added"] += 1
-            except Exception as e:  # noqa: BLE001 — never block reporting
+            except CommandError as e:
                 summary["skipped_other"] += 1
+                err_text = (e.message or str(e)).strip() or type(e).__name__
                 logging.warning(
                     "Failed to register %s mapping for %s on %s: %s",
-                    service_type, dep.get("service_name", "?"),
-                    dep.get("machine_address", "?"), type(e).__name__,
+                    service_type, service_name,
+                    dep.get("machine_address", "?"), err_text,
                 )
                 summary["details"].append({
-                    "service": dep.get("service_name", ""),
+                    "service": service_name,
                     "host": dep.get("machine_address", ""),
                     "type": dep.get("raw_type", ""),
-                    "reason": f"pam action service add failed: {type(e).__name__}",
+                    "reason": f"pam action service add failed: {err_text.splitlines()[0]}",
+                })
+            except Exception as e:  # noqa: BLE001 — never block reporting
+                summary["skipped_other"] += 1
+                err_text = str(e).strip() or type(e).__name__
+                logging.warning(
+                    "Failed to register %s mapping for %s on %s: %s: %s",
+                    service_type, service_name,
+                    dep.get("machine_address", "?"), type(e).__name__,
+                    err_text,
+                )
+                summary["details"].append({
+                    "service": service_name,
+                    "host": dep.get("machine_address", ""),
+                    "type": dep.get("raw_type", ""),
+                    "reason": (
+                        f"pam action service add failed: {type(e).__name__}: "
+                        f"{err_text.splitlines()[0]}"
+                    ),
                 })
 
         return summary
@@ -1834,6 +1868,17 @@ class CyberArkImportOrchestrator:
                     os.unlink(path)
                 except OSError:
                     pass
+
+
+# Unicode dashes that users commonly paste instead of ASCII '-'.
+_DASH_TRANSLATE = str.maketrans({
+    '\u2010': '-',  # hyphen
+    '\u2011': '-',  # non-breaking hyphen
+    '\u2012': '-',  # figure dash
+    '\u2013': '-',  # en dash
+    '\u2014': '-',  # em dash
+    '\u2212': '-',  # minus
+})
 
 
 class CyberArkPAMImportCommand(Command):
@@ -2202,11 +2247,46 @@ Examples:
         print()
 
     @staticmethod
-    def _interactive_safe_picker(safes: list[dict]) -> Optional[str]:
-        """Show safes and let user select which to import.
+    def _parse_index_selection(choice: str, count: int) -> list[int]:
+        """Parse a 1-based selection string into 0-based indices."""
+        selected: list[int] = []
+        seen: set[int] = set()
+        if count <= 0:
+            return selected
+        token_re = re.compile(r'^(\d+)(?:-(\d+))?$')
+        errors: list[str] = []
+        for part in choice.split(','):
+            part = part.strip().translate(_DASH_TRANSLATE)
+            part = re.sub(r'\s+', '', part)
+            if not part:
+                continue
+            m = token_re.match(part)
+            if not m:
+                errors.append(part)
+                continue
+            start = int(m.group(1))
+            end = int(m.group(2)) if m.group(2) is not None else start
+            lo, hi = min(start, end), max(start, end)
+            if lo < 1 or hi > count:
+                errors.append(part)
+                continue
+            for num in range(lo, hi + 1):
+                idx = num - 1
+                if idx not in seen:
+                    selected.append(idx)
+                    seen.add(idx)
+        if errors:
+            raise ValueError(
+                f"invalid or out-of-range index(es): {', '.join(errors)}"
+            )
+        return selected
 
-        Returns comma-separated safe names for apply_safe_filter,
-        or None to import all.
+    @staticmethod
+    def _interactive_safe_picker(safes: list[dict]) -> Optional[list[str]]:
+        """Show safes and let the user select which to import.
+
+        Returns ``None`` to import all, an empty list if the user cancelled
+        or the selection was invalid, or the list of selected safe names.
         """
         print(f'\n{bcolors.OKBLUE}CyberArk Safes Found:{bcolors.ENDC}')
         print('─' * 50)
@@ -2219,28 +2299,32 @@ Examples:
         print()
 
         try:
-            choice = input(f'  Select safes (comma-separated numbers, or A for all) [A]: ').strip()
+            choice = input(
+                '  Select safes (numbers/ranges e.g. 1-4,6,8-10, or A for all) [A]: '
+            ).strip()
         except EOFError:
             return None
 
         if not choice or choice.upper() == 'A':
             return None
 
-        selected = []
-        for part in choice.split(','):
-            part = part.strip()
-            try:
-                idx = int(part) - 1
-                if 0 <= idx < len(numbered):
-                    selected.append(numbered[idx])
-            except ValueError:
-                continue
+        try:
+            indices = CyberArkPAMImportCommand._parse_index_selection(
+                choice, len(numbered)
+            )
+        except ValueError as e:
+            print(f'{bcolors.FAIL}{e}. Import cancelled.{bcolors.ENDC}')
+            return []
 
+        selected = [numbered[idx] for idx in indices]
         if not selected:
-            return None
+            print(
+                f'{bcolors.FAIL}No valid indexes in {choice!r}. Import cancelled.{bcolors.ENDC}'
+            )
+            return []
 
         logging.warning('Selected safes: %s', ', '.join(selected))
-        return ','.join(selected)
+        return selected
 
 
 class CyberArkPAMCleanupCommand(Command):

--- a/keepercommander/commands/pam_service/add.py
+++ b/keepercommander/commands/pam_service/add.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 from . import record_lookup
 from ..discover import PAMGatewayActionDiscoverCommandBase, GatewayContext, MultiConfigurationException, multi_conf_msg
-from ...display import bcolors
+from ...error import CommandError
 from ... import vault
 from ...discovery_common.user_service import UserService
 from ...discovery_common.record_link import RecordLink
@@ -11,7 +11,7 @@ from ...discovery_common.constants import PAM_USER, PAM_MACHINE
 from ...discovery_common.types import UserAcl, ServiceEnum
 from ...keeper_dag.types import RefType, EdgeType
 from ... import __version__
-from typing import Optional, TYPE_CHECKING
+from typing import NoReturn, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ...vault import TypedRecord
@@ -40,6 +40,10 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
     def get_parser(self):
         return PAMActionServiceAddCommand.parser
 
+    @staticmethod
+    def _fail(message: str) -> NoReturn:
+        raise CommandError('pam action service add', message)
+
     def execute(self, params: KeeperParams, **kwargs):
 
         gateway = kwargs.get("gateway", "not_set")
@@ -55,15 +59,15 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
                                                           gateway=gateway,
                                                           configuration_uid=kwargs.get('configuration_uid'))
             if gateway_context is None:
-                print(f"{bcolors.FAIL}Could not find the gateway configuration for {gateway}.{bcolors.ENDC}")
-                return
+                self._fail(f"Could not find the gateway configuration for {gateway}.")
         except MultiConfigurationException as err:
             multi_conf_msg(gateway, err)
-            return
+            self._fail(
+                f"Multiple PAM configurations match gateway {gateway}. Use --configuration-uid."
+            )
 
         if gateway_context is None:
-            print(f"  {self._f('Cannot get gateway information. Gateway may not be up.')}")
-            return
+            self._fail("Cannot get gateway information. Gateway may not be up.")
 
         record_link = RecordLink(record=gateway_context.configuration,
                                  params=params,
@@ -82,54 +86,45 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
         # Check to see if the record exists.
         machine_record = vault.KeeperRecord.load(params, machine_uid)  # type: Optional[TypedRecord]
         if machine_record is None:
-            print(self._f("The machine record does not exists."))
-            return
+            self._fail("The machine record does not exists.")
 
         # Make sure the record is a PAM Machine.
         if machine_record.record_type != PAM_MACHINE:
-            print(self._f("The machine record is not a PAM Machine."))
-            return
+            self._fail("The machine record is not a PAM Machine.")
 
         # Make sure this machine is linked to the configuration record.
         machine_rl = record_link.get_record_link(machine_record.record_uid)
         if machine_rl is None:
-            print(self._f("The machine record does not exists in the graph."))
-            return
+            self._fail("The machine record does not exists in the graph.")
 
         # Edges from provider and machine might be wrong.
         # Should be a LINK edge, could be an ACL edge.
         root_vertex = record_link.dag.get_root
         if root_vertex is None:
-            print(self._f("Could not get the root of the graph."))
-            return
+            self._fail("Could not get the root of the graph.")
 
         if (machine_rl.get_edge(root_vertex, edge_type=EdgeType.LINK) is None and
                 machine_rl.get_edge(root_vertex, edge_type=EdgeType.ACL) is None):
-            print(self._f("The machine record does not belong to this gateway."))
-            return
+            self._fail("The machine record does not belong to this gateway.")
 
         ###############
 
         # Check to see if the record exists.
         user_record = vault.KeeperRecord.load(params, user_uid)  # type: Optional[TypedRecord]
         if user_record is None:
-            print(self._f("The user record does not exists."))
-            return
+            self._fail("The user record does not exists.")
 
         # Make sure this user is a PAM User.
         if user_record.record_type != PAM_USER:
-            print(self._f("The user record is not a PAM User."))
-            return
+            self._fail("The user record is not a PAM User.")
 
         record_rotation = params.record_rotation_cache.get(user_record.record_uid)
         if record_rotation is not None:
             controller_uid = record_rotation.get("configuration_uid")
             if controller_uid is None or controller_uid != gateway_context.configuration_uid:
-                print(self._f("The user record does not belong to this gateway. Cannot use this user."))
-                return
+                self._fail("The user record does not belong to this gateway. Cannot use this user.")
         else:
-            print(self._f("The user record does not have any rotation settings."))
-            return
+            self._fail("The user record does not have any rotation settings.")
 
         ########
 
@@ -137,18 +132,15 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
         # Linux and Mac do not use passwords in services and cron jobs; no need to link.
         os_field = next((x for x in machine_record.fields if x.label == "operatingSystem"), None)
         if os_field is None:
-            print(self._f("Cannot find the operating system field in this record."))
-            return
+            self._fail("Cannot find the operating system field in this record.")
         os_type = None
         if len(os_field.value) > 0:
             os_type = os_field.value[0]
         if os_type is None:
-            print(self._f("The operating system field of the machine record is blank."))
-            return
+            self._fail("The operating system field of the machine record is blank.")
         if os_type.lower() != "windows":
-            print(self._f("The operating system is not Windows. "
-                          "PAM can only rotate the services and scheduled task password on Windows."))
-            return
+            self._fail("The operating system is not Windows. "
+                       "PAM can only rotate the services and scheduled task password on Windows.")
 
         # Get the machine service vertex.
         # If it doesn't exist, create one.

--- a/keepercommander/commands/pam_service/add.py
+++ b/keepercommander/commands/pam_service/add.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 from . import record_lookup
 from ..discover import PAMGatewayActionDiscoverCommandBase, GatewayContext, MultiConfigurationException, multi_conf_msg
-from ...error import CommandError
+from ...display import bcolors
 from ... import vault
 from ...discovery_common.user_service import UserService
 from ...discovery_common.record_link import RecordLink
@@ -11,7 +11,7 @@ from ...discovery_common.constants import PAM_USER, PAM_MACHINE
 from ...discovery_common.types import UserAcl, ServiceEnum
 from ...keeper_dag.types import RefType, EdgeType
 from ... import __version__
-from typing import NoReturn, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ...vault import TypedRecord
@@ -40,10 +40,6 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
     def get_parser(self):
         return PAMActionServiceAddCommand.parser
 
-    @staticmethod
-    def _fail(message: str) -> NoReturn:
-        raise CommandError('pam action service add', message)
-
     def execute(self, params: KeeperParams, **kwargs):
 
         gateway = kwargs.get("gateway", "not_set")
@@ -59,15 +55,15 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
                                                           gateway=gateway,
                                                           configuration_uid=kwargs.get('configuration_uid'))
             if gateway_context is None:
-                self._fail(f"Could not find the gateway configuration for {gateway}.")
+                print(f"{bcolors.FAIL}Could not find the gateway configuration for {gateway}.{bcolors.ENDC}")
+                return
         except MultiConfigurationException as err:
             multi_conf_msg(gateway, err)
-            self._fail(
-                f"Multiple PAM configurations match gateway {gateway}. Use --configuration-uid."
-            )
+            return
 
         if gateway_context is None:
-            self._fail("Cannot get gateway information. Gateway may not be up.")
+            print(f"  {self._f('Cannot get gateway information. Gateway may not be up.')}")
+            return
 
         record_link = RecordLink(record=gateway_context.configuration,
                                  params=params,
@@ -86,45 +82,54 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
         # Check to see if the record exists.
         machine_record = vault.KeeperRecord.load(params, machine_uid)  # type: Optional[TypedRecord]
         if machine_record is None:
-            self._fail("The machine record does not exists.")
+            print(self._f("The machine record does not exists."))
+            return
 
         # Make sure the record is a PAM Machine.
         if machine_record.record_type != PAM_MACHINE:
-            self._fail("The machine record is not a PAM Machine.")
+            print(self._f("The machine record is not a PAM Machine."))
+            return
 
         # Make sure this machine is linked to the configuration record.
         machine_rl = record_link.get_record_link(machine_record.record_uid)
         if machine_rl is None:
-            self._fail("The machine record does not exists in the graph.")
+            print(self._f("The machine record does not exists in the graph."))
+            return
 
         # Edges from provider and machine might be wrong.
         # Should be a LINK edge, could be an ACL edge.
         root_vertex = record_link.dag.get_root
         if root_vertex is None:
-            self._fail("Could not get the root of the graph.")
+            print(self._f("Could not get the root of the graph."))
+            return
 
         if (machine_rl.get_edge(root_vertex, edge_type=EdgeType.LINK) is None and
                 machine_rl.get_edge(root_vertex, edge_type=EdgeType.ACL) is None):
-            self._fail("The machine record does not belong to this gateway.")
+            print(self._f("The machine record does not belong to this gateway."))
+            return
 
         ###############
 
         # Check to see if the record exists.
         user_record = vault.KeeperRecord.load(params, user_uid)  # type: Optional[TypedRecord]
         if user_record is None:
-            self._fail("The user record does not exists.")
+            print(self._f("The user record does not exists."))
+            return
 
         # Make sure this user is a PAM User.
         if user_record.record_type != PAM_USER:
-            self._fail("The user record is not a PAM User.")
+            print(self._f("The user record is not a PAM User."))
+            return
 
         record_rotation = params.record_rotation_cache.get(user_record.record_uid)
         if record_rotation is not None:
             controller_uid = record_rotation.get("configuration_uid")
             if controller_uid is None or controller_uid != gateway_context.configuration_uid:
-                self._fail("The user record does not belong to this gateway. Cannot use this user.")
+                print(self._f("The user record does not belong to this gateway. Cannot use this user."))
+                return
         else:
-            self._fail("The user record does not have any rotation settings.")
+            print(self._f("The user record does not have any rotation settings."))
+            return
 
         ########
 
@@ -132,15 +137,18 @@ class PAMActionServiceAddCommand(PAMGatewayActionDiscoverCommandBase):
         # Linux and Mac do not use passwords in services and cron jobs; no need to link.
         os_field = next((x for x in machine_record.fields if x.label == "operatingSystem"), None)
         if os_field is None:
-            self._fail("Cannot find the operating system field in this record.")
+            print(self._f("Cannot find the operating system field in this record."))
+            return
         os_type = None
         if len(os_field.value) > 0:
             os_type = os_field.value[0]
         if os_type is None:
-            self._fail("The operating system field of the machine record is blank.")
+            print(self._f("The operating system field of the machine record is blank."))
+            return
         if os_type.lower() != "windows":
-            self._fail("The operating system is not Windows. "
-                       "PAM can only rotate the services and scheduled task password on Windows.")
+            print(self._f("The operating system is not Windows. "
+                          "PAM can only rotate the services and scheduled task password on Windows."))
+            return
 
         # Get the machine service vertex.
         # If it doesn't exist, create one.

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -85,6 +85,8 @@ import_parser.add_argument('--show-skipped', dest='show_skipped', action='store_
                            help='Display skipped records')
 import_parser.add_argument('--secret-ids', dest='secret_ids', action='store',
                            help='Comma separated list of secret IDs to fetch (Thycotic)')
+import_parser.add_argument('--target-node', '--node', dest='target_node', action='store',
+                           help='node name or ID for CyberArk-provisioned users, teams, and roles (default: root node)')
 import_parser.add_argument(
     'name', type=str,
     help='file name (json, csv , keepass, 1password), account name (lastpass), or URL (ManageEngine, Thycotic). '
@@ -284,6 +286,10 @@ class RecordImportCommand(ImporterCommand):
             if rti is None:
                 logging.warning(f'Record type "{record_type}" not found.')
                 return
+
+        if kwargs.get('target_node') and import_format != 'cyberark':
+            logging.warning('--target-node/--node is only used with --format=cyberark; ignoring')
+            kwargs['target_node'] = None
 
         logging.info('Processing... please wait.')
         imp_exp._import(params, import_format, import_name, manage_users=manage_users, manage_records=manage_records,

--- a/keepercommander/importer/cyberark/cyberark.py
+++ b/keepercommander/importer/cyberark/cyberark.py
@@ -22,6 +22,8 @@ from urllib3.exceptions import InsecureRequestWarning
 from ... import api, crypto, utils
 from ...commands.enterprise_common import EnterpriseCommand
 from ...constants import EMAIL_PATTERN
+from ...error import CommandError
+from .pam import _esc
 from ..importer import (
     BaseDownloadMembership,
     BaseImporter,
@@ -978,6 +980,16 @@ class CyberArkImporter(BaseImporter):
             return
         pvwa_host, authorization_token, query_params = auth
 
+        params = kwargs.get("params")
+        will_teams = environ.get("_CYBERARK_SKIP_TEAMS", "").lower() not in ("1", "true", "yes")
+        will_create_users = environ.get("_CYBERARK_SKIP_CREATE_USERS", "").lower() not in ("1", "true", "yes")
+        will_print_users = environ.get("_CYBERARK_SKIP_USERS_LIST", "").lower() not in ("1", "true", "yes")
+        target_node = kwargs.get("target_node")
+
+        provision_node_id = None
+        if will_teams:
+            provision_node_id = self._resolve_provisioning_node_id(params, target_node)
+
         safes = self._resolve_safes(pvwa_host, authorization_token)
         if not safes:
             return
@@ -1012,11 +1024,6 @@ class CyberArkImporter(BaseImporter):
                 print_formatted_text(HTML(f"<ansiyellow>No accounts in safe {safe}</ansiyellow>"))
                 continue
             safe_accounts[safe] = accounts
-
-        params = kwargs.get("params")
-        will_teams = environ.get("_CYBERARK_SKIP_TEAMS", "").lower() not in ("1", "true", "yes")
-        will_create_users = environ.get("_CYBERARK_SKIP_CREATE_USERS", "").lower() not in ("1", "true", "yes")
-        will_print_users = environ.get("_CYBERARK_SKIP_USERS_LIST", "").lower() not in ("1", "true", "yes")
 
         # Gather the CyberArk identities (groups + users) that will become Keeper
         # teams, roles and users so they can be previewed before the import. The
@@ -1090,6 +1097,21 @@ class CyberArkImporter(BaseImporter):
             summary_lines.append(f"  - <b>{len(group_names)}</b> user group(s) as Keeper teams and roles")
         if eligible_users:
             summary_lines.append(f"  - <b>{len(eligible_users)}</b> user(s) provisioned as Keeper users")
+        if will_teams and provision_node_id is not None:
+            if target_node:
+                summary_lines.append(
+                    f'  - provision teams, roles, and users into node <b>{_esc(target_node)}</b> '
+                    f'(id <b>{provision_node_id}</b>)'
+                )
+            else:
+                summary_lines.append(
+                    f'  - provision teams, roles, and users into the default root node '
+                    f'(id <b>{provision_node_id}</b>)'
+                )
+        elif will_teams:
+            summary_lines.append(
+                '  - <ansired>teams/roles/users will be skipped</ansired> (no provisioning node)'
+            )
         if not self._confirm_import(pvwa_host, summary="\n".join(summary_lines)):
             print_formatted_text(HTML("\nImport <ansiyellow>cancelled</ansiyellow> by user"))
             return
@@ -1210,15 +1232,92 @@ class CyberArkImporter(BaseImporter):
         # Import CyberArk User Groups as Keeper Enterprise Teams + Roles, then optionally
         # create Keeper users (using their real CyberArk business emails) and
         # assign them to the matching Keeper Roles.
-        if will_teams:
+        if will_teams and provision_node_id is not None:
             self.import_user_groups(
                 pvwa_host, authorization_token, params,
                 cyberark_users=cyberark_users,
+                target_node=target_node,
+                node_id=provision_node_id,
             )
 
         print_formatted_text(HTML("\nImport <ansigreen>completed</ansigreen>"))
 
-    def import_user_groups(self, pvwa_host, authorization_token, params, cyberark_users=None):
+    def _resolve_provisioning_node_id(self, params, target_node=None):
+        """Resolve the enterprise node for CyberArk teams/roles/users.
+
+        If ``target_node`` is set (name or numeric ID), resolve it via
+
+        Returns the node id, or ``None`` if the default-node path fails
+        (errors are printed).
+        """
+        if target_node is not None:
+            target_node = str(target_node).strip() or None
+
+        if not params or not getattr(params, "enterprise", None):
+            if params is None:
+                msg = (
+                    "Cannot create Keeper Teams: Keeper session is not "
+                    "available to the importer (no params)."
+                )
+                html = (
+                    "<ansired>Cannot create Keeper Teams:</ansired> Keeper session is not "
+                    "available to the importer (no <i>params</i>)."
+                )
+            else:
+                msg = (
+                    "Cannot create Keeper Teams/users: the logged-in account "
+                    "is not an enterprise admin (no enterprise data loaded)."
+                )
+                html = (
+                    "<ansired>Cannot create Keeper Teams/users:</ansired> the logged-in account "
+                    "is not an enterprise admin (no enterprise data loaded)."
+                )
+            if target_node:
+                raise CommandError("import", msg)
+            print_formatted_text(HTML(html))
+            return None
+
+        if target_node:
+            try:
+                nodes = list(EnterpriseCommand.resolve_nodes(params, target_node))
+            except (KeyError, TypeError) as e:
+                logging.debug("resolve_nodes(%r) failed: %s", target_node, e)
+                nodes = []
+            if len(nodes) == 0:
+                raise CommandError(
+                    "import",
+                    f'Cannot provision into node: node "{target_node}" was not found.',
+                )
+            if len(nodes) > 1:
+                raise CommandError(
+                    "import",
+                    f'Cannot provision into node: more than one node matches "{target_node}". '
+                    "Use the numeric node ID.",
+                )
+            return nodes[0]["node_id"]
+
+        # Default: first user-root node (loads managed nodes if needed), then
+        # the first tree root (parent_id unset/0).
+        try:
+            root_nodes = list(EnterpriseCommand.get_user_root_nodes(params))
+        except Exception as e:
+            logging.debug("Failed to load user root nodes: %s", e)
+            root_nodes = []
+        if root_nodes:
+            return root_nodes[0]
+        for n in params.enterprise.get("nodes", []) or []:
+            if not n.get("parent_id"):
+                return n["node_id"]
+        print_formatted_text(
+            HTML(
+                "<ansired>Cannot create Keeper Teams/users:</ansired> no root node found in the "
+                "enterprise tree."
+            )
+        )
+        return None
+
+    def import_user_groups(self, pvwa_host, authorization_token, params, cyberark_users=None,
+                           target_node=None, node_id=None):
         """Fetch CyberArk User Groups and create them as Keeper Enterprise Teams.
 
         This mirrors the ``enterprise-team --add`` command flow: for each
@@ -1304,25 +1403,18 @@ class CyberArkImporter(BaseImporter):
                 existing_team_names.add(team["name"].lower())
 
         # Determine the target node id (same default as enterprise-team --add):
-        # the first user-root node when no --node was specified.
-        node_id = None
-        for nid in params.enterprise.get("user_root_nodes", []) or []:
-            node_id = nid
-            break
+        # --target-node when specified, otherwise the first user-root node.
         if node_id is None:
-            # Fall back to the first node in the tree (root has parent_id=0)
-            for n in params.enterprise.get("nodes", []) or []:
-                if not n.get("parent_id"):
-                    node_id = n["node_id"]
-                    break
+            node_id = self._resolve_provisioning_node_id(params, target_node)
         if node_id is None:
+            return
+        if target_node:
             print_formatted_text(
                 HTML(
-                    "<ansired>Cannot create Keeper Teams:</ansired> no root node found in the "
-                    "enterprise tree."
+                    f"Provisioning teams, roles, and users into node "
+                    f"<b>{_esc(target_node)}</b> (id <b>{node_id}</b>)"
                 )
             )
-            return
 
         print_formatted_text(
             HTML(f"Importing <b>{len(groups)}</b> user groups as Keeper Teams (members not provisioned):\n"),
@@ -1743,24 +1835,10 @@ class CyberArkImporter(BaseImporter):
             if uname:
                 existing_user_by_email[uname] = u
 
-        # Determine the target node (root node) for new invitations.
-        invite_node_id = None
-        for nid in params.enterprise.get("user_root_nodes", []) or []:
-            invite_node_id = nid
-            break
-        if invite_node_id is None:
-            for n in params.enterprise.get("nodes", []) or []:
-                if not n.get("parent_id"):
-                    invite_node_id = n["node_id"]
-                    break
-        if invite_node_id is None:
-            print_formatted_text(
-                HTML(
-                    "\n<ansired>Cannot invite Keeper users:</ansired> no root node found in "
-                    "the enterprise tree."
-                )
-            )
+        # Caller already resolved --target-node (or the default root).
+        if node_id is None:
             return
+        invite_node_id = node_id
 
         tree_key = params.enterprise.get("unencrypted_tree_key")
         if not tree_key:

--- a/keepercommander/importer/cyberark/pam/__init__.py
+++ b/keepercommander/importer/cyberark/pam/__init__.py
@@ -39,6 +39,7 @@ from .import_builder import (
     validate_import_data,
 )
 from .dependents import (
+    PAM_SERVICE_ADD_TYPES,
     _normalize_dependent_type,
     resolve_account_dependents,
 )
@@ -91,6 +92,7 @@ __all__ = [
     "RecordDecision",
     "MAX_FETCH_RECORDS",
     "MAX_SAFE_NAME_LENGTH",
+    "PAM_SERVICE_ADD_TYPES",
     "PermissionMapper",
     "RecordKind",
     "SafeFolderMapper",

--- a/keepercommander/importer/cyberark/pam/dependents.py
+++ b/keepercommander/importer/cyberark/pam/dependents.py
@@ -12,9 +12,9 @@
 # scheduled tasks and IIS application pools running on remote hosts. The
 # ``/Accounts/{id}/Dependents`` endpoint returns one entry per (host, service,
 # type) tuple. KeeperPAM models the same relationship via
-# ``pam action service add`` (machine-uid + user-uid + type), so the importer
-# collects dependents during the mapping phase and replays them as service
-# mappings after the vault import succeeds.
+# ``pam action service add`` (--machine-uid, --user-uid, --type, --name), so
+# the importer collects dependents during the mapping phase and replays them
+# as service mappings after the vault import succeeds.
 
 from __future__ import annotations
 
@@ -30,11 +30,14 @@ if TYPE_CHECKING:
     from .client import CyberArkPVWAClient
 
 
-# CyberArk dependent ``type`` / ``platformId`` values → Keeper service-mapping
-# verbs accepted by ``PAMActionServiceAddCommand`` (--type service|task|iis).
-# Keys are matched case-insensitively after stripping non-alphanumerics so
-# spellings like ``Windows Service``, ``Win32Service``, ``WinService``, and
-# the Privilege Cloud ``SchedTask`` platformId all resolve.
+# Exact ``pam action service add --type`` choices.
+PAM_SERVICE_ADD_TYPES = frozenset({"service", "task", "iis_pool"})
+
+# CyberArk dependent ``type`` / ``platformId`` values → Keeper ``--type``
+# values (service | task | iis_pool). Keys are matched case-insensitively
+# after stripping non-alphanumerics so spellings like ``Windows Service``,
+# ``Win32Service``, ``WinService``, and Privilege Cloud ``SchedTask`` /
+# ``IISAppPool`` all resolve.
 _DEPENDENT_TYPE_ALIASES: Dict[str, str] = {
     # Windows services
     "windowsservice": "service",
@@ -47,11 +50,13 @@ _DEPENDENT_TYPE_ALIASES: Dict[str, str] = {
     "windowsscheduledtask": "task",
     "schedtask": "task",
     "task": "task",
-    # IIS application pools
-    "iisapppool": "iis",
-    "iisapplicationpool": "iis",
-    "iisapppools": "iis",
-    "iis": "iis",
+    # IIS application pools → Keeper --type iis_pool
+    "iisapppool": "iis_pool",
+    "iisapplicationpool": "iis_pool",
+    "iisapppools": "iis_pool",
+    "iispool": "iis_pool",
+    "iis_pool": "iis_pool",
+    "iis": "iis_pool",
 }
 
 
@@ -78,10 +83,11 @@ def resolve_account_dependents(client: 'CyberArkPVWAClient',
 
     * ``machine_address`` — host where the service runs (used to find the
       Keeper PAM Machine record).
-    * ``service_type`` — Keeper verb (service|task|iis) or ``None`` for
-      unsupported categories.
+    * ``service_type`` — ``pam action service add --type`` value
+      (service|task|iis_pool) or ``None`` for unsupported categories.
     * ``raw_type`` — original CyberArk ``Type`` string (kept for reporting).
-    * ``service_name`` — informational, surfaced in the report only.
+    * ``service_name`` — ``pam action service add --name`` (Windows
+      service / scheduled-task / IIS pool name).
     * ``master_user_title`` — Keeper title of the pamUser record that holds
       the rotated credential (i.e. the user the service runs as).
     * ``master_account_id`` / ``master_account_name`` — CyberArk source IDs

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -750,6 +750,7 @@ def _import(params, file_format, filename, **kwargs):
     dry_run = kwargs.get('dry_run') is True
     show_skipped = kwargs.get('show_skipped') is True
     secret_ids = kwargs.get('secret_ids')
+    target_node = kwargs.get('target_node')
 
     import_into = kwargs.get('import_into') or ''
     if import_into:
@@ -771,7 +772,8 @@ def _import(params, file_format, filename, **kwargs):
     classic_shared = shared and not use_nsf
 
     for x in importer.execute(filename, params=params, users_only=import_users, filter_folder=filter_folder,
-                              old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids, dry_run=dry_run):
+                              old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids,
+                              dry_run=dry_run, target_node=target_node):
         if isinstance(x, ImportRecord):
             if filter_folder and not importer.support_folder_filter():
                 if not x.folders:

--- a/tests/test_cyberark_pam_import.py
+++ b/tests/test_cyberark_pam_import.py
@@ -1451,7 +1451,42 @@ class TestInteractiveSafePicker:
         safes = [{"safeName": "Alpha"}, {"safeName": "Beta"}, {"safeName": "Gamma"}]
         with patch("builtins.input", return_value="1,3"):
             result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
-        assert result == "Alpha,Gamma"
+        assert result == ["Alpha", "Gamma"]
+
+    def test_select_range(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 6)]
+        with patch("builtins.input", return_value="2-4"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == ["S2", "S3", "S4"]
+
+    def test_select_mixed_ranges_and_indexes(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 21)]
+        with patch("builtins.input", return_value="1,2,3,6-9,11,14-18"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == [
+            "S1", "S2", "S3", "S6", "S7", "S8", "S9", "S11",
+            "S14", "S15", "S16", "S17", "S18",
+        ]
+
+    def test_select_reversed_range(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 6)]
+        with patch("builtins.input", return_value="4-1"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == ["S1", "S2", "S3", "S4"]
+
+    def test_select_deduplicates(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 6)]
+        with patch("builtins.input", return_value="1,1-3,2"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == ["S1", "S2", "S3"]
 
     def test_select_invalid_input(self):
         from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
@@ -1459,7 +1494,24 @@ class TestInteractiveSafePicker:
         safes = [{"safeName": "Safe1"}]
         with patch("builtins.input", return_value="abc"):
             result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
-        assert result is None  # invalid → all
+        assert result == []  # invalid non-empty → abort, do not import all
+
+    def test_select_invalid_range_syntax_aborts(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 6)]
+        with patch("builtins.input", return_value="1..4"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == []
+
+    def test_partially_invalid_aborts(self, capsys):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        from unittest.mock import patch
+        safes = [{"safeName": f"S{i}"} for i in range(1, 8)]
+        with patch("builtins.input", return_value="1,abc,7"):
+            result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
+        assert result == []
+        assert "abc" in capsys.readouterr().out
 
     def test_eof_returns_none(self):
         from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
@@ -1468,6 +1520,235 @@ class TestInteractiveSafePicker:
         with patch("builtins.input", side_effect=EOFError):
             result = CyberArkPAMImportCommand._interactive_safe_picker(safes)
         assert result is None
+
+
+class TestMaybeInteractiveSafePick:
+    """Picker abort must not emit a second 'No safes selected' message."""
+
+    def _orch(self):
+        from keepercommander.commands.pam_import.cyberark_import import (
+            CyberArkImportOrchestrator, CyberArkPAMImportCommand,
+        )
+        orch = CyberArkImportOrchestrator.__new__(CyberArkImportOrchestrator)
+        orch.options = MagicMock(
+            safe_include="", safe_exclude="", skip_confirm=False,
+            dry_run=False, output_file="",
+        )
+        orch.params = MagicMock(batch_mode=False)
+        orch._cmd = CyberArkPAMImportCommand()
+        return orch
+
+    def test_cancelled_does_not_print_no_safes_selected(self, capsys):
+        orch = self._orch()
+        safes = [{"safeName": "A"}]
+        with patch.object(orch._cmd, "_interactive_safe_picker", return_value=[]):
+            result = orch._maybe_interactive_safe_pick(safes)
+        assert result == []
+        assert "No safes selected" not in capsys.readouterr().out
+
+    def test_all_returns_original(self):
+        orch = self._orch()
+        safes = [{"safeName": "A"}]
+        with patch.object(orch._cmd, "_interactive_safe_picker", return_value=None):
+            assert orch._maybe_interactive_safe_pick(safes) is safes
+
+
+class TestParseIndexSelection:
+    """Unit tests for _parse_index_selection."""
+
+    def test_single_indexes(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection("1,3", 5) == [0, 2]
+
+    def test_range(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection("1-4", 10) == [0, 1, 2, 3]
+
+    def test_mixed(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection("1,2,3,6-9,11,14-18", 20) == [
+            0, 1, 2, 5, 6, 7, 8, 10, 13, 14, 15, 16, 17
+        ]
+
+    def test_out_of_range_rejected(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        with pytest.raises(ValueError, match="99"):
+            CyberArkPAMImportCommand._parse_index_selection("1,99,2-3,50-60", 5)
+
+    def test_zero_start_rejected(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        with pytest.raises(ValueError, match="0-2"):
+            CyberArkPAMImportCommand._parse_index_selection("0-2", 5)
+
+    def test_partially_invalid_token_rejected(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        with pytest.raises(ValueError, match="abc"):
+            CyberArkPAMImportCommand._parse_index_selection("1,abc,7", 10)
+
+    def test_whitespace_tolerant(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection(" 1 , 3 - 5 , 7 ", 10) == [0, 2, 3, 4, 6]
+
+    def test_huge_range_rejected(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        with pytest.raises(ValueError, match="1-1000000"):
+            CyberArkPAMImportCommand._parse_index_selection("1-1000000", 5)
+
+    def test_unicode_en_dash(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection("2–4", 6) == [1, 2, 3]
+
+    def test_rejects_malformed_tokens(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        for bad in ("1-2-3", "1--5", "1..4", "1:4"):
+            with pytest.raises(ValueError, match="invalid or out-of-range"):
+                CyberArkPAMImportCommand._parse_index_selection(bad, 10)
+
+    def test_empty_tokens_ignored(self):
+        from keepercommander.commands.pam_import.cyberark_import import CyberArkPAMImportCommand
+        assert CyberArkPAMImportCommand._parse_index_selection("1,,3", 5) == [0, 2]
+
+
+def _enterprise_params(nodes=None, user_root_nodes=None, enterprise_name="Acme"):
+    params = MagicMock()
+    params.enterprise = {
+        "nodes": nodes if nodes is not None else [
+            {"node_id": 1, "data": {}},
+            {"node_id": 2, "parent_id": 1, "data": {"displayname": "Engineering"}},
+            {"node_id": 3, "parent_id": 1, "data": {"displayname": "R&D"}},
+            {"node_id": 4, "parent_id": 1, "data": {"displayname": "Dup"}},
+            {"node_id": 5, "parent_id": 1, "data": {"displayname": "Dup"}},
+        ],
+        "user_root_nodes": user_root_nodes if user_root_nodes is not None else [1],
+        "enterprise_name": enterprise_name,
+    }
+    return params
+
+
+class TestResolveProvisioningNodeId:
+    """Tests for CyberArkImporter._resolve_provisioning_node_id."""
+
+    def _importer(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        return CyberArkImporter()
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_resolves_by_name(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(_enterprise_params(), "Engineering") == 2
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_resolves_by_numeric_id(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(_enterprise_params(), "3") == 3
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_strips_whitespace(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(_enterprise_params(), "  Engineering  ") == 2
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_ampersand_name_found(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(_enterprise_params(), "R&D") == 3
+
+    def test_ampersand_name_not_found_raises(self):
+        from keepercommander.error import CommandError
+        importer = self._importer()
+        with pytest.raises(CommandError, match="No&Such"):
+            importer._resolve_provisioning_node_id(_enterprise_params(), "No&Such")
+
+    def test_not_found_raises(self):
+        from keepercommander.error import CommandError
+        importer = self._importer()
+        with pytest.raises(CommandError, match="was not found"):
+            importer._resolve_provisioning_node_id(_enterprise_params(), "Missing")
+
+    def test_ambiguous_name_raises(self):
+        from keepercommander.error import CommandError
+        importer = self._importer()
+        with pytest.raises(CommandError, match="more than one node matches"):
+            importer._resolve_provisioning_node_id(_enterprise_params(), "Dup")
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_default_user_root_node(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(
+            _enterprise_params(user_root_nodes=[99]), None
+        ) == 99
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_default_falls_back_to_tree_root(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(
+            _enterprise_params(user_root_nodes=[]), None
+        ) == 1
+
+    def test_no_enterprise_with_target_node_raises(self):
+        from keepercommander.error import CommandError
+        importer = self._importer()
+        params = MagicMock()
+        params.enterprise = None
+        with pytest.raises(CommandError, match="not an enterprise admin"):
+            importer._resolve_provisioning_node_id(params, "Engineering")
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_no_enterprise_default_path_returns_none(self, _print):
+        importer = self._importer()
+        params = MagicMock()
+        params.enterprise = None
+        assert importer._resolve_provisioning_node_id(params, None) is None
+
+    def test_no_params_with_target_node_raises(self):
+        from keepercommander.error import CommandError
+        importer = self._importer()
+        with pytest.raises(CommandError, match="Keeper session is not available"):
+            importer._resolve_provisioning_node_id(None, "Engineering")
+
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    def test_no_params_default_path_returns_none(self, _print):
+        importer = self._importer()
+        assert importer._resolve_provisioning_node_id(None, None) is None
+
+    def test_success_html_escapes_ampersand(self):
+        from prompt_toolkit import HTML
+        from keepercommander.importer.cyberark.pam import _esc
+        HTML(
+            f"Provisioning teams, roles, and users into node "
+            f"<b>{_esc('R&D')}</b> (id <b>3</b>)"
+        )
+
+
+class TestImportTargetNodeArgparse:
+    """--target-node / --node on the vault import parser."""
+
+    def test_target_node_flag(self):
+        from keepercommander.importer.commands import import_parser
+        ns = import_parser.parse_args(["--format", "cyberark", "--target-node", "Eng", "https://pvwa"])
+        assert ns.target_node == "Eng"
+
+    def test_node_alias(self):
+        from keepercommander.importer.commands import import_parser
+        ns = import_parser.parse_args(["--format", "cyberark", "--node", "Eng", "https://pvwa"])
+        assert ns.target_node == "Eng"
+
+    def test_ignored_for_non_cyberark_format(self):
+        from keepercommander.importer.commands import RecordImportCommand
+        cmd = RecordImportCommand()
+        params = MagicMock()
+        params.enforcements = None
+        with patch("keepercommander.importer.commands.imp_exp._import") as mock_import:
+            cmd.execute(params, format="json", name="vault.json", target_node="Eng")
+        assert mock_import.call_args.kwargs.get("target_node") is None
+
+    def test_kept_for_cyberark_format(self):
+        from keepercommander.importer.commands import RecordImportCommand
+        cmd = RecordImportCommand()
+        params = MagicMock()
+        params.enforcements = None
+        with patch("keepercommander.importer.commands.imp_exp._import") as mock_import:
+            cmd.execute(params, format="cyberark", name="https://pvwa", target_node="Eng")
+        assert mock_import.call_args.kwargs.get("target_node") == "Eng"
 
 
 class TestListSafesDetailed:


### PR DESCRIPTION
- Add range support to the interactive CyberArk PAM safe picker:
  - `1-4`,`1,3,6-9`

- Add `--target-node`  to `import --format=cyberark` to provision CyberArk teams, roles, and users into a specific enterprise node.
  - Defaults to the root node.