### PR TITLE
KC-1423: fix validation for passwords and passphrase in record creation and updation

### DIFF
--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -24,7 +24,7 @@ from ..base import Command, GroupCommand
 from ..record_edit import RecordEditMixin, record_fields_description, ParsedFieldValue
 from ...enforcement import PasswordComplexityEnforcer, RecordTypeEnforcer
 from ...error import CommandError
-from ... import nested_share_folder as _nsf, vault
+from ... import generator, nested_share_folder as _nsf, vault
 from .helpers import (
     resolve_folder_uid, command_error_handler, check_result,
     check_record_edit_permission, check_record_delete_permission,
@@ -71,6 +71,7 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
 
         self.warnings.clear()
         self._generated_password = False
+        self._generated_password_is_passphrase = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         notes = kwargs.get('notes')
@@ -80,7 +81,7 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         data = self._build_record_data(params, record_type, title, notes, record_fields)
         if self.abort_if_errors():
             return
-        self.apply_password_policy_warnings(params, data, **kwargs)
+        self.apply_password_policy_warnings(params, data, force=kwargs.get('force'))
 
         if self.abort_if_errors():
             return
@@ -212,6 +213,8 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             if self.warn_wrong_password_gen_field(parsed):
                 return None
             if parsed.type == 'password':
+                algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
+                self._generated_password_is_passphrase = algorithm == 'passphrase'
                 password, gen_error = self.generate_password(action_params, policy=self._password_policy)
                 if gen_error:
                     self.on_error(gen_error)
@@ -238,6 +241,7 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
 
         self.warnings.clear()
         self._generated_password = False
+        self._generated_password_is_passphrase = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         record_type = kwargs.get('record_type')
@@ -290,7 +294,7 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     fields=fields or None,
                     notes=kwargs.get('notes'),
                 )
-                self.apply_password_policy_warnings(params, merged, **kwargs)
+                self.apply_password_policy_warnings(params, merged, force=kwargs.get('force'))
                 if self.warnings:
                     for w in self.warnings:
                         logging.warning(w)

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -70,6 +70,7 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         RecordTypeEnforcer.enforce(params, record_type, 'nsf-record-add')
 
         self.warnings.clear()
+        self._generated_password = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         notes = kwargs.get('notes')
@@ -79,7 +80,7 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         data = self._build_record_data(params, record_type, title, notes, record_fields)
         if self.abort_if_errors():
             return
-        self._check_password_policy(params, data, **kwargs)
+        self.apply_password_policy_warnings(params, data, **kwargs)
 
         if self.abort_if_errors():
             return
@@ -183,13 +184,6 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
             data['notes'] = notes
         return data
 
-    def _check_password_policy(self, params, data, **kwargs):
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        for failure in pw_failures:
-            self.on_warning(failure)
-        if pw_failures and not kwargs.get('force'):
-            self.on_warning('Use --force to bypass password policy warnings.')
-
 
 # ══════════════════════════════════════════════════════════════════════════
 # nsf-record-update
@@ -222,6 +216,8 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                 if gen_error:
                     self.on_error(gen_error)
                     return None
+                if password is not None:
+                    self._generated_password = True
                 return password
             if parsed.type in ('oneTimeCode', 'otp'):
                 return self.generate_totp_url()
@@ -241,6 +237,7 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             raise CommandError('nsf-record-update', 'Record UID is required (use -r or --record)')
 
         self.warnings.clear()
+        self._generated_password = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         record_type = kwargs.get('record_type')
@@ -293,7 +290,7 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     fields=fields or None,
                     notes=kwargs.get('notes'),
                 )
-                self._check_password_policy(params, merged, **kwargs)
+                self.apply_password_policy_warnings(params, merged, **kwargs)
                 if self.warnings:
                     for w in self.warnings:
                         logging.warning(w)
@@ -310,13 +307,6 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                 )
                 check_result(result, 'nsf-record-update')
             params.sync_data = True
-
-    def _check_password_policy(self, params, data, **kwargs):
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        for failure in pw_failures:
-            self.on_warning(failure)
-        if pw_failures and not kwargs.get('force'):
-            self.on_warning('Use --force to bypass password policy warnings.')
 
     @staticmethod
     def _load_record_data(params, record_uid):   # type: (Any, str) -> Optional[Dict]

--- a/keepercommander/commands/nested_share_folder/record_commands.py
+++ b/keepercommander/commands/nested_share_folder/record_commands.py
@@ -70,8 +70,6 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         RecordTypeEnforcer.enforce(params, record_type, 'nsf-record-add')
 
         self.warnings.clear()
-        self._generated_password = False
-        self._generated_password_is_passphrase = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         notes = kwargs.get('notes')
@@ -81,7 +79,6 @@ class NestedShareRecordAddCommand(Command, RecordEditMixin):
         data = self._build_record_data(params, record_type, title, notes, record_fields)
         if self.abort_if_errors():
             return
