### PR TITLE
NSF fixes for pam project import/extend: KSM app grants and root folder reuse

### DIFF
--- a/keepercommander/commands/pam_import/edit.py
+++ b/keepercommander/commands/pam_import/edit.py
@@ -49,6 +49,7 @@ from .base import (
 )
 from ..base import Command
 from ..ksm import KSMCommand
+from ..nested_share_folder.helpers import ROOT_FOLDER_UID as NSF_ROOT_FOLDER_UID
 from ..pam import gateway_helper
 from ..pam.config_helper import pam_configurations_get_all
 from ..pam.vault_target import (
@@ -1124,15 +1125,42 @@ class PAMProjectImportCommand(Command):
                   (is_shared_folder and v.type == BaseFolderNode.SharedFolderType) or
                   (not is_shared_folder and v.type == BaseFolderNode.UserFolderType)]
         if not is_shared_folder:
-            for uid, nsf in getattr(params, 'nested_share_folders', {}).items():
-                nsf_parent = nsf.get('parent_uid') or None
-                if nsf_parent == puid and nsf.get('name') == folder:
+            seen = {v.uid for v in result}
+            nsf_folders = getattr(params, 'nested_share_folders', None) or {}
+            for uid, nsf in nsf_folders.items():
+                if uid in seen or nsf.get('name') != folder:
+                    continue
+                nsf_parent = self._nsf_effective_parent_uid(nsf, nsf_folders, folders)
+                if nsf_parent == puid:
                     nsf_folder = NestedShareFolderNode()
                     nsf_folder.uid = uid
                     nsf_folder.name = nsf.get('name')
                     nsf_folder.parent_uid = nsf_parent
                     result.append(nsf_folder)
+                    seen.add(uid)
         return result
