### PR TITLE
KC-1434: Mask secrets consistently in service-mode command logs

### DIFF
--- a/keepercommander/service/config/cli_handler.py
+++ b/keepercommander/service/config/cli_handler.py
@@ -14,7 +14,7 @@ import sys
 import re
 from pathlib import Path
 from typing import Optional
-from ..decorators.logging import logger, debug_decorator
+from ..decorators.logging import logger, debug_decorator, sanitize_command_fields, sanitize_debug_data
 from ...params import KeeperParams
 
 class CommandHandler:
@@ -32,7 +32,7 @@ class CommandHandler:
             cli.do_command(params, command)
             return output.getvalue()
         except Exception as e:
-            logger.debug(f"Error executing CLI command '{command}': {e}")
+            logger.debug(f"Error executing CLI command '{sanitize_command_fields(command)}': {sanitize_debug_data(str(e))}")
             return ''
         finally:
             sys.stdout = sys.__stdout__

--- a/keepercommander/service/core/request_queue.py
+++ b/keepercommander/service/core/request_queue.py
@@ -21,7 +21,7 @@ from typing import Dict, Any, Optional, Tuple
 from dataclasses import dataclass, asdict
 
 from ..util.command_util import CommandExecutor
-from ..decorators.logging import logger, debug_decorator
+from ..decorators.logging import logger, debug_decorator, sanitize_command_fields, sanitize_debug_data
 
 
 def derive_owner_key(api_key: Optional[str]) -> Optional[str]:
@@ -150,7 +150,7 @@ class RequestQueueManager:
             self.request_queue.put(request, block=False)
             with self.data_lock:
                 self.active_requests[request_id] = request
-            logger.info(f"Request {request_id} queued: {command}")
+            logger.info(f"Request {request_id} queued: {sanitize_command_fields(command)}")
             return request_id
         except queue.Full:
             logger.error("Error: Request queue is full")
@@ -304,7 +304,7 @@ class RequestQueueManager:
                 self._cleanup_expired_requests()
                 continue
             except Exception as e:
-                logger.error(f"Unexpected error in queue worker: {e}")
+                logger.error(f"Unexpected error in queue worker: {sanitize_debug_data(str(e))}")
                 time.sleep(1)
         
         logger.info("Queue worker thread stopped")
@@ -321,7 +321,7 @@ class RequestQueueManager:
         request.status = RequestStatus.PROCESSING
         request.started_at = datetime.now()
         
-        logger.info(f"Processing request {request.request_id}: {request.command}")
+        logger.info(f"Processing request {request.request_id}: {sanitize_command_fields(request.command)}")
         
         try:
             # Execute the command using existing CommandExecutor
@@ -341,7 +341,7 @@ class RequestQueueManager:
             request.completed_at = datetime.now()
             request.error_message = str(e)
             
-            logger.error(f"Request {request.request_id} failed: {e}")
+            logger.error(f"Request {request.request_id} failed: {sanitize_debug_data(str(e))}")
         
         finally:
             # Clean up temporary files

--- a/keepercommander/service/decorators/api_logging.py
+++ b/keepercommander/service/decorators/api_logging.py
@@ -14,8 +14,11 @@ from functools import wraps
 from typing import Callable, Any
 from flask import request
 import time
-import re
-from .logging import logger
+from .logging import logger, sanitize_command_fields, SENSITIVE_FIELD_TYPES
+
+# Legacy generic keys (kept for JSON payloads that aren't shaped like Keeper
+# record fields, e.g. arbitrary nested config blobs).
+_SENSITIVE_DICT_KEYS = frozenset({'password', 'login', 'secret', 'token', 'key'}) | SENSITIVE_FIELD_TYPES
 
 
 class SSLHandshakeFilter(logging.Filter):
@@ -29,32 +32,44 @@ class SSLHandshakeFilter(logging.Filter):
         return True
 
 def sanitize_password_in_command(data):