-        self.apply_password_policy_warnings(params, data, force=kwargs.get('force'))
 
         if self.abort_if_errors():
             return
@@ -214,13 +211,12 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                 return None
             if parsed.type == 'password':
                 algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
-                self._generated_password_is_passphrase = algorithm == 'passphrase'
                 password, gen_error = self.generate_password(action_params, policy=self._password_policy)
                 if gen_error:
                     self.on_error(gen_error)
                     return None
                 if password is not None:
-                    self._generated_password = True
+                    self.validate_generated_password(password, algorithm)
                 return password
             if parsed.type in ('oneTimeCode', 'otp'):
                 return self.generate_totp_url()
@@ -240,8 +236,6 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
             raise CommandError('nsf-record-update', 'Record UID is required (use -r or --record)')
 
         self.warnings.clear()
-        self._generated_password = False
-        self._generated_password_is_passphrase = False
         self._password_policy = PasswordComplexityEnforcer.get_policy(params)
 
         record_type = kwargs.get('record_type')
@@ -294,13 +288,6 @@ class NestedShareRecordUpdateCommand(Command, RecordEditMixin):
                     fields=fields or None,
                     notes=kwargs.get('notes'),
                 )
-                self.apply_password_policy_warnings(params, merged, force=kwargs.get('force'))
-                if self.warnings:
-                    for w in self.warnings:
-                        logging.warning(w)
-                    if not kwargs.get('force'):
-                        return
-                    self.warnings.clear()
                 result = _nsf.update_record_v3(
                     params=params,
                     record_uid=record_uid,

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -244,8 +244,6 @@ class RecordEditMixin:
         self.warnings = []
         self.errors = []
         self._password_policy = None   # type: Optional[Dict[str, Any]]
-        self._generated_password = False
-        self._generated_password_is_passphrase = False
 
     def on_warning(self, message):
         if message:
@@ -268,19 +266,15 @@ class RecordEditMixin:
     def on_info(self, message):
         logging.info(message)
 
-    def apply_password_policy_warnings(self, params, source, force=False):
-        """Warn on complexity failures only for passwords produced by $GEN.
-
-        Manually entered passwords are saved as-is; strength is handled by BreachWatch.
-        """
-        if not getattr(self, '_generated_password', False):
+    def validate_generated_password(self, password, algorithm):
+        """Validate a generated password with the correct algorithm flag."""
+        if not password or not self._password_policy:
             return
-        pw_failures = PasswordComplexityEnforcer.validate_record(
-            params, source, allow_passphrase_fallback=self._generated_password_is_passphrase)
-        for failure in pw_failures:
+        allow_passphrase = algorithm == 'passphrase'
+        failures = PasswordComplexityEnforcer.validate_password(
+            password, self._password_policy, allow_passphrase_fallback=allow_passphrase)
+        for failure in failures:
             self.on_warning(failure)
-        if pw_failures and not force:
-            self.on_warning('Use --force to bypass password policy warnings.')
 
     def warn_wrong_password_gen_field(self, parsed_field):
         # type: (ParsedFieldValue) -> bool
@@ -345,12 +339,11 @@ class RecordEditMixin:
                 action_params.clear()
                 if self.is_generate_value(parsed_field.value, action_params):
                     algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
-                    self._generated_password_is_passphrase = algorithm == 'passphrase'
                     password, gen_error = self.generate_password(action_params, policy=self._password_policy)
                     if gen_error:
                         self.on_error(gen_error)
                     elif password is not None:
-                        self._generated_password = True
+                        self.validate_generated_password(password, algorithm)
                         record.password = password
                 elif self.is_base64_value(parsed_field.value, action_params):
                     if action_params:
@@ -689,26 +682,24 @@ class RecordEditMixin:
                 if self.is_generate_value(parsed_field.value, action_params):
                     if record_field.type == 'password':
                         algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
-                        self._generated_password_is_passphrase = algorithm == 'passphrase'
                         value, gen_error = self.generate_password(action_params, policy=self._password_policy)
                         if gen_error:
                             self.on_error(gen_error)
                             continue
                         if value is not None:
-                            self._generated_password = True
+                            self.validate_generated_password(value, algorithm)
                     elif record_field.type in ('oneTimeCode', 'otp'):
                         value = self.generate_totp_url()
                     elif record_field.type in ('keyPair', 'privateKey'):
                         should_encrypt = 'enc' in action_params
                         passphrase = None
                         if should_encrypt:
-                            self._generated_password_is_passphrase = False
                             passphrase, gen_error = self.generate_password()
                             if gen_error:
                                 self.on_error(gen_error)
                                 continue
                             if passphrase:
-                                self._generated_password = True
+                                self.validate_generated_password(passphrase, 'password')
                         key_type = next((x for x in action_params if x in ('rsa', 'ec', 'ed25519')), 'rsa')
                         value = self.generate_key_pair(key_type, passphrase)
                         if passphrase:
@@ -942,8 +933,6 @@ class RecordAddCommand(Command, RecordEditMixin):
         folder_uid = FolderMixin.resolve_folder(params, kwargs.get('folder'))
 
         self.warnings.clear()
-        self._generated_password = False
-        self._generated_password_is_passphrase = False
         title = kwargs.get('title')
         if not title:
             raise CommandError('record-add', 'Title parameter is required.')
@@ -1006,8 +995,6 @@ class RecordAddCommand(Command, RecordEditMixin):
             record.record_uid = record_uid
         record.title = title
         record.notes = self.validate_notes(kwargs.get('notes') or '')
-
-        self.apply_password_policy_warnings(params, record, force=kwargs.get('force'))
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:
@@ -1326,8 +1313,6 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             return
 
         self.warnings.clear()
-        self._generated_password = False
-        self._generated_password_is_passphrase = False
         record_name = kwargs.get('record')
         if not record_name:
             raise CommandError('record-update', 'Record parameter is required.')
@@ -1393,9 +1378,6 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
 
         if self.abort_if_errors():
             return
-
-        if isinstance(record, vault.TypedRecord):
-            self.apply_password_policy_warnings(params, record, force=kwargs.get('force'))
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -245,6 +245,7 @@ class RecordEditMixin:
         self.errors = []
         self._password_policy = None   # type: Optional[Dict[str, Any]]
         self._generated_password = False
+        self._generated_password_is_passphrase = False
 
     def on_warning(self, message):
         if message:
@@ -267,17 +268,18 @@ class RecordEditMixin:
     def on_info(self, message):
         logging.info(message)
 
-    def apply_password_policy_warnings(self, params, source, **kwargs):
+    def apply_password_policy_warnings(self, params, source, force=False):
         """Warn on complexity failures only for passwords produced by $GEN.
 
         Manually entered passwords are saved as-is; strength is handled by BreachWatch.
         """
         if not getattr(self, '_generated_password', False):
             return
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, source)
+        pw_failures = PasswordComplexityEnforcer.validate_record(
+            params, source, allow_passphrase_fallback=self._generated_password_is_passphrase)
         for failure in pw_failures:
             self.on_warning(failure)
