### PR TITLE
KC-1441: Restrict SailPoint integration to documented capabilities only

### DIFF
--- a/keepercommander/service/commands/integrations/sailpoint/command_hook.py
+++ b/keepercommander/service/commands/integrations/sailpoint/command_hook.py
@@ -21,11 +21,10 @@ from ....decorators.logging import logger
 from .command_parse import ParsedShare, SailPointCommandParser
 from .command_policy import SailPointCommandPolicy
 from .config_fields import SailPointCapabilities, read_capabilities
+from .constants import SAILPOINT_BANNED_COMMANDS
 from .pending_store import SailPointPendingStore
 from .scim_guard import SailPointScimGuard
 from .share_targets import validate_share_targets
-
-_ER_CMDS = frozenset({'enterprise-role', 'er'})
 
 
 class SailPointCommandHook:
@@ -42,6 +41,14 @@ class SailPointCommandHook:
         set, do not execute the command. ``command_to_run`` may be rewritten
         (e.g. transfer-user target injection).
         """
+        tokens = SailPointCommandParser.tokenize(command)
+        if tokens and tokens[0].lower() in SAILPOINT_BANNED_COMMANDS:
+            return self._reject(
+                command,
+                f'SailPoint does not allow command: {tokens[0]}',
+                403
+            )
+
         caps = read_capabilities(params, self.record_uid)
 
         scope_error = self._check_capability_gates(command, caps)
@@ -49,8 +56,8 @@ class SailPointCommandHook:
             return self._reject(command, scope_error, 403)
 
         policy_error = (
-            SailPointCommandPolicy.validate_enterprise_role(command)
-            or SailPointCommandPolicy.validate_enterprise_user_delete(command)
+            SailPointCommandPolicy.validate_enterprise_user(command)
+            or SailPointCommandPolicy.validate_share_record(command)
         )
         if policy_error:
             return self._reject(command, policy_error, 403)
@@ -96,12 +103,6 @@ class SailPointCommandHook:
         tokens = SailPointCommandParser.tokenize(command)
         if not tokens:
             return None
-        name = tokens[0].lower()
-
-        if name in _ER_CMDS and not caps.allow_roles:
-            return (
-                'SailPoint allow_roles is disabled; enterprise-role / er is not allowed.'
-            )
 
         invite = SailPointCommandParser.parse_invite(command)
         if invite:

--- a/keepercommander/service/commands/integrations/sailpoint/command_policy.py
+++ b/keepercommander/service/commands/integrations/sailpoint/command_policy.py
@@ -20,29 +20,12 @@ from .....utils import is_email
 from .command_parse import SailPointCommandParser
 from .constants import SAILPOINT_ALLOWED_COMMANDS, SAILPOINT_BANNED_COMMANDS
 
-_ENTERPRISE_ROLE_CMDS = frozenset({'enterprise-role', 'er'})
 _ENTERPRISE_USER_CMDS = frozenset({'enterprise-user', 'eu'})
 
-# Destinations SailPoint may set on enterprise-role (argparse dest names).
-# Anything else that resolves on the real parser is refused — spelling-independent.
-_ER_ALLOWED_DESTS = frozenset({
-    'role',
-    'force',
-    'verbose',
-    'format',
-    'output',
-    'node',
-    'cascade',
-    'add_admin',
-    'remove_admin',
-    'add_privilege',
-    'remove_privilege',
+_EU_BANNED_DESTS = frozenset({
+    'disable_2fa',
+    'expire',
 })
-
-_ER_ALLOWED_HINT = (
-    '--add-admin, --remove-admin, --add-privilege, --remove-privilege '
-    '(plus --node, --cascade, -f)'
-)
 
 
 def _arg_is_set(value: Any) -> bool:
@@ -88,45 +71,8 @@ class SailPointCommandPolicy:
         return cls.sanitize(','.join(SAILPOINT_ALLOWED_COMMANDS))
 
     @classmethod
-    def validate_enterprise_role(cls, command: str) -> Optional[str]:
-        """
-        Restrict enterprise-role to admin/privilege ops only.
-
-        Uses Commander's ``enterprise_role_parser`` so ``--add-user``,
-        ``--add-user=``, ``--add-us``, and ``-au=`` are treated identically.
-        """
-        tokens = SailPointCommandParser.tokenize(command)
-        if not tokens or tokens[0].lower() not in _ENTERPRISE_ROLE_CMDS:
-            return None
-
-        from .....commands.enterprise import enterprise_role_parser
-
-        parsed = SailPointCommandParser.parse_known(enterprise_role_parser, tokens[1:])
-        if not parsed:
-            return None
-        ns, unknown = parsed
-
-        for token in unknown:
-            if token.startswith('-'):
-                flag = token.split('=', 1)[0]
-                return (
-                    f'SailPoint mode does not allow enterprise-role {flag}. '
-                    f'Allowed: {_ER_ALLOWED_HINT}.'
-                )
-
-        for dest, value in vars(ns).items():
-            if dest in _ER_ALLOWED_DESTS or not _arg_is_set(value):
-                continue
-            flag = f'--{dest.replace("_", "-")}'
-            return (
-                f'SailPoint mode does not allow enterprise-role {flag}. '
-                f'Allowed: {_ER_ALLOWED_HINT}.'
-            )
-        return None
-
-    @classmethod
-    def validate_enterprise_user_delete(cls, command: str) -> Optional[str]:
-        """Ban enterprise-user --delete; offboard must use transfer-user."""
+    def validate_enterprise_user(cls, command: str) -> Optional[str]:
+        """Restrict enterprise-user from dangerous operations like --disable-2fa and --expire."""
         tokens = SailPointCommandParser.tokenize(command)
         if not tokens or tokens[0].lower() not in _ENTERPRISE_USER_CMDS:
             return None
@@ -137,12 +83,30 @@ class SailPointCommandPolicy:
         if not parsed:
             return None
         ns, _unknown = parsed
+
         if ns.delete:
             return (
                 'SailPoint mode does not allow enterprise-user --delete. '
                 'Use transfer-user with the configured vault transfer target instead.'
             )
+
+        for dest in _EU_BANNED_DESTS:
+            if _arg_is_set(getattr(ns, dest, None)):
+                flag = f'--{dest.replace("_", "-")}'
+                return f'SailPoint mode does not allow enterprise-user {flag}.'
+
         return None
+
+    @classmethod
+    def validate_share_record(cls, command: str) -> Optional[str]:
+        """Prevent ownership transfer in share-record and nsf-share-record."""
+        share = SailPointCommandParser.parse_share(command)
+        if share is None or share.action != 'owner':
+            return None
+        return (
+            'SailPoint mode does not allow share-record --action owner. '
+            'Record ownership transfer is not permitted.'
+        )
 
     @classmethod
     def prepare_transfer(cls, command: str, target_email: str) -> Tuple[str, Optional[str]]:

--- a/keepercommander/service/commands/integrations/sailpoint/constants.py
+++ b/keepercommander/service/commands/integrations/sailpoint/constants.py
@@ -37,7 +37,6 @@ SAILPOINT_ALLOWED_COMMANDS = (
     'sync-down',
     'enterprise-info',
     'enterprise-user',
-    'enterprise-role',
     'enterprise-down',
     'transfer-user',
     'share-folder',
@@ -62,4 +61,6 @@ SAILPOINT_BANNED_COMMANDS = frozenset({
     'one-time-share',
     'connect',
     'ssh',
+    'enterprise-role',
+    'er',
 })

--- a/unit-tests/service/test_sailpoint_pending.py
+++ b/unit-tests/service/test_sailpoint_pending.py
@@ -224,19 +224,9 @@ class SailPointPolicyTest(unittest.TestCase):
         self.assertIn('enterprise-user', cleaned.split(','))
         self.assertIn('share-record', cleaned.split(','))
 
-    def test_sanitize_adds_enterprise_role_when_missing(self):
-        cleaned = SailPointCommandPolicy.sanitize(
-            'whoami,sync-down,get,enterprise-info,enterprise-user,enterprise-down,'
-            'share-folder,share-record,nsf-share-folder,nsf-share-record,tree'
-        )
-        parts = cleaned.split(',')
-        self.assertNotIn('get', parts)
-        self.assertIn('enterprise-role', parts)
-        self.assertNotIn('er', parts)
-
     def test_default_allowlist_matches_integration_list(self):
         expected = [
-            'whoami', 'sync-down', 'enterprise-info', 'enterprise-user', 'enterprise-role',
+            'whoami', 'sync-down', 'enterprise-info', 'enterprise-user',
             'enterprise-down', 'transfer-user',
             'share-folder', 'share-record', 'nsf-share-folder', 'nsf-share-record',
             'tree',
@@ -252,62 +242,48 @@ class SailPointPolicyTest(unittest.TestCase):
         self.assertIn('transfer-user', parts)
         self.assertNotIn('tu', parts)
 
-    def test_enterprise_role_blocks_add_delete_add_user(self):
-        for cmd in (
-            "enterprise-role --add 'New Role'",
-            "er 'QA Role' --delete",
-            "er 'QA Role' --add-user user@co.com",
-            "enterprise-role 'QA Role' --copy",
-            "er 'QA Role' --name 'Renamed'",
-            "er 'QA Role' --enforcement restrict_sharing:true",
-            # Equals / abbrev / short= forms must resolve the same as blocked long flags.
-            "enterprise-role 'QA Role' --add-user=user@co.com",
-            "enterprise-role 'QA Role' --add-us user@co.com",
-            "enterprise-role 'QA Role' -au=user@co.com",
-            "enterprise-role 'QA Role' --dele -f",
-            "enterprise-role 'QA Role' --nam=Pwned",
-            "enterprise-role 'QA Role' --enforce=restrict_sharing_all:true",
-        ):
-            err = SailPointCommandPolicy.validate_enterprise_role(cmd)
-            self.assertIsNotNone(err, cmd)
-            self.assertIn('does not allow enterprise-role', err)
-
-    def test_enterprise_role_allows_admin_and_privilege(self):
-        for cmd in (
-            "er 'QA Role'",
-            "enterprise-role 'QA Role' -aa 'Metron Security' --cascade on",
-            "er 'QA Role' --node 'Metron Security' -ap MANAGE_USER -ap MANAGE_NODES",
-            "er -f 'QA Role' -ra 'Metron Security'",
-            "er 'QA Role' --node 'Metron Security' -rp MANAGE_TEAMS",
-        ):
-            self.assertIsNone(SailPointCommandPolicy.validate_enterprise_role(cmd), cmd)
-
-    def test_enterprise_role_gate_ignores_other_commands(self):
-        self.assertIsNone(
-            SailPointCommandPolicy.validate_enterprise_role(
-                'enterprise-user user@co.com --add-role Admin'
-            )
-        )
-
     def test_enterprise_user_delete_blocked(self):
         for cmd in (
             'enterprise-user leaving@co.com --delete',
             'eu leaving@co.com --delete',
         ):
-            err = SailPointCommandPolicy.validate_enterprise_user_delete(cmd)
+            err = SailPointCommandPolicy.validate_enterprise_user(cmd)
             self.assertIsNotNone(err, cmd)
             self.assertIn('--delete', err)
             self.assertIn('transfer-user', err)
 
-    def test_enterprise_user_delete_allows_other_ops(self):
+    def test_enterprise_user_disable_2fa_blocked(self):
+        for cmd in (
+            'enterprise-user user@co.com --disable-2fa',
+            'eu user@co.com --disable-2fa',
+        ):
+            err = SailPointCommandPolicy.validate_enterprise_user(cmd)
+            self.assertIsNotNone(err, cmd)
+            self.assertIn('--disable-2fa', err)
+
+    def test_enterprise_user_expire_blocked(self):
+        for cmd in (
+            'enterprise-user user@co.com --expire',
+            'eu user@co.com --expire',
+        ):
+            err = SailPointCommandPolicy.validate_enterprise_user(cmd)
+            self.assertIsNotNone(err, cmd)
+            self.assertIn('--expire', err)
+
+    def test_enterprise_user_allows_safe_ops(self):
         self.assertIsNone(
-            SailPointCommandPolicy.validate_enterprise_user_delete(
+            SailPointCommandPolicy.validate_enterprise_user(
                 'eu user@co.com --add-role Admin'
             )
         )
         self.assertIsNone(
-            SailPointCommandPolicy.validate_enterprise_user_delete(
+            SailPointCommandPolicy.validate_enterprise_user(
                 'enterprise-user user@co.com --delete-alias old@co.com'
+            )
+        )
+        self.assertIsNone(
+            SailPointCommandPolicy.validate_enterprise_user(
+                'enterprise-user user@co.com --add-team AWS'
             )
         )
 
@@ -354,6 +330,24 @@ class SailPointPolicyTest(unittest.TestCase):
         rewritten, err = SailPointCommandPolicy.prepare_transfer(cmd, 'target@co.com')
         self.assertEqual(rewritten, cmd)
         self.assertIsNone(err)
+
+    def test_share_record_ownership_transfer_blocked(self):
+        for cmd in (
+            'share-record record@uid --action owner -e user@co.com',
+            'share-record record@uid -a owner -e user@co.com',
+        ):
+            err = SailPointCommandPolicy.validate_share_record(cmd)
+            self.assertIsNotNone(err, cmd)
+            self.assertIn('owner', err)
+
+    def test_share_record_grant_allowed(self):
+        for cmd in (
+            'share-record record@uid -e user@co.com',
+            'share-record record@uid --action grant -e user@co.com',
+            'nsf-share-record record@uid -e user@co.com -r viewer',
+        ):
+            err = SailPointCommandPolicy.validate_share_record(cmd)
+            self.assertIsNone(err, cmd)
 
 
 class SailPointPendingMergeTest(unittest.TestCase):
@@ -639,7 +633,7 @@ class EnterpriseUserForceValidationTest(unittest.TestCase):
 
 
 class SailPointCapabilityGateTest(unittest.TestCase):
-    def test_roles_off_blocks_invite_add_role_and_er(self):
+    def test_roles_off_blocks_invite_add_role(self):
         from keepercommander.service.commands.integrations.sailpoint.command_hook import (
             SailPointCommandHook,
         )
@@ -653,12 +647,6 @@ class SailPointCapabilityGateTest(unittest.TestCase):
         )
         self.assertIsNotNone(err)
         self.assertIn('allow_roles', err)
-
-        err = SailPointCommandHook._check_capability_gates(
-            "er 'Demo Role' -aa 'Node'", caps
-        )
-        self.assertIsNotNone(err)
-        self.assertIn('enterprise-role', err)
 
     def test_teams_off_blocks_add_team_allows_node(self):
         from keepercommander.service.commands.integrations.sailpoint.command_hook import (
@@ -879,6 +867,31 @@ class SailPointCapabilityGateTest(unittest.TestCase):
         self.assertIsNotNone(short)
         self.assertEqual(short[1], 403)
         self.assertIn('--delete', short[0]['error'])
+
+    def test_before_command_rejects_banned_commands_at_runtime(self):
+        """Banned commands rejected even if present in stored config (in-place upgrade scenario)."""
+        from keepercommander.service.commands.integrations.sailpoint.command_hook import (
+            SailPointCommandHook,
+        )
+        from keepercommander.service.commands.integrations.sailpoint.config_fields import (
+            SailPointCapabilities,
+        )
+
+        hook = SailPointCommandHook('config_uid')
+        caps = SailPointCapabilities(allow_roles=True, allow_teams=True)
+
+        for cmd in (
+            "enterprise-role 'Role' -aa 'Node'",
+            "er 'Role' --add-privilege MANAGE_USERS",
+        ):
+            with mock.patch(
+                'keepercommander.service.commands.integrations.sailpoint.command_hook.read_capabilities',
+                return_value=caps,
+            ):
+                command, short = hook.before_command(mock.Mock(), cmd)
+            self.assertIsNotNone(short, cmd)
+            self.assertEqual(short[1], 403, cmd)
+            self.assertIn('does not allow', short[0]['error'], cmd)
 
     def test_after_command_skips_missing_user(self):
         from keepercommander.service.commands.integrations.sailpoint.command_hook import (


### PR DESCRIPTION
# Restrict SailPoint integration to documented capabilities only

## Summary
Closes security findings where SailPoint integration key could perform undocumented dangerous operations beyond what setup toggles advertise. Integration now enforces least-privilege: only documented operations are allowed.

## Changes
- **Remove `enterprise-role`** — Unused by the integration; eliminates privilege escalation vector
- **Restrict `enterprise-user`** — Block `--disable-2fa` and `--expire` flags (security policy mutations)
- **Prevent ownership transfer** — Block `--action owner` in `share-record` and `nsf-share-record`