### PR TITLE
KC-1416: Add Tenable CNAPP integration support

### DIFF
--- a/keepercommander/commands/pam/cnapp_commands.py
+++ b/keepercommander/commands/pam/cnapp_commands.py
@@ -45,6 +45,7 @@ from ..base import Command, GroupCommand, dump_report_data
 from ... import vault
 from ...display import bcolors
 from ...error import CommandError
+from ...proto import cnapp_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -228,19 +229,49 @@ def _add_configuration_args(parser, require_secret=True, optional_secret_on_set=
     parser.add_argument('--network-uid', '-n', required=True, dest='network_uid',
                         help='Network record UID (base64url).')
     parser.add_argument('--provider', '-p', required=True, dest='provider',
-                        help='CNAPP provider keyword: wiz (case-insensitive).')
-    parser.add_argument('--client-id', required=True, dest='client_id',
-                        help='Provider API client ID / app ID.')
+                        help='CNAPP provider keyword: wiz, tenable (case-insensitive).')
+    parser.add_argument('--client-id', required=False, default=None, dest='client_id',
+                        help='Provider API client ID / app ID. Optional for Tenable.')
     if optional_secret_on_set:
         parser.add_argument('--client-secret', required=False, default=None, dest='client_secret',
                             help='Provider API client secret. Omit on `config set` to keep the existing secret.')
     else:
-        parser.add_argument('--client-secret', required=require_secret, dest='client_secret',
-                            help='Provider API client secret.')
+        parser.add_argument('--client-secret', required=False, default=None, dest='client_secret',
+                            help='Provider API client secret. Optional for Tenable.')
     parser.add_argument('--api-endpoint', required=True, dest='api_endpoint_url',
-                        help='Provider API endpoint URL (e.g. https://api.us1.app.wiz.io/graphql).')
+                        help='Provider API endpoint URL (e.g. https://api.us1.app.wiz.io/graphql, '
+                             'https://us.app.ermetic.com/api/graph).')
     parser.add_argument('--auth-endpoint', required=True, dest='auth_endpoint_url',
                         help='Provider OAuth2 token endpoint URL (e.g. https://auth.app.wiz.io/oauth/token).')
+    parser.add_argument('--url-base-encrypter', required=False, dest='url_base_encrypter',
+                        help='Customer-deployed Encrypter base URL used to hash provider-specific '
+                             'identifiers (e.g. Tenable asset/plugin ids) before queuing.')
+    parser.add_argument('--api-token-encrypter', required=False, dest='api_token_encrypter',
+                        help='Auth token for the customer-deployed Encrypter, if it requires one.')
+
+
+def _configuration_credentials(provider, client_id, client_secret, require_secret):
+    """Validate provider-specific credential requirements and normalize omitted values.
+
+    Tenable configurations authenticate through the customer Encrypter and intentionally
+    allow both generic credential fields to be empty. Wiz still requires a client ID and,
+    for `config test`, a secret. Smart quotes are rejected because `--client-id=“”` is a
+    two-character credential, not an empty shell value.
+    """
+    for option, value in (('--client-id', client_id), ('--client-secret', client_secret)):
+        if value in ('“”', '‘’'):
+            raise CommandError(
+                'pam cnapp config',
+                f'{option} contains smart quotes. Use {option}="" for an empty value.',
+            )
+    client_id = '' if client_id is None else client_id
+    client_secret = '' if client_secret is None else client_secret
+    if provider == cnapp_pb2.CNAPP_PROVIDER_WIZ:
+        if not client_id:
+            raise CommandError('pam cnapp config', '--client-id is required for Wiz.')
+        if require_secret and not client_secret:
+            raise CommandError('pam cnapp config', '--client-secret is required when testing Wiz.')
+    return client_id, client_secret
 
 
 class PAMCnappConfigSetCommand(Command):
@@ -254,15 +285,19 @@ class PAMCnappConfigSetCommand(Command):
 
     def execute(self, params, **kwargs):
         provider = cnapp_helper.provider_from_name(kwargs.get('provider'))
+        client_id, client_secret = _configuration_credentials(
+            provider, kwargs.get('client_id'), kwargs.get('client_secret'), require_secret=False)
         response = cnapp_helper.set_cnapp_configuration(
             params,
             network_uid=kwargs.get('network_uid'),
             provider=provider,
-            client_id=kwargs.get('client_id'),
-            client_secret='' if kwargs.get('client_secret') is None else kwargs.get('client_secret'),
+            client_id=client_id,
+            client_secret=client_secret,
             api_endpoint_url=kwargs.get('api_endpoint_url'),
             cnapp_config_record_uid=kwargs.get('cnapp_config_record_uid'),
             auth_endpoint_url=kwargs.get('auth_endpoint_url'),
+            url_base_encrypter=kwargs.get('url_base_encrypter'),
+            api_token_encrypter=kwargs.get('api_token_encrypter'),
         )
         print(f"{bcolors.OKGREEN}CNAPP configuration saved.{bcolors.ENDC}")
         if response is not None:
@@ -279,14 +314,18 @@ class PAMCnappConfigTestCommand(Command):
 
     def execute(self, params, **kwargs):
         provider = cnapp_helper.provider_from_name(kwargs.get('provider'))
+        client_id, client_secret = _configuration_credentials(
+            provider, kwargs.get('client_id'), kwargs.get('client_secret'), require_secret=True)
         cnapp_helper.test_cnapp_configuration(
             params,
             network_uid=kwargs.get('network_uid'),
             provider=provider,
-            client_id=kwargs.get('client_id'),
-            client_secret=kwargs.get('client_secret'),
+            client_id=client_id,
+            client_secret=client_secret,
             api_endpoint_url=kwargs.get('api_endpoint_url'),
             auth_endpoint_url=kwargs.get('auth_endpoint_url'),
+            url_base_encrypter=kwargs.get('url_base_encrypter'),
+            api_token_encrypter=kwargs.get('api_token_encrypter'),
         )
         print(f"{bcolors.OKGREEN}CNAPP credentials validated successfully.{bcolors.ENDC}")
 
@@ -309,7 +348,7 @@ class PAMCnappConfigReadCommand(Command):
     parser.add_argument('--network-uid', '-n', required=True, dest='network_uid',
                         help='Network record UID (base64url).')
     parser.add_argument('--provider', '-p', required=True, dest='provider',
-                        help='CNAPP provider keyword: wiz.')
+                        help='CNAPP provider keyword: wiz, tenable.')
     parser.add_argument('--format', dest='format', choices=['table', 'json'], default='table',
                         help='Output format.')
 