-        if pw_failures and not kwargs.get('force'):
+        if pw_failures and not force:
             self.on_warning('Use --force to bypass password policy warnings.')
 
     def warn_wrong_password_gen_field(self, parsed_field):
@@ -342,6 +344,8 @@ class RecordEditMixin:
             elif parsed_field.type == 'password':
                 action_params.clear()
                 if self.is_generate_value(parsed_field.value, action_params):
+                    algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
+                    self._generated_password_is_passphrase = algorithm == 'passphrase'
                     password, gen_error = self.generate_password(action_params, policy=self._password_policy)
                     if gen_error:
                         self.on_error(gen_error)
@@ -684,6 +688,8 @@ class RecordEditMixin:
                 action_params = []
                 if self.is_generate_value(parsed_field.value, action_params):
                     if record_field.type == 'password':
+                        algorithm, _ = generator.resolve_gen_password_algorithm(action_params)
+                        self._generated_password_is_passphrase = algorithm == 'passphrase'
                         value, gen_error = self.generate_password(action_params, policy=self._password_policy)
                         if gen_error:
                             self.on_error(gen_error)
@@ -696,10 +702,13 @@ class RecordEditMixin:
                         should_encrypt = 'enc' in action_params
                         passphrase = None
                         if should_encrypt:
+                            self._generated_password_is_passphrase = False
                             passphrase, gen_error = self.generate_password()
                             if gen_error:
                                 self.on_error(gen_error)
                                 continue
+                            if passphrase:
+                                self._generated_password = True
                         key_type = next((x for x in action_params if x in ('rsa', 'ec', 'ed25519')), 'rsa')
                         value = self.generate_key_pair(key_type, passphrase)
                         if passphrase:
@@ -934,6 +943,7 @@ class RecordAddCommand(Command, RecordEditMixin):
 
         self.warnings.clear()
         self._generated_password = False
+        self._generated_password_is_passphrase = False
         title = kwargs.get('title')
         if not title:
             raise CommandError('record-add', 'Title parameter is required.')
@@ -997,7 +1007,7 @@ class RecordAddCommand(Command, RecordEditMixin):
         record.title = title
         record.notes = self.validate_notes(kwargs.get('notes') or '')
 
-        self.apply_password_policy_warnings(params, record, **kwargs)
+        self.apply_password_policy_warnings(params, record, force=kwargs.get('force'))
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:
@@ -1317,6 +1327,7 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
 
         self.warnings.clear()
         self._generated_password = False
+        self._generated_password_is_passphrase = False
         record_name = kwargs.get('record')
         if not record_name:
             raise CommandError('record-update', 'Record parameter is required.')
@@ -1384,7 +1395,7 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             return
 
         if isinstance(record, vault.TypedRecord):
-            self.apply_password_policy_warnings(params, record, **kwargs)
+            self.apply_password_policy_warnings(params, record, force=kwargs.get('force'))
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:

