### PR TITLE
KC-1419: Fix pam project export by discovering from project folders

### DIFF
--- a/keepercommander/commands/pam_import/export.py
+++ b/keepercommander/commands/pam_import/export.py
@@ -11,22 +11,24 @@
 
 from __future__ import annotations
 import argparse
+import copy
+import itertools
 import json
 import logging
+import os
+from typing import Dict, List, Optional, Set, Tuple
 
-from .base import (
-    PAM_RESOURCES_RECORD_TYPES,
-    PAM_CONFIG_TYPES,
-    PAM_ENVIRONMENT_TYPES,
-)
+from .base import PAM_CONFIG_TYPES, PAM_RESOURCES_RECORD_TYPES
 from ..base import Command
 from ..pam.config_facades import PamConfigurationRecordFacade
+from .nsf_helpers import get_folder_record_uids
 from .record_loader import iter_accessible_record_uids, load_pam_record
-from ... import vault
+from ... import utils, vault
 from ...display import bcolors
+from ...recordv3 import RecordV3
+from ...subfolder import find_folders as find_record_folders
 
 
-# Maps v6 record_type -> environment name used by pam project import
 _RECORD_TYPE_TO_ENV = {
     "pamNetworkConfiguration": "local",
     "pamAwsConfiguration": "aws",
@@ -36,21 +38,64 @@ _RECORD_TYPE_TO_ENV = {
     "pamOciConfiguration": "oci",
 }
 
-# Maps DAG allowedSettings keys -> JSON keys used in PROJECT_IMPORT_JSON_TEMPLATE
 _DAG_KEY_TO_JSON = {
-    "connections":          "connections",
-    "portForwards":         "tunneling",
-    "rotation":             "rotation",
+    "connections": "connections",
+    "portForwards": "tunneling",
+    "rotation": "rotation",
     "remoteBrowserIsolation": "remote_browser_isolation",
-    "sessionRecording":     "graphical_session_recording",
-    "typescriptRecording":  "text_session_recording",
-    "aiEnabled":            "ai_threat_detection",
-    "aiSessionTerminate":   "ai_terminate_session_on_detection",
+    "sessionRecording": "graphical_session_recording",
+    "typescriptRecording": "text_session_recording",
+    "aiEnabled": "ai_threat_detection",
+    "aiSessionTerminate": "ai_terminate_session_on_detection",
+}
+
+_RESOURCE_FIELD_MAP = {
+    "operatingsystem": "operating_system",
+    "instancename": "instance_name",
+    "instanceid": "instance_id",
+    "providergroup": "provider_group",
+    "providerregion": "provider_region",
+    "databaseid": "database_id",
+    "databasetype": "database_type",
+    "domainname": "domain_name",
+    "directoryid": "directory_id",
+    "directorytype": "directory_type",
+    "usermatch": "user_match",
+    "sslverification": "ssl_verification",
+    "usessl": "use_ssl",
+}
+
+_USER_RECORD_TYPES = ("pamUser", "login")
+_PAM_ROOT_FOLDER_NAME = "pam environments"
+_BOOL_EXPORT_KEYS = ("ssl_verification", "use_ssl")
+
+_DEFAULT_ALLOWED_SETTINGS = {
+    "connections": "on",
+    "rotation": "on",
+    "tunneling": "on",
+    "remote_browser_isolation": "on",
+    "graphical_session_recording": "off",
+    "text_session_recording": "off",
+    "ai_threat_detection": "off",
+    "ai_terminate_session_on_detection": "off",
 }
 
 
+class _LazyUserTitleIndex:
+    """Build the vault title→UID map only when a non-UID credential ref is resolved."""
+
+    def __init__(self, build_fn):
+        self._build_fn = build_fn
+        self._index = None
+
+    def get(self, key, default=None):
+        if self._index is None:
+            self._index = self._build_fn() or {}
+        return self._index.get(key, default)
+
+
 class PAMProjectExportCommand(Command):
-    """Export a PAM project to a JSON document that can be re-imported via pam project import."""
+    """Export a PAM project to JSON for re-import via pam project import."""
 
     parser = argparse.ArgumentParser(prog="pam project export")
     parser.add_argument(
@@ -67,29 +112,19 @@ class PAMProjectExportCommand(Command):
     def get_parser(self):
         return PAMProjectExportCommand.parser
 
-    # ------------------------------------------------------------------
-    # Public execute
-    # ------------------------------------------------------------------
-
     def execute(self, params, **kwargs):
         project_uid = (kwargs.get("project_uid") or "").strip()
         output_file = (kwargs.get("output") or "").strip()
+        self._nsf_perm_noted = False
 
         if not project_uid:
             logging.warning(f"{bcolors.FAIL}--project-uid is required{bcolors.ENDC}")
             return
 
-        # 1. Load PAM configuration record (v6)
         config_record = load_pam_record(params, project_uid)
         if not config_record:
             logging.warning(
                 f"{bcolors.FAIL}PAM configuration '{project_uid}' not found in vault{bcolors.ENDC}"
-            )
-            return
-        if config_record.version != 6:
-            logging.warning(
-                f"{bcolors.FAIL}Record '{project_uid}' (version {config_record.version}) "
-                f"is not a PAM configuration — version 6 required{bcolors.ENDC}"
             )
             return
         if not isinstance(config_record, vault.TypedRecord):
@@ -97,38 +132,35 @@ class PAMProjectExportCommand(Command):
                 f"{bcolors.FAIL}Record '{project_uid}' is not a TypedRecord{bcolors.ENDC}"
             )
             return
+        if config_record.version != 6 or config_record.record_type not in PAM_CONFIG_TYPES:
+            logging.warning(
+                f"{bcolors.FAIL}Record '{project_uid}' is not a PAM configuration "
+                f"(version 6 / known PAM config type required){bcolors.ENDC}"
+            )
+            return
 
-        # 2. Determine environment
-        environment = _RECORD_TYPE_TO_ENV.get(config_record.record_type, "local")
-
-        # 3. Get resource UIDs from pamResources.resourceRef
         facade = PamConfigurationRecordFacade()
         facade.record = config_record
-        resource_uids = list(facade.resource_ref or [])
 
-        # 4. Try to read connection/rotation/tunneling settings from DAG (best-effort)
-        allowed_settings = self._get_allowed_settings(params, project_uid)
+        allowed_settings, dag_resource_uids = self._load_dag_context(params, project_uid)
+        resource_uids, folder_user_uids, resources_folder_uid, users_folder_uid = (
+            self._discover_project_record_uids(
+                params, facade, project_uid, dag_resource_uids
+            )
+        )
+        resources_list, top_level_users = self._build_resources_and_users(
+            params, resource_uids, extra_user_uids=folder_user_uids
+        )
 
-        # 5. Walk resources and gather users
-        resources_list, top_level_users = self._build_resources_and_users(params, resource_uids)
-
-        # 6. Assemble result dict
         result = {
             "tool_version": "commander-export-1.0",
             "project": config_record.title,
-            "shared_folder_users": {},
-            "shared_folder_resources": {},
+            "shared_folder_users": self._export_folder_permissions(params, users_folder_uid),
+            "shared_folder_resources": self._export_folder_permissions(params, resources_folder_uid),
             "pam_configuration": {
-                "environment": environment,
+                "environment": _RECORD_TYPE_TO_ENV.get(config_record.record_type, "local"),
                 "title": config_record.title,
-                "connections":                      allowed_settings.get("connections",                      "on"),
-                "rotation":                         allowed_settings.get("rotation",                         "on"),
-                "tunneling":                        allowed_settings.get("tunneling",                        "on"),
-                "remote_browser_isolation":         allowed_settings.get("remote_browser_isolation",         "on"),
-                "graphical_session_recording":      allowed_settings.get("graphical_session_recording",      "off"),
-                "text_session_recording":           allowed_settings.get("text_session_recording",           "off"),
-                "ai_threat_detection":              allowed_settings.get("ai_threat_detection",              "off"),
-                "ai_terminate_session_on_detection": allowed_settings.get("ai_terminate_session_on_detection", "off"),
+                **{k: allowed_settings.get(k, v) for k, v in _DEFAULT_ALLOWED_SETTINGS.items()},
             },
             "pam_data": {
                 "resources": resources_list,
@@ -137,32 +169,178 @@ class PAMProjectExportCommand(Command):
         }
 
         output_json = json.dumps(result, indent=2, sort_keys=True)
+        if self._export_contains_password(resources_list, top_level_users):
+            logging.warning(
+                f"{bcolors.WARNING}Export includes passwords; treat output as sensitive.{bcolors.ENDC}"
+            )
+        if not output_file:
+            return output_json
 
-        if output_file:
-            with open(output_file, "w", encoding="utf-8") as fh:
-                fh.write(output_json)
-            print(f"{bcolors.OKGREEN}PAM project exported to: {output_file}{bcolors.ENDC}")
-            return
-
-        return output_json
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _get_allowed_settings(self, params, config_uid):
-        """Return on/off dict for tunneling config, falling back to safe defaults."""
-        defaults = {
-            "connections": "on",
-            "rotation": "on",
-            "tunneling": "on",
-            "remote_browser_isolation": "on",
-            "graphical_session_recording": "off",
-            "text_session_recording": "off",
-            "ai_threat_detection": "off",
-            "ai_terminate_session_on_detection": "off",
-        }
+        path = os.path.expanduser(output_file)
         try:
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            # O_CREAT mode applies only on create; force private perms on overwrite too.
+            os.chmod(path, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(output_json)
+        except OSError as exc:
+            logging.warning(
+                f"{bcolors.FAIL}Failed to write export file '{path}': {exc}{bcolors.ENDC}"
+            )
+            return
+        print(f"{bcolors.OKGREEN}PAM project exported to: {path}{bcolors.ENDC}")
+
+    @staticmethod
+    def _export_contains_password(resources_list, top_level_users) -> bool:
+        if any(u.get("password") for u in top_level_users):
+            return True
+        for res in resources_list:
+            for user in res.get("users") or []:
+                if user.get("password"):
+                    return True
+        return False
+
+    def _discover_project_record_uids(self, params, facade, config_uid, dag_resource_uids):
+        """Merge resourceRef + DAG + folder-tree UIDs under the project wrapper."""
+        resource_uids: List[str] = []
+        seen_resources: Set[str] = set()
+
+        def add_resource(uid: str) -> None:
+            if not uid or uid == config_uid or uid in seen_resources:
+                return
+            seen_resources.add(uid)
+            resource_uids.append(uid)
+
+        for uid in facade.resource_ref or []:
+            add_resource(uid)
+        for uid in dag_resource_uids or []:
+            add_resource(uid)
+
+        resources_folder_uid, users_folder_uid, scan_roots = self._resolve_project_folders(
+            params, facade.folder_uid, config_uid
+        )
+
+        folder_user_uids: List[str] = []
+        seen_users: Set[str] = set()
+        skipped_loads = 0
+        seen_folders: Set[str] = set()
+        for root_uid in scan_roots:
+            rows, skipped = self._collect_folder_record_types(params, root_uid, seen_folders)
+            skipped_loads += skipped
+            for rec_uid, rtype in rows:
+                if not rec_uid or rec_uid == config_uid:
+                    continue
+                if rtype in PAM_RESOURCES_RECORD_TYPES:
+                    add_resource(rec_uid)
+                elif rtype in _USER_RECORD_TYPES and rec_uid not in seen_users:
+                    seen_users.add(rec_uid)
+                    folder_user_uids.append(rec_uid)
+
+        if skipped_loads:
+            logging.warning(
+                f"{bcolors.WARNING}Export: skipped {skipped_loads} unloadable record(s) during folder scan{bcolors.ENDC}"
+            )
+
+        return resource_uids, folder_user_uids, resources_folder_uid, users_folder_uid
+
+    @staticmethod
+    def _is_pam_content_folder_name(name: str) -> bool:
+        n = (name or "").casefold()
+        return n.endswith(" - resources") or n.endswith(" - users")
+
+    @staticmethod
+    def _is_resources_folder_name(name: str) -> bool:
+        return (name or "").casefold().endswith(" - resources")
+
+    @staticmethod
+    def _is_users_folder_name(name: str) -> bool:
+        return (name or "").casefold().endswith(" - users")
+
+    def _project_wrapper_uid(self, params, folder_uid):
+        """Project folder for folder_uid; never returns the PAM Environments root."""
+        if not folder_uid:
+            return ""
+        parent_uid = self._folder_parent_uid(params, folder_uid)
+        if not parent_uid:
+            return folder_uid
+        parent_name = (self._folder_name(params, parent_uid) or "").casefold()
+        if parent_name == _PAM_ROOT_FOLDER_NAME:
+            return folder_uid
+        return parent_uid
+
+    def _resolve_project_folders(self, params, folder_uid, config_uid):
+        """Return (resources_folder_uid, users_folder_uid, scan_roots)."""
+        folder_uid = (folder_uid or "").strip()
+        anchors: List[str] = []
+        if folder_uid:
+            anchors.append(folder_uid)
+        else:
+            anchors.extend(uid for uid in (find_record_folders(params, config_uid) or []) if uid)
+
+        resources_candidates: List[str] = []
+        users_candidates: List[str] = []
+        scan_roots: List[str] = []
+        seen_roots: Set[str] = set()
+
+        def add_scan_root(uid: str) -> None:
+            if uid and uid not in seen_roots:
+                seen_roots.add(uid)
+                scan_roots.append(uid)
+
+        for anchor in anchors:
+            add_scan_root(anchor)
+            project_uid = self._project_wrapper_uid(params, anchor)
+            if not project_uid:
+                continue
+
+            for fuid in self._iter_descendant_folders(params, project_uid):
+                name = self._folder_name(params, fuid) or ""
+                if not self._is_pam_content_folder_name(name):
+                    continue
+                add_scan_root(fuid)
+                if self._is_resources_folder_name(name):
+                    if fuid not in resources_candidates:
+                        resources_candidates.append(fuid)
+                elif self._is_users_folder_name(name):
+                    if fuid not in users_candidates:
+                        users_candidates.append(fuid)
+
+        if len(resources_candidates) > 1:
+            logging.warning(
+                f"{bcolors.WARNING}Export: multiple Resources folders found; "
+                f"using first for shared_folder_resources ACL{bcolors.ENDC}"
+            )
+        if len(users_candidates) > 1:
+            logging.warning(
+                f"{bcolors.WARNING}Export: multiple Users folders found; "
+                f"using first for shared_folder_users ACL{bcolors.ENDC}"
+            )
+
+        # Prefer real matches; never invent resources ACL from the users folder.
+        resources_folder_uid = resources_candidates[0] if resources_candidates else ""
+        users_folder_uid = users_candidates[0] if users_candidates else (folder_uid or "")
+        return resources_folder_uid, users_folder_uid, scan_roots
+
+    def _iter_descendant_folders(self, params, folder_uid):
+        """Yield every folder UID under folder_uid (not including folder_uid)."""
+        if not folder_uid:
+            return
+        seen: Set[str] = set()
+        stack = list(self._child_folder_uids(params, folder_uid))
+        while stack:
+            fuid = stack.pop()
+            if not fuid or fuid in seen:
+                continue
+            seen.add(fuid)
+            yield fuid
+            stack.extend(self._child_folder_uids(params, fuid))
+
+    def _load_dag_context(self, params, config_uid):
+        """Load allowed settings and linked resource UIDs from TunnelDAG (best-effort)."""
+        allowed = dict(_DEFAULT_ALLOWED_SETTINGS)
+        resource_uids: List[str] = []
+        try:
+            from ...keeper_dag import EdgeType
             from ..tunnel.port_forward.tunnel_helpers import get_keeper_tokens
             from ..tunnel.port_forward.TunnelGraph import TunnelDAG, get_vertex_content
 
@@ -173,36 +351,161 @@ class PAMProjectExportCommand(Command):
             )
             tmp_dag.linking_dag.load()
             vertex = tmp_dag.linking_dag.get_vertex(config_uid)
-            content = get_vertex_content(vertex) if vertex else None
-            dag_allowed = (content or {}).get("allowedSettings") or {}
+            if not vertex:
+                logging.debug("PAMProjectExportCommand: no DAG vertex for config %s", config_uid)
+                return allowed, resource_uids
+
+            content = get_vertex_content(vertex) or {}
+            dag_allowed = content.get("allowedSettings") or {}
             for dag_key, json_key in _DAG_KEY_TO_JSON.items():
                 if dag_key in dag_allowed:
-                    defaults[json_key] = "on" if dag_allowed[dag_key] else "off"
+                    allowed[json_key] = "on" if dag_allowed[dag_key] else "off"
+
+            for child in vertex.has_vertices(EdgeType.LINK):
+                uid = getattr(child, "uid", None)
+                if uid:
+                    resource_uids.append(uid)
+        except ImportError as exc:
+            logging.warning(
+                f"{bcolors.WARNING}Export: DAG dependencies unavailable; "
+                f"using default pam_configuration flags ({exc}){bcolors.ENDC}"
+            )
         except Exception as exc:
-            logging.debug("PAMProjectExportCommand: could not load DAG allowed settings: %s", exc)
-        return defaults
+            logging.warning(
+                f"{bcolors.WARNING}Export: could not load DAG context; "
+                f"using default pam_configuration flags ({exc}){bcolors.ENDC}"
+            )
+        return allowed, resource_uids
 
-    def _build_resources_and_users(self, params, resource_uids):
-        """Walk resource UIDs and collect resources + deduplicated top-level users.
+    def _collect_folder_record_types(self, params, folder_uid, seen_folders: Optional[Set[str]] = None):
+        """Return ([(uid, record_type), ...], skipped_unloadable_count)."""
+        rows: List[Tuple[str, str]] = []
+        skipped = 0
+        if not folder_uid:
+            return rows, skipped
+        if seen_folders is None:
+            seen_folders = set()
+        stack = [folder_uid]
+        while stack:
+            fuid = stack.pop()
+            if not fuid or fuid in seen_folders:
+                continue
+            seen_folders.add(fuid)
+            for rec_uid in get_folder_record_uids(params, fuid):
+                rec = load_pam_record(params, rec_uid)
+                if not rec:
+                    skipped += 1
+                    continue
+                rows.append((rec_uid, getattr(rec, "record_type", None) or ""))
+            stack.extend(self._child_folder_uids(params, fuid))
+        return rows, skipped
 
-        Two linking strategies are supported:
+    @staticmethod
+    def _folder_parent_uid(params, folder_uid):
+        folder = (getattr(params, "folder_cache", None) or {}).get(folder_uid)
+        if folder and getattr(folder, "parent_uid", None):
+            return folder.parent_uid
+        nsf = getattr(params, "nested_share_folders", None) or {}
+        info = nsf.get(folder_uid)
+        if isinstance(info, dict):
+            return info.get("parent_uid") or ""
+        return ""
 
-        1. Standard: ``pam_settings.connection.userRecords[]`` and
-           top-level ``adminRef`` / ``adminCredentialRef`` carry user UIDs.
-        2. Title-based (e.g. KCM imports — see PR #1942): the resource
-           record references users by **title** in
-           ``pam_settings.connection.{launch,administrative}_credentials``
-           (e.g. ``"KCM User - prod-db"``) without a userRecords list. We
-           resolve those by scanning the project's vault for pamUser /
-           login records with matching titles.
-        """
-        resources_list = []
-        top_level_users = []
-        seen_user_uids = set()
+    @staticmethod
+    def _folder_name(params, folder_uid):
+        folder = (getattr(params, "folder_cache", None) or {}).get(folder_uid)
+        if folder and getattr(folder, "name", None):
+            return folder.name
+        nsf = getattr(params, "nested_share_folders", None) or {}
+        info = nsf.get(folder_uid)
+        if isinstance(info, dict) and info.get("name"):
+            return info["name"]
+        sf = (getattr(params, "shared_folder_cache", None) or {}).get(folder_uid) or {}
+        return sf.get("name_unencrypted") or ""
 
-        # Pre-build a lookup of (record_type, title.lower()) -> uid for fallback resolution
-        title_to_uid = self._build_user_title_index(params)
+    @staticmethod
+    def _child_folder_uids(params, folder_uid):
+        children: List[str] = []
+        folder = (getattr(params, "folder_cache", None) or {}).get(folder_uid)
+        if folder:
+            children.extend(getattr(folder, "subfolders", None) or [])
+        for fuid, info in (getattr(params, "nested_share_folders", None) or {}).items():
+            if not isinstance(info, dict):
+                continue
+            if (info.get("parent_uid") or "") == folder_uid:
+                children.append(fuid)
+        seen: Set[str] = set()
+        out: List[str] = []
+        for uid in children:
+            if uid and uid not in seen:
+                seen.add(uid)
+                out.append(uid)
+        return out
 
+    def _export_folder_permissions(self, params, folder_uid):
+        """Import-compatible shared_folder_* dict, or {} when permissions are unknown."""
+        if not folder_uid:
+            return {}
+        sf = (getattr(params, "shared_folder_cache", None) or {}).get(folder_uid)
+        if isinstance(sf, dict):
+            return self._permissions_from_classic_sf(sf)
+
+        nsf = getattr(params, "nested_share_folders", None) or {}
+        if folder_uid in nsf:
+            if not getattr(self, "_nsf_perm_noted", False):
+                logging.info(
+                    f"{bcolors.OKBLUE}Export: NSF folder permissions are not exported "
+                    f"(shared_folder_* left empty){bcolors.ENDC}"
+                )
+                self._nsf_perm_noted = True
+            return {}
+        return {}
+
+    @staticmethod
+    def _permissions_from_classic_sf(sf):
+        result = {
+            "manage_users": bool(sf.get("default_manage_users")),
+            "manage_records": bool(sf.get("default_manage_records")),
+            "can_edit": bool(sf.get("default_can_edit")),
+            "can_share": bool(sf.get("default_can_share")),
+            "permissions": [],
+        }
+        for user in sf.get("users") or []:
+            if not isinstance(user, dict):
+                continue
+            name = (user.get("username") or "").strip()
+            if not name:
+                continue
+            result["permissions"].append({
+                "name": name,
+                "manage_users": bool(user.get("manage_users")),
+                "manage_records": bool(user.get("manage_records")),
+            })
+        for team in sf.get("teams") or []:
+            if not isinstance(team, dict):
+                continue
+            name = (team.get("name") or "").strip()
+            uid = (team.get("team_uid") or "").strip()
+            if not name and not uid:
+                continue
+            entry = {
+                "manage_users": bool(team.get("manage_users")),
+                "manage_records": bool(team.get("manage_records")),
+            }
+            if name:
+                entry["name"] = name
+            if uid:
+                entry["uid"] = uid
+            result["permissions"].append(entry)
+        return result
+
+    def _build_resources_and_users(self, params, resource_uids, extra_user_uids=None):
+        """Build pam_data for re-import: one full user object per user, credentials by title."""
+        title_index = _LazyUserTitleIndex(lambda: self._build_user_title_index(params))
+
+        # Pass 1: load resources and linked user UIDs
+        resource_rows = []  # (res_record, pam_settings, linked_uids)
+        user_link_count: Dict[str, int] = {}
         for res_uid in resource_uids:
             res_record = load_pam_record(params, res_uid)
             if not res_record or not isinstance(res_record, vault.TypedRecord):
@@ -214,86 +517,237 @@ class PAMProjectExportCommand(Command):
                     res_uid, res_record.record_type,
                 )
                 continue
+            pam_settings_dict = self._extract_pam_settings(res_record)
+            linked_uids = self._extract_user_uids(pam_settings_dict, title_index)
+            resource_rows.append((res_record, pam_settings_dict, linked_uids))
+            for uid in linked_uids:
+                user_link_count[uid] = user_link_count.get(uid, 0) + 1
 
-            # Extract raw pamSettings payload (keep as-is for round-trip fidelity)
-            pam_settings_dict = {}
-            pam_settings_field = res_record.get_typed_field("pamSettings")
-            if (
-                pam_settings_field
-                and isinstance(pam_settings_field.value, list)
-                and pam_settings_field.value
-                and isinstance(pam_settings_field.value[0], dict)
-            ):
-                pam_settings_dict = dict(pam_settings_field.value[0])
+        user_cache: Dict[str, dict] = {}
 
-            # Gather user UIDs referenced by this resource
-            resource_user_entries = []
-            user_uids_for_resource = self._extract_user_uids(pam_settings_dict, title_to_uid)
+        def cached_user(uid: str):
+            if uid not in user_cache:
+                user_cache[uid] = self._load_user_obj(params, uid)
+            return user_cache[uid]
 
-            for usr_uid in user_uids_for_resource:
-                user_obj = self._load_user_obj(params, usr_uid)
+        resources_list = []
+        top_level_users = []
+        seen_top: Set[str] = set()
+
+        for res_record, pam_settings_dict, linked_uids in resource_rows:
+            uid_to_user = {}
+            nested_users = []
+            for usr_uid in linked_uids:
+                user_obj = cached_user(usr_uid)
                 if user_obj is None:
                     continue
-                resource_user_entries.append({"uid": usr_uid, "type": user_obj["type"], "title": user_obj["title"], "login": user_obj["login"]})
-                if usr_uid not in seen_user_uids:
-                    seen_user_uids.add(usr_uid)
-                    top_level_users.append(user_obj)
+                uid_to_user[usr_uid] = user_obj
+                # Single-resource users live fully under the resource; shared → top-level only.
+                if user_link_count.get(usr_uid, 0) == 1:
+                    nested_users.append(dict(user_obj))
+                elif usr_uid not in seen_top:
+                    seen_top.add(usr_uid)
+                    top_level_users.append(dict(user_obj))
 
-            resources_list.append({
-                "uid": res_uid,
-                "type": res_record.record_type,
-                "title": res_record.title,
-                "pam_settings": pam_settings_dict,
-                "users": resource_user_entries,
-            })
+            import_settings = self._rewrite_pam_settings_for_import(
+                pam_settings_dict, uid_to_user, resource_title=res_record.title or res_record.record_uid
+            )
+            resources_list.append(
+                self._load_resource_obj(res_record, import_settings, nested_users)
+            )
+
+        for usr_uid in extra_user_uids or []:
+            # Orphans only: already-linked users are nested (count==1) or top-level (count>=2).
+            if usr_uid in seen_top or usr_uid in user_link_count:
+                continue
+            user_obj = cached_user(usr_uid)
+            if user_obj is None:
+                continue
+            seen_top.add(usr_uid)
+            top_level_users.append(dict(user_obj))
 
         return resources_list, top_level_users
 
+    @staticmethod
+    def _user_ref_name(user_obj: dict) -> str:
+        return (user_obj.get("title") or user_obj.get("login") or user_obj.get("uid") or "").strip()
+
+    def _rewrite_pam_settings_for_import(
+        self, pam_settings_dict, uid_to_user: Dict[str, dict], resource_title: str = ""
+    ):
+        """Convert vault wire keys (userRecords UIDs) to import JSON credential titles."""
+        settings = copy.deepcopy(pam_settings_dict) if pam_settings_dict else {}
+        conn = settings.get("connection")
+        if not isinstance(conn, dict):
+            return settings
+        res_label = resource_title or "(unknown resource)"
+
+        def warn_unresolved(kind: str, ref: str) -> None:
+            logging.warning(
+                f"{bcolors.WARNING}Export: could not resolve {kind} credential "
+                f"'{ref}' for resource '{res_label}'; omitting from export{bcolors.ENDC}"
+            )
+
+        def resolve_ref(ref, kind: str = "credential") -> str:
+            if not isinstance(ref, str) or not ref.strip():
+                return ""
+            ref = ref.strip()
+            if RecordV3.is_valid_ref_uid(ref):
+                user_obj = uid_to_user.get(ref)
+                if user_obj:
+                    return self._user_ref_name(user_obj)
+                warn_unresolved(kind, ref)
+                return ""
+            return ref
+
+        admin_names: List[str] = []
+        for uid in conn.get("userRecords") or []:
+            if not isinstance(uid, str) or not uid:
+                continue
+            user_obj = uid_to_user.get(uid)
+            if not user_obj:
+                warn_unresolved("administrative", uid)
+                continue
+            name = self._user_ref_name(user_obj)
+            if name and name not in admin_names:
+                admin_names.append(name)
+
+        existing_admin = conn.get("administrative_credentials")
+        if isinstance(existing_admin, str) and existing_admin.strip():
+            name = resolve_ref(existing_admin, "administrative")
+            if name and name not in admin_names:
+                admin_names.append(name)
+        elif isinstance(existing_admin, list):
+            for item in existing_admin:
+                name = resolve_ref(item, "administrative") if isinstance(item, str) else ""
+                if name and name not in admin_names:
+                    admin_names.append(name)
+
+        for key in ("adminRef", "adminCredentialRef"):
+            uid = settings.pop(key, None)
+            if not isinstance(uid, str) or not uid:
+                continue
+            if uid in uid_to_user:
+                name = self._user_ref_name(uid_to_user[uid])
+                if name and name not in admin_names:
+                    admin_names.append(name)
+            else:
+                warn_unresolved("administrative", uid)
+
+        launch_name = ""
+        launch_ref = conn.get("launch_credentials")
+        if isinstance(launch_ref, list):
+            # Import's get_launch_credential uses the first non-empty entry only.
+            launch_ref = next(
+                (item for item in launch_ref if isinstance(item, str) and item.strip()),
+                "",
+            )
+        if isinstance(launch_ref, str) and launch_ref.strip():
+            launch_name = resolve_ref(launch_ref, "launch")
+
+        conn.pop("userRecords", None)
+        if admin_names:
+            conn["administrative_credentials"] = admin_names if len(admin_names) > 1 else admin_names[0]
+        else:
+            conn.pop("administrative_credentials", None)
+        if launch_name:
+            conn["launch_credentials"] = launch_name
+        else:
+            conn.pop("launch_credentials", None)
+
+        settings["connection"] = conn
+        return settings
+
+    @staticmethod
+    def _extract_pam_settings(res_record):
+        field = res_record.get_typed_field("pamSettings")
+        if not field or not isinstance(field.value, list) or not field.value:
+            return {}
+        first = field.value[0]
+        return dict(first) if isinstance(first, dict) else {}
+
+    def _load_resource_obj(self, res_record, pam_settings_dict, resource_user_entries):
+        obj = {
+            "uid": res_record.record_uid,
+            "type": res_record.record_type,
+            "title": res_record.title,
+            "pam_settings": pam_settings_dict,
+            "users": resource_user_entries,
+        }
+        if res_record.notes:
+            obj["notes"] = res_record.notes
+
+        host_field = res_record.get_typed_field("pamHostname")
+        if host_field:
+            raw = host_field.get_default_value()
+            if isinstance(raw, dict):
+                host = raw.get("hostName")
+                port = raw.get("port")
+                if host:
+                    obj["host"] = str(host)
+                if port is not None and str(port) != "":
+                    obj["port"] = str(port)
+
+        for field in itertools.chain(
+            getattr(res_record, "fields", None) or [],
+            getattr(res_record, "custom", None) or [],
+        ):
+            label = (getattr(field, "label", None) or "").strip()
+            ftype = (getattr(field, "type", None) or "").strip()
+            key = (
+                _RESOURCE_FIELD_MAP.get(label.casefold())
+                or _RESOURCE_FIELD_MAP.get(ftype.casefold())
+            )
+            if not key or key in obj:
+                continue
+            raw = field.get_default_value() if hasattr(field, "get_default_value") else None
+            if raw is None or raw == "":
+                continue
+            if ftype == "checkbox" or key in _BOOL_EXPORT_KEYS:
+                coerced = utils.value_to_boolean(raw)
+                if coerced is not None:
+                    obj[key] = coerced
+            else:
+                obj[key] = str(raw)
+
+        return obj
+
     def _build_user_title_index(self, params):
-        """Index every pamUser / login record by lowercased title for title-based linking."""
         index = {}
         for uid in iter_accessible_record_uids(params):
             try:
                 rec = load_pam_record(params, uid)
-            except Exception:
+            except Exception as exc:
+                logging.debug("Export: title index skip UID %s: %s", uid, exc)
                 continue
             if not rec or not isinstance(rec, vault.TypedRecord):
                 continue
-            if rec.record_type not in ("pamUser", "login"):
+            if rec.record_type not in _USER_RECORD_TYPES or not rec.title:
                 continue
-            if rec.title:
-                index.setdefault(rec.title.strip().lower(), uid)
+            index.setdefault(rec.title.strip().lower(), uid)
         return index
 
     def _extract_user_uids(self, pam_settings_dict, title_to_uid=None):
-        """Return all user record UIDs referenced inside a pamSettings dict.
-
-        Falls back to title-based resolution against ``title_to_uid`` when
-        the record stores a title (e.g. KCM-imported records, PR #1942)
-        instead of a UID in launch_credentials / administrative_credentials.
-        """
-        user_uids = []
+        user_uids: List[str] = []
         title_to_uid = title_to_uid or {}
         conn = pam_settings_dict.get("connection") or {}
         if isinstance(conn, dict):
-            for uid in (conn.get("userRecords") or []):
+            for uid in conn.get("userRecords") or []:
                 if uid and uid not in user_uids:
                     user_uids.append(uid)
-            # KCM-style title references (PR #1942 schema)
             for key in ("launch_credentials", "administrative_credentials"):
                 ref = conn.get(key)
-                if not isinstance(ref, str) or not ref:
-                    continue
-                # If it already looks like a UID, accept as-is
-                if len(ref) == 22 and "/" not in ref and " " not in ref:
-                    if ref not in user_uids:
-                        user_uids.append(ref)
-                    continue
-                # Otherwise treat as a title and resolve against the index
-                resolved = title_to_uid.get(ref.strip().lower())
-                if resolved and resolved not in user_uids:
-                    user_uids.append(resolved)
-        # Some record types also reference admin via adminRef / adminCredentialRef at top level
+                refs = ref if isinstance(ref, list) else ([ref] if isinstance(ref, str) else [])
+                for item in refs:
+                    if not isinstance(item, str) or not item:
+                        continue
+                    if RecordV3.is_valid_ref_uid(item):
+                        if item not in user_uids:
+                            user_uids.append(item)
+                        continue
+                    resolved = title_to_uid.get(item.strip().lower())
+                    if resolved and resolved not in user_uids:
+                        user_uids.append(resolved)
         for key in ("adminRef", "adminCredentialRef"):
             uid = pam_settings_dict.get(key)
             if uid and uid not in user_uids:
@@ -301,19 +755,34 @@ class PAMProjectExportCommand(Command):
         return user_uids
 
     def _load_user_obj(self, params, usr_uid):
-        """Load a pamUser/login record and return a plain dict, or None on failure."""
         usr_record = load_pam_record(params, usr_uid)
         if not usr_record or not isinstance(usr_record, vault.TypedRecord):
             logging.debug("Export: user UID %s not found or not TypedRecord", usr_uid)
             return None
-        login_field = usr_record.get_typed_field("login")
+        if usr_record.record_type not in _USER_RECORD_TYPES:
+            logging.debug(
+                "Export: skipping UID %s with type '%s' (not a PAM user type)",
+                usr_uid, usr_record.record_type,
+            )
+            return None
+
         login = ""
+        login_field = usr_record.get_typed_field("login")
         if login_field:
             raw = login_field.get_default_value()
             login = str(raw) if raw is not None else ""
-        return {
+
+        obj = {
             "uid": usr_uid,
             "type": usr_record.record_type,
             "title": usr_record.title,
             "login": login,
         }
+        if usr_record.notes:
+            obj["notes"] = usr_record.notes
+        pwd_field = usr_record.get_typed_field("password")
+        if pwd_field:
+            raw = pwd_field.get_default_value()
+            if raw is not None and str(raw) != "":
+                obj["password"] = str(raw)
+        return obj

--- a/unit-tests/pam/test_pam_project_export.py
+++ b/unit-tests/pam/test_pam_project_export.py
@@ -20,7 +20,7 @@ import json
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import keepercommander.commands.record  # noqa: F401
 
@@ -113,8 +113,6 @@ _DEFAULT_ALLOWED = {
 # ── tests ──────────────────────────────────────────────────────────────────
 
 
-from unittest.mock import MagicMock
-
 class TestPAMProjectExportCommand(unittest.TestCase):
 
     def setUp(self):
@@ -127,8 +125,8 @@ class TestPAMProjectExportCommand(unittest.TestCase):
         """Run execute() with load_pam_record mocked."""
         with patch("keepercommander.commands.pam_import.export.load_pam_record",
                    side_effect=_fake_load):
-            with patch.object(self.cmd, "_get_allowed_settings",
-                              return_value=dict(_DEFAULT_ALLOWED)):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
                 kwargs = {"project_uid": project_uid}
                 if output:
                     kwargs["output"] = output
@@ -213,15 +211,77 @@ class TestPAMProjectExportCommand(unittest.TestCase):
                          "top-level user UIDs must be unique (de-duplicated)")
 
     def test_top_level_users_count(self):
-        # USER1 shared across both resources, USER2 only in DB → 2 unique users
+        # USER1 shared → top-level only; USER2 single-resource → nested under DB
         parsed = json.loads(self._execute())
-        self.assertEqual(len(parsed["pam_data"]["users"]), 2)
+        self.assertEqual(len(parsed["pam_data"]["users"]), 1)
+        self.assertEqual(parsed["pam_data"]["users"][0]["uid"], USER1_UID)
+
+    def test_single_resource_user_nested_with_password_keys(self):
+        parsed = json.loads(self._execute())
+        by_uid = {r["uid"]: r for r in parsed["pam_data"]["resources"]}
+        machine_uids = {u["uid"] for u in by_uid[MACHINE_UID]["users"]}
+        db_uids = {u["uid"] for u in by_uid[DB_UID]["users"]}
+        self.assertNotIn(USER1_UID, machine_uids)
+        self.assertNotIn(USER1_UID, db_uids)
+        self.assertEqual(db_uids, {USER2_UID})
+        db_user = by_uid[DB_UID]["users"][0]
+        for key in ("uid", "type", "title", "login"):
+            self.assertIn(key, db_user)
+
+    def test_user_records_rewritten_to_administrative_credentials(self):
+        parsed = json.loads(self._execute())
+        by_uid = {r["uid"]: r for r in parsed["pam_data"]["resources"]}
+        machine_conn = by_uid[MACHINE_UID]["pam_settings"]["connection"]
+        db_conn = by_uid[DB_UID]["pam_settings"]["connection"]
+        self.assertNotIn("userRecords", machine_conn)
+        self.assertNotIn("userRecords", db_conn)
+        self.assertEqual(machine_conn["administrative_credentials"], "Admin User")
+        self.assertEqual(
+            db_conn["administrative_credentials"],
+            ["Admin User", "DB User"],
+        )
 
     def test_user_has_required_keys(self):
         parsed = json.loads(self._execute())
         for usr in parsed["pam_data"]["users"]:
             for key in ("uid", "type", "title", "login"):
                 self.assertIn(key, usr, f"user missing key: {key}")
+
+    def test_output_file_mode_is_private(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            os.unlink(tmp_path)
+            self._execute(output=tmp_path)
+            mode = os.stat(tmp_path).st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_output_file_mode_overwrites_existing_world_readable(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            tmp.write("{}")
+            tmp_path = tmp.name
+        try:
+            os.chmod(tmp_path, 0o644)
+            self._execute(output=tmp_path)
+            mode = os.stat(tmp_path).st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    def test_title_index_not_built_when_all_refs_are_uids(self):
+        with patch("keepercommander.commands.pam_import.export.load_pam_record",
+                   side_effect=_fake_load):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
+                with patch.object(
+                    self.cmd, "_build_user_title_index", wraps=self.cmd._build_user_title_index
+                ) as mock_index:
+                    self.cmd.execute(self.params, project_uid=CONFIG_UID)
+                    mock_index.assert_not_called()
 
     # ── --output flag ────────────────────────────────────────────
 
@@ -331,7 +391,6 @@ class TestKCMImportRoundTrip(unittest.TestCase):
 
     def setUp(self):
         from keepercommander.commands.pam_import.export import PAMProjectExportCommand
-        from unittest.mock import MagicMock
         self.cmd = PAMProjectExportCommand()
         self.records = self._make_kcm_records()
         self.params = MagicMock()
@@ -342,8 +401,8 @@ class TestKCMImportRoundTrip(unittest.TestCase):
             return self.records.get(uid)
         with patch("keepercommander.commands.pam_import.export.load_pam_record",
                    side_effect=_load):
-            with patch.object(self.cmd, "_get_allowed_settings",
-                              return_value=dict(_DEFAULT_ALLOWED)):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
                 return self.cmd.execute(self.params, project_uid=self.KCM_CFG)
 
     def test_title_based_user_link_resolved(self):
@@ -357,23 +416,44 @@ class TestKCMImportRoundTrip(unittest.TestCase):
         self.assertEqual(res["users"][0]["uid"], self.KCM_USR)
         self.assertEqual(res["users"][0]["title"], "KCM User - prod-db")
 
-    def test_top_level_users_includes_resolved_user(self):
+    def test_title_index_built_for_non_uid_credential_ref(self):
+        with patch("keepercommander.commands.pam_import.export.load_pam_record",
+                   side_effect=lambda _p, uid: self.records.get(uid)):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
+                with patch.object(
+                    self.cmd, "_build_user_title_index", wraps=self.cmd._build_user_title_index
+                ) as mock_index:
+                    self.cmd.execute(self.params, project_uid=self.KCM_CFG)
+                    mock_index.assert_called_once()
+
+    def test_list_launch_credentials_exports_first_entry(self):
+        res = self.records[self.KCM_RES]
+        ps = res.get_typed_field("pamSettings").value[0]
+        ps["connection"]["launch_credentials"] = ["KCM User - prod-db", "ignored"]
         parsed = json.loads(self._execute())
-        top_users = parsed["pam_data"]["users"]
-        self.assertEqual(len(top_users), 1)
-        self.assertEqual(top_users[0]["uid"], self.KCM_USR)
+        conn = parsed["pam_data"]["resources"][0]["pam_settings"]["connection"]
+        self.assertEqual(conn["launch_credentials"], "KCM User - prod-db")
+
+    def test_single_resource_user_not_duplicated_at_top_level(self):
+        parsed = json.loads(self._execute())
+        self.assertEqual(parsed["pam_data"]["users"], [])
+        self.assertEqual(
+            parsed["pam_data"]["resources"][0]["users"][0]["uid"], self.KCM_USR
+        )
 
     def test_pam_settings_preserved_for_round_trip(self):
-        """Round-trip safety: KCM-specific pam_settings keys preserved verbatim."""
+        """Round-trip safety: KCM launch_credentials title preserved for import."""
         parsed = json.loads(self._execute())
         res = parsed["pam_data"]["resources"][0]
         conn = res["pam_settings"]["connection"]
         self.assertEqual(conn["protocol"], "ssh")
         self.assertEqual(conn["port"], "22")
         self.assertEqual(conn["launch_credentials"], "KCM User - prod-db")
+        self.assertNotIn("userRecords", conn)
 
-    def test_uid_in_launch_credentials_accepted(self):
-        """If launch_credentials already holds a 22-char UID (non-KCM path), keep it as-is."""
+    def test_uid_in_launch_credentials_rewritten_to_title(self):
+        """Vault UID in launch_credentials must export as title for re-import."""
         uid_22 = "AAAAAAAAAAAAAAAAAAAAAA"  # 22 chars, no slash, no space
         usr = vault.TypedRecord(version=3)
         usr.type_name = "pamUser"
@@ -387,9 +467,14 @@ class TestKCMImportRoundTrip(unittest.TestCase):
         ps = res.get_typed_field("pamSettings").value[0]
         ps["connection"]["launch_credentials"] = uid_22
         parsed = json.loads(self._execute())
-        users = parsed["pam_data"]["resources"][0]["users"]
+        resource = parsed["pam_data"]["resources"][0]
+        users = resource["users"]
         self.assertEqual(len(users), 1)
         self.assertEqual(users[0]["uid"], uid_22)
+        self.assertEqual(
+            resource["pam_settings"]["connection"]["launch_credentials"],
+            "Direct UID User",
+        )
 
 
 class TestPAMProjectExportNSF(unittest.TestCase):
@@ -452,8 +537,8 @@ class TestPAMProjectExportNSF(unittest.TestCase):
         }
 
     def _execute(self):
-        with patch.object(self.cmd, "_get_allowed_settings",
-                          return_value=dict(_DEFAULT_ALLOWED)):
+        with patch.object(self.cmd, "_load_dag_context",
+                          return_value=(dict(_DEFAULT_ALLOWED), [])):
             return self.cmd.execute(self.params, project_uid=self.NSF_CFG)
 
     def test_nsf_config_export_succeeds(self):
@@ -469,8 +554,390 @@ class TestPAMProjectExportNSF(unittest.TestCase):
         self.assertEqual(res["type"], "pamMachine")
         self.assertEqual(len(res["users"]), 1)
         self.assertEqual(res["users"][0]["uid"], self.NSF_USER)
-        self.assertEqual(len(parsed["pam_data"]["users"]), 1)
-        self.assertEqual(parsed["pam_data"]["users"][0]["login"], "root")
+        self.assertEqual(res["users"][0]["login"], "root")
+        self.assertEqual(parsed["pam_data"]["users"], [])
+        conn = res["pam_settings"]["connection"]
+        self.assertNotIn("userRecords", conn)
+        self.assertEqual(conn["administrative_credentials"], "NSF Admin")
+
+
+class TestPAMProjectExportFolderDiscovery(unittest.TestCase):
+    """Modern projects leave resourceRef empty; export must walk folderUid."""
+
+    CFG = "fold-cfg-001"
+    MACHINE = "fold-res-machine"
+    USER = "fold-usr-admin"
+    ORPHAN_USER = "fold-usr-orphan"
+    PROJECT_FOLDER = "fold-project"
+    RES_FOLDER = "fold-resources"
+    USR_FOLDER = "fold-users"
+
+    def setUp(self):
+        from keepercommander.commands.pam_import.export import PAMProjectExportCommand
+        from types import SimpleNamespace
+
+        self.cmd = PAMProjectExportCommand()
+        self.params = MagicMock()
+
+        # Config with empty resourceRef (modern import layout)
+        cfg = vault.TypedRecord(version=6)
+        cfg.type_name = "pamNetworkConfiguration"
+        cfg.title = "Folder Project"
+        cfg.record_uid = self.CFG
+        cfg.fields.append(_make_typed_field("pamResources", [{
+            "controllerUid": "gw-1",
+            "folderUid": self.USR_FOLDER,
+            "resourceRef": [],
+        }]))
+
+        machine = vault.TypedRecord(version=3)
+        machine.type_name = "pamMachine"
+        machine.title = "App Server"
+        machine.record_uid = self.MACHINE
+        machine.fields.append(_make_typed_field("pamHostname", [{
+            "hostName": "10.0.0.5",
+            "port": "22",
+        }]))
+        machine.fields.append(_make_typed_field("pamSettings", [{
+            "connection": {
+                "userRecords": [self.USER],
+                "protocol": "ssh",
+                "port": "22",
+            },
+        }]))
+        machine.fields.append(_make_typed_field("text", ["Linux"], label="operatingSystem"))
+
+        user = _make_user_record(self.USER, "Admin", "root")
+        user.fields.append(_make_typed_field("password", ["s3cret"]))
+
+        orphan = _make_user_record(self.ORPHAN_USER, "Orphan User", "orphan")
+
+        self.records = {
+            self.CFG: cfg,
+            self.MACHINE: machine,
+            self.USER: user,
+            self.ORPHAN_USER: orphan,
+        }
+        self.params.record_cache = {uid: {} for uid in self.records}
+        self.params.nested_share_records = {}
+        self.params.nested_share_record_data = {}
+        self.params.nested_share_folders = {}
+        self.params.shared_folder_cache = {
+            self.RES_FOLDER: {
+                "default_manage_users": True,
+                "default_manage_records": True,
+                "default_can_edit": True,
+                "default_can_share": False,
+                "users": [{
+                    "username": "admin@example.com",
+                    "manage_users": True,
+                    "manage_records": True,
+                }],
+                "teams": [{
+                    "name": "Ops Team",
+                    "team_uid": "team-uid-1",
+                    "manage_users": False,
+                    "manage_records": True,
+                }],
+            },
+            self.USR_FOLDER: {
+                "default_manage_users": False,
+                "default_manage_records": True,
+                "default_can_edit": True,
+                "default_can_share": True,
+                "users": [],
+                "teams": [],
+            },
+        }
+        self.params.subfolder_record_cache = {
+            self.RES_FOLDER: {self.MACHINE},
+            self.USR_FOLDER: {self.USER, self.ORPHAN_USER, self.CFG},
+        }
+        self.params.nested_share_folder_records = {}
+        self.params.folder_cache = {
+            self.PROJECT_FOLDER: SimpleNamespace(
+                uid=self.PROJECT_FOLDER, name="Folder Project",
+                parent_uid="", subfolders=[self.RES_FOLDER, self.USR_FOLDER],
+            ),
+            self.RES_FOLDER: SimpleNamespace(
+                uid=self.RES_FOLDER, name="Folder Project - Resources",
+                parent_uid=self.PROJECT_FOLDER, subfolders=[],
+            ),
+            self.USR_FOLDER: SimpleNamespace(
+                uid=self.USR_FOLDER, name="Folder Project - Users",
+                parent_uid=self.PROJECT_FOLDER, subfolders=[],
+            ),
+        }
+
+    def _execute(self):
+        def _load(_p, uid):
+            return self.records.get(uid)
+        with patch("keepercommander.commands.pam_import.export.load_pam_record",
+                   side_effect=_load):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
+                return self.cmd.execute(self.params, project_uid=self.CFG)
+
+    def test_empty_resource_ref_discovers_folder_resources(self):
+        parsed = json.loads(self._execute())
+        self.assertEqual(len(parsed["pam_data"]["resources"]), 1)
+        res = parsed["pam_data"]["resources"][0]
+        self.assertEqual(res["uid"], self.MACHINE)
+        self.assertEqual(res["host"], "10.0.0.5")
+        self.assertEqual(res["port"], "22")
+        self.assertEqual(res["operating_system"], "Linux")
+
+    def test_folder_users_exported_including_orphan(self):
+        parsed = json.loads(self._execute())
+        # Linked admin lives under the resource; orphan stays top-level only.
+        self.assertEqual(
+            {u["login"] for u in parsed["pam_data"]["users"]},
+            {"orphan"},
+        )
+        res = parsed["pam_data"]["resources"][0]
+        self.assertEqual(len(res["users"]), 1)
+        root = res["users"][0]
+        self.assertEqual(root["login"], "root")
+        self.assertEqual(root.get("password"), "s3cret")
+        conn = res["pam_settings"]["connection"]
+        self.assertNotIn("userRecords", conn)
+        self.assertEqual(conn["administrative_credentials"], "Admin")
+
+    def test_shared_folder_permissions_exported(self):
+        parsed = json.loads(self._execute())
+        sfr = parsed["shared_folder_resources"]
+        self.assertTrue(sfr.get("manage_users"))
+        self.assertTrue(sfr.get("manage_records"))
+        self.assertFalse(sfr.get("can_share"))
+        names = {p.get("name") for p in sfr.get("permissions") or []}
+        self.assertIn("admin@example.com", names)
+        self.assertIn("Ops Team", names)
+
+        sfu = parsed["shared_folder_users"]
+        self.assertFalse(sfu.get("manage_users"))
+        self.assertTrue(sfu.get("can_share"))
+
+    def test_does_not_scan_sibling_projects_under_pam_root(self):
+        """Sibling projects under PAM Environments must not be exported."""
+        from types import SimpleNamespace
+
+        pam_root = "fold-pam-root"
+        sibling_project = "fold-sibling-project"
+        sibling_res = "fold-sibling-resources"
+        sibling_machine = "fold-sibling-machine"
+
+        other = vault.TypedRecord(version=3)
+        other.type_name = "pamMachine"
+        other.title = "Other Project Machine"
+        other.record_uid = sibling_machine
+        other.fields.append(_make_typed_field("pamSettings", [{"connection": {}}]))
+        self.records[sibling_machine] = other
+        self.params.record_cache[sibling_machine] = {}
+        self.params.subfolder_record_cache[sibling_res] = {sibling_machine}
+
+        self.params.folder_cache[self.PROJECT_FOLDER].parent_uid = pam_root
+        self.params.folder_cache[pam_root] = SimpleNamespace(
+            uid=pam_root, name="PAM Environments",
+            parent_uid="", subfolders=[self.PROJECT_FOLDER, sibling_project],
+        )
+        self.params.folder_cache[sibling_project] = SimpleNamespace(
+            uid=sibling_project, name="Other Project",
+            parent_uid=pam_root, subfolders=[sibling_res],
+        )
+        self.params.folder_cache[sibling_res] = SimpleNamespace(
+            uid=sibling_res, name="Other Project - Resources",
+            parent_uid=sibling_project, subfolders=[],
+        )
+
+        parsed = json.loads(self._execute())
+        uids = {r["uid"] for r in parsed["pam_data"]["resources"]}
+        self.assertEqual(uids, {self.MACHINE})
+        self.assertNotIn(sibling_machine, uids)
+
+    def test_nested_safe_mode_resources_discovered(self):
+        """Safe-mode: Resources/Users nested under per-safe folders."""
+        from types import SimpleNamespace
+
+        config_folder = "fold-config"
+        safe_folder = "fold-safe-a"
+        safe_res = "fold-safe-a-resources"
+        safe_usr = "fold-safe-a-users"
+        safe_machine = "fold-safe-machine"
+        safe_user = "fold-safe-user"
+
+        cfg = self.records[self.CFG]
+        pam = cfg.get_typed_field("pamResources").value[0]
+        pam["folderUid"] = config_folder
+
+        machine = vault.TypedRecord(version=3)
+        machine.type_name = "pamMachine"
+        machine.title = "Safe Machine"
+        machine.record_uid = safe_machine
+        machine.fields.append(_make_typed_field("pamHostname", [{"hostName": "1.2.3.4", "port": "22"}]))
+        machine.fields.append(_make_typed_field("pamSettings", [{
+            "connection": {"userRecords": [safe_user], "protocol": "ssh"},
+        }]))
+        user = _make_user_record(safe_user, "Safe Admin", "safeadmin")
+
+        self.records[safe_machine] = machine
+        self.records[safe_user] = user
+        self.params.record_cache[safe_machine] = {}
+        self.params.record_cache[safe_user] = {}
+        self.params.subfolder_record_cache = {
+            config_folder: {self.CFG},
+            safe_res: {safe_machine},
+            safe_usr: {safe_user},
+        }
+        self.params.folder_cache = {
+            self.PROJECT_FOLDER: SimpleNamespace(
+                uid=self.PROJECT_FOLDER, name="Folder Project",
+                parent_uid="", subfolders=[config_folder, safe_folder],
+            ),
+            config_folder: SimpleNamespace(
+                uid=config_folder, name="Folder Project - Config",
+                parent_uid=self.PROJECT_FOLDER, subfolders=[],
+            ),
+            safe_folder: SimpleNamespace(
+                uid=safe_folder, name="SafeA",
+                parent_uid=self.PROJECT_FOLDER, subfolders=[safe_res, safe_usr],
+            ),
+            safe_res: SimpleNamespace(
+                uid=safe_res, name="SafeA - Resources",
+                parent_uid=safe_folder, subfolders=[],
+            ),
+            safe_usr: SimpleNamespace(
+                uid=safe_usr, name="SafeA - Users",
+                parent_uid=safe_folder, subfolders=[],
+            ),
+        }
+
+        parsed = json.loads(self._execute())
+        uids = {r["uid"] for r in parsed["pam_data"]["resources"]}
+        self.assertEqual(uids, {safe_machine})
+        res = next(r for r in parsed["pam_data"]["resources"] if r["uid"] == safe_machine)
+        self.assertEqual(res["users"][0]["login"], "safeadmin")
+        self.assertEqual(parsed["pam_data"]["users"], [])
+
+    def test_unloadable_folder_records_warn_once(self):
+        missing_uid = "fold-missing-rec"
+        self.params.subfolder_record_cache[self.RES_FOLDER].add(missing_uid)
+        with self.assertLogs(level="WARNING") as logs:
+            self._execute()
+        self.assertTrue(any("skipped 1 unloadable" in m for m in logs.output))
+
+    def test_password_warning_on_file_output(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            path = tmp.name
+        try:
+            with patch("keepercommander.commands.pam_import.export.load_pam_record",
+                       side_effect=lambda _p, uid: self.records.get(uid)):
+                with patch.object(self.cmd, "_load_dag_context",
+                                  return_value=(dict(_DEFAULT_ALLOWED), [])):
+                    with self.assertLogs(level="WARNING") as logs:
+                        self.cmd.execute(self.params, project_uid=self.CFG, output=path)
+            self.assertTrue(any("passwords" in m.lower() for m in logs.output))
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_unresolvable_admin_uid_warns_with_resource_name(self):
+        missing = "AAAAAAAAAAAAAAAAAAAAAA"
+        machine = self.records[self.MACHINE]
+        ps = machine.get_typed_field("pamSettings").value[0]
+        ps["connection"]["userRecords"] = [missing]
+        with self.assertLogs(level="WARNING") as logs:
+            parsed = json.loads(self._execute())
+        self.assertTrue(
+            any("could not resolve administrative" in m and "App Server" in m
+                for m in logs.output)
+        )
+        conn = parsed["pam_data"]["resources"][0]["pam_settings"]["connection"]
+        self.assertNotIn("administrative_credentials", conn)
+        self.assertNotIn("userRecords", conn)
+
+
+class TestExportImportParseContract(unittest.TestCase):
+    """Parse exported JSON through import loaders (no vault dry-run)."""
+
+    def setUp(self):
+        from keepercommander.commands.pam_import.export import PAMProjectExportCommand
+
+        self.cmd = PAMProjectExportCommand()
+        self.params = MagicMock()
+        # Clone fixture records and attach passwords so import sees them.
+        self.records = {
+            CONFIG_UID: _make_config_record(CONFIG_UID, "Test Project",
+                                            resource_uids=[MACHINE_UID, DB_UID]),
+            MACHINE_UID: _make_resource_record(MACHINE_UID, "Linux Server", "pamMachine",
+                                               user_uids=[USER1_UID]),
+            DB_UID: _make_resource_record(DB_UID, "Postgres DB", "pamDatabase",
+                                          user_uids=[USER1_UID, USER2_UID]),
+            USER1_UID: _make_user_record(USER1_UID, "Admin User", "root"),
+            USER2_UID: _make_user_record(USER2_UID, "DB User", "dbuser"),
+        }
+        for uid in (USER1_UID, USER2_UID):
+            self.records[uid].fields.append(_make_typed_field("password", [f"pw-{uid}"]))
+        self.params.record_cache = {uid: {} for uid in self.records}
+
+    def _export(self):
+        with patch("keepercommander.commands.pam_import.export.load_pam_record",
+                   side_effect=lambda _p, uid: self.records.get(uid)):
+            with patch.object(self.cmd, "_load_dag_context",
+                              return_value=(dict(_DEFAULT_ALLOWED), [])):
+                return json.loads(self.cmd.execute(self.params, project_uid=CONFIG_UID))
+
+    def test_exported_json_loads_via_import_object_loaders(self):
+        from keepercommander.commands.pam_import.base import (
+            PamDatabaseObject,
+            PamMachineObject,
+            PamUserObject,
+            get_admin_credential,
+        )
+
+        parsed = self._export()
+        loaders = {
+            "pamMachine": PamMachineObject.load,
+            "pamDatabase": PamDatabaseObject.load,
+        }
+
+        for res in parsed["pam_data"]["resources"]:
+            # Import regenerates UIDs; drop export UIDs so validators don't fire on fixtures.
+            payload = dict(res)
+            payload.pop("uid", None)
+            nested = []
+            for user in payload.get("users") or []:
+                u = dict(user)
+                u.pop("uid", None)
+                nested.append(u)
+            payload["users"] = nested
+
+            obj = loaders[res["type"]](payload)
+            admin = get_admin_credential(obj)
+            self.assertTrue(
+                admin,
+                f"{res['title']}: administrative_credentials must populate import userRecords",
+            )
+            self.assertNotIn(
+                "userRecords",
+                (res.get("pam_settings") or {}).get("connection") or {},
+            )
+            for nested_user in obj.users or []:
+                self.assertTrue(
+                    nested_user.password,
+                    f"nested user {nested_user.title} missing password",
+                )
+
+        for user in parsed["pam_data"]["users"]:
+            payload = dict(user)
+            payload.pop("uid", None)
+            loaded = PamUserObject.load(payload)
+            self.assertEqual(loaded.title, user["title"])
+            self.assertTrue(loaded.password, f"top-level user {loaded.title} missing password")
+
+        # Shared admin is top-level only; single-resource DB user is nested only.
+        self.assertEqual({u["uid"] for u in parsed["pam_data"]["users"]}, {USER1_UID})
+        db = next(r for r in parsed["pam_data"]["resources"] if r["uid"] == DB_UID)
+        self.assertEqual({u["uid"] for u in db["users"]}, {USER2_UID})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `pam project export` returned empty `pam_data` and shared-folder blocks for modern projects because it only read legacy `resourceRef`, which import no longer populates.
- Export now discovers resources/users from the project folder tree (and DAG), and includes shared-folder permissions plus host/port fields needed for re-import.

## Changes
- Resolve resources and users from `folderUid` project folders in addition to `resourceRef` and DAG links
- Export `shared_folder_resources` / `shared_folder_users` permissions from the vault
- Include host, port, and related typed fields (and user passwords) in export JSON
- Add unit tests for empty-`resourceRef` folder discovery and permission export