@@ -371,8 +410,9 @@ class PAMCnappQueueListCommand(Command):
                         help='Network record UID (base64url).')
     parser.add_argument('--status', '-s', required=False, dest='status', default=0,
                         help='Filter by status name or id (pending/in_progress/resolved/failed/cancelled). Default: all.')
-    parser.add_argument('--provider', '-p', required=False, dest='provider', default='wiz',
-                        help='CNAPP provider keyword for the config lookup (default: wiz).')
+    parser.add_argument('--provider', '-p', required=False, dest='provider', default=None,
+                        help='Override the provider used for config lookup (wiz or tenable). '
+                             'By default, each queue item selects its own provider configuration.')
     parser.add_argument('--config-record', required=False, dest='config_record_uid',
                         help='Explicit encrypter vault record UID. Overrides the lookup via `config read`.')
     parser.add_argument('--no-decrypt', dest='no_decrypt', action='store_true',
@@ -383,25 +423,50 @@ class PAMCnappQueueListCommand(Command):
     def get_parser(self):
         return PAMCnappQueueListCommand.parser
 
-    def _resolve_encrypter_key(self, params, kwargs):
-        """Resolve the AES key: --config-record wins; otherwise fetch `config read` to get
-        the cnappConfigRecordUid and load the encrypter record from the local vault."""
+    def _resolve_encrypter_keys(self, params, kwargs, items):
+        """Resolve AES keys by queue-item provider.
+
+        `--config-record` wins and supplies one key for every item. `--provider` similarly
+        forces a single provider configuration. With neither override, mixed Wiz/Tenable
+        responses load the configuration associated with each item's provider.
+        """
         if kwargs.get('no_decrypt'):
-            return None, None
+            return {}
+        item_provider_ids = {item.cnappProviderId for item in items if item.payload}
+        if not item_provider_ids:
+            return {}
         config_record_uid = kwargs.get('config_record_uid')
-        if not config_record_uid:
+        if config_record_uid:
+            key = _load_encrypter_key(params, config_record_uid)
+            return {provider_id: key for provider_id in item_provider_ids if key}
+
+        provider_override = kwargs.get('provider')
+        provider_ids = item_provider_ids
+        if provider_override:
+            provider_ids = {cnapp_helper.provider_from_name(provider_override)}
+
+        keys_by_provider = {}
+        for provider_id in provider_ids:
             try:
-                provider = cnapp_helper.provider_from_name(kwargs.get('provider') or 'wiz')
                 config = cnapp_helper.read_cnapp_configuration(
-                    params, network_uid=kwargs.get('network_uid'), provider=provider)
+                    params, network_uid=kwargs.get('network_uid'), provider=provider_id)
             except Exception as e:
-                logger.debug('CNAPP: could not read configuration for decryption: %s', e)
-                return None, None
+                logger.debug(
+                    'CNAPP: could not read %s configuration for decryption: %s',
+                    cnapp_helper.CnappProvider.Name(provider_id), e,
+                )
+                continue
             if config is None or not config.cnappConfigRecordUid:
-                return None, None
+                continue
             config_record_uid = bytes_to_base64(config.cnappConfigRecordUid)
-        key = _load_encrypter_key(params, config_record_uid)
-        return key, config_record_uid
+            key = _load_encrypter_key(params, config_record_uid)
+            if key:
+                keys_by_provider[provider_id] = key
+
+        if provider_override and keys_by_provider:
+            override_key = keys_by_provider[next(iter(provider_ids))]
+            return {provider_id: override_key for provider_id in item_provider_ids}
+        return keys_by_provider
 
     @staticmethod
     def _decrypted_summary(decrypted):
@@ -434,13 +499,12 @@ class PAMCnappQueueListCommand(Command):
         items = list(response.items) if response is not None else []
         has_more = bool(response.hasMore) if response is not None else False
 
-        encrypter_key, encrypter_uid = self._resolve_encrypter_key(params, kwargs)
+        encrypter_keys = self._resolve_encrypter_keys(params, kwargs, items)
         decrypted_by_id = {}
         decrypt_errors = {}  # type: dict[int, str]
-        if encrypter_key:
-            for item in items:
-                if not item.payload:
-                    continue
+        for item in items:
+            encrypter_key = encrypter_keys.get(item.cnappProviderId)
+            if item.payload and encrypter_key:
                 try:
                     decrypted_by_id[item.cnappQueueId] = _decrypt_cnapp_payload(item.payload, encrypter_key)
                 except Exception as e:
@@ -464,7 +528,9 @@ class PAMCnappQueueListCommand(Command):
             print('No CNAPP queue items.')
             return None
 
-        if encrypter_key is None and not kwargs.get('no_decrypt'):
+        encrypted_without_key = any(
+            item.payload and item.cnappProviderId not in encrypter_keys for item in items)
+        if encrypted_without_key and not kwargs.get('no_decrypt'):
             print(f"{bcolors.WARNING}No encrypter key resolved — payloads will be shown as 'encrypted'. "
                   f"Pass --config-record <UID> or run after `pam cnapp config read` succeeds.{bcolors.ENDC}")
 
@@ -523,7 +589,7 @@ class PAMCnappQueueRemediateCommand(Command):
     parser.add_argument('--action', '-a', required=True, dest='action_type',
                         help='Remediation action: rotate_credentials, manage_access, jit_access, remove_standing_privilege.')
     parser.add_argument('--provider', '-p', required=False, dest='provider',
-                        help='Provider keyword (wiz). Optional — krouter resolves from queue item if omitted.')
+                        help='Provider keyword (wiz or tenable). Optional — krouter resolves from queue item if omitted.')
     parser.add_argument('--config-record', required=False, dest='cnapp_config_record_uid',
                         help='Configuration record UID (only required for some action types).')
     parser.add_argument('--resource-ref', required=False, dest='resource_ref',
@@ -620,6 +686,8 @@ def _configuration_to_dict(config):
         'apiEndpointUrl': config.apiEndpointUrl,
         'authEndpointUrl': config.authEndpointUrl,
         'cnappConfigRecordUid': bytes_to_base64(config.cnappConfigRecordUid) if config.cnappConfigRecordUid else '',
+        'urlBaseEncrypter': config.urlBaseEncrypter,
+        'apiTokenEncrypterSet': bool(config.apiTokenEncrypter),
     }
 
 