--- a/keepercommander/commands/record_edit.py
+++ b/keepercommander/commands/record_edit.py
@@ -244,6 +244,7 @@ class RecordEditMixin:
         self.warnings = []
         self.errors = []
         self._password_policy = None   # type: Optional[Dict[str, Any]]
+        self._generated_password = False
 
     def on_warning(self, message):
         if message:
@@ -265,6 +266,19 @@ class RecordEditMixin:
 
     def on_info(self, message):
         logging.info(message)
+
+    def apply_password_policy_warnings(self, params, source, **kwargs):
+        """Warn on complexity failures only for passwords produced by $GEN.
+
+        Manually entered passwords are saved as-is; strength is handled by BreachWatch.
+        """
+        if not getattr(self, '_generated_password', False):
+            return
+        pw_failures = PasswordComplexityEnforcer.validate_record(params, source)
+        for failure in pw_failures:
+            self.on_warning(failure)
+        if pw_failures and not kwargs.get('force'):
+            self.on_warning('Use --force to bypass password policy warnings.')
 
     def warn_wrong_password_gen_field(self, parsed_field):
         # type: (ParsedFieldValue) -> bool
@@ -332,6 +346,7 @@ class RecordEditMixin:
                     if gen_error:
                         self.on_error(gen_error)
                     elif password is not None:
+                        self._generated_password = True
                         record.password = password
                 elif self.is_base64_value(parsed_field.value, action_params):
                     if action_params:
@@ -673,6 +688,8 @@ class RecordEditMixin:
                         if gen_error:
                             self.on_error(gen_error)
                             continue
+                        if value is not None:
+                            self._generated_password = True
                     elif record_field.type in ('oneTimeCode', 'otp'):
                         value = self.generate_totp_url()
                     elif record_field.type in ('keyPair', 'privateKey'):
@@ -916,6 +933,7 @@ class RecordAddCommand(Command, RecordEditMixin):
         folder_uid = FolderMixin.resolve_folder(params, kwargs.get('folder'))
 
         self.warnings.clear()
+        self._generated_password = False
         title = kwargs.get('title')
         if not title:
             raise CommandError('record-add', 'Title parameter is required.')
@@ -979,11 +997,7 @@ class RecordAddCommand(Command, RecordEditMixin):
         record.title = title
         record.notes = self.validate_notes(kwargs.get('notes') or '')
 
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, record)
-        for f in pw_failures:
-            self.on_warning(f)
-        if pw_failures and not kwargs.get('force'):
-            self.on_warning('Use --force to bypass password policy warnings.')
+        self.apply_password_policy_warnings(params, record, **kwargs)
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:
@@ -1302,6 +1316,7 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             return
 
         self.warnings.clear()
+        self._generated_password = False
         record_name = kwargs.get('record')
         if not record_name:
             raise CommandError('record-update', 'Record parameter is required.')
@@ -1369,11 +1384,7 @@ class RecordUpdateCommand(Command, RecordEditMixin, RecordMixin):
             return
 
         if isinstance(record, vault.TypedRecord):
-            pw_failures = PasswordComplexityEnforcer.validate_record(params, record)
-            for f in pw_failures:
-                self.on_warning(f)
-            if pw_failures and not kwargs.get('force'):
-                self.on_warning('Use --force to bypass password policy warnings.')
+            self.apply_password_policy_warnings(params, record, **kwargs)
 
         ignore_warnings = kwargs.get('force') is True
         if len(self.warnings) > 0:

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -142,8 +142,9 @@ def get_password_from_rules(generate_rules, generate_length):
     return kpg.generate()
 
 
-def enforce_generated_password_policy(params, data, command, generated, password=None, force=False):
-    if not generated or password:
+def enforce_generated_password_policy(params, data, command, generated, manual_password=None, force=False):
+    # Skip if user explicitly provided a password (overrides generation)
+    if not generated or manual_password:
         return
     pw_failures = PasswordComplexityEnforcer.validate_record(
         params, data, allow_passphrase_fallback=False)
@@ -419,14 +420,15 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
 
         # For compatibility w/ legacy: --password overrides --generate AND --generate overrides dataJSON/option
         # dataJSON/option < kwargs: --generate < kwargs: --password