-    """Sanitize password values in command string and filedata"""
+    """Sanitize password, login, secret and TOTP (oneTimeCode) values in command string and filedata"""
     if not data:
         return data
-    
+
     sanitized = data.copy()
-    
+
     # Sanitize command string if present
-    if 'command' in sanitized:
-        command = sanitized['command']
-        # Pattern to match password=value (with or without quotes)
-        password_pattern = r"password=(['\"]?)([^'\"\s]{1,1024})\1"
-        sanitized['command'] = re.sub(password_pattern, r"password=\1***\1", command)
-    
+    if 'command' in sanitized and isinstance(sanitized['command'], str):
+        sanitized['command'] = sanitize_command_fields(sanitized['command'])
+
     # Sanitize filedata if present
     if 'filedata' in sanitized:
         sanitized['filedata'] = _sanitize_nested_data(sanitized['filedata'])
     
     return sanitized
 
+def _mask_field_value(value):
+    """Mask a Keeper record field's `value`, preserving its container shape."""
+    if isinstance(value, list):
+        return ['***' for _ in value]
+    if isinstance(value, dict):
+        return {k: '***' for k in value}
+    return '***'
+
+
 def _sanitize_nested_data(data):
     """Recursively sanitize nested data structures"""
     if isinstance(data, dict):
+        field_type = data.get('type')
+        if isinstance(field_type, str) and field_type.lower() in SENSITIVE_FIELD_TYPES and 'value' in data:
+            sanitized = dict(data)
+            sanitized['value'] = _mask_field_value(data['value'])
+            return sanitized
+
         sanitized = {}
         for key, value in data.items():
             # Sanitize sensitive field names
-            if key.lower() in ['password', 'login', 'secret', 'token', 'key']:
+            if key.lower() in _SENSITIVE_DICT_KEYS:
                 if isinstance(value, str) and len(value) > 0:
                     sanitized[key] = '*' * min(len(value), 15)
                 else:

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -14,8 +14,17 @@ from typing import Callable, Any
 import logging
 import sys, os, yaml
 import re
+import shlex
 from enum import Enum
 from ... import utils
+
+# Values that must never reach the logs when set via record-add/record-update/
+# nsf-record-* CLI args.
+SENSITIVE_FIELD_TYPES = frozenset({
+    'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
+    'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
+    'securityquestion', 'passkey',
+})
 
 class LogLevel(Enum):
     ERROR = logging.ERROR
@@ -112,15 +121,15 @@ def debug_decorator(fn: Callable) -> Callable:
     @wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         if logger._logger.isEnabledFor(logging.DEBUG):
-            args_repr = [repr(a) for a in args]
-            kwargs_repr = [f"{k}={v!r}" for k, v in kwargs.items()]
+            args_repr = [sanitize_debug_data(repr(a)) for a in args]
+            kwargs_repr = [f"{k}={sanitize_debug_data(repr(v))}" for k, v in kwargs.items()]
             signature = ", ".join(args_repr + kwargs_repr)
             logger.debug(f"Call: {fn.__name__}({signature})")
-        
+
         value = fn(*args, **kwargs)
-        
+
         if logger._logger.isEnabledFor(logging.INFO):
-            logger.debug(f"Return: {fn.__name__} → {value!r}")
+            logger.debug(f"Return: {fn.__name__} → {sanitize_debug_data(repr(value))}")
         
         return value
     return wrapper
@@ -151,16 +160,71 @@ def sanitize_debug_data(data: str) -> str:
         (r'"secret"\s*:\s*"[^"]*"', '"secret": "***"'),
         (r'"token"\s*:\s*"[^"]*"', '"token": "***"'),
         (r'"key"\s*:\s*"[^"]*"', '"key": "***"'),