@@ -648,3 +716,5 @@ def _print_configuration(config):
     print(f"  API Endpoint   : {config.apiEndpointUrl or '(none)'}")
     print(f"  Auth Endpoint  : {config.authEndpointUrl or '(none)'}")
     print(f"  Config Record  : {_uid_display(config.cnappConfigRecordUid)}")
+    print(f"  URL Base Encr. : {config.urlBaseEncrypter or '(none)'}")
+    print(f"  API Token Encr.: {'(set)' if config.apiTokenEncrypter else '(none)'}")

--- a/keepercommander/commands/pam/cnapp_helper.py
+++ b/keepercommander/commands/pam/cnapp_helper.py
@@ -115,8 +115,9 @@ def action_from_name(name):  # type: (str) -> int
 
 def _build_configuration(network_uid, provider, client_id=None, client_secret=None,
                          api_endpoint_url=None, cnapp_config_record_uid=None,
-                         auth_endpoint_url=None):
-    # type: (str, int, Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]) -> cnapp_pb2.CnappConfiguration
+                         auth_endpoint_url=None, url_base_encrypter=None,
+                         api_token_encrypter=None):
+    # type: (str, int, Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]) -> cnapp_pb2.CnappConfiguration
     rq = cnapp_pb2.CnappConfiguration()
     rq.networkUid = _to_uid_bytes(network_uid)
     rq.provider = provider
@@ -130,12 +131,17 @@ def _build_configuration(network_uid, provider, client_id=None, client_secret=No
         rq.cnappConfigRecordUid = _to_uid_bytes(cnapp_config_record_uid)
     if auth_endpoint_url:
         rq.authEndpointUrl = auth_endpoint_url
+    if url_base_encrypter:
+        rq.urlBaseEncrypter = url_base_encrypter
+    if api_token_encrypter:
+        rq.apiTokenEncrypter = api_token_encrypter
     return rq
 
 
 def set_cnapp_configuration(params, network_uid, provider, client_id, client_secret,
-                            api_endpoint_url, cnapp_config_record_uid, auth_endpoint_url=None):
-    # type: (KeeperParams, str, int, str, str, str, str, Optional[str]) -> cnapp_pb2.CnappConfiguration
+                            api_endpoint_url, cnapp_config_record_uid, auth_endpoint_url=None,
+                            url_base_encrypter=None, api_token_encrypter=None):
+    # type: (KeeperParams, str, int, str, str, str, str, Optional[str], Optional[str], Optional[str]) -> cnapp_pb2.CnappConfiguration
     """Create or update the CNAPP provider configuration on a network.
 
     krouter validates the credentials against the provider before persisting; an empty
@@ -143,23 +149,31 @@ def set_cnapp_configuration(params, network_uid, provider, client_id, client_sec
     that only change the endpoint or record UID).
 
     `auth_endpoint_url` is the provider's OAuth2 token endpoint, letting customers point
-    at their own tenant/region (e.g. EU vs US Wiz auth host) without a code change."""
+    at their own tenant/region (e.g. EU vs US Wiz auth host) without a code change.
+
+    `url_base_encrypter`/`api_token_encrypter` identify the customer-deployed Encrypter
+    used to hash provider-specific identifiers (e.g. Tenable asset/plugin ids) before
+    they're queued, so raw provider data never reaches Keeper's servers."""
     rq = _build_configuration(network_uid, provider, client_id, client_secret,
-                              api_endpoint_url, cnapp_config_record_uid, auth_endpoint_url)
+                              api_endpoint_url, cnapp_config_record_uid, auth_endpoint_url,
+                              url_base_encrypter, api_token_encrypter)
     return _post_request_to_router(params, 'cnapp/configuration/set', rq_proto=rq,
                                    rs_type=cnapp_pb2.CnappConfiguration)
 
 
 def test_cnapp_configuration(params, network_uid, provider, client_id, client_secret,
-                             api_endpoint_url, auth_endpoint_url=None):
-    # type: (KeeperParams, str, int, str, str, str, Optional[str]) -> None
+                             api_endpoint_url, auth_endpoint_url=None,
+                             url_base_encrypter=None, api_token_encrypter=None):
+    # type: (KeeperParams, str, int, str, str, str, Optional[str], Optional[str], Optional[str]) -> None
     """Probe the provider with the supplied credentials without persisting anything.
 
     Returns None on success; raises on validation failure (RRC_BAD_REQUEST with the
     provider's reason in the message)."""
     rq = _build_configuration(network_uid, provider, client_id, client_secret,
                               api_endpoint_url, cnapp_config_record_uid=None,
-                              auth_endpoint_url=auth_endpoint_url)
+                              auth_endpoint_url=auth_endpoint_url,
+                              url_base_encrypter=url_base_encrypter,
+                              api_token_encrypter=api_token_encrypter)
     return _post_request_to_router(params, 'cnapp/configuration/test', rq_proto=rq)
 
 

