### PR TITLE
Fix invalid time unit used in auto-logout timer example

### DIFF
--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -254,7 +254,7 @@ Sub-commands:
 
   this-device timeout <duration>
       Set auto-logout timer
-      Examples: this-device timeout 10m   (10 minutes)
+      Examples: this-device timeout 10mi  (10 minutes)
                 this-device timeout 1h    (1 hour)
                 this-device timeout 7d    (7 days)
                 this-device timeout 30d   (30 days)


### PR DESCRIPTION
running `this-device timeout 10m` I got:
> Valid units are "years/y, months/mo, days/d, hours/h, minutes/mi"

i.e. unit "m" is invalid.

In this PR the example unit is changed to the correct one `mi`