-        (r'password=[^\s]*', 'password=***'),
-        (r'login=[^\s]*', 'login=***'),
+        (r'\bpassword=[^\s]*', 'password=***'),
+        (r'\blogin=[^\s]*', 'login=***'),
+        # oneTimeCode=otpauth://totp/...?secret=... — mask the whole value, TOTP seed included
+        (r'\boneTimeCode=[^\s]*', 'oneTimeCode=***'),
+        (r'\bsecret=[^\s]*', 'secret=***'),
+        # Other sensitive record field types (see SENSITIVE_FIELD_TYPES) that can
+        # appear as bare CLI args on record-add/record-update/nsf-* commands.
+        (r'\bpinCode=[^\s]*', 'pinCode=***'),
+        (r'\bkeyPair=[^\s]*', 'keyPair=***'),
+        (r'\bprivateKey=[^\s]*', 'privateKey=***'),
+        (r'\bpassphrase=[^\s]*', 'passphrase=***'),
+        (r'\bpaymentCard=[^\s]*', 'paymentCard=***'),
+        (r'\bbankAccount=[^\s]*', 'bankAccount=***'),
+        (r'\bsecurityQuestion=[^\s]*', 'securityQuestion=***'),
+        (r'\bpasskey=[^\s]*', 'passkey=***'),
         # Sanitize email addresses in logs to protect PII
         (r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '***@***.***'),
     ]
     
     for pattern, replacement in patterns:
         sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
-    
+
     return sanitized
+
+
+def _record_field_type(token_key: str) -> str:
+    """Extract the FIELD_TYPE from a record-add/record-update field token key.
+
+    Field tokens follow [f.|c.]<FIELD_TYPE>[.<FIELD_LABEL>]=<VALUE> (see the
+    `record-add`/`record-update` --syntax-help). Custom fields carrying a
+    sensitive type (e.g. c.secret.APIKey=...) must be masked the same as bare
+    fields (secret=...).
+    """
+    key = token_key[2:] if token_key[:2] in ('f.', 'c.') else token_key
+    return key.split('.', 1)[0]
+
+
+def sanitize_command_fields(command: str) -> str:
+    """Mask sensitive record field values (password, secret, keyPair, private
+    key passphrases, payment/bank data, security answers, ...) in a
+    record-add/record-update/nsf-record-* command string.
+
+    Unlike the plain keyword patterns in `sanitize_debug_data`, this masks
+    labeled and custom fields too (password.Label=..., c.secret.APIKey=...),
+    which a literal `password=` substring match cannot catch.
+    """
+    if not command:
+        return command
+
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        # Unbalanced quotes: fall back to whitespace split so we still mask
+        # what we can instead of logging the raw string.
+        tokens = command.split()
+
+    masked_tokens = []
+    for token in tokens:
+        key, sep, value = token.partition('=')
+        if sep and value and _record_field_type(key).lower() in SENSITIVE_FIELD_TYPES:
+            masked_tokens.append(f'{key}=***')
+        else:
+            masked_tokens.append(token)
+
+    return sanitize_debug_data(' '.join(masked_tokens))
 
 
 logger = GlobalLogger()

--- a/keepercommander/service/util/command_util.py
+++ b/keepercommander/service/util/command_util.py
@@ -27,7 +27,7 @@ from .throttle import (
 )
 from .verified_command import Verifycommand
 from ..core.globals import get_current_params
-from ..decorators.logging import logger, debug_decorator, sanitize_debug_data
+from ..decorators.logging import logger, debug_decorator, sanitize_debug_data, sanitize_command_fields
 from ... import cli, utils
 from ...crypto import encrypt_aes_v2
 from ...error import KeeperApiError
@@ -149,7 +149,7 @@ class CommandExecutor:
 
     @classmethod
     def execute(cls, command: str) -> Tuple[Any, int]:
-        logger.debug(f"Executing command: {command}")
+        logger.debug(f"Executing command: {sanitize_command_fields(command)}")
         
         validation_error = cls.validate_command(command)
         if validation_error:
@@ -209,7 +209,7 @@ class CommandExecutor:
                 try:
                     SailPointService.after_command(params, command, success=True)
                 except Exception as e:
-                    logger.error(f'SailPoint post-process failed: {e}')
+                    logger.error(f'SailPoint post-process failed: {sanitize_debug_data(str(e))}')
                     err = {
                         'status': 'error',
                         'error': (
@@ -224,18 +224,18 @@ class CommandExecutor:
             return response, status_code
         except CommandExecutionError as e:
             # Return the actual command error instead of generic "server busy"
-            logger.error(f"Command execution error: {e}")
+            logger.error(f"Command execution error: {sanitize_debug_data(str(e))}")
             if is_throttle_error(e):
                 return throttle_error_response(str(e))
             return {"status": "error", "error": str(e)}, 400
         except KeeperApiError as e:
             if is_throttle_error(e):
                 return throttle_error_response(e.message or str(e), e.result_code)
-            logger.error(f"Unexpected error during command execution: {e}")
+            logger.error(f"Unexpected error during command execution: {sanitize_debug_data(str(e))}")
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}, 500
         except Exception as e:
             if is_throttle_error(e):
                 return throttle_error_response(str(e))
             # Log unexpected errors and return a proper error response
-            logger.error(f"Unexpected error during command execution: {e}")
+            logger.error(f"Unexpected error during command execution: {sanitize_debug_data(str(e))}")
             return {"status": "error", "error": f"Unexpected error: {str(e)}"}, 500

--- a/keepercommander/service/util/request_validation.py
+++ b/keepercommander/service/util/request_validation.py
@@ -15,7 +15,7 @@ from html import escape
 import tempfile
 import os
 import json
-from ..decorators.logging import logger
+from ..decorators.logging import logger, sanitize_command_fields
 
 
 class RequestValidator:
@@ -46,7 +46,7 @@ class RequestValidator:
             
         # Escape HTML to prevent XSS
         escaped_command = escape(command)
-        logger.debug(f"Command validated and escaped: {escaped_command}")
+        logger.debug(f"Command validated and escaped: {sanitize_command_fields(escaped_command)}")
         return escaped_command, None
     
     @staticmethod

--- a/unit-tests/service/test_log_sanitization.py
+++ b/unit-tests/service/test_log_sanitization.py
@@ -1,0 +1,189 @@
+from unittest import TestCase, mock
+
+from keepercommander.service.decorators.logging import (
+    SENSITIVE_FIELD_TYPES,
+    sanitize_command_fields,
+    sanitize_debug_data,
+)
+from keepercommander.service.decorators.api_logging import (
+    _sanitize_nested_data,
+    sanitize_password_in_command,
+)
+from keepercommander.service.util.command_util import CommandExecutor
+from keepercommander.service.util.exceptions import CommandExecutionError
+from keepercommander.service.util.request_validation import RequestValidator
+from keepercommander.service.config.cli_handler import CommandHandler
+
+SECRET_VALUE = "TopSecretValue123"
+
+
+class TestSanitizeCommandFields(TestCase):
+    """Table-driven coverage: every SENSITIVE_FIELD_TYPES entry must be masked
+    whether it's a bare field, a labeled field, a custom (c.) field, or a
+    field/custom (f./c.) field with a dotted label."""
+
+    def _assert_masked(self, command):
+        result = sanitize_command_fields(command)
+        self.assertNotIn(SECRET_VALUE, result)
+        self.assertIn('***', result)
+
+    def test_bare_field(self):
+        for field_type in sorted(SENSITIVE_FIELD_TYPES):
+            with self.subTest(field_type=field_type):
+                self._assert_masked(f'record-add -rt login -t x {field_type}={SECRET_VALUE} --force')
+
+    def test_labeled_field(self):
+        for field_type in sorted(SENSITIVE_FIELD_TYPES):
+            with self.subTest(field_type=field_type):
+                self._assert_masked(
+                    f'record-update --uid=XYZ f.{field_type}.MyLabel={SECRET_VALUE} --force'
+                )
+
+    def test_custom_section_field(self):
+        for field_type in sorted(SENSITIVE_FIELD_TYPES):
+            with self.subTest(field_type=field_type):
+                self._assert_masked(
+                    f'record-update --uid=XYZ c.{field_type}.CustomLabel={SECRET_VALUE} --force'
+                )
+
+    def test_dotted_label_without_section_prefix(self):
+        for field_type in sorted(SENSITIVE_FIELD_TYPES):
+            with self.subTest(field_type=field_type):
+                self._assert_masked(f'record-add -rt general -t x {field_type}.SubLabel={SECRET_VALUE} --force')
+
+    def test_non_sensitive_field_untouched(self):
+        # A field merely labeled with a sensitive-looking substring (not a
+        # sensitive field TYPE) must not be masked or corrupted.
+        result = sanitize_command_fields('record-add -rt login -t x c.text.MyLoginId=notasecret --force')
+        self.assertIn('c.text.MyLoginId=notasecret', result)
+
+    def test_label_containing_keyword_as_substring_not_corrupted(self):
+        # Regression: password=[^\s]* without a word boundary used to eat into
+        # "OldPassword", turning the label into "Oldpassword".
+        result = sanitize_command_fields(f'record-update --uid=XYZ f.password.OldPassword={SECRET_VALUE} --force')
+        self.assertIn('f.password.OldPassword=***', result)
+
+    def test_quoted_value_with_spaces_fully_masked(self):
+        result = sanitize_command_fields('record-add -rt bankCard -t x paymentCard="4111111111111111 04/2026 123" --force')
+        self.assertNotIn('4111111111111111', result)
+        self.assertNotIn('123', result)
+
+    def test_malformed_quoting_falls_back_and_still_masks(self):
+        result = sanitize_command_fields(f'record-add password="{SECRET_VALUE}')
+        self.assertNotIn(SECRET_VALUE, result)
+
+
+class TestFiledataSanitization(TestCase):
+    """Keeper record field JSON shape: {"type": "password", "value": [...]}.
+    The secret lives under `value`, not under a sensitively-named dict key."""
+
+    def test_sensitive_type_value_shape_is_masked(self):
+        filedata = [
+            {"type": "login", "value": ["bob"]},
+            {"type": "password", "value": [SECRET_VALUE]},
+            {"type": "keyPair", "value": [{"publicKey": "pub", "privateKey": SECRET_VALUE}]},
+            {"type": "paymentCard", "value": [{"cardNumber": "4111111111111111",
+                                                "cardExpirationDate": "04/2026",
+                                                "cardSecurityCode": "123"}]},
+        ]
+        sanitized = _sanitize_nested_data(filedata)
+        dumped = str(sanitized)
+        self.assertNotIn(SECRET_VALUE, dumped)
+        self.assertNotIn('4111111111111111', dumped)
+        self.assertNotIn('123', dumped)
+
+    def test_non_sensitive_type_value_untouched(self):
+        filedata = [{"type": "text", "value": ["not a secret"]}]
+        sanitized = _sanitize_nested_data(filedata)
+        self.assertEqual(sanitized, filedata)
+
+    def test_sanitize_password_in_command_masks_command_and_filedata(self):
+        payload = {
+            "command": f'record-add -rt login -t x password={SECRET_VALUE} --force',
+            "filedata": [{"type": "password", "value": [SECRET_VALUE]}],
+        }
+        sanitized = sanitize_password_in_command(payload)
+        dumped = str(sanitized)
+        self.assertNotIn(SECRET_VALUE, dumped)
+
+
+class TestRequestValidationLogging(TestCase):
+    """Regression: validate_and_escape_command must not log the raw command."""
+
+    def test_debug_log_is_masked(self):
+        command = f'record-add -rt login -t x password={SECRET_VALUE} --force'
+        with mock.patch('keepercommander.service.util.request_validation.logger.debug') as mock_debug:
+            escaped_command, error = RequestValidator.validate_and_escape_command({"command": command})
+
+        self.assertIsNone(error)
+        # The value returned for execution must remain intact...
+        self.assertIn(SECRET_VALUE, escaped_command)
+        # ...but nothing logged should contain it.
+        mock_debug.assert_called_once()
+        self.assertNotIn(SECRET_VALUE, mock_debug.call_args[0][0])
+
+
+class TestCliHandlerLogging(TestCase):
+    """Regression: execute_cli_command must not log the raw command or a raw exception message."""
+
+    def test_error_path_masks_command_and_exception(self):
+        command = f'record-add -rt login -t x password={SECRET_VALUE} --force'
+        handler = CommandHandler()
+        params = mock.Mock(service_mode=False)
+
+        with mock.patch('keepercommander.cli.do_command',
+                         side_effect=Exception(f"boom while handling password={SECRET_VALUE}")), \
+             mock.patch('keepercommander.service.config.cli_handler.logger.debug') as mock_debug:
+            result = handler.execute_cli_command(params, command)
+
+        self.assertEqual(result, '')
+        # debug_decorator logs a "Call:" line and CommandHandler logs the error;
+        # none of them should contain the secret.
+        for call in mock_debug.call_args_list:
+            self.assertNotIn(SECRET_VALUE, call[0][0])
+
+
+class TestCommandExecutorErrorLogging(TestCase):
+    """Regression: CommandExecutor.execute must not leak secrets via str(exception)."""
+
+    def test_command_execution_error_is_sanitized_in_logs(self):
+        command = f'record-add -rt login -t x password={SECRET_VALUE} --force'
+
+        with mock.patch('keepercommander.service.core.globals.ensure_params_loaded',
+                         return_value=mock.Mock(service_mode=False)), \
+             mock.patch('keepercommander.service.util.command_util.Verifycommand.validate_service_mode_restrictions',
+                         return_value=None), \
+             mock.patch('keepercommander.service.util.command_util.Verifycommand.validate_enterprise_user_add_role_force',
+                         return_value=None), \
+             mock.patch.object(CommandExecutor, 'capture_output_and_logs',
+                                side_effect=CommandExecutionError(f"failed on password={SECRET_VALUE}")), \
+             mock.patch('keepercommander.service.util.command_util.logger.error') as mock_error:
+            response, status_code = CommandExecutor.execute(command)
+
+        self.assertEqual(status_code, 400)
+        mock_error.assert_called_once()
+        self.assertNotIn(SECRET_VALUE, mock_error.call_args[0][0])
+
+
+class TestRequestQueueErrorLogging(TestCase):
+    """Regression: the queue worker's failure log must not leak secrets from str(exception)."""
+
+    def test_process_request_failure_is_sanitized_in_logs(self):
+        from datetime import datetime
+        from keepercommander.service.core.request_queue import QueuedRequest, RequestStatus, queue_manager
+
+        request = QueuedRequest(
+            request_id='test-request-id',
+            command=f'record-add -rt login -t x password={SECRET_VALUE} --force',
+            status=RequestStatus.PROCESSING,
+            created_at=datetime.now(),
+        )
+
+        with mock.patch.object(CommandExecutor, 'execute',
+                                side_effect=Exception(f"boom password={SECRET_VALUE}")), \
+             mock.patch('keepercommander.service.core.request_queue.logger.error') as mock_error, \
+             mock.patch('keepercommander.service.core.request_queue.logger.info'):
+            queue_manager._process_request(request)
+
+        mock_error.assert_called_once()
+        self.assertNotIn(SECRET_VALUE, mock_error.call_args[0][0])


### PR DESCRIPTION
## Summary
Secrets in service-mode command logs (passwords, TOTP codes, private keys, payment/bank data, etc.) were inconsistently masked. This fixes it so they're always hidden.

## Changes
- Mask TOTP codes, private keys, passphrases, payment cards, bank accounts, and security answers
- Mask secrets even when set with a custom field label, not just the default name
- Apply masking to every log line that prints a command - previously only one of several did