--- a/keepercommander/proto/cnapp_pb2.py
+++ b/keepercommander/proto/cnapp_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0b\x63napp.proto\x12\x05\x43NAPP\"A\n\x15\x43nappQueueListRequest\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\x12\x14\n\x0cstatusFilter\x18\x02 \x01(\x05\"O\n\x16\x43nappQueueListResponse\x12$\n\x05items\x18\x01 \x03(\x0b\x32\x15.CNAPP.CnappQueueItem\x12\x0f\n\x07hasMore\x18\x02 \x01(\x08\"\xd0\x01\n\x0e\x43nappQueueItem\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12-\n\x0f\x63nappProviderId\x18\x02 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x1a\n\x12\x63nappQueueStatusId\x18\x03 \x01(\x05\x12\x12\n\nreceivedAt\x18\x04 \x01(\x03\x12\x12\n\nresolvedAt\x18\x05 \x01(\x03\x12\x11\n\tnetworkId\x18\x06 \x01(\x0c\x12\x0f\n\x07payload\x18\x07 \x01(\x0c\x12\x11\n\trecordUid\x18\x08 \x01(\x0c\"@\n\x15\x43nappAssociateRequest\x12\x11\n\trecordUid\x18\x01 \x01(\x0c\x12\x14\n\x0c\x63nappQueueId\x18\x02 \x01(\x05\"4\n\x16\x43nappAssociateResponse\x12\x1a\n\x12\x63nappQueueStatusId\x18\x01 \x01(\x05\"\x97\x02\n\x15\x43nappRemediateRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12\x31\n\nactionType\x18\x02 \x01(\x0e\x32\x1d.CNAPP.CnappRemediationAction\x12#\n\x1b\x63nappConfigurationRecordUid\x18\x03 \x01(\x0c\x12\x15\n\rpwdComplexity\x18\x04 \x01(\t\x12\x13\n\x0bresourceRef\x18\x05 \x01(\x0c\x12&\n\x08provider\x18\x06 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x15\n\rcontrollerUid\x18\x07 \x01(\t\x12\x12\n\nmessageUid\x18\x08 \x01(\x0c\x12\x11\n\tgroupName\x18\t \x01(\t\"w\n\x16\x43nappRemediateResponse\x12\x31\n\nactionType\x18\x01 \x01(\x0e\x32\x1d.CNAPP.CnappRemediationAction\x12\x0e\n\x06result\x18\x02 \x01(\t\x12\x1a\n\x12\x63nappQueueStatusId\x18\x03 \x01(\x05\"Y\n\x15\x43nappSetStatusRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12\x1a\n\x12\x63nappQueueStatusId\x18\x02 \x01(\x05\x12\x0e\n\x06reason\x18\x03 \x01(\t\"4\n\x16\x43nappSetStatusResponse\x12\x1a\n\x12\x63nappQueueStatusId\x18\x01 \x01(\x05\"3\n\x1b\x43nappDeleteQueueItemRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\"\x1e\n\x1c\x43nappDeleteQueueItemResponse\"\xc7\x01\n\x12\x43nappConfiguration\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\x12&\n\x08provider\x18\x02 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x10\n\x08\x63lientId\x18\x03 \x01(\t\x12\x14\n\x0c\x63lientSecret\x18\x04 \x01(\t\x12\x16\n\x0e\x61piEndpointUrl\x18\x05 \x01(\t\x12\x1c\n\x14\x63nappConfigRecordUid\x18\x06 \x01(\x0c\x12\x17\n\x0f\x61uthEndpointUrl\x18\x07 \x01(\t\"5\n\x1f\x43nappDeleteConfigurationRequest\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\"5\n\x19\x43nappTestEncrypterRequest\x12\x18\n\x10urlBaseEncrypter\x18\x01 \x01(\t*G\n\rCnappProvider\x12\x1e\n\x1a\x43NAPP_PROVIDER_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43NAPP_PROVIDER_WIZ\x10\x01*\x83\x01\n\x16\x43nappRemediationAction\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x16\n\x12ROTATE_CREDENTIALS\x10\x01\x12\x11\n\rMANAGE_ACCESS\x10\x02\x12\x0e\n\nJIT_ACCESS\x10\x03\x12\x1d\n\x19REMOVE_STANDING_PRIVILEGE\x10\x04\x42!\n\x18\x63om.keepersecurity.protoB\x05\x43nappb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0b\x63napp.proto\x12\x05\x43NAPP\"A\n\x15\x43nappQueueListRequest\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\x12\x14\n\x0cstatusFilter\x18\x02 \x01(\x05\"O\n\x16\x43nappQueueListResponse\x12$\n\x05items\x18\x01 \x03(\x0b\x32\x15.CNAPP.CnappQueueItem\x12\x0f\n\x07hasMore\x18\x02 \x01(\x08\"\xd0\x01\n\x0e\x43nappQueueItem\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12-\n\x0f\x63nappProviderId\x18\x02 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x1a\n\x12\x63nappQueueStatusId\x18\x03 \x01(\x05\x12\x12\n\nreceivedAt\x18\x04 \x01(\x03\x12\x12\n\nresolvedAt\x18\x05 \x01(\x03\x12\x11\n\tnetworkId\x18\x06 \x01(\x0c\x12\x0f\n\x07payload\x18\x07 \x01(\x0c\x12\x11\n\trecordUid\x18\x08 \x01(\x0c\"@\n\x15\x43nappAssociateRequest\x12\x11\n\trecordUid\x18\x01 \x01(\x0c\x12\x14\n\x0c\x63nappQueueId\x18\x02 \x01(\x05\"4\n\x16\x43nappAssociateResponse\x12\x1a\n\x12\x63nappQueueStatusId\x18\x01 \x01(\x05\"\x97\x02\n\x15\x43nappRemediateRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12\x31\n\nactionType\x18\x02 \x01(\x0e\x32\x1d.CNAPP.CnappRemediationAction\x12#\n\x1b\x63nappConfigurationRecordUid\x18\x03 \x01(\x0c\x12\x15\n\rpwdComplexity\x18\x04 \x01(\t\x12\x13\n\x0bresourceRef\x18\x05 \x01(\x0c\x12&\n\x08provider\x18\x06 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x15\n\rcontrollerUid\x18\x07 \x01(\t\x12\x12\n\nmessageUid\x18\x08 \x01(\x0c\x12\x11\n\tgroupName\x18\t \x01(\t\"w\n\x16\x43nappRemediateResponse\x12\x31\n\nactionType\x18\x01 \x01(\x0e\x32\x1d.CNAPP.CnappRemediationAction\x12\x0e\n\x06result\x18\x02 \x01(\t\x12\x1a\n\x12\x63nappQueueStatusId\x18\x03 \x01(\x05\"Y\n\x15\x43nappSetStatusRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\x12\x1a\n\x12\x63nappQueueStatusId\x18\x02 \x01(\x05\x12\x0e\n\x06reason\x18\x03 \x01(\t\"4\n\x16\x43nappSetStatusResponse\x12\x1a\n\x12\x63nappQueueStatusId\x18\x01 \x01(\x05\"3\n\x1b\x43nappDeleteQueueItemRequest\x12\x14\n\x0c\x63nappQueueId\x18\x01 \x01(\x05\"\x1e\n\x1c\x43nappDeleteQueueItemResponse\"\xfc\x01\n\x12\x43nappConfiguration\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\x12&\n\x08provider\x18\x02 \x01(\x0e\x32\x14.CNAPP.CnappProvider\x12\x10\n\x08\x63lientId\x18\x03 \x01(\t\x12\x14\n\x0c\x63lientSecret\x18\x04 \x01(\t\x12\x16\n\x0e\x61piEndpointUrl\x18\x05 \x01(\t\x12\x1c\n\x14\x63nappConfigRecordUid\x18\x06 \x01(\x0c\x12\x17\n\x0f\x61uthEndpointUrl\x18\x07 \x01(\t\x12\x18\n\x10urlBaseEncrypter\x18\x08 \x01(\t\x12\x19\n\x11\x61piTokenEncrypter\x18\t \x01(\t\"5\n\x1f\x43nappDeleteConfigurationRequest\x12\x12\n\nnetworkUid\x18\x01 \x01(\x0c\"5\n\x19\x43nappTestEncrypterRequest\x12\x18\n\x10urlBaseEncrypter\x18\x01 \x01(\t*c\n\rCnappProvider\x12\x1e\n\x1a\x43NAPP_PROVIDER_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43NAPP_PROVIDER_WIZ\x10\x01\x12\x1a\n\x16\x43NAPP_PROVIDER_TENABLE\x10\x02*\x83\x01\n\x16\x43nappRemediationAction\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x16\n\x12ROTATE_CREDENTIALS\x10\x01\x12\x11\n\rMANAGE_ACCESS\x10\x02\x12\x0e\n\nJIT_ACCESS\x10\x03\x12\x1d\n\x19REMOVE_STANDING_PRIVILEGE\x10\x04\x42!\n\x18\x63om.keepersecurity.protoB\x05\x43nappb\x06proto3')
 
 _CNAPPPROVIDER = DESCRIPTOR.enum_types_by_name['CnappProvider']
 CnappProvider = enum_type_wrapper.EnumTypeWrapper(_CNAPPPROVIDER)