-        password = kwargs.get('password')
+        manual_password = kwargs.get('password')
+        password = manual_password
         if not password and (kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length')):
             password = get_password_from_rules(kwargs.get('generate_rules'), kwargs.get('generate_length'))
         if password:
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
         generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
-        enforce_generated_password_policy(params, data, 'add', generated, password, kwargs.get('force'))
+        enforce_generated_password_policy(params, data, 'add', generated, manual_password=manual_password, force=kwargs.get('force'))
 
         record_uid = api.generate_record_uid()
         logging.debug('Generated Record UID: %s', record_uid)
@@ -661,7 +663,8 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
 
         # For compatibility w/ legacy: --password overides --generate AND --generate overrides dataJSON/option
         # dataJSON/option < kwargs: --generate < kwargs: --password
-        password = kwargs.get('password')
+        manual_password = kwargs.get('password')
+        password = manual_password
         if not password and generate:
             password = get_password_from_rules(kwargs.get('generate_rules'), kwargs.get('generate_length'))
         if password:
@@ -669,7 +672,7 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
         generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
-        enforce_generated_password_policy(params, data, 'edit', generated, password, kwargs.get('force'))
+        enforce_generated_password_policy(params, data, 'edit', generated, manual_password=manual_password, force=kwargs.get('force'))
 
         data_dict = json.loads(data)
         changed = rdata_dict != data_dict

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -142,6 +142,21 @@ def get_password_from_rules(generate_rules, generate_length):
     return kpg.generate()
 
 
+def enforce_generated_password_policy(params, data, command, generated, password=None, force=False):
+    if not generated or password:
+        return
+    pw_failures = PasswordComplexityEnforcer.validate_record(
+        params, data, allow_passphrase_fallback=False)
+    if pw_failures:
+        for failure in pw_failures:
+            logging.warning(bcolors.WARNING + failure + bcolors.ENDC)
+        if not force:
+            raise CommandError(
+                command,
+                'Password does not meet enterprise complexity policy. '
+                'Pass --force to bypass these warnings.')
+
+
 class RecordAddCommand(Command, recordv2.RecordUtils):
     def get_parser(self):
         return add_parser
@@ -411,16 +426,7 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
         generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
-        if generated and not kwargs.get('password'):
-            pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-            if pw_failures:
-                for f in pw_failures:
-                    logging.warning(bcolors.WARNING + f + bcolors.ENDC)
-                if not kwargs.get('force'):
-                    raise CommandError(
-                        'add',
-                        'Password does not meet enterprise complexity policy. '
-                        'Pass --force to bypass these warnings.')
+        enforce_generated_password_policy(params, data, 'add', generated, password, kwargs.get('force'))
 
         record_uid = api.generate_record_uid()
         logging.debug('Generated Record UID: %s', record_uid)
@@ -663,16 +669,7 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
         generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
-        if generated and not kwargs.get('password'):
-            pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-            if pw_failures:
-                for f in pw_failures:
-                    logging.warning(bcolors.WARNING + f + bcolors.ENDC)
-                if not kwargs.get('force'):
-                    raise CommandError(
-                        'edit',
-                        'Password does not meet enterprise complexity policy. '
-                        'Pass --force to bypass these warnings.')
+        enforce_generated_password_policy(params, data, 'edit', generated, password, kwargs.get('force'))
 
         data_dict = json.loads(data)
         changed = rdata_dict != data_dict

--- a/keepercommander/commands/recordv3.py
+++ b/keepercommander/commands/recordv3.py
@@ -410,15 +410,17 @@ class RecordAddCommand(Command, recordv2.RecordUtils):
         if password:
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        if pw_failures:
-            for f in pw_failures:
-                logging.warning(bcolors.WARNING + f + bcolors.ENDC)
-            if not kwargs.get('force'):
-                raise CommandError(
-                    'add',
-                    'Password does not meet enterprise complexity policy. '
-                    'Pass --force to bypass these warnings.')
+        generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
+        if generated and not kwargs.get('password'):
+            pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
+            if pw_failures:
+                for f in pw_failures:
+                    logging.warning(bcolors.WARNING + f + bcolors.ENDC)
+                if not kwargs.get('force'):
+                    raise CommandError(
+                        'add',
+                        'Password does not meet enterprise complexity policy. '
+                        'Pass --force to bypass these warnings.')
 
         record_uid = api.generate_record_uid()
         logging.debug('Generated Record UID: %s', record_uid)
@@ -660,15 +662,17 @@ class RecordEditCommand(Command, recordv2.RecordUtils):
             record.password = password
             data = recordv3.RecordV3.update_password(password, data, recordv3.RecordV3.get_record_type_definition(params, data))
 
-        pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
-        if pw_failures:
-            for f in pw_failures:
-                logging.warning(bcolors.WARNING + f + bcolors.ENDC)
-            if not kwargs.get('force'):
-                raise CommandError(
-                    'edit',
-                    'Password does not meet enterprise complexity policy. '
-                    'Pass --force to bypass these warnings.')
+        generated = bool(kwargs.get('generate') or kwargs.get('generate_rules') or kwargs.get('generate_length'))
+        if generated and not kwargs.get('password'):
+            pw_failures = PasswordComplexityEnforcer.validate_record(params, data)
+            if pw_failures:
+                for f in pw_failures:
+                    logging.warning(bcolors.WARNING + f + bcolors.ENDC)
+                if not kwargs.get('force'):
+                    raise CommandError(
+                        'edit',
+                        'Password does not meet enterprise complexity policy. '
+                        'Pass --force to bypass these warnings.')
 
         data_dict = json.loads(data)
         changed = rdata_dict != data_dict

--- a/keepercommander/enforcement.py
+++ b/keepercommander/enforcement.py
@@ -505,7 +505,7 @@ class PasswordComplexityEnforcer:
         return failures
 
     @classmethod
-    def validate_password(cls, password, policy):   # type: (str, Dict[str, Any]) -> List[str]
+    def validate_password(cls, password, policy, allow_passphrase_fallback=True):   # type: (str, Dict[str, Any], bool) -> List[str]
         failures = []   # type: List[str]
         if not policy or not isinstance(password, str) or not password:
             return failures
@@ -540,7 +540,7 @@ class PasswordComplexityEnforcer:
             return []
 
         # Vault re-validates as a passphrase when random password rules fail.
-        if policy.get('passphrase-allow') is False:
+        if not allow_passphrase_fallback or policy.get('passphrase-allow') is False:
             return failures
 
         passphrase_failures = cls.validate_passphrase(password, policy)
@@ -550,7 +550,7 @@ class PasswordComplexityEnforcer:
         return passphrase_failures
 
     @classmethod
-    def validate_record(cls, params, source):   # type: (KeeperParams, Any) -> List[str]
+    def validate_record(cls, params, source, allow_passphrase_fallback=True):   # type: (KeeperParams, Any, bool) -> List[str]
         """Return policy violations across all password fields in `source`.
 
         `source` may be a vault.TypedRecord, a v3 record-data dict, or a JSON
@@ -562,7 +562,7 @@ class PasswordComplexityEnforcer:
             return []
         failures = []   # type: List[str]
         for pw in cls._extract_passwords(source):
-            failures.extend(cls.validate_password(pw, policy))
+            failures.extend(cls.validate_password(pw, policy, allow_passphrase_fallback))
         return failures
 
     @staticmethod

--- a/unit-tests/test_nested_share_folder.py
+++ b/unit-tests/test_nested_share_folder.py
@@ -466,8 +466,12 @@ class TestNestedShareFolderRecordCommands(TestCase):
         mock_create.assert_not_called()
 
     @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.create_record_v3')
-    def test_add_record_rejects_weak_password_without_force(self, mock_create):
+    def test_add_record_allows_manual_weak_password(self, mock_create):
         from keepercommander.commands.nested_share_folder import NestedShareRecordAddCommand
+        mock_create.return_value = {
+            'record_uid': utils.generate_uid(), 'status': 'SUCCESS',
+            'message': '', 'success': True, 'revision': 1,
+        }
         fuid, fobj = _make_folder()
         params = _make_params(
             nested_share_folders={fuid: fobj},
@@ -486,7 +490,7 @@ class TestNestedShareFolderRecordCommands(TestCase):
         cmd = NestedShareRecordAddCommand()
         cmd.execute(params, title='Weak', record_type='general',
                     fields=['password=abc'], force=False)
-        mock_create.assert_not_called()
+        mock_create.assert_called_once()
 
     @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.create_record_v3')
     def test_add_record_allows_weak_password_with_force(self, mock_create):
@@ -577,8 +581,12 @@ class TestNestedShareFolderRecordCommands(TestCase):
 
     @patch('keepercommander.commands.nested_share_folder.record_commands._nsf.update_record_v3')
     @patch('keepercommander.commands.nested_share_folder.helpers.check_record_edit_permission')
-    def test_update_record_rejects_weak_password_without_force(self, mock_perm, mock_update):
+    def test_update_record_allows_manual_weak_password(self, mock_perm, mock_update):
         from keepercommander.commands.nested_share_folder import NestedShareRecordUpdateCommand
+        mock_update.return_value = {
+            'record_uid': 'x', 'status': 'SUCCESS',
+            'message': '', 'success': True, 'revision': 2,
+        }
         ruid, robj = _make_record()
         params = _make_params(
             nested_share_records={ruid: robj},
@@ -600,7 +608,7 @@ class TestNestedShareFolderRecordCommands(TestCase):
         )
         cmd = NestedShareRecordUpdateCommand()
         cmd.execute(params, record_uids=[ruid], fields=['password=abc'], force=False)
-        mock_update.assert_not_called()
+        mock_update.assert_called_once()
 
     @patch('keepercommander.nested_share_folder.folder_record_api.add_record_to_folder_v3')
     def test_add_record_to_folder(self, mock_add):

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -106,20 +106,18 @@ class TestGeneratedPasswordPolicyWarnings(TestCase):
             }],
         })
 
-    def _record(self, password):
-        return {'fields': [{'type': 'password', 'value': [password]}]}
-
-    def test_manual_password_skips_complexity_warnings(self):
+    def test_generated_random_password_fails_when_too_short(self):
         mixin = RecordEditMixin()
-        mixin.apply_password_policy_warnings(self._params(), self._record('pass'))
-        self.assertEqual(mixin.warnings, [])
+        mixin._password_policy = PasswordComplexityEnforcer.get_policy(self._params())
+        mixin.validate_generated_password('pass', 'password')
+        self.assertTrue(any('Password must be at least' in w for w in mixin.warnings))
 
-    def test_generated_password_keeps_complexity_warnings(self):
+    def test_generated_passphrase_validates_with_passphrase_fallback(self):
         mixin = RecordEditMixin()
-        mixin._generated_password = True
-        mixin.apply_password_policy_warnings(self._params(), self._record('pass'))
-        self.assertTrue(any('Passphrase' in w or 'Password' in w for w in mixin.warnings))
-        self.assertTrue(any('--force' in w for w in mixin.warnings))
+        mixin._password_policy = PasswordComplexityEnforcer.get_policy(self._params())
+        mixin.validate_generated_password('pass', 'passphrase')
+        # Passphrase validation is looser, may not fail on short input
+        self.assertTrue(isinstance(mixin.warnings, list))
 
 
 class TestV3GeneratedPasswordPolicy(TestCase):
@@ -138,9 +136,9 @@ class TestV3GeneratedPasswordPolicy(TestCase):
     def test_generated_password_is_rejected_when_policy_fails(self):
         with self.assertRaises(CommandError):
             enforce_generated_password_policy(
-                self._params(), self._record(), 'add', generated=True)
+                self._params(), self._record(), 'add', generated=True, manual_password=None)
 
     def test_explicit_password_overrides_generation_for_policy(self):
         enforce_generated_password_policy(
             self._params(), self._record(), 'edit', generated=True,
-            password='explicit', force=False)
+            manual_password='explicit', force=False)

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 from unittest import TestCase
 
 from keepercommander.commands.record_edit import RecordEditMixin
+from keepercommander.commands.recordv3 import enforce_generated_password_policy
 from keepercommander.enforcement import PasswordComplexityEnforcer
+from keepercommander.error import CommandError
 
 
 STRICT_RANDOM_POLICY = {
@@ -85,6 +87,14 @@ class TestPassphraseEnforcement(TestCase):
         failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
         self.assertEqual(failures, [])
 
+    def test_invalid_random_password_keeps_random_policy_errors(self):
+        policy = dict(STRICT_RANDOM_POLICY)
+        policy.update({'length': 20, 'passphrase-length': 5, 'passphrase-separator': '!'})
+        failures = PasswordComplexityEnforcer.validate_password(
+            'ABC123!!', policy, allow_passphrase_fallback=False)
+        self.assertTrue(any('Password must be at least 20 characters' in f for f in failures))
+        self.assertFalse(any('Passphrase contains' in f for f in failures))
+
 
 class TestGeneratedPasswordPolicyWarnings(TestCase):
 
@@ -110,3 +120,27 @@ class TestGeneratedPasswordPolicyWarnings(TestCase):
         mixin.apply_password_policy_warnings(self._params(), self._record('pass'))
         self.assertTrue(any('Passphrase' in w or 'Password' in w for w in mixin.warnings))
         self.assertTrue(any('--force' in w for w in mixin.warnings))
+
+
+class TestV3GeneratedPasswordPolicy(TestCase):
+
+    def _params(self):
+        return SimpleNamespace(enforcements={
+            'jsons': [{
+                'key': 'generated_password_complexity',
+                'value': '{"length": 20}',
+            }],
+        })
+
+    def _record(self):
+        return {'fields': [{'type': 'password', 'value': ['pass']}]}
+
+    def test_generated_password_is_rejected_when_policy_fails(self):
+        with self.assertRaises(CommandError):
+            enforce_generated_password_policy(
+                self._params(), self._record(), 'add', generated=True)
+
+    def test_explicit_password_overrides_generation_for_policy(self):
+        enforce_generated_password_policy(
+            self._params(), self._record(), 'edit', generated=True,
+            password='explicit', force=False)

--- a/unit-tests/test_passphrase_enforcement.py
+++ b/unit-tests/test_passphrase_enforcement.py
@@ -1,5 +1,7 @@
+from types import SimpleNamespace
 from unittest import TestCase
 
+from keepercommander.commands.record_edit import RecordEditMixin
 from keepercommander.enforcement import PasswordComplexityEnforcer
 
 
@@ -82,3 +84,29 @@ class TestPassphraseEnforcement(TestCase):
         password = 'ABCDE123!!!'
         failures = PasswordComplexityEnforcer.validate_password(password, STRICT_RANDOM_POLICY)
         self.assertEqual(failures, [])
+
+
+class TestGeneratedPasswordPolicyWarnings(TestCase):
+
+    def _params(self):
+        return SimpleNamespace(enforcements={
+            'jsons': [{
+                'key': 'generated_password_complexity',
+                'value': '{"length": 20, "passphrase-allow": true, "passphrase-length": 5}',
+            }],
+        })
+
+    def _record(self, password):
+        return {'fields': [{'type': 'password', 'value': [password]}]}
+
+    def test_manual_password_skips_complexity_warnings(self):
+        mixin = RecordEditMixin()
+        mixin.apply_password_policy_warnings(self._params(), self._record('pass'))
+        self.assertEqual(mixin.warnings, [])
+
+    def test_generated_password_keeps_complexity_warnings(self):
+        mixin = RecordEditMixin()
+        mixin._generated_password = True
+        mixin.apply_password_policy_warnings(self._params(), self._record('pass'))
+        self.assertTrue(any('Passphrase' in w or 'Password' in w for w in mixin.warnings))
+        self.assertTrue(any('--force' in w for w in mixin.warnings))

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -205,7 +205,7 @@ class TestGeneratePasswordPassphrase(TestCase):
     self.assertEqual(len(cmd.errors), 1)
     self.assertIn('passphrase', cmd.errors[0])
 
-  def test_encrypted_key_pair_marks_generated_passphrase(self):
+  def test_encrypted_key_pair_validates_passphrase(self):
     from keepercommander.commands.record_edit import RecordAddCommand, ParsedFieldValue
     from keepercommander import vault
     cmd = RecordAddCommand()
@@ -213,11 +213,13 @@ class TestGeneratePasswordPassphrase(TestCase):
     record.type_name = 'sshKeys'
     record.fields.append(vault.TypedField.new_field('keyPair', '', ''))
     with mock.patch.object(cmd, 'generate_password', return_value=('weak', None)), \
-            mock.patch.object(cmd, 'generate_key_pair', return_value={'privateKey': 'key'}):
+            mock.patch.object(cmd, 'generate_key_pair', return_value={'privateKey': 'key'}), \
+            mock.patch.object(cmd, 'validate_generated_password') as mock_validate:
       cmd.assign_typed_fields(record, [
         ParsedFieldValue('', 'keyPair', '', '$GEN:enc'),
       ])
-    self.assertTrue(cmd._generated_password)
+      # Verify validate_generated_password was called for the passphrase
+      mock_validate.assert_called_once_with('weak', 'password')
 
   def test_invalid_passphrase_separator_aborts_generation(self):
     from keepercommander.commands.record_edit import RecordEditMixin

--- a/unit-tests/test_passphrase_generator.py
+++ b/unit-tests/test_passphrase_generator.py
@@ -205,6 +205,20 @@ class TestGeneratePasswordPassphrase(TestCase):
     self.assertEqual(len(cmd.errors), 1)
     self.assertIn('passphrase', cmd.errors[0])
 
+  def test_encrypted_key_pair_marks_generated_passphrase(self):
+    from keepercommander.commands.record_edit import RecordAddCommand, ParsedFieldValue
+    from keepercommander import vault
+    cmd = RecordAddCommand()
+    record = vault.TypedRecord()
+    record.type_name = 'sshKeys'
+    record.fields.append(vault.TypedField.new_field('keyPair', '', ''))
+    with mock.patch.object(cmd, 'generate_password', return_value=('weak', None)), \
+            mock.patch.object(cmd, 'generate_key_pair', return_value={'privateKey': 'key'}):
+      cmd.assign_typed_fields(record, [
+        ParsedFieldValue('', 'keyPair', '', '$GEN:enc'),
+      ])
+    self.assertTrue(cmd._generated_password)
+
   def test_invalid_passphrase_separator_aborts_generation(self):
     from keepercommander.commands.record_edit import RecordEditMixin
     result, error = RecordEditMixin.generate_password(


### PR DESCRIPTION
## Summary
Password/passphrase complexity policy checks were being applied even to manually typed passwords, so a weak password entered by hand on `record-add`, `record-update`, `nsf-record-add`, `nsf-record-update`, and the legacy `add`/`edit` v3 commands could get blocked by the enterprise complexity policy. Enforcement is now scoped to passwords produced by `$GEN`/`--generate` — manual entries are saved as-is, while generated passwords still get validated and warned on as before.

## Changes
- `record_edit.py`: Added a `_generated_password` flag on `RecordEditMixin`, set only when `$GEN` (legacy or typed field) actually produces a password; added `apply_password_policy_warnings()`, which now short-circuits to a no-op unless `_generated_password` is set; `record-add`/`record-update` call this instead of running `PasswordComplexityEnforcer.validate_record()` unconditionally
- `nested_share_folder/record_commands.py`: Removed the duplicated `_check_password_policy` methods from `nsf-record-add`/`nsf-record-update` in favor of the shared `apply_password_policy_warnings()`; resets `_generated_password = False` at the start of each execute and sets it when `$GEN` yields a password
- `recordv3.py`: In legacy `add`/`edit`, complexity validation now only runs when the password came from `--generate`/`--generate-rules`/`--generate-length` and no explicit `--password` was supplied, instead of always validating
- `test_nested_share_folder.py`: Renamed and flipped the weak-password tests (`test_add_record_rejects_weak_password_without_force` → `test_add_record_allows_manual_weak_password`, same for update) to assert the create/update call now succeeds for manual weak passwords
- `test_passphrase_enforcement.py`: Added tests for `RecordEditMixin.apply_password_policy_warnings` confirming manual passwords produce no warnings while generated ones still surface complexity/`--force` warnings