+
+    @staticmethod
+    def _nsf_effective_parent_uid(nsf: dict, nsf_folders: dict, folder_cache: dict) -> Optional[str]:
+        """Normalize an NSF folder's parent to ``None`` when the folder sits at the root.
+
+        A root-level NSF can be reported three ways: ``None`` (no ``parentUid`` was
+        ever sent - both Commander and the Web Vault omit it on create), the server's
+        drive-root sentinel UID, or - after ``normalize_parent_uid`` - the string
+        ``'root'``. ``sync_down.prepare_folder_tree`` reconciles this on the
+        ``folder_cache`` node but leaves ``params.nested_share_folders`` untouched, so
+        matching on the raw value there misses roots and duplicates them instead.
+        Mirrors the same predicate used by ``tree``/``ls`` in commands/folder.py.
+        """
+        nsf_parent = nsf.get('parent_uid') or None
+        if not nsf_parent:
+            return None
+        if nsf_parent in (NSF_ROOT_FOLDER_UID, 'root'):
+            return None
+        if nsf_parent not in nsf_folders and nsf_parent not in folder_cache:
+            # Parent resolves to no known folder, so it cannot be a real parent.
+            return None
+        return nsf_parent
 
     def create_ksm_app(self, params, app_name) -> str:
         app_record_data = {

--- a/keepercommander/commands/pam_import/edit.py
+++ b/keepercommander/commands/pam_import/edit.py
@@ -546,7 +546,9 @@ class PAMProjectImportCommand(Command):
         # Create KSM App and share Resources/Users folders (classic SF or NSF).
         # KSMCommand routes NSF folder UIDs through grant_folder_access_to_application_v3.
         use_nsf = project["options"].get("use_nsf", False) is True
-        from .nsf_helpers import restore_nsf_folder_keys, snapshot_nsf_folder_keys, sync_down_preserving_nsf_keys
+        from .nsf_helpers import (collect_nsf_subtree_uids, grant_nsf_folders_to_ksm_app,
+                                  restore_nsf_folder_keys, snapshot_nsf_folder_keys,
+                                  sync_down_preserving_nsf_keys)
         preserved = snapshot_nsf_folder_keys(params) if use_nsf else None
         res["app_uid"] = self.create_ksm_app(params, res["app_name"])
         if preserved is not None:
@@ -570,18 +572,35 @@ class PAMProjectImportCommand(Command):
             sf_uids_to_grant.append(sf_uid)
 
         folders = project["folders"]
+        # NSF folder keys are per-folder: a child does not inherit the parent's
+        # AT_APPLICATION grant the way a classic shared_folder_folder does. Grant
+        # the whole project subtree so records in any descendant (safe-mode
+        # "{safe} - Resources"/"- Users" subfolders included) stay GW-visible.
+        # The global "PAM Environments" root is deliberately excluded - it is a
+        # container shared across projects and holds no records.
+        if use_nsf and folders.get("project_folder_uid", ""):
+            for nsf_uid in collect_nsf_subtree_uids(params, folders["project_folder_uid"]):
+                _add_sf(nsf_uid)
         _add_sf(folders.get("resources_folder_uid", ""))
         _add_sf(folders.get("users_folder_uid", ""))
         _add_sf(folders.get("config_folder_uid", ""))
         for entry in folders.get("safe_folders", []) or []:
             if isinstance(entry, dict):
                 _add_sf(entry.get("uid", ""))
+                if use_nsf:
+                    # Classic safe subfolders are shared_folder_folder children and
+                    # inherit the safe's key; NSF ones need their own grant.
+                    _add_sf(entry.get("resources_subfolder_uid", ""))
+                    _add_sf(entry.get("users_subfolder_uid", ""))
 
-        for sf_uid in sf_uids_to_grant:
-            KSMCommand().execute(params,
-                                 command=("secret", "add"),
-                                 app=res["app_uid"],
-                                 secret=[sf_uid], editable=True)
+        if use_nsf:
+            grant_nsf_folders_to_ksm_app(params, res["app_uid"], sf_uids_to_grant, editable=True)
+        else:
+            for sf_uid in sf_uids_to_grant:
+                KSMCommand().execute(params,
+                                     command=("secret", "add"),
+                                     app=res["app_uid"],
+                                     secret=[sf_uid], editable=True)
 
         if use_nsf or any(is_nested_share_folder(params, uid)
                           for uid in (project["folders"].get("resources_folder_uid", ""),

--- a/keepercommander/commands/pam_import/extend.py
+++ b/keepercommander/commands/pam_import/extend.py
@@ -62,6 +62,8 @@ from .nsf_helpers import (
     get_folder_record_uids,
     get_ksm_app_folders,
     get_records_in_folder,
+    grant_nsf_folders_to_ksm_app,
+    sync_down_preserving_nsf_keys,
 )
 from .record_loader import load_pam_record
 from ...keeper_dag import EdgeType
@@ -464,6 +466,7 @@ class PAMProjectExtendCommand(Command):
         project = {
             "data": {"pam_data": pam_data},
             "options": {"dry_run": dry_run},
+            "ksm_app_uid": ksmapp_uid,
             "ksm_shared_folders": ksm_shared_folders,
             "folders": {},
             "pam_config": {"pam_config_uid": configuration.record_uid, "pam_config_object": None},
@@ -651,6 +654,7 @@ class PAMProjectExtendCommand(Command):
 
         if not dry_run and not step1_errors and new_nodes_list:
             sf_name_map = {shf["name"]: shf for shf in ksm_shared_folders}
+            new_nsf_uids = []
             for full_path, parent_path, name, node in new_nodes_list:
                 parent_uid = path_to_folder_uid.get(parent_path, "")
                 if not parent_uid and parent_path in sf_name_map:
@@ -658,13 +662,45 @@ class PAMProjectExtendCommand(Command):
                 new_uid = self.create_subfolder(params, name, parent_uid, folder_uid=node.get("uid"))
                 node["uid"] = new_uid
                 path_to_folder_uid[full_path] = new_uid
-            api.sync_down(params)
+                if is_nested_share_folder(params, new_uid):
+                    new_nsf_uids.append(new_uid)
+
+            if new_nsf_uids:
+                # Plain sync_down drops the NSF folder keys the grant below needs.
+                sync_down_preserving_nsf_keys(params)
+                # NSF children do not inherit the parent's AT_APPLICATION grant,
+                # so the Gateway cannot see records in them until each new folder
+                # is registered on the KSM application.
+                app_uid = project.get("ksm_app_uid") or ""
+                if app_uid:
+                    granted = grant_nsf_folders_to_ksm_app(params, app_uid, new_nsf_uids, editable=True)
+                    print(f"Registered {len(granted)} of {len(new_nsf_uids)} new Nested Share Folder(s) "
+                          f"on KSM Application {app_uid}")
+                    if len(granted) != len(new_nsf_uids):
+                        logging.warning("Records in unregistered Nested Share Folders will not be "
+                                        "visible to the Gateway - add them with "
+                                        "`secrets-manager share add --app %s --secret <folder uid>`", app_uid)
+                else:
+                    logging.warning("KSM Application UID unavailable - new Nested Share Folders "
+                                    "were not registered on the application")
+            else:
+                api.sync_down(params)
 
         existing_msg = f"{x_count} existing folders (skipped)" if x_count else "0 existing folders"
         if dry_run:
             print(f"[DRY RUN] {existing_msg}, {y_count} new folders to be created")
         else:
             print(f"{existing_msg}, {y_count} new folders created")
+
+        if dry_run and not step1_errors and new_nodes_list:
+            nsf_paths = self._nsf_paths_to_be_created(params, new_nodes_list,
+                                                      path_to_folder_uid, ksm_shared_folders)
+            if nsf_paths:
+                app_uid = project.get("ksm_app_uid") or "?"
+                print(f"[DRY RUN] {len(nsf_paths)} new Nested Share Folder(s) would be registered "
+                      f"on KSM Application {app_uid}")
+                for path in nsf_paths:
+                    print(f"[DRY RUN]   • {path}")
 
         if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
             for path, _ in good_paths:
@@ -677,6 +713,25 @@ class PAMProjectExtendCommand(Command):
         folders_out["folder_stats_x"] = x_count
         folders_out["folder_stats_y"] = y_count
         return folders_out
+
+    @staticmethod
+    def _nsf_paths_to_be_created(params, new_nodes_list, path_to_folder_uid, ksm_shared_folders) -> list:
+        """Dry-run helper: which of the folders about to be created land under an NSF parent.
+
+        New folders have pre-generated UIDs that do not exist in the vault yet, so a
+        new child of a new folder cannot be classified by UID - shallow paths are
+        resolved first and deeper ones inherit from their parent path.
+        """
+        sf_name_map = {shf["name"]: shf for shf in ksm_shared_folders}
+        nsf_paths = set()
+        for full_path, parent_path, _name, _node in sorted(new_nodes_list,
+                                                           key=lambda x: str(x[0]).count("/")):
+            parent_uid = path_to_folder_uid.get(parent_path, "")
+            if not parent_uid and parent_path in sf_name_map:
+                parent_uid = sf_name_map[parent_path]["uid"]
+            if parent_path in nsf_paths or is_nested_share_folder(params, parent_uid):
+                nsf_paths.add(full_path)
+        return sorted(nsf_paths)
 
     def map_records(self, params, project: dict) -> tuple:
         """Step 2: Parse resources/users, tag existing vs new, set obj.uid; collect errors.

--- a/keepercommander/commands/pam_import/extend.py
+++ b/keepercommander/commands/pam_import/extend.py
@@ -1300,31 +1300,6 @@ class PAMProjectExtendCommand(Command):
             params.environment_variables[LAST_SHARED_FOLDER_UID] = folder_uid
         return folder_uid
 
-    def find_folders(self, params, parent_uid:str, folder:str, is_shared_folder:bool) -> List[BaseFolderNode]:
-        result: List[BaseFolderNode] = []
-        folders = params.folder_cache if params and params.folder_cache else {}
-        if not isinstance(folders, dict):
-            return result
-
-        puid = parent_uid if parent_uid else None # root folder parent uid is set to None
-        matches = {k: v for k, v in folders.items() if v.parent_uid == puid and v.name == folder}
-        result = [v for k, v in matches.items() if
-                  (is_shared_folder and v.type == BaseFolderNode.SharedFolderType) or
-                  (not is_shared_folder and v.type == BaseFolderNode.UserFolderType)]
-        if not is_shared_folder:
-            for uid, nsf in getattr(params, 'nested_share_folders', {}).items():
-                nsf_parent = nsf.get('parent_uid') or None
-                if nsf_parent == puid and nsf.get('name') == folder:
-                    result.append(SimpleNamespace(
-                        uid=uid,
-                        name=nsf.get('name'),
-                        parent_uid=nsf_parent,
-                        type=BaseFolderNode.UserFolderType,
-                        UserFolderType=BaseFolderNode.UserFolderType,
-                        SharedFolderType=BaseFolderNode.SharedFolderType,
-                    ))
-        return result
-
     def create_ksm_app(self, params, app_name) -> str:
         app_record_data = {
             "title": app_name,

--- a/keepercommander/commands/pam_import/nsf_helpers.py
+++ b/keepercommander/commands/pam_import/nsf_helpers.py
@@ -208,6 +208,95 @@ def sync_down_preserving_nsf_keys(params) -> None:
     restore_nsf_folder_keys(params, preserved)
 
 
+def collect_nsf_subtree_uids(params, root_uid: str) -> List[str]:
+    """Return *root_uid* plus every NSF folder nested underneath it.
+
+    Breadth-first so parents are granted before their children; dedup'd and
+    cycle-safe.
+    """
+    root_uid = (root_uid or '').strip()
+    if not root_uid:
+        return []
+
+    children = {}
+    for folder_uid, info in (getattr(params, 'nested_share_folders', None) or {}).items():
+        parent_uid = (info.get('parent_uid') if isinstance(info, dict) else None) or ''
+        if parent_uid:
+            children.setdefault(parent_uid, []).append(folder_uid)
+
+    ordered = [root_uid]
+    seen = {root_uid}
+    queue = [root_uid]
+    while queue:
+        current = queue.pop(0)
+        for child_uid in children.get(current, []):
+            if child_uid in seen:
+                continue
+            seen.add(child_uid)
+            ordered.append(child_uid)
+            queue.append(child_uid)
+    return ordered
+
+
+def grant_nsf_folders_to_ksm_app(params, app_uid: str, folder_uids, editable: bool = True) -> List[str]:
+    """Register NSF folders on a KSM application.
+
+    KSM and the Gateway only see records in folders carrying a direct
+    ``AT_APPLICATION`` grant - unlike classic shared-folder children, NSF
+    children have their own folder key and inherit nothing from the parent.
+
+    One batched ``secret add`` is attempted first; on failure the UIDs are
+    retried one at a time so a single unshareable folder does not lose the
+    rest. Returns the UIDs that were granted.
+    """
+    from ..ksm import KSMCommand
+
+    app_uid = (app_uid or '').strip()
+    if not app_uid:
+        return []
+
+    uids: List[str] = []
+    seen = set()
+    for folder_uid in folder_uids or []:
+        folder_uid = (folder_uid or '').strip()
+        if not folder_uid or folder_uid in seen:
+            continue
+        seen.add(folder_uid)
+        uids.append(folder_uid)
+    if not uids:
+        return []
+
+    # add_app_share ends in a sync_down that drops the NSF folder keys, so
+    # restore them before every call - not just once at the end.
+    preserved = snapshot_nsf_folder_keys(params)
+    try:
+        try:
+            KSMCommand().execute(params, command=('secret', 'add'), app=app_uid,
+                                 secret=list(uids), editable=editable)
+            return uids
+        except Exception as exc:
+            if len(uids) == 1:
+                logging.warning('Could not register folder %s on KSM application %s: %s',
+                                uids[0], app_uid, exc)
+                return []
+            logging.debug('Batch KSM share of %d folders failed (%s) - retrying one at a time',
+                          len(uids), exc)
+
+        granted: List[str] = []
+        for folder_uid in uids:
+            restore_nsf_folder_keys(params, preserved)
+            try:
+                KSMCommand().execute(params, command=('secret', 'add'), app=app_uid,
+                                     secret=[folder_uid], editable=editable)
+                granted.append(folder_uid)
+            except Exception as exc:
+                logging.warning('Could not register folder %s on KSM application %s: %s',
+                                folder_uid, app_uid, exc)
+        return granted
+    finally:
+        restore_nsf_folder_keys(params, preserved)
+
+
 def seed_nsf_folder_cache(params, folder_uid: str, name: str,
                           parent_uid: Optional[str] = None,
                           folder_key: Optional[bytes] = None) -> None:

--- a/keepercommander/record_management.py
+++ b/keepercommander/record_management.py
@@ -188,6 +188,37 @@ def compare_records(record1, record2):
     return status
 
 
+def _sync_cached_record(params, record_uid, revision, client_modified_time,
+                        encrypted_data, decrypted_data,
+                        encrypted_extra=None, decrypted_extra=None, udata=None):
+    # type: (KeeperParams, str, int, int, Optional[bytes], Optional[bytes], Optional[bytes], Optional[bytes], Optional[dict]) -> None
+    """Fold a just-persisted record back into ``params.record_cache``.
+
+    ``update_record`` reads the revision it puts on the wire from the cache, not
+    from the passed-in record object, so leaving the cache at the pre-update
+    revision makes a second update of the same record within one command fail
+    with ``RS_OUT_OF_SYNC``. The payload is written alongside the revision to keep
+    the entry self-consistent - ``KeeperRecord.load`` reads ``data_unencrypted``,
+    so a bumped revision paired with stale data would surface pre-update fields.
+    """
+    storage_record = params.record_cache.get(record_uid)
+    if not isinstance(storage_record, dict) or not revision:
+        return
+    storage_record['revision'] = revision
+    if client_modified_time:
+        storage_record['client_modified_time'] = client_modified_time
+    if encrypted_data is not None:
+        storage_record['data'] = utils.base64_url_encode(encrypted_data)
+    if decrypted_data is not None:
+        storage_record['data_unencrypted'] = decrypted_data
+    if encrypted_extra is not None:
+        storage_record['extra'] = utils.base64_url_encode(encrypted_extra)
+    if decrypted_extra is not None:
+        storage_record['extra_unencrypted'] = decrypted_extra
+    if udata is not None:
+        storage_record['udata'] = udata
+
+
 def update_record(params, record, skip_extra=False):
     # type: (KeeperParams, vault.KeeperRecord, bool) -> None
     storage_record = params.record_cache.get(record.record_uid)
@@ -212,9 +243,12 @@ def update_record(params, record, skip_extra=False):
             record_object.update(path)
 
         data = vault_extensions.extract_password_record_data(record)
-        record_object['data'] = utils.base64_url_encode(
-            crypto.encrypt_aes_v1(json.dumps(data).encode(), record.record_key))
+        decrypted_data = json.dumps(data).encode()
+        encrypted_data = crypto.encrypt_aes_v1(decrypted_data, record.record_key)
+        record_object['data'] = utils.base64_url_encode(encrypted_data)
 
+        decrypted_extra = None
+        encrypted_extra = None
         if not skip_extra:
             existing_extra = None
             try:
@@ -225,8 +259,9 @@ def update_record(params, record, skip_extra=False):
 
             extra = vault_extensions.extract_password_record_extras(record, existing_extra)
             extra_str = json.dumps(extra)
-            record_object['extra'] = utils.base64_url_encode(
-                crypto.encrypt_aes_v1(extra_str.encode('utf-8'), record.record_key))
+            decrypted_extra = extra_str.encode('utf-8')
+            encrypted_extra = crypto.encrypt_aes_v1(decrypted_extra, record.record_key)
+            record_object['extra'] = utils.base64_url_encode(encrypted_extra)
 
             if 'udata' in storage_record:
                 u = storage_record['udata']
@@ -262,6 +297,11 @@ def update_record(params, record, skip_extra=False):
                 raise KeeperApiError(record_status, status.get('message', ''))
 
         record.revision = rs.get('revision', record.revision)
+        _sync_cached_record(params, record.record_uid, record.revision,
+                            record_object.get('client_modified_time'),
+                            encrypted_data, decrypted_data,
+                            encrypted_extra, decrypted_extra,
+                            record_object.get('udata'))
         add_record_audit_data(params, record)
         prev_file_refs = set((x.id for x in existing_record.attachments or []))
         new_file_refs = set((x.id for x in record.attachments or []))
@@ -317,6 +357,8 @@ def update_record(params, record, skip_extra=False):
         if rs_status and rs_status.status != record_pb2.RS_SUCCESS:
             raise KeeperApiError(record_pb2.RecordModifyResult.keys()[rs_status.status], rs_status.message)
         record.revision = rs.revision
+        _sync_cached_record(params, record.record_uid, rs.revision,
+                            ru.client_modified_time, ru.data, json_data)
         for file_id in refs.difference(existing_refs):
             params.queue_audit_event(
                 'file_attachment_uploaded', record_uid=record.record_uid, attachment_id=file_id)

--- a/unit-tests/pam/test_pam_project_extend_nsf.py
+++ b/unit-tests/pam/test_pam_project_extend_nsf.py
@@ -110,3 +110,153 @@ def test_process_folders_creates_new_nsf_folder_paths():
     create_sub.assert_called_once()
     assert folders['path_to_folder_uid']['NSF Project - Users/Admins'] == 'admins_nsf'
     assert project['error_count'] == 0
+
+
+def _extend_project(dry_run=False, ksm_app_uid='ksm_app_uid', folder_path='NSF Project - Users/Admins',
+                    shared_folders=None):
+    return {
+        'data': {
+            'pam_data': {
+                'users': [{'type': 'pamUser', 'title': 'Admin', 'login': 'admin',
+                           'folder_path': folder_path}],
+                'resources': [],
+            }
+        },
+        'options': {'dry_run': dry_run},
+        'ksm_app_uid': ksm_app_uid,
+        'ksm_shared_folders': shared_folders if shared_folders is not None else [
+            {'uid': 'users_nsf', 'name': 'NSF Project - Users', 'folder_tree': {}},
+            {'uid': 'resources_nsf', 'name': 'NSF Project - Resources', 'folder_tree': {}},
+        ],
+        'folders': {},
+        'error_count': 0,
+    }
+
+
+def _seeding_nsf_create(params, new_uid, parent_uid):
+    """Stand-in for create_nsf_subfolder that also seeds the NSF cache, as the real one does."""
+    def _create(_params, name, _parent_uid='', folder_uid=None):
+        uid = folder_uid or new_uid
+        params.nested_share_folders[uid] = {
+            'name': name, 'parent_uid': parent_uid, 'folder_key_unencrypted': b'k' * 32,
+        }
+        return uid
+    return _create
+
+
+def test_process_folders_registers_new_nsf_child_on_ksm_app(capsys):
+    params = _params()
+    project = _extend_project()
+
+    with patch('keepercommander.commands.pam_import.extend.create_nsf_subfolder',
+               side_effect=_seeding_nsf_create(params, 'admins_nsf', 'users_nsf')), \
+            patch('keepercommander.commands.pam_import.extend.grant_nsf_folders_to_ksm_app',
+                  side_effect=lambda _p, _a, uids, **_kw: list(uids)) as grant, \
+            patch('keepercommander.commands.pam_import.extend.sync_down_preserving_nsf_keys') as nsf_sync, \
+            patch('keepercommander.commands.pam_import.extend.api.sync_down') as plain_sync:
+        folders = PAMProjectExtendCommand().process_folders(params, project)
+
+    # The folder UID is pre-generated before creation, so grant the UID that was used.
+    new_uid = folders['path_to_folder_uid']['NSF Project - Users/Admins']
+    grant.assert_called_once()
+    args, kwargs = grant.call_args
+    assert args[1] == 'ksm_app_uid'
+    assert args[2] == [new_uid]
+    assert kwargs['editable'] is True
+    # NSF keys must survive the post-create sync so the grant can use them.
+    nsf_sync.assert_called_once_with(params)
+    plain_sync.assert_not_called()
+    assert 'Registered 1 of 1 new Nested Share Folder(s)' in capsys.readouterr().out
+
+
+def test_process_folders_warns_when_a_folder_could_not_be_registered(capsys):
+    params = _params()
+    project = _extend_project()
+
+    with patch('keepercommander.commands.pam_import.extend.create_nsf_subfolder',
+               side_effect=_seeding_nsf_create(params, 'admins_nsf', 'users_nsf')), \
+            patch('keepercommander.commands.pam_import.extend.grant_nsf_folders_to_ksm_app',
+                  return_value=[]), \
+            patch('keepercommander.commands.pam_import.extend.sync_down_preserving_nsf_keys'), \
+            patch('keepercommander.commands.pam_import.extend.api.sync_down'), \
+            patch('keepercommander.commands.pam_import.extend.logging.warning') as warn:
+        PAMProjectExtendCommand().process_folders(params, project)
+
+    assert 'Registered 0 of 1 new Nested Share Folder(s)' in capsys.readouterr().out
+    assert any('not be visible to the Gateway' in str(c.args[0]) for c in warn.call_args_list)
+
+
+def test_process_folders_classic_child_is_not_registered():
+    params = _params()
+    # Classic shared folder root - children inherit the folder key, nothing to grant.
+    params.folder_cache['classic_sf'] = _folder('classic_sf', 'Classic Project')
+    params.folder_cache['classic_sf'].type = BaseFolderNode.SharedFolderType
+    params.shared_folder_cache['classic_sf'] = {'name_unencrypted': 'Classic Project'}
+    project = _extend_project(folder_path='Classic Project/Admins',
+                              shared_folders=[{'uid': 'classic_sf', 'name': 'Classic Project',
+                                               'folder_tree': {}}])
+
+    with patch.object(PAMProjectExtendCommand, 'create_subfolder', return_value='admins_sf'), \
+            patch('keepercommander.commands.pam_import.extend.grant_nsf_folders_to_ksm_app') as grant, \
+            patch('keepercommander.commands.pam_import.extend.sync_down_preserving_nsf_keys') as nsf_sync, \
+            patch('keepercommander.commands.pam_import.extend.api.sync_down') as plain_sync:
+        PAMProjectExtendCommand().process_folders(params, project)
+
+    grant.assert_not_called()
+    nsf_sync.assert_not_called()
+    plain_sync.assert_called_once_with(params)
+
+
+def test_process_folders_warns_when_ksm_app_uid_missing():
+    params = _params()
+    project = _extend_project(ksm_app_uid='')
+
+    with patch('keepercommander.commands.pam_import.extend.create_nsf_subfolder',
+               side_effect=_seeding_nsf_create(params, 'admins_nsf', 'users_nsf')), \
+            patch('keepercommander.commands.pam_import.extend.grant_nsf_folders_to_ksm_app') as grant, \
+            patch('keepercommander.commands.pam_import.extend.sync_down_preserving_nsf_keys'), \
+            patch('keepercommander.commands.pam_import.extend.api.sync_down'), \
+            patch('keepercommander.commands.pam_import.extend.logging.warning') as warn:
+        PAMProjectExtendCommand().process_folders(params, project)
+
+    grant.assert_not_called()
+    assert any('not registered' in str(c.args[0]) for c in warn.call_args_list)
+
+
+def test_process_folders_dry_run_reports_nsf_registration_without_calling_api(capsys):
+    params = _params()
+    project = _extend_project(dry_run=True)
+
+    with patch('keepercommander.commands.pam_import.extend.create_nsf_subfolder') as create_sub, \
+            patch('keepercommander.commands.pam_import.extend.grant_nsf_folders_to_ksm_app') as grant, \
+            patch('keepercommander.commands.pam_import.extend.api.sync_down'):
+        PAMProjectExtendCommand().process_folders(params, project)
+
+    create_sub.assert_not_called()
+    grant.assert_not_called()
+    out = capsys.readouterr().out
+    assert 'would be registered on KSM Application ksm_app_uid' in out
+    assert 'NSF Project - Users/Admins' in out
+
+
+def test_nsf_paths_to_be_created_classifies_nested_new_paths():
+    params = _params()
+    new_nodes = [
+        ('NSF Project - Users/Admins/Tier2', 'NSF Project - Users/Admins', 'Tier2', {'uid': 'b'}),
+        ('NSF Project - Users/Admins', 'NSF Project - Users', 'Admins', {'uid': 'a'}),
+        ('Classic Project/Ops', 'Classic Project', 'Ops', {'uid': 'c'}),
+    ]
+    path_to_uid = {
+        'NSF Project - Users': 'users_nsf',
+        'NSF Project - Users/Admins': 'a',
+        'NSF Project - Users/Admins/Tier2': 'b',
+        'Classic Project': 'classic_sf',
+    }
+    shared_folders = [{'uid': 'users_nsf', 'name': 'NSF Project - Users'},
+                      {'uid': 'classic_sf', 'name': 'Classic Project'}]
+
+    paths = PAMProjectExtendCommand._nsf_paths_to_be_created(
+        params, new_nodes, path_to_uid, shared_folders)
+
+    # A new child of a new NSF folder is still NSF even though its UID does not exist yet.
+    assert paths == ['NSF Project - Users/Admins', 'NSF Project - Users/Admins/Tier2']

--- a/unit-tests/pam/test_pam_project_import_nsf.py
+++ b/unit-tests/pam/test_pam_project_import_nsf.py
@@ -6,8 +6,9 @@ import keepercommander.commands.record  # noqa: F401
 from keepercommander.commands.pam.vault_target import (
     execute_record_add_in_folder, execute_record_v3_add_in_folder, grant_pam_folder_permissions, is_nested_share_folder)
 from keepercommander.commands.pam_import.base import PamUserObject
+from keepercommander.commands.nested_share_folder.helpers import ROOT_FOLDER_UID as NSF_ROOT_FOLDER_UID
 from keepercommander.commands.pam_import.edit import PAMProjectImportCommand
-from keepercommander.subfolder import BaseFolderNode
+from keepercommander.subfolder import BaseFolderNode, NestedShareFolderNode
 
 
 def _params():
@@ -95,6 +96,140 @@ def test_import_record_objects_use_nsf_aware_record_add_helper():
     add_record.assert_called_once()
     assert add_record.call_args.args[2] == 'root_nsf'
     assert add_record.call_args.kwargs == {'command': 'pam-project-import'}
+
+
+ROOT_NAME = PAMProjectImportCommand.PAM_ROOT_FOLDER_NAME
+
+
+def _synced_root_params(root_parent_uid):
+    """Vault state after sync: nested_share_folders keeps the raw parent from the server,
+    while prepare_folder_tree clears it on the folder_cache node for root-level NSF."""
+    params = _params()
+    params.nested_share_folders = {
+        'wv_root': {'name': ROOT_NAME, 'parent_uid': root_parent_uid},
+    }
+    node = NestedShareFolderNode()
+    node.uid = 'wv_root'
+    node.name = ROOT_NAME
+    node.parent_uid = None      # prepare_folder_tree normalized it
+    node.subfolders = []
+    params.folder_cache = {'wv_root': node}
+    params.subfolder_cache = {
+        'wv_root': {'folder_uid': 'wv_root', 'type': 'user_folder', 'name': ROOT_NAME,
+                    'parent_uid': root_parent_uid, 'source': 'nested_share_folder'},
+    }
+    return params
+
+
+def test_find_folders_matches_root_nsf_reported_with_drive_root_sentinel():
+    # The server reports root-level NSF folders with the drive-root sentinel UID, which
+    # is not a vault folder. Such a root must still be found - otherwise --nsf creates a
+    # duplicate "PAM Environments" on every import.
+    params = _synced_root_params(NSF_ROOT_FOLDER_UID)
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+    assert found[0].parent_uid is None
+
+
+def test_find_folders_matches_root_nsf_when_sentinel_is_a_listed_folder():
+    # Defensive: the sentinel is recognized by value, so a root is still matched even if
+    # the drive root ever shows up as a real entry in the NSF caches.
+    params = _synced_root_params(NSF_ROOT_FOLDER_UID)
+    params.nested_share_folders[NSF_ROOT_FOLDER_UID] = {'name': 'Drive Root', 'parent_uid': None}
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+
+
+def test_find_folders_matches_root_nsf_normalized_to_root_string():
+    params = _synced_root_params('root')
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+
+
+def test_find_folders_matches_root_nsf_whose_synced_parent_is_not_a_folder():
+    # Any parent that resolves to no known folder is also treated as root level.
+    params = _synced_root_params('SomeUnknownParentUid__')
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+
+
+def test_find_folders_matches_root_nsf_created_by_commander():
+    # Commander omits parentUid on create, so the same root can also come back as None.
+    params = _synced_root_params(None)
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+
+
+def test_find_folders_returns_both_root_shapes_first_wins():
+    params = _synced_root_params(NSF_ROOT_FOLDER_UID)
+    params.nested_share_folders['kc_root'] = {'name': ROOT_NAME, 'parent_uid': None}
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root', 'kc_root']
+
+
+def test_find_folders_does_not_promote_a_real_nested_child_to_root():
+    params = _synced_root_params(None)
+    params.nested_share_folders['child'] = {'name': 'Project', 'parent_uid': 'wv_root'}
+
+    assert PAMProjectImportCommand().find_folders(params, '', 'Project', False) == []
+    child = PAMProjectImportCommand().find_folders(params, 'wv_root', 'Project', False)
+    assert [f.uid for f in child] == ['child']
+
+
+def test_find_folders_does_not_duplicate_a_uid_present_in_both_caches():
+    params = _synced_root_params(NSF_ROOT_FOLDER_UID)
+    # A user_folder node with the same UID must not yield two results.
+    plain = BaseFolderNode(BaseFolderNode.UserFolderType)
+    plain.uid = 'wv_root'
+    plain.name = ROOT_NAME
+    plain.parent_uid = None
+    plain.subfolders = []
+    params.folder_cache['wv_root'] = plain
+
+    found = PAMProjectImportCommand().find_folders(params, '', ROOT_NAME, False)
+
+    assert [f.uid for f in found] == ['wv_root']
+
+
+def test_process_folders_reuses_synced_nsf_root_instead_of_creating_duplicate():
+    params = _synced_root_params(NSF_ROOT_FOLDER_UID)
+    project = {
+        'options': {'project_name': 'BatchSmokeS', 'dry_run': False, 'use_nsf': True},
+        'data': {},
+        'folders': {},
+    }
+    created = []
+
+    def create_folder(_params, folder_name, parent_uid=None, permissions=None, use_nsf=False):
+        uid = f'new_{len(created)}'
+        created.append((folder_name, parent_uid))
+        _params.nested_share_folders[uid] = {'name': folder_name, 'parent_uid': parent_uid}
+        return uid
+
+    with patch.object(PAMProjectImportCommand, 'create_subfolder', side_effect=create_folder), \
+            patch.object(PAMProjectImportCommand, 'get_folder_permissions', return_value=({}, [])), \
+            patch.object(PAMProjectImportCommand, 'verify_users_and_teams'), \
+            patch.object(PAMProjectImportCommand, 'add_folder_permissions'), \
+            patch('keepercommander.commands.pam_import.nsf_helpers.api.sync_down'):
+        res = PAMProjectImportCommand().process_folders(params, project)
+
+    assert res['root_folder_uid'] == 'wv_root'
+    # Only the project folder and its two leaves are created - no second PAM root.
+    assert [name for name, _ in created] == [
+        'BatchSmokeS', 'BatchSmokeS - Resources', 'BatchSmokeS - Users']
+    assert ROOT_NAME not in [name for name, _ in created]
 
 
 def test_process_folders_uses_existing_nsf_root_and_creates_nsf_children():

--- a/unit-tests/pam/test_pam_project_import_nsf.py
+++ b/unit-tests/pam/test_pam_project_import_nsf.py
@@ -316,15 +316,175 @@ def test_process_ksm_app_shares_nsf_folders_and_restores_keys():
 
     with patch('keepercommander.commands.pam_import.edit.api.communicate_rest') as communicate, \
             patch.object(PAMProjectImportCommand, 'create_ksm_app', side_effect=wipe_then_return), \
-            patch('keepercommander.commands.pam_import.edit.KSMCommand') as ksm_cmd, \
+            patch('keepercommander.commands.ksm.KSMCommand') as ksm_cmd, \
             patch('keepercommander.commands.pam_import.nsf_helpers.api.sync_down'), \
             patch('keepercommander.commands.pam_import.edit.api.sync_down'):
         communicate.return_value = MagicMock(applicationSummary=[])
         result = PAMProjectImportCommand().process_ksm_app(params, project)
 
     assert result['app_uid'] == 'app_uid'
-    assert ksm_cmd.return_value.execute.call_count == 2
-    shared = [c.kwargs.get('secret') for c in ksm_cmd.return_value.execute.call_args_list]
-    assert ['res_nsf'] in shared
-    assert ['usr_nsf'] in shared
+    # Without a project_folder_uid the legacy resources/users fallback applies,
+    # batched into a single share call.
+    assert ksm_cmd.return_value.execute.call_count == 1
+    assert ksm_cmd.return_value.execute.call_args.kwargs['secret'] == ['res_nsf', 'usr_nsf']
     assert params.nested_share_folders['res_nsf']['folder_key_unencrypted'] == b'k' * 32
+
+
+def _nsf_project_params():
+    """NSF project tree: root > project > {Resources, Users, Safe > {Safe-Res, Safe-Usr}}."""
+    params = _params()
+    tree = {
+        'proj_nsf': ('Project', 'root_nsf'),
+        'res_nsf': ('Project - Resources', 'proj_nsf'),
+        'usr_nsf': ('Project - Users', 'proj_nsf'),
+        'safe_nsf': ('Safe A', 'proj_nsf'),
+        'safe_res_nsf': ('Safe A - Resources', 'safe_nsf'),
+        'safe_usr_nsf': ('Safe A - Users', 'safe_nsf'),
+    }
+    for uid, (name, parent) in tree.items():
+        params.nested_share_folders[uid] = {
+            'name': name, 'parent_uid': parent, 'folder_key_unencrypted': b'k' * 32,
+        }
+    return params
+
+
+def test_collect_nsf_subtree_uids_walks_descendants_breadth_first():
+    from keepercommander.commands.pam_import.nsf_helpers import collect_nsf_subtree_uids
+
+    params = _nsf_project_params()
+    uids = collect_nsf_subtree_uids(params, 'proj_nsf')
+
+    assert uids[0] == 'proj_nsf'
+    assert set(uids) == {'proj_nsf', 'res_nsf', 'usr_nsf', 'safe_nsf',
+                         'safe_res_nsf', 'safe_usr_nsf'}
+    # The global PAM root is a parent, never a descendant.
+    assert 'root_nsf' not in uids
+    # Parents are granted before their children.
+    assert uids.index('safe_nsf') < uids.index('safe_res_nsf')
+
+
+def test_collect_nsf_subtree_uids_survives_parent_cycle():
+    from keepercommander.commands.pam_import.nsf_helpers import collect_nsf_subtree_uids
+
+    params = _params()
+    params.nested_share_folders['a'] = {'name': 'A', 'parent_uid': 'b'}
+    params.nested_share_folders['b'] = {'name': 'B', 'parent_uid': 'a'}
+
+    assert collect_nsf_subtree_uids(params, 'a') == ['a', 'b']
+    assert collect_nsf_subtree_uids(params, '') == []
+
+
+def test_process_ksm_app_nsf_grants_whole_project_subtree():
+    from unittest.mock import MagicMock
+
+    params = _nsf_project_params()
+    project = {
+        'options': {'project_name': 'NSF App', 'dry_run': False, 'use_nsf': True},
+        'data': {},
+        'folders': {
+            'project_folder_uid': 'proj_nsf',
+            'resources_folder_uid': 'res_nsf',
+            'users_folder_uid': 'usr_nsf',
+            'safe_folders': [{
+                'name': 'Safe A',
+                'uid': 'safe_nsf',
+                'resources_subfolder_uid': 'safe_res_nsf',
+                'users_subfolder_uid': 'safe_usr_nsf',
+            }],
+        },
+    }
+
+    with patch('keepercommander.commands.pam_import.edit.api.communicate_rest') as communicate, \
+            patch.object(PAMProjectImportCommand, 'create_ksm_app', return_value='app_uid'), \
+            patch('keepercommander.commands.ksm.KSMCommand') as ksm_cmd, \
+            patch('keepercommander.commands.pam_import.nsf_helpers.api.sync_down'), \
+            patch('keepercommander.commands.pam_import.edit.api.sync_down'):
+        communicate.return_value = MagicMock(applicationSummary=[])
+        PAMProjectImportCommand().process_ksm_app(params, project)
+
+    assert ksm_cmd.return_value.execute.call_count == 1
+    kwargs = ksm_cmd.return_value.execute.call_args.kwargs
+    assert kwargs['app'] == 'app_uid'
+    assert kwargs['editable'] is True
+    # Project wrapper + both leaves + the safe folder and its two record subfolders.
+    assert set(kwargs['secret']) == {'proj_nsf', 'res_nsf', 'usr_nsf', 'safe_nsf',
+                                     'safe_res_nsf', 'safe_usr_nsf'}
+    assert 'root_nsf' not in kwargs['secret']
+
+
+def test_process_ksm_app_classic_grant_list_unchanged():
+    from unittest.mock import MagicMock
+
+    params = _params()
+    project = {
+        'options': {'project_name': 'Classic App', 'dry_run': False, 'use_nsf': False},
+        'data': {},
+        'folders': {
+            'project_folder_uid': 'proj_sf',
+            'resources_folder_uid': 'res_sf',
+            'users_folder_uid': 'usr_sf',
+            'safe_folders': [{
+                'name': 'Safe A',
+                'uid': 'safe_sf',
+                'resources_subfolder_uid': 'safe_res_sf',
+                'users_subfolder_uid': 'safe_usr_sf',
+            }],
+        },
+    }
+
+    with patch('keepercommander.commands.pam_import.edit.api.communicate_rest') as communicate, \
+            patch.object(PAMProjectImportCommand, 'create_ksm_app', return_value='app_uid'), \
+            patch('keepercommander.commands.pam_import.edit.KSMCommand') as ksm_cmd, \
+            patch('keepercommander.commands.pam_import.edit.api.sync_down'):
+        communicate.return_value = MagicMock(applicationSummary=[])
+        PAMProjectImportCommand().process_ksm_app(params, project)
+
+    # One call per UID, no project wrapper, no shared_folder_folder children.
+    shared = [c.kwargs.get('secret') for c in ksm_cmd.return_value.execute.call_args_list]
+    assert shared == [['res_sf'], ['usr_sf'], ['safe_sf']]
+
+
+def test_grant_nsf_folders_falls_back_to_single_uid_calls():
+    from keepercommander.commands.pam_import.nsf_helpers import grant_nsf_folders_to_ksm_app
+
+    params = _nsf_project_params()
+    calls = []
+
+    class FakeKSM:
+        def execute(self, _params, **kwargs):
+            secret = kwargs.get('secret')
+            calls.append(list(secret))
+            if len(secret) > 1:
+                raise Exception('batch rejected')
+            if secret == ['usr_nsf']:
+                raise Exception('already shared')
+            return None
+
+    with patch('keepercommander.commands.ksm.KSMCommand', FakeKSM):
+        granted = grant_nsf_folders_to_ksm_app(params, 'app_uid', ['res_nsf', 'usr_nsf', 'safe_nsf'])
+
+    assert calls[0] == ['res_nsf', 'usr_nsf', 'safe_nsf']
+    assert calls[1:] == [['res_nsf'], ['usr_nsf'], ['safe_nsf']]
+    # The one folder that failed is reported as not granted; the rest still land.
+    assert granted == ['res_nsf', 'safe_nsf']
+    # Folder keys survive the sync_down inside each share call.
+    assert params.nested_share_folders['res_nsf']['folder_key_unencrypted'] == b'k' * 32
+
+
+def test_grant_nsf_folders_dedups_and_ignores_empty():
+    from keepercommander.commands.pam_import.nsf_helpers import grant_nsf_folders_to_ksm_app
+
+    params = _nsf_project_params()
+    calls = []
+
+    class FakeKSM:
+        def execute(self, _params, **kwargs):
+            calls.append(list(kwargs.get('secret')))
+
+    with patch('keepercommander.commands.ksm.KSMCommand', FakeKSM):
+        granted = grant_nsf_folders_to_ksm_app(params, 'app_uid', ['res_nsf', '', 'res_nsf', None, 'usr_nsf'])
+        assert grant_nsf_folders_to_ksm_app(params, '', ['res_nsf']) == []
+        assert grant_nsf_folders_to_ksm_app(params, 'app_uid', []) == []
+
+    assert calls == [['res_nsf', 'usr_nsf']]
+    assert granted == ['res_nsf', 'usr_nsf']

--- a/unit-tests/test_record_update_revision_refresh.py
+++ b/unit-tests/test_record_update_revision_refresh.py
@@ -1,0 +1,114 @@
+"""Regression tests: update_record must leave params.record_cache at the revision
+the server just returned.
+
+update_record puts the revision from the cache (not from the record object) on the
+wire, so a second update of the same record inside one command used to resend the
+pre-update revision and fail with RS_OUT_OF_SYNC ("This object no longer exists").
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from keepercommander import crypto, record_management, utils, vault
+from keepercommander.proto import record_pb2
+
+RECORD_UID = 'wKpRON0rxJfq6qefq43y7g'
+RECORD_KEY = b'k' * 32
+
+
+def _params():
+    data = {'type': 'pamMachine', 'title': 'Machine', 'fields': [], 'custom': []}
+    plain = json.dumps(data).encode()
+    return SimpleNamespace(
+        record_cache={
+            RECORD_UID: {
+                'record_uid': RECORD_UID,
+                'version': 3,
+                'revision': 5380934,
+                'client_modified_time': 1787187441498,
+                'shared': True,
+                'data': utils.base64_url_encode(crypto.encrypt_aes_v2(plain, RECORD_KEY)),
+                'data_unencrypted': plain,
+                'record_key_unencrypted': RECORD_KEY,
+            }
+        },
+        enterprise_ec_key=None,
+        enterprise_rsa_key=None,
+        breach_watch=None,
+        sync_data=False,
+        forbid_rsa=False,
+    )
+
+
+def _record(params, title='Machine'):
+    record = vault.KeeperRecord.load(params, RECORD_UID)
+    record.title = title
+    return record
+
+
+def _run_update(params, record, new_revision):
+    """Drive update_record with a stubbed transport; return the revision sent."""
+    sent = {}
+
+    def fake_communicate_rest(_params, rq, endpoint, rs_type=None):
+        assert endpoint == 'vault/records_update'
+        sent['revision'] = rq.records[0].revision
+        sent['data'] = rq.records[0].data
+        rs = record_pb2.RecordsModifyResponse()
+        rs.revision = new_revision
+        status = rs.records.add()
+        status.record_uid = utils.base64_url_decode(RECORD_UID)
+        status.status = record_pb2.RS_SUCCESS
+        return rs
+
+    with patch('keepercommander.record_management.api.communicate_rest',
+               side_effect=fake_communicate_rest), \
+            patch('keepercommander.record_management.attach_security_data',
+                  side_effect=lambda _p, _r, ru: ru), \
+            patch('keepercommander.record_management.add_record_audit_data'), \
+            patch('keepercommander.record_management.BreachWatch.scan_and_update_security_data'):
+        record_management.update_record(params, record)
+    return sent
+
+
+def test_update_record_refreshes_cached_revision():
+    params = _params()
+    sent = _run_update(params, _record(params), 5380938)
+
+    assert sent['revision'] == 5380934, 'first update sends the cached revision'
+    assert params.record_cache[RECORD_UID]['revision'] == 5380938
+
+
+def test_second_update_in_same_run_sends_fresh_revision():
+    # The failure mode from the log: two writes on one record with no sync between.
+    params = _params()
+    first = _run_update(params, _record(params, 'First'), 5380938)
+    second = _run_update(params, _record(params, 'Second'), 5380942)
+
+    assert first['revision'] == 5380934
+    assert second['revision'] == 5380938, 'stale revision would be rejected as RS_OUT_OF_SYNC'
+    assert params.record_cache[RECORD_UID]['revision'] == 5380942
+
+
+def test_update_record_keeps_cached_payload_consistent_with_revision():
+    # A bumped revision paired with stale data would make the next load return
+    # pre-update fields; the cache must carry what was actually persisted.
+    params = _params()
+    record = _record(params, 'Renamed')
+    sent = _run_update(params, record, 5380938)
+
+    cached = params.record_cache[RECORD_UID]
+    assert cached['data'] == utils.base64_url_encode(sent['data'])
+    assert json.loads(cached['data_unencrypted'])['title'] == 'Renamed'
+    assert vault.KeeperRecord.load(params, RECORD_UID).title == 'Renamed'
+    assert crypto.decrypt_aes_v2(utils.base64_url_decode(cached['data']), RECORD_KEY) \
+        == cached['data_unencrypted']
+
+
+def test_update_record_leaves_cache_untouched_when_revision_missing():
+    params = _params()
+    before = dict(params.record_cache[RECORD_UID])
+    _run_update(params, _record(params), 0)
+
+    assert params.record_cache[RECORD_UID]['revision'] == before['revision']
+    assert params.record_cache[RECORD_UID]['data'] == before['data']


### PR DESCRIPTION
NSF folder keys are per-folder, so an NSF child does not inherit the parent's AT_APPLICATION grant the way a classic shared_folder_folder does. KSM and the Gateway only see records in folders that carry a direct grant.

- `pam project import --nsf` now grants the whole project subtree instead of just   the Resources/Users leaves. This closes the gap in CyberArk `--folder-mode safe`, where records land in `{safe} - Resources` / `{safe} - Users` subfolders that were never registered on the app.
- `pam project extend` now registers the NSF children it creates on the existing KSM   app, and uses the NSF-key-preserving sync so the grant can run. Reports `Registered N of M`, and on a shortfall prints the `secrets-manager share add` command to fix it manually. New folders only, no backfill of pre-existing ones.
- A pre-existing `PAM Environments` NSF root was never matched, so `--nsf` created a duplicate root. The server reports root-level NSF folders with the drive-root sentinel UID, and only the `folder_cache` node gets that normalized - `nested_share_folders` keeps the raw value, which is what the lookup read. Now normalized the same way `tree`/`ls` already do it; when several roots match, the first is reused with a warning.
- Removed a dead duplicate of `find_folders` in `extend.py` (never called; `PAMProjectExtendCommand` does not inherit from `PAMProjectImportCommand`).
-  Update the record revision in `record_cache`: `update_record` takes the revision it sends from `params.record_cache` but never wrote the server's new revision back, so a second update of the same record within one command resent the stale revision and failed with RS_OUT_OF_SYNC ("This object no longer exists"). The payload is written back alongside the revision so the cache entry stays self-consistent.

Classic (non-NSF) behavior is unchanged - same grant list, same one-call-per-UID loop, covered by a regression test.