@@ -23,6 +23,7 @@ _CNAPPREMEDIATIONACTION = DESCRIPTOR.enum_types_by_name['CnappRemediationAction'
 CnappRemediationAction = enum_type_wrapper.EnumTypeWrapper(_CNAPPREMEDIATIONACTION)
 CNAPP_PROVIDER_UNSPECIFIED = 0
 CNAPP_PROVIDER_WIZ = 1
+CNAPP_PROVIDER_TENABLE = 2
 UNSPECIFIED = 0
 ROTATE_CREDENTIALS = 1
 MANAGE_ACCESS = 2
@@ -146,10 +147,10 @@ if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
   DESCRIPTOR._serialized_options = b'\n\030com.keepersecurity.protoB\005Cnapp'
-  _CNAPPPROVIDER._serialized_start=1446
-  _CNAPPPROVIDER._serialized_end=1517
-  _CNAPPREMEDIATIONACTION._serialized_start=1520
-  _CNAPPREMEDIATIONACTION._serialized_end=1651
+  _CNAPPPROVIDER._serialized_start=1499
+  _CNAPPPROVIDER._serialized_end=1598
+  _CNAPPREMEDIATIONACTION._serialized_start=1601
+  _CNAPPREMEDIATIONACTION._serialized_end=1732
   _CNAPPQUEUELISTREQUEST._serialized_start=22
   _CNAPPQUEUELISTREQUEST._serialized_end=87
   _CNAPPQUEUELISTRESPONSE._serialized_start=89
@@ -173,9 +174,9 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _CNAPPDELETEQUEUEITEMRESPONSE._serialized_start=1102
   _CNAPPDELETEQUEUEITEMRESPONSE._serialized_end=1132
   _CNAPPCONFIGURATION._serialized_start=1135
-  _CNAPPCONFIGURATION._serialized_end=1334
-  _CNAPPDELETECONFIGURATIONREQUEST._serialized_start=1336
-  _CNAPPDELETECONFIGURATIONREQUEST._serialized_end=1389
-  _CNAPPTESTENCRYPTERREQUEST._serialized_start=1391
-  _CNAPPTESTENCRYPTERREQUEST._serialized_end=1444
+  _CNAPPCONFIGURATION._serialized_end=1387
+  _CNAPPDELETECONFIGURATIONREQUEST._serialized_start=1389
+  _CNAPPDELETECONFIGURATIONREQUEST._serialized_end=1442
+  _CNAPPTESTENCRYPTERREQUEST._serialized_start=1444
+  _CNAPPTESTENCRYPTERREQUEST._serialized_end=1497
 # @@protoc_insertion_point(module_scope)

--- a/unit-tests/pam/test_cnapp.py
+++ b/unit-tests/pam/test_cnapp.py
@@ -58,6 +58,15 @@ class TestEnumParsing(unittest.TestCase):
             cnapp_pb2.CNAPP_PROVIDER_WIZ,
         )
 
+    def test_provider_tenable_short_name(self):
+        self.assertEqual(cnapp_helper.provider_from_name('tenable'), cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+
+    def test_provider_tenable_full_name_case_insensitive(self):
+        self.assertEqual(
+            cnapp_helper.provider_from_name('CNAPP_PROVIDER_TENABLE'),
+            cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+        )
+
     def test_provider_empty_returns_unspecified(self):
         self.assertEqual(cnapp_helper.provider_from_name(''), cnapp_pb2.CNAPP_PROVIDER_UNSPECIFIED)
 
@@ -144,6 +153,72 @@ class TestConfigurationHelpers(unittest.TestCase):
             )
         rq = post.call_args.kwargs['rq_proto']
         self.assertEqual(rq.clientSecret, '')
+
+    def test_set_configuration_tenable_with_encrypter_fields(self):
+        """Tenable configurations round-trip the new urlBaseEncrypter/apiTokenEncrypter
+        fields alongside the CNAPP_PROVIDER_TENABLE provider value."""
+        expected_response = cnapp_pb2.CnappConfiguration(
+            apiEndpointUrl='https://us.app.ermetic.com/api/graph',
+            provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        with self._patch_post(return_value=expected_response) as post:
+            result = cnapp_helper.set_cnapp_configuration(
+                self.params,
+                network_uid=NETWORK_UID,
+                provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+                client_id='',
+                client_secret='',
+                api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                cnapp_config_record_uid=CONFIG_RECORD_UID,
+                auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+                url_base_encrypter='https://encrypter.internal',
+                api_token_encrypter='encrypter-token-abc',
+            )
+        self.assertIs(result, expected_response)
+        rq = post.call_args.kwargs['rq_proto']
+        self.assertEqual(rq.provider, cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        self.assertEqual(rq.clientId, '')
+        self.assertEqual(rq.clientSecret, '')
+        self.assertEqual(rq.apiEndpointUrl, 'https://us.app.ermetic.com/api/graph')
+        self.assertEqual(rq.urlBaseEncrypter, 'https://encrypter.internal')
+        self.assertEqual(rq.apiTokenEncrypter, 'encrypter-token-abc')
+
+    def test_set_configuration_omits_encrypter_fields_when_not_provided(self):
+        """Edge case: encrypter fields are optional — a Wiz configuration that doesn't
+        set them must leave both blank on the wire rather than sending garbage defaults."""
+        with self._patch_post() as post:
+            cnapp_helper.set_cnapp_configuration(
+                self.params,
+                network_uid=NETWORK_UID,
+                provider=cnapp_pb2.CNAPP_PROVIDER_WIZ,
+                client_id='abc',
+                client_secret='secret',
+                api_endpoint_url='https://api.wiz.io',
+                cnapp_config_record_uid=CONFIG_RECORD_UID,
+            )
+        rq = post.call_args.kwargs['rq_proto']
+        self.assertEqual(rq.urlBaseEncrypter, '')
+        self.assertEqual(rq.apiTokenEncrypter, '')
+
+    def test_test_configuration_tenable_dispatches_with_encrypter_fields(self):
+        with self._patch_post() as post:
+            cnapp_helper.test_cnapp_configuration(
+                self.params,
+                network_uid=NETWORK_UID,
+                provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+                client_id='',
+                client_secret='',
+                api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+                url_base_encrypter='https://encrypter.internal',
+                api_token_encrypter='encrypter-token-abc',
+            )
+        rq = post.call_args.kwargs['rq_proto']
+        self.assertEqual(post.call_args.args[1], 'cnapp/configuration/test')
+        self.assertEqual(rq.provider, cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        self.assertEqual(rq.urlBaseEncrypter, 'https://encrypter.internal')
+        self.assertEqual(rq.apiTokenEncrypter, 'encrypter-token-abc')
+        # test endpoint never persists, so it must not require / send config record UID
+        self.assertEqual(rq.cnappConfigRecordUid, b'')
 
     def test_test_configuration_dispatches_to_test_endpoint(self):
         with self._patch_post() as post:
@@ -356,6 +431,37 @@ class TestConfigCommands(unittest.TestCase):
         self.assertEqual(kwargs['auth_endpoint_url'], 'https://auth.wiz.io/oauth/token')
         self.assertIn('saved', buf.getvalue().lower())
 
+    def test_config_set_tenable_forwards_encrypter_fields(self):
+        """CLI-level test: `pam cnapp config set --provider tenable` must resolve the
+        Tenable enum and forward the new --url-base-encrypter/--api-token-encrypter
+        flags through to the helper unchanged."""
+        with patch.object(cnapp_commands.cnapp_helper, 'set_cnapp_configuration',
+                          return_value=cnapp_pb2.CnappConfiguration(
+                              apiEndpointUrl='https://us.app.ermetic.com/api/graph',
+                              provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE)) as helper:
+            buf, ctx = self._capture_stdout()
+            with ctx:
+                cnapp_commands.PAMCnappConfigSetCommand().execute(
+                    self.params,
+                    network_uid=NETWORK_UID,
+                    provider='tenable',
+                    client_id='',
+                    client_secret='',
+                    api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                    cnapp_config_record_uid=CONFIG_RECORD_UID,
+                    auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+                    url_base_encrypter='https://encrypter.internal',
+                    api_token_encrypter='encrypter-token-abc',
+                )
+        helper.assert_called_once()
+        kwargs = helper.call_args.kwargs
+        self.assertEqual(kwargs['provider'], cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        self.assertEqual(kwargs['client_id'], '')
+        self.assertEqual(kwargs['client_secret'], '')
+        self.assertEqual(kwargs['url_base_encrypter'], 'https://encrypter.internal')
+        self.assertEqual(kwargs['api_token_encrypter'], 'encrypter-token-abc')
+        self.assertIn('saved', buf.getvalue().lower())
+
     def test_config_set_blank_secret_passes_through(self):
         """Edge case: the CLI must forward an empty secret unchanged so krouter can
         keep the existing value."""
@@ -416,6 +522,60 @@ class TestConfigCommands(unittest.TestCase):
             self.assertEqual(helper.call_args.kwargs['auth_endpoint_url'], 'https://auth.wiz.io/oauth/token')
             self.assertIn('validated', buf.getvalue().lower())
 
+    def test_config_test_tenable_forwards_encrypter_fields(self):
+        """CLI-level test: `pam cnapp config test --provider tenable` resolves the
+        Tenable enum and forwards the Encrypter settings to the helper."""
+        with patch.object(cnapp_commands.cnapp_helper, 'test_cnapp_configuration', return_value=None) as helper:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cnapp_commands.PAMCnappConfigTestCommand().execute(
+                    self.params,
+                    network_uid=NETWORK_UID,
+                    provider='tenable',
+                    client_id='',
+                    client_secret='',
+                    api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                    auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+                    url_base_encrypter='https://encrypter.internal',
+                    api_token_encrypter='encrypter-token-abc',
+                )
+        helper.assert_called_once()
+        kwargs = helper.call_args.kwargs
+        self.assertEqual(kwargs['provider'], cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        self.assertEqual(kwargs['client_id'], '')
+        self.assertEqual(kwargs['client_secret'], '')
+        self.assertEqual(kwargs['url_base_encrypter'], 'https://encrypter.internal')
+        self.assertEqual(kwargs['api_token_encrypter'], 'encrypter-token-abc')
+        self.assertIn('validated', buf.getvalue().lower())
+
+    def test_config_test_tenable_allows_omitted_credentials(self):
+        with patch.object(cnapp_commands.cnapp_helper, 'test_cnapp_configuration', return_value=None) as helper:
+            with redirect_stdout(io.StringIO()):
+                cnapp_commands.PAMCnappConfigTestCommand().execute(
+                    self.params,
+                    network_uid=NETWORK_UID,
+                    provider='tenable',
+                    api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                    auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+                    url_base_encrypter='http://localhost:9099',
+                    api_token_encrypter='test-token',
+                )
+        self.assertEqual(helper.call_args.kwargs['client_id'], '')
+        self.assertEqual(helper.call_args.kwargs['client_secret'], '')
+
+    def test_config_test_rejects_smart_quote_placeholder(self):
+        with self.assertRaises(CommandError) as ctx:
+            cnapp_commands.PAMCnappConfigTestCommand().execute(
+                self.params,
+                network_uid=NETWORK_UID,
+                provider='tenable',
+                client_id='“”',
+                client_secret='',
+                api_endpoint_url='https://us.app.ermetic.com/api/graph',
+                auth_endpoint_url='https://cloud.tenable.com/oauth/token',
+            )
+        self.assertIn('smart quotes', str(ctx.exception))
+
     def test_config_test_propagates_helper_error(self):
         with patch.object(cnapp_commands.cnapp_helper, 'test_cnapp_configuration',
                           side_effect=Exception('Credential validation failed: bad')):
@@ -474,6 +634,47 @@ class TestConfigCommands(unittest.TestCase):
             self.assertEqual(payload['authEndpointUrl'], 'https://auth.wiz.io/oauth/token')
             self.assertIsNone(result, 'JSON output is the channel — no value returned to the REPL')
 
+    def test_config_read_table_format_tenable_with_encrypter_fields(self):
+        config = cnapp_pb2.CnappConfiguration(
+            apiEndpointUrl='https://us.app.ermetic.com/api/graph',
+            authEndpointUrl='https://cloud.tenable.com/oauth/token',
+            provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+            urlBaseEncrypter='https://encrypter.internal',
+            apiTokenEncrypter='encrypter-token-abc',
+        )
+        with patch.object(cnapp_commands.cnapp_helper, 'read_cnapp_configuration', return_value=config):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cnapp_commands.PAMCnappConfigReadCommand().execute(
+                    self.params, network_uid=NETWORK_UID, provider='tenable', format='table')
+            output = buf.getvalue()
+            self.assertIn('https://us.app.ermetic.com/api/graph', output)
+            self.assertIn('https://encrypter.internal', output)
+            # the encrypter token is a secret — must be masked, never printed in the clear
+            self.assertNotIn('encrypter-token-abc', output)
+            self.assertIn('(set)', output)
+
+    def test_config_read_json_format_tenable_includes_new_fields(self):
+        config = cnapp_pb2.CnappConfiguration(
+            apiEndpointUrl='https://us.app.ermetic.com/api/graph',
+            authEndpointUrl='https://cloud.tenable.com/oauth/token',
+            provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+            urlBaseEncrypter='https://encrypter.internal',
+            apiTokenEncrypter='encrypter-token-abc',
+        )
+        with patch.object(cnapp_commands.cnapp_helper, 'read_cnapp_configuration', return_value=config):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cnapp_commands.PAMCnappConfigReadCommand().execute(
+                    self.params, network_uid=NETWORK_UID, provider='tenable', format='json')
+            payload = json.loads(buf.getvalue())
+            self.assertEqual(payload['provider'], 'CNAPP_PROVIDER_TENABLE')
+            self.assertEqual(payload['clientId'], '')
+            self.assertEqual(payload['apiEndpointUrl'], 'https://us.app.ermetic.com/api/graph')
+            self.assertEqual(payload['urlBaseEncrypter'], 'https://encrypter.internal')
+            self.assertTrue(payload['apiTokenEncrypterSet'])
+            self.assertNotIn('apiTokenEncrypter', payload)
+
     def test_config_read_handles_none_response(self):
         with patch.object(cnapp_commands.cnapp_helper, 'read_cnapp_configuration', return_value=None):
             self.assertIsNone(cnapp_commands.PAMCnappConfigReadCommand().execute(
@@ -495,14 +696,16 @@ class TestQueueCommands(unittest.TestCase):
     def _queue_response(self, items=None, has_more=False):
         return cnapp_pb2.CnappQueueListResponse(items=items or [], hasMore=has_more)
 
-    def _queue_item(self, queue_id=1, status_id=1, record_uid=b''):
+    def _queue_item(self, queue_id=1, status_id=1, record_uid=b'',
+                    provider=cnapp_pb2.CNAPP_PROVIDER_WIZ, payload=b''):
         return cnapp_pb2.CnappQueueItem(
             cnappQueueId=queue_id,
-            cnappProviderId=cnapp_pb2.CNAPP_PROVIDER_WIZ,
+            cnappProviderId=provider,
             cnappQueueStatusId=status_id,
             receivedAt=1700000000000,
             networkId=b'\x00' * 16,
             recordUid=record_uid,
+            payload=payload,
         )
 
     def test_queue_list_empty(self):
@@ -530,6 +733,45 @@ class TestQueueCommands(unittest.TestCase):
             self.assertIn('IN_PROGRESS', output)
             self.assertIn('CNAPP_PROVIDER_WIZ', output)
             self.assertIsNone(result)
+
+    def test_queue_list_with_tenable_item_table(self):
+        item = self._queue_item(queue_id=100, provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE)
+        with patch.object(cnapp_commands.cnapp_helper, 'list_cnapp_queue',
+                          return_value=self._queue_response([item])):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cnapp_commands.PAMCnappQueueListCommand().execute(
+                    self.params, network_uid=NETWORK_UID, status=0, format='table',
+                    no_decrypt=True)
+        self.assertIn('CNAPP_PROVIDER_TENABLE', buf.getvalue())
+
+    def test_queue_list_auto_resolves_each_provider_configuration(self):
+        items = [
+            self._queue_item(queue_id=1, provider=cnapp_pb2.CNAPP_PROVIDER_WIZ, payload=b'payload'),
+            self._queue_item(queue_id=2, provider=cnapp_pb2.CNAPP_PROVIDER_TENABLE, payload=b'payload'),
+        ]
+
+        def read_config(params, network_uid, provider):
+            uid = b'\x01' * 16 if provider == cnapp_pb2.CNAPP_PROVIDER_WIZ else b'\x02' * 16
+            return cnapp_pb2.CnappConfiguration(cnappConfigRecordUid=uid)
+
+        command = cnapp_commands.PAMCnappQueueListCommand()
+        with patch.object(cnapp_commands.cnapp_helper, 'read_cnapp_configuration',
+                          side_effect=read_config) as read, \
+                patch.object(cnapp_commands, '_load_encrypter_key', return_value=b'k' * 32):
+            keys = command._resolve_encrypter_keys(
+                self.params,
+                {'network_uid': NETWORK_UID, 'provider': None, 'no_decrypt': False},
+                items,
+            )
+        self.assertEqual(set(keys), {
+            cnapp_pb2.CNAPP_PROVIDER_WIZ,
+            cnapp_pb2.CNAPP_PROVIDER_TENABLE,
+        })
+        self.assertEqual(
+            {call.kwargs['provider'] for call in read.call_args_list},
+            {cnapp_pb2.CNAPP_PROVIDER_WIZ, cnapp_pb2.CNAPP_PROVIDER_TENABLE},
+        )
 
     def test_queue_list_filter_resolves_named_status(self):
         with patch.object(cnapp_commands.cnapp_helper, 'list_cnapp_queue',
@@ -599,6 +841,22 @@ class TestQueueCommands(unittest.TestCase):
             self.assertIn('ROTATE_CREDENTIALS', output)
             self.assertIn('IN_PROGRESS', output)
             self.assertIn('Scheduled', output)
+
+    def test_queue_remediate_forwards_tenable_provider(self):
+        response = cnapp_pb2.CnappRemediateResponse(
+            actionType=cnapp_pb2.ROTATE_CREDENTIALS,
+            cnappQueueStatusId=2,
+        )
+        with patch.object(cnapp_commands.cnapp_helper, 'remediate_cnapp_queue_item',
+                          return_value=response) as helper:
+            with redirect_stdout(io.StringIO()):
+                cnapp_commands.PAMCnappQueueRemediateCommand().execute(
+                    self.params,
+                    cnapp_queue_id=4,
+                    action_type='rotate_credentials',
+                    provider='tenable',
+                )
+        self.assertEqual(helper.call_args.kwargs['provider'], cnapp_pb2.CNAPP_PROVIDER_TENABLE)
 
     def test_queue_remediate_unsupported_action_propagates(self):
         with patch.object(cnapp_commands.cnapp_helper, 'remediate_cnapp_queue_item',


### PR DESCRIPTION
## Summary

This change extends the CNAPP command set with Tenable support and the Encrypter settings needed to protect provider-specific identifiers before they are queued.

It also makes queue payload decryption provider-aware, allowing mixed Wiz and Tenable queue results to resolve the correct configuration automatically.

## Changes

- add `CNAPP_PROVIDER_TENABLE` support to the generated CNAPP protobuf bindings
- accept Tenable in configuration, queue, and remediation commands
- add `--url-base-encrypter` and `--api-token-encrypter` configuration options
- allow empty or omitted client credentials for Tenable while preserving Wiz validation requirements
- reject smart-quote placeholders that could otherwise be mistaken for credentials
- mask the Encrypter API token in table and JSON configuration output
- resolve queue decryption keys per provider, with explicit provider and configuration-record overrides
- add focused coverage for Tenable configuration, secret masking, queue listing, and remediation

## Security considerations

The Encrypter API token is sent to the router when configuring or testing the integration, but it is never emitted by `config read`. JSON output exposes only `apiTokenEncrypterSet: true` when a token is configured.

## Automated tests

```text
python -m pytest unit-tests/pam/test_cnapp.py -q
88 passed in 1.16s
```

## Usage and manual verification

Test Encrypter connectivity:

```shell
pam cnapp config test-encrypter \
  --url "$ENCRYPTER_URL"
```

Test Tenable configuration without saving:

```shell
pam cnapp config test \
  --network-uid "$NETWORK_UID" \
  --provider tenable \
  --api-endpoint "$API_ENDPOINT" \
  --auth-endpoint "$AUTH_ENDPOINT" \
  --url-base-encrypter "$ENCRYPTER_URL" \
  --api-token-encrypter "$ENCRYPTER_TOKEN" \
  --client-id="" \
  --client-secret=""
```

Save Tenable configuration:

```shell
pam cnapp config set \
  --network-uid "$NETWORK_UID" \
  --provider tenable \
  --api-endpoint "$API_ENDPOINT" \
  --auth-endpoint "$AUTH_ENDPOINT" \
  --url-base-encrypter "$ENCRYPTER_URL" \
  --api-token-encrypter "$ENCRYPTER_TOKEN" \
  --config-record "$CONFIG_RECORD_UID" \
  --client-id="" \
  --client-secret=""
```

Read configuration as a table:

```shell
pam cnapp config read \
  --network-uid "$NETWORK_UID" \
  --provider tenable \
  --format table
```

Read configuration as JSON:

```shell
pam cnapp config read \
  --network-uid "$NETWORK_UID" \
  --provider tenable \
  --format json
```

The JSON output should contain `apiTokenEncrypterSet: true`, never the token itself.

List all queue items with automatic provider detection and decryption:

```shell
pam cnapp queue list \
  --network-uid "$NETWORK_UID" \
  --format table
```

List Tenable items using an explicit configuration lookup:

```shell
pam cnapp queue list \
  --network-uid "$NETWORK_UID" \
  --provider tenable \
  --format table
```

List pending items as JSON:

```shell
pam cnapp queue list \
  --network-uid "$NETWORK_UID" \
  --status pending \
  --format json
```

List using an explicit Encrypter record:

```shell
pam cnapp queue list \
  --network-uid "$NETWORK_UID" \
  --config-record "$CONFIG_RECORD_UID" \
  --format table
```

List without attempting payload decryption:

```shell
pam cnapp queue list \
  --network-uid "$NETWORK_UID" \
  --no-decrypt \
  --format table
```

For the following commands, obtain the IDs from `queue list`:

```shell
QUEUE_ID="REPLACE_WITH_QUEUE_ID"
RECORD_UID="REPLACE_WITH_VAULT_RECORD_UID"
```

Associate a vault record:

```shell
pam cnapp queue associate \
  --queue-id "$QUEUE_ID" \
  --record-uid "$RECORD_UID"
```

Dispatch credential rotation:

```shell
pam cnapp queue remediate \
  --queue-id "$QUEUE_ID" \
  --action rotate_credentials \
  --provider tenable \
  --config-record "$CONFIG_RECORD_UID"
```

Update queue status:

```shell
pam cnapp queue set-status \
  --queue-id "$QUEUE_ID" \
  --status resolved \
  --reason "Resolved during Tenable integration testing"
```

Delete a queue item:

```shell
pam cnapp queue delete \
  --queue-id "$QUEUE_ID"
```

Delete the saved CNAPP configuration last:

```shell
pam cnapp config delete \
  --network-uid "$NETWORK_UID"
```
