### PR TITLE
Improve CyberArk classic import metadata and skip handling

### DIFF
--- a/keepercommander/commands/pam_import/cyberark_import.py
+++ b/keepercommander/commands/pam_import/cyberark_import.py
@@ -562,6 +562,7 @@ class CyberArkImportOrchestrator:
         # Clear it immediately after map_account copies it into the record.
         token = None
         record = None
+        password_failed = False
         try:
             if not opts.dry_run or opts.include_creds:
                 token = self.client.retrieve_password(
@@ -571,12 +572,15 @@ class CyberArkImportOrchestrator:
                     skip_all=skip_all_passwords,
                 )
                 if token is None:
+                    password_failed = True
                     skipped.append({
                         "account": account.get("name", ""),
                         "safe": safe_name,
                         "reason": "password retrieval failed",
                     })
-                    return
+                    # Still map host/username so the account is not dropped from
+                    # the PAM project (legacy import also keeps going after Skip).
+                    token = ""
             try:
                 record = mapper.map_account(account, token, safe_name)
             except StrictPolicyError as e:
@@ -611,8 +615,13 @@ class CyberArkImportOrchestrator:
                 # can update the pamUser independently from its parent.
                 annotate_record_with_marker(nested, account_id, safe_name)
         self._apply_folder_paths(record, safe_name, folder_mapper)
+        if password_failed:
+            reason = "password retrieval failed"
+            is_incomplete = True
         if is_incomplete:
-            record["notes"] = f"INCOMPLETE: {reason}"
+            note = f"INCOMPLETE: {reason}"
+            existing = (record.get("notes") or "").strip()
+            record["notes"] = f"{existing}\n{note}".strip() if existing else note
             incomplete.append(record)
         dual_fields = detect_dual_account(account)
         if dual_fields:
@@ -1910,6 +1919,9 @@ Examples:
 
   # Self-hosted with SSL verification disabled
   pam project cyberark-import pvwa.internal.com --no-verify-ssl --name "Internal"
+
+  # Self-hosted with mutual TLS client cert (P12)
+  pam project cyberark-import pvwa.internal.com --client-cert-p12 ./client.p12 --name "Internal"
         ''')
     parser.add_argument("server", action="store", help="CyberArk PVWA host (e.g. mycompany.cyberark.cloud or pvwa.example.com)")
     parser.add_argument("--name", "-n", required=False, dest="project_name", action="store",
@@ -1956,6 +1968,10 @@ Examples:
                         default="", help="Comma-separated CPM states to include (default: all)")
     parser.add_argument("--no-verify-ssl", required=False, dest="no_verify_ssl", action="store_true",
                         default=False, help="Disable SSL certificate verification for self-hosted PVWA (insecure)")
+    parser.add_argument("--client-cert-p12", required=False, dest="client_cert_p12", action="store",
+                        default="", help="Path to client certificate P12/PFX for self-hosted PVWA mutual TLS")
+    parser.add_argument("--client-cert-password", required=False, dest="client_cert_password", action="store",
+                        default="", help="Passphrase for --client-cert-p12 (prefer env var in automation)")
     parser.add_argument("--include-system-safes", required=False, dest="include_system_safes",
                         action="store_true", default=False,
                         help="Include CyberArk system safes (VaultInternal, PVWAConfig, etc.)")
@@ -2037,7 +2053,27 @@ Examples:
                                        f"Platform map entry '{key}' must be an object with a 'record_type' field")
 
         no_verify_ssl = kwargs.get("no_verify_ssl", False)
+        client_cert_p12 = kwargs.get("client_cert_p12", "")
+        client_cert_password = kwargs.get("client_cert_password", "")
         state_filter = [s.strip() for s in state_filter_str.split(",") if s.strip()] if state_filter_str else None
+
+        if client_cert_p12:
+            os.environ["KEEPER_CYBERARK_CLIENT_CERT_P12"] = client_cert_p12
+        if client_cert_password:
+            os.environ["KEEPER_CYBERARK_CLIENT_CERT_PASSWORD"] = client_cert_password
+
+        # Match legacy `import --format=cyberark` behavior for self-hosted PVWA:
+        # default to verify=False unless a CA bundle is explicitly provided.
+        verify_ssl = not no_verify_ssl
+        if not server.endswith(".cyberark.cloud"):
+            ca_bundle = (
+                os.environ.get("KEEPER_CYBERARK_CA_BUNDLE")
+                or os.environ.get("_CYBERARK_CA_BUNDLE")
+            )
+            if ca_bundle:
+                verify_ssl = ca_bundle
+            elif not no_verify_ssl:
+                verify_ssl = False
 
         # ── Resolve gateway UID → name if needed ─────────────
         if gateway_name and not config_uid:
@@ -2056,7 +2092,7 @@ Examples:
 
         # ── Phase 0: Authenticate ────────────────────────────
         try:
-            client = CyberArkPVWAClient(server, verify_ssl=not no_verify_ssl)
+            client = CyberArkPVWAClient(server, verify_ssl=verify_ssl)
         except ValueError as e:
             raise CommandError("pam project cyberark-import", str(e))
         if not client.authenticate():

--- a/keepercommander/importer/commands.py
+++ b/keepercommander/importer/commands.py
@@ -44,6 +44,24 @@ def register_command_info(aliases, command_info):
         command_info[p.prog] = p.description
 
 
+def _cyberark_skip_arg(value):
+    skip_targets = []
+    valid_targets = {"team", "role", "user"}
+    aliases = {"teams": "team", "roles": "role", "users": "user"}
+    for target in str(value or "").split(","):
+        target = target.strip().lower()
+        if not target:
+            continue
+        target = aliases.get(target, target)
+        if target not in valid_targets:
+            raise argparse.ArgumentTypeError(
+                f"unsupported CyberArk skip target '{target}'. Use team, role, user"
+            )
+        if target not in skip_targets:
+            skip_targets.append(target)
+    return ",".join(skip_targets)
+
+
 import_parser = argparse.ArgumentParser(prog='import', description='Import vault data from a local file into Keeper')
 import_parser.add_argument('--display-csv', '-dc', dest='display_csv', action='store_true',
                            help='display Keeper CSV import instructions')
@@ -88,6 +106,8 @@ import_parser.add_argument('--secret-ids', dest='secret_ids', action='store',
                            help='Comma separated list of secret IDs to fetch (Thycotic)')
 import_parser.add_argument('--target-node', '--node', dest='target_node', action='store',
                            help='node name or ID for CyberArk-provisioned users, teams, and roles (default: root node)')
+import_parser.add_argument('--skip', dest='skip', action='store', type=_cyberark_skip_arg,
+                           help='CyberArk only: comma-separated targets to skip: team, role, user')
 import_parser.add_argument(
     'name', type=str,
     help='file name (json, csv , keepass, 1password), account name (lastpass), or URL (ManageEngine, Thycotic). '
@@ -298,6 +318,10 @@ class RecordImportCommand(ImporterCommand):
         if kwargs.get('target_node') and import_format != 'cyberark':
             logging.warning('--target-node/--node is only used with --format=cyberark; ignoring')
             kwargs['target_node'] = None
+
+        if kwargs.get('skip') and import_format != 'cyberark':
+            logging.warning('--skip is only used with --format=cyberark; ignoring')
+            kwargs['skip'] = ''
 
         logging.info('Processing... please wait.')
         imp_exp._import(params, import_format, import_name, manage_users=manage_users, manage_records=manage_records,

--- a/keepercommander/importer/cyberark/cyberark.py
+++ b/keepercommander/importer/cyberark/cyberark.py
@@ -266,6 +266,7 @@ class CyberArkImporter(BaseImporter):
 
     # Delay between requests to avoid hitting the API rate limits
     DELAY = 0.025
+    _PLATFORM_NAME_KEYS = ("platformName", "platformId")
     # CyberArk REST API endpoints (relative to the base URL)
     ENDPOINTS = {
         "accounts": "Accounts",
@@ -287,6 +288,155 @@ class CyberArkImporter(BaseImporter):
         self._tmp_cert_files = []
         # ``verify`` value used for every PVWA request. Defaults to False (self-hosted PVWAs typically use a private CA), but can be overridden by the ``_CYBERARK_CA_BUNDLE`` env var to point at a CA file/dir.
         self._verify_tls = False
+        timeout_env = environ.get("_CYBERARK_TIMEOUT")
+        if timeout_env:
+            try:
+                self.TIMEOUT = int(timeout_env)
+            except ValueError:
+                pass
+
+    @classmethod
+    def _normalize_property_key(cls, key):
+        return re.sub(r"[^a-z0-9]", "", str(key).casefold())
+
+    @classmethod
+    def _platform_properties(cls, account):
+        if not isinstance(account, dict):
+            return {}
+        properties = account.get("platformAccountProperties")
+        return properties if isinstance(properties, dict) else {}
+
+    @classmethod
+    def _get_platform_property(cls, account, *names):
+        properties = cls._platform_properties(account)
+        if not properties:
+            return None
+        normalized_names = {cls._normalize_property_key(name) for name in names}
+        for key, value in properties.items():
+            if cls._normalize_property_key(key) in normalized_names:
+                return value
+        return None
+
+    @classmethod
+    def _add_account_metadata(cls, record, account):
+        """Add CyberArk platform account properties as Keeper custom fields."""
+        if not isinstance(account, dict):
+            return
+
+        platform_properties = cls._platform_properties(account)
+        properties = dict(platform_properties) if isinstance(platform_properties, dict) else {}
+        for key in cls._PLATFORM_NAME_KEYS:
+            value = account.get(key)
+            if value not in (None, ""):
+                properties.setdefault("Platform Name", value)
+                break
+        for key in ("deviceType", "device type"):
+            value = account.get(key)
+            if value not in (None, ""):
+                properties.setdefault("Device Type", value)
+                break
+        if not properties:
+            return
+
+        existing_labels = {
+            str(field.label).casefold()
+            for field in getattr(record, "fields", [])
+            if getattr(field, "label", None)
+        }
+        host_values = set()
+        port_values = set()
+        for field in getattr(record, "fields", []):
+            if getattr(field, "type", None) != "host":
+                continue
+            host_value = getattr(field, "value", None)
+            if isinstance(host_value, dict):
+                for host_key in ("hostName", "host"):
+                    if host_value.get(host_key):
+                        host_values.add(str(host_value[host_key]))
+                if host_value.get("port"):
+                    port_values.add(str(host_value["port"]))
+            elif host_value:
+                host_values.add(str(host_value))
+
+        def field_value_to_text(value):
+            if isinstance(value, str):
+                return value
+            return json.dumps(
+                value, ensure_ascii=False, sort_keys=True,
+                separators=(",", ":"),
+            )
+
+        def is_standard_mapped_value(label, field_value):
+            label_key = label.casefold()
+            normalized_label_key = cls._normalize_property_key(label)
+            if normalized_label_key in {"name", "itemname"}:
+                return bool(record.title) and field_value == record.title
+            if normalized_label_key == "url":
+                return bool(record.login_url) and field_value == record.login_url
+            if normalized_label_key == "logondomain":
+                return bool(record.login) and record.login.casefold().startswith(
+                    f"{field_value}\\".casefold()
+                )
+            if normalized_label_key in {"address", "host", "hostname"}:
+                return field_value in host_values
+            if normalized_label_key in {"port", "portnumber"}:
+                return field_value in port_values or any(
+                    getattr(field, "type", None) == "port" and str(getattr(field, "value", "")) == field_value
+                    for field in getattr(record, "fields", [])
+                )
+            if normalized_label_key in {"username", "accountname"}:
+                return bool(record.login) and (
+                    field_value == record.login or record.login.endswith(f"\\{field_value}")
+                )
+            return False
+
+        def field_label_to_text(label):
+            parts = []
+            for part in str(label).replace("_", " ").split("."):
+                part = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", " ", part)
+                part = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", part)
+                parts.append(" ".join(part.split()))
+            return ".".join(parts)
+
+        def add_value(label, value):
+            raw_label = str(label)
+            label = field_label_to_text(raw_label)
+            label_key = label.casefold()
+            if not label or label_key in existing_labels:
+                return
+            field_value = field_value_to_text(value)
+            if (is_standard_mapped_value(raw_label, field_value)
+                    or is_standard_mapped_value(label, field_value)):
+                return
+            record.fields.append(RecordField(
+                "text", label=label, value=field_value,
+            ))
+            existing_labels.add(label_key)
+
+        def flatten(value, label):
+            if isinstance(value, dict) and value:
+                for child_key, child_value in value.items():
+                    child_label = f"{label}.{child_key}" if label else str(child_key)
+                    flatten(child_value, child_label)
+            else:
+                add_value(label, value)
+
+        for property_key, property_value in properties.items():
+            property_label = str(property_key)
+            flatten(property_value, property_label)
+
+    @classmethod
+    def _account_title(cls, account):
+        """Return the Keeper title for a CyberArk account."""
+        if not isinstance(account, dict):
+            return "CyberArk Account"
+        properties = account.get("platformAccountProperties")
+        if not isinstance(properties, dict):
+            properties = {}
+        for value in (account.get("name"), properties.get("ItemName"), account.get("id")):
+            if value:
+                return str(value)
+        return "CyberArk Account"
 
     @classmethod
     def get_url(cls, pvwa_host, endpoint):
@@ -301,6 +451,33 @@ class CyberArkImporter(BaseImporter):
                 warnings.simplefilter("ignore", InsecureRequestWarning)
                 return requests.request(method, url, **kwargs)
         return requests.request(method, url, **kwargs)
+
+    @staticmethod
+    def _connection_error_hint(pvwa_host, error):
+        """Return user-facing guidance for a PVWA connection failure."""
+        err = str(error).lower()
+        host = _esc(pvwa_host)
+        if "getaddrinfo failed" in err or "failed to resolve" in err or "name resolution" in err:
+            return (
+                f"Could not resolve hostname <b>{host}</b>.\n"
+                "For self-hosted PVWA, use the exact hostname or IP from your CyberArk admin, "
+                "connect to VPN, or add an entry to your hosts file."
+            )
+        if "timed out" in err or "timeout" in err:
+            return (
+                f"Connection to <b>{host}</b> timed out.\n"
+                "Ensure VPN is connected, the PVWA is running, and the port is reachable. "
+                "If PVWA uses a non-standard port, specify it as <b>hostname:port</b>."
+            )
+        if "connection refused" in err:
+            return (
+                f"Connection to <b>{host}</b> was refused.\n"
+                "Verify the PVWA service is running and the port is correct."
+            )
+        return (
+            f"Could not connect to <b>{host}</b>.\n"
+            "Verify the PVWA hostname is correct and reachable from this machine."
+        )
 
     def _load_p12_client_cert(self, p12_path, p12_password):
         """Convert a PKCS#12 bundle to a temporary PEM cert+key pair for ``requests``.
@@ -471,7 +648,7 @@ class CyberArkImporter(BaseImporter):
             )
         except requests.exceptions.RequestException as e:
             print_formatted_text(
-                HTML(f"Request to <b>{url}</b> <ansired>failed</ansired>: {e}")
+                HTML(f"Request to <b>{_esc(url)}</b> <ansired>failed</ansired>: {_esc(e)}")
             )
             return None
 
@@ -771,14 +948,16 @@ class CyberArkImporter(BaseImporter):
             except requests.exceptions.ConnectionError as e:
                 print_formatted_text(
                     HTML(
-                        f"CyberArk Log on <ansired>failed</ansired>: could not connect to <b>{pvwa_host}</b>.\n"
-                        "Verify the PVWA hostname is correct and reachable from this machine."
+                        f"CyberArk Log on <ansired>failed</ansired>: "
+                        f"{self._connection_error_hint(pvwa_host, e)}"
                     )
                 )
-                print_formatted_text(HTML(f"<ansired>Details:</ansired> {e}"))
+                print_formatted_text(HTML(f"<ansired>Details:</ansired> {_esc(e)}"))
                 return None
             except requests.exceptions.RequestException as e:
-                print_formatted_text(HTML(f"CyberArk Log on <ansired>failed</ansired>: {e}"))
+                print_formatted_text(
+                    HTML(f"CyberArk Log on <ansired>failed</ansired>: {_esc(e)}")
+                )
                 return None
             if response.status_code != 200:
                 print_formatted_text(
@@ -943,13 +1122,22 @@ class CyberArkImporter(BaseImporter):
         use_nsf = bool(kwargs.get("use_nsf"))
 
         params = kwargs.get("params")
-        will_teams = environ.get("_CYBERARK_SKIP_TEAMS", "").lower() not in ("1", "true", "yes")
-        will_create_users = environ.get("_CYBERARK_SKIP_CREATE_USERS", "").lower() not in ("1", "true", "yes")
-        will_print_users = environ.get("_CYBERARK_SKIP_USERS_LIST", "").lower() not in ("1", "true", "yes")
+        skip_teams = (bool(kwargs.get("skip_team"))
+                      or environ.get("_CYBERARK_SKIP_TEAMS", "").lower() in ("1", "true", "yes"))
+        skip_roles = (bool(kwargs.get("skip_role"))
+                      or environ.get("_CYBERARK_SKIP_ROLES", "").lower() in ("1", "true", "yes"))
+        skip_users = (bool(kwargs.get("skip_user"))
+                      or environ.get("_CYBERARK_SKIP_CREATE_USERS", "").lower() in ("1", "true", "yes"))
+        will_teams = not skip_teams
+        will_roles = not skip_roles
+        will_create_users = not skip_users
+        will_provision = will_teams or will_roles or will_create_users
+        will_print_users = (will_create_users
+                            and environ.get("_CYBERARK_SKIP_USERS_LIST", "").lower() not in ("1", "true", "yes"))
         target_node = kwargs.get("target_node")
 
         provision_node_id = None
-        if will_teams:
+        if will_provision:
             provision_node_id = self._resolve_provisioning_node_id(params, target_node)
 
         safes = self._resolve_safes(pvwa_host, authorization_token)
@@ -997,10 +1185,11 @@ class CyberArkImporter(BaseImporter):
         # Gather the CyberArk identities (groups + users) that will become Keeper
         # teams, roles and users so they can be previewed before the import. The
         # fetched users are reused after the import (no second fetch).
-        group_names = self._preview_user_group_names(pvwa_host, authorization_token) if will_teams else []
+        group_names = self._preview_user_group_names(pvwa_host, authorization_token) if will_provision else []
         cyberark_users = []
-        if will_print_users or will_create_users:
-            print_formatted_text(HTML("\nFetching CyberArk Users..."))
+        if will_create_users:
+            if will_print_users:
+                print_formatted_text(HTML("\nFetching CyberArk Users..."))
             cyberark_users = self.fetch_cyberark_users(
                 pvwa_host, authorization_token,
                 fetch_groups_membership=will_create_users,
@@ -1024,7 +1213,7 @@ class CyberArkImporter(BaseImporter):
                 tabulate(account_rows, headers="keys"),
                 end="\n\n",
             )
-        if group_names:
+        if group_names and will_teams:
             team_rows = [
                 {"Team": g, "Status": "exists" if g.lower() in existing_teams else "new"}
                 for g in group_names
@@ -1034,6 +1223,7 @@ class CyberArkImporter(BaseImporter):
                 tabulate(team_rows, headers="keys"),
                 end="\n\n",
             )
+        if group_names and will_roles:
             role_rows = [
                 {"Role": g, "Status": "exists" if g.lower() in existing_roles else "new"}
                 for g in group_names
@@ -1066,24 +1256,33 @@ class CyberArkImporter(BaseImporter):
             summary_lines.append(
                 "  - Safes as Nested Share Folders (--nsf); records created with the NSF API"
             )
-        if group_names:
-            summary_lines.append(f"  - <b>{len(group_names)}</b> user group(s) as Keeper teams and roles")
+        if group_names and will_teams:
+            summary_lines.append(f"  - <b>{len(group_names)}</b> user group(s) as Keeper teams")
+        if group_names and will_roles:
+            summary_lines.append(f"  - <b>{len(group_names)}</b> user group(s) as Keeper roles")
         if eligible_users:
             summary_lines.append(f"  - <b>{len(eligible_users)}</b> user(s) provisioned as Keeper users")
-        if will_teams and provision_node_id is not None:
+        provision_labels = [
+            label for enabled, label in (
+                (will_teams, "teams"), (will_roles, "roles"),
+                (will_create_users, "users"),
+            ) if enabled
+        ]
+        provision_description = ", ".join(provision_labels)
+        if will_provision and provision_node_id is not None:
             if target_node:
                 summary_lines.append(
-                    f'  - provision teams, roles, and users into node <b>{_esc(target_node)}</b> '
+                    f'  - provision {provision_description} into node <b>{_esc(target_node)}</b> '
                     f'(id <b>{provision_node_id}</b>)'
                 )
             else:
                 summary_lines.append(
-                    f'  - provision teams, roles, and users into the default root node '
+                    f'  - provision {provision_description} into the default root node '
                     f'(id <b>{provision_node_id}</b>)'
                 )
-        elif will_teams:
+        elif will_provision:
             summary_lines.append(
-                '  - <ansired>teams/roles/users will be skipped</ansired> (no provisioning node)'
+                f'  - <ansired>{provision_description} will be skipped</ansired> (no provisioning node)'
             )
         if not self._confirm_import(pvwa_host, summary="\n".join(summary_lines)):
             print_formatted_text(HTML("\nImport <ansiyellow>cancelled</ansiyellow> by user"))
@@ -1092,9 +1291,7 @@ class CyberArkImporter(BaseImporter):
         # Import the accounts we already gathered above.
         for safe, accounts in safe_accounts.items():
             print_formatted_text(
-                HTML(f"Importing <b>{len(accounts)}</b> accounts from safe {safe}:\n"),
-                tabulate([{"ID": x["id"], "Safe": x["safeName"], "Account": x["name"]} for x in accounts], headers="keys"),
-                end="\n\n",
+                HTML(f"\nImporting <b>{len(accounts)}</b> accounts from safe <b>{_esc(safe)}</b>...\n")
             )
             if use_nsf:
                 # Explicit NSF folder so prepare_nsf_folders has a SharedFolder target;
@@ -1115,20 +1312,26 @@ class CyberArkImporter(BaseImporter):
                         folder.domain = r["safeName"].replace(PathDelimiter, 2 * PathDelimiter)
                     record = Record()
                     record.folders = [folder]
-                    record.title = re.sub(rf"^.*{re.escape(r['platformId'])}[\-_ ]", "", r["name"])
+                    record.title = self._account_title(r)
                     record.type = "Password"
                     if "userName" in r:
                         record.type = "login"
                         record.login = r["userName"]
                         if "address" in r:
                             record.type = "serverCredentials"
-                            if r["platformAccountProperties"].get("LogonDomain"):
-                                record.login = r["platformAccountProperties"]["LogonDomain"] + "\\" + r["userName"]
+                            logon_domain = self._get_platform_property(r, "LogonDomain", "Logon Domain")
+                            if logon_domain:
+                                record.login = str(logon_domain) + "\\" + r["userName"]
                     if "address" in r:
-                        record.fields.append(RecordField("host", value={"hostName": r["address"]}))
-                    if r["platformAccountProperties"].get("URL"):
-                        record.title = r["platformAccountProperties"]["ItemName"]
-                        record.login_url = r["platformAccountProperties"]["URL"]
+                        host_value = {"hostName": r["address"]}
+                        port = self._get_platform_property(r, "Port", "PortNumber", "Port Number")
+                        if port not in (None, ""):
+                            host_value["port"] = str(port)
+                        record.fields.append(RecordField("host", value=host_value))
+                    url = self._get_platform_property(r, "URL")
+                    if url:
+                        record.login_url = str(url)
+                    self._add_account_metadata(record, r)
                     retry = True
                     while retry is True:
                         try:
@@ -1139,7 +1342,7 @@ class CyberArkImporter(BaseImporter):
                                     "Authorization": authorization_token,
                                     "Content-Type": "application/json",
                                 },
-                                json={"reason": "test"},
+                                json={"reason": "Keeper Commander Import"},
                                 timeout=self.TIMEOUT,
                                 verify=True if pvwa_host.endswith(".cyberark.cloud") else self._verify_tls,
                                 cert=None if pvwa_host.endswith(".cyberark.cloud") else self._client_cert,
@@ -1216,12 +1419,15 @@ class CyberArkImporter(BaseImporter):
         # Import CyberArk User Groups as Keeper Enterprise Teams + Roles, then optionally
         # create Keeper users (using their real CyberArk business emails) and
         # assign them to the matching Keeper Roles.
-        if will_teams and provision_node_id is not None:
+        if will_provision and provision_node_id is not None:
             self.import_user_groups(
                 pvwa_host, authorization_token, params,
                 cyberark_users=cyberark_users,
                 target_node=target_node,
                 node_id=provision_node_id,
+                skip_teams=skip_teams,
+                skip_roles=skip_roles,
+                skip_users=skip_users,
             )
 
         print_formatted_text(HTML("\nImport <ansigreen>completed</ansigreen>"))
@@ -1301,7 +1507,8 @@ class CyberArkImporter(BaseImporter):
         return None
 
     def import_user_groups(self, pvwa_host, authorization_token, params, cyberark_users=None,
-                           target_node=None, node_id=None):
+                           target_node=None, node_id=None, skip_teams=False,
+                           skip_roles=False, skip_users=False):
         """Fetch CyberArk User Groups and create them as Keeper Enterprise Teams.
 
         This mirrors the ``enterprise-team --add`` command flow: for each
@@ -1393,28 +1600,35 @@ class CyberArkImporter(BaseImporter):
         if node_id is None:
             return
         if target_node:
+            selected_objects = ", ".join(
+                label for skipped, label in (
+                    (skip_teams, "teams"), (skip_roles, "roles"),
+                    (skip_users, "users"),
+                ) if not skipped
+            )
             print_formatted_text(
                 HTML(
-                    f"Provisioning teams, roles, and users into node "
+                    f"Provisioning {selected_objects} into node "
                     f"<b>{_esc(target_node)}</b> (id <b>{node_id}</b>)"
                 )
             )
 
-        print_formatted_text(
-            HTML(f"Importing <b>{len(groups)}</b> user groups as Keeper Teams (members not provisioned):\n"),
-            tabulate(
-                [
-                    {
-                        "ID": g.get("id"),
-                        "Name": g.get("groupName") or g.get("name"),
-                        "CyberArk Members": len(g.get("members") or []),
-                    }
-                    for g in groups
-                ],
-                headers="keys",
-            ),
-            end="\n\n",
-        )
+        if not skip_teams:
+            print_formatted_text(
+                HTML(f"Importing <b>{len(groups)}</b> user groups as Keeper Teams (members not provisioned):\n"),
+                tabulate(
+                    [
+                        {
+                            "ID": g.get("id"),
+                            "Name": g.get("groupName") or g.get("name"),
+                            "CyberArk Members": len(g.get("members") or []),
+                        }
+                        for g in groups
+                    ],
+                    headers="keys",
+                ),
+                end="\n\n",
+            )
 
         request_batch = []
         request_team_names = []  # parallel list for reporting per-batch results
@@ -1455,6 +1669,9 @@ class CyberArkImporter(BaseImporter):
                 (": " + ", ".join(member_names)) if member_names else "",
             )
 
+            if skip_teams:
+                continue
+
             if group_name.lower() in existing_team_names:
                 skipped_existing.append(group_name)
                 continue
@@ -1494,7 +1711,9 @@ class CyberArkImporter(BaseImporter):
             # Track locally so duplicates within the same run are also skipped
             existing_team_names.add(group_name.lower())
 
-        if skipped_existing:
+        if skip_teams:
+            print_formatted_text(HTML("\nSkipping Keeper Team creation (--skip=team)."))
+        elif skipped_existing:
             print_formatted_text(
                 HTML(
                     f"\n<ansiyellow>Skipped {len(skipped_existing)} group(s) that already exist as "
@@ -1502,7 +1721,9 @@ class CyberArkImporter(BaseImporter):
                 )
             )
 
-        if not request_batch:
+        if skip_teams:
+            pass
+        elif not request_batch:
             print_formatted_text(HTML("\nNo new Keeper Teams to create."))
         else:
             try:
@@ -1537,18 +1758,22 @@ class CyberArkImporter(BaseImporter):
                 )
 
         # Also create a Keeper Enterprise Role for each user group (mirrors enterprise-role --add)
-        if environ.get("_CYBERARK_SKIP_ROLES", "").lower() not in ("1", "true", "yes"):
+        if not skip_roles:
             self._create_keeper_roles(groups, params, node_id)
+        else:
+            print_formatted_text(HTML("\nSkipping Keeper Role creation (--skip=role)."))
 
         # Provision Keeper users (using their real CyberArk business emails)
         # and assign them to matching Roles.
-        if environ.get("_CYBERARK_SKIP_CREATE_USERS", "").lower() not in ("1", "true", "yes"):
+        if not skip_users:
             if cyberark_users is None:
                 print_formatted_text(HTML("\nFetching CyberArk Users for provisioning..."))
                 cyberark_users = self.fetch_cyberark_users(
                     pvwa_host, authorization_token, fetch_groups_membership=True,
                 )
             self._create_keeper_users_and_assign_roles(groups, cyberark_users, params, node_id)
+        else:
+            print_formatted_text(HTML("\nSkipping Keeper User provisioning (--skip=user)."))
 
     def _create_keeper_roles(self, groups, params, node_id):
         """Create one Keeper Enterprise Role per CyberArk user group.

--- a/keepercommander/importer/cyberark/pam/client.py
+++ b/keepercommander/importer/cyberark/pam/client.py
@@ -14,14 +14,19 @@ import ipaddress
 import json
 import logging
 import math
+import os
 import re
+import stat
 import sys
+import tempfile
 import webbrowser
+import warnings
 from os import environ, path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qsl, quote, unquote, urljoin, urlparse
 
 import requests as _requests_module
+from urllib3.exceptions import InsecureRequestWarning
 
 from .constants import (
     MAX_FETCH_RECORDS,
@@ -89,6 +94,8 @@ class CyberArkPVWAClient:
         host, query_params = self._normalize_host(pvwa_host)
         self.pvwa_host = host
         self.query_params = query_params
+        self.client_cert = None
+        self._tmp_cert_files: List[str] = []
         # SSL verification: always True for Privilege Cloud.
         # For self-hosted: default True, caller can disable with verify_ssl=False.
         if self.pvwa_host.endswith(".cyberark.cloud"):
@@ -99,7 +106,209 @@ class CyberArkPVWAClient:
                 logging.warning("SSL certificate verification is disabled for self-hosted PVWA. "
                                 "This is insecure and vulnerable to man-in-the-middle attacks.")
         self.auth_token = None
+        timeout_env = environ.get("KEEPER_CYBERARK_TIMEOUT") or environ.get("_CYBERARK_TIMEOUT")
+        if timeout_env:
+            try:
+                self.TIMEOUT = int(timeout_env)
+            except ValueError:
+                pass
         self._validate_host(self.pvwa_host)
+
+    def _pvwa_request(self, method: str, url: str, **kwargs):
+        """Send a PVWA request the same way as ``import --format=cyberark``.
+
+        Applies mTLS client cert, timeout, TLS verify, and suppresses the
+        urllib3 warning when verification is intentionally disabled.
+        GET/POST go through ``requests.get``/``requests.post`` so unit tests
+        that patch those helpers still intercept PVWA traffic.
+        """
+        kwargs.setdefault("timeout", self.TIMEOUT)
+        kwargs.setdefault("verify", self.verify_ssl)
+        if self.client_cert and "cert" not in kwargs:
+            kwargs["cert"] = self.client_cert
+        method_u = method.upper()
+
+        def _do():
+            if method_u == "GET":
+                return requests.get(url, **kwargs)
+            if method_u == "POST":
+                return requests.post(url, **kwargs)
+            return requests.request(method_u, url, **kwargs)
+
+        if kwargs.get("verify") is False:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", InsecureRequestWarning)
+                return _do()
+        return _do()
+
+    @staticmethod
+    def _connection_error_hint(pvwa_host, error):
+        """Return user-facing guidance for a PVWA connection failure."""
+        err = str(error).lower()
+        host = _esc(pvwa_host)
+        if "getaddrinfo failed" in err or "failed to resolve" in err or "name resolution" in err:
+            return (
+                f"Could not resolve hostname <b>{host}</b>.\n"
+                "For self-hosted PVWA, use the exact hostname or IP from your CyberArk admin, "
+                "connect to VPN, or add an entry to your hosts file."
+            )
+        if "ssl" in err or "certificate" in err:
+            return (
+                f"TLS handshake to <b>{host}</b> failed.\n"
+                "If this is a private-CA PVWA, the server certificate chain may be incomplete, "
+                "or the P12 client certificate may not be trusted by IIS. "
+                "Retry with the same host used by <i>import --format=cyberark</i>."
+            )
+        if "timed out" in err or "timeout" in err:
+            return (
+                f"Connection to <b>{host}</b> timed out.\n"
+                "Ensure VPN is connected, the PVWA is running, and the port is reachable. "
+                "If PVWA uses a non-standard port, specify it as <b>hostname:port</b>."
+            )
+        if "connection refused" in err:
+            return (
+                f"Connection to <b>{host}</b> was refused.\n"
+                "Verify the PVWA service is running and the port is correct."
+            )
+        return (
+            f"Could not connect to <b>{host}</b>.\n"
+            "Verify the PVWA hostname is correct and reachable from this machine."
+        )
+
+    def _load_p12_client_cert(self, p12_path: str, p12_password: Optional[str]) -> Optional[Tuple[str, str]]:
+        """Convert a PKCS#12 bundle to temporary PEM cert+key files for requests."""
+        try:
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.serialization import pkcs12
+        except ImportError as e:
+            print_formatted_text(
+                HTML(
+                    "<ansired>cryptography package is required for P12 client certificates</ansired>: "
+                    f"{_esc(e)}"
+                )
+            )
+            return None
+
+        try:
+            with open(p12_path, "rb") as fh:
+                p12_bytes = fh.read()
+        except OSError as e:
+            print_formatted_text(
+                HTML(
+                    f"<ansired>Could not read P12 file</ansired> <b>{_esc(p12_path)}</b>: {_esc(e)}"
+                )
+            )
+            return None
+
+        password_bytes = p12_password.encode("utf-8") if p12_password else None
+        try:
+            private_key, cert, additional_certs = pkcs12.load_key_and_certificates(
+                p12_bytes, password_bytes
+            )
+        except ValueError as e:
+            print_formatted_text(
+                HTML(
+                    "<ansired>Failed to decode P12 bundle</ansired> — check the file and passphrase: "
+                    f"{_esc(e)}"
+                )
+            )
+            return None
+
+        if private_key is None or cert is None:
+            print_formatted_text(
+                HTML(
+                    "<ansired>P12 bundle is missing a private key or certificate</ansired>; "
+                    "client-certificate authentication requires both."
+                )
+            )
+            return None
+
+        cert_fd, cert_path = tempfile.mkstemp(prefix="ca_pvwa_", suffix=".pem")
+        key_fd, key_path = tempfile.mkstemp(prefix="ca_pvwa_", suffix=".key.pem")
+        try:
+            with os.fdopen(cert_fd, "wb") as cert_file:
+                cert_file.write(cert.public_bytes(serialization.Encoding.PEM))
+                for extra in additional_certs or []:
+                    cert_file.write(extra.public_bytes(serialization.Encoding.PEM))
+            with os.fdopen(key_fd, "wb") as key_file:
+                key_file.write(
+                    private_key.private_bytes(
+                        encoding=serialization.Encoding.PEM,
+                        format=serialization.PrivateFormat.TraditionalOpenSSL,
+                        encryption_algorithm=serialization.NoEncryption(),
+                    )
+                )
+            try:
+                os.chmod(cert_path, stat.S_IRUSR | stat.S_IWUSR)
+                os.chmod(key_path, stat.S_IRUSR | stat.S_IWUSR)
+            except OSError:
+                pass
+        except OSError as e:
+            print_formatted_text(
+                HTML(f"<ansired>Failed to materialize P12 to PEM</ansired>: {_esc(e)}")
+            )
+            for p in (cert_path, key_path):
+                try:
+                    os.remove(p)
+                except OSError:
+                    pass
+            return None
+
+        self._tmp_cert_files.extend([cert_path, key_path])
+        return cert_path, key_path
+
+    def _cleanup_tmp_cert_files(self):
+        """Delete temporary PEM files materialized from a P12 bundle."""
+        for p in self._tmp_cert_files:
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+        self._tmp_cert_files = []
+        self.client_cert = None
+
+    def _maybe_configure_client_cert(self) -> bool:
+        """Load a self-hosted PVWA client cert from P12 when configured."""
+        if self.pvwa_host.endswith(".cyberark.cloud"):
+            return True
+        if self.client_cert:
+            return True
+
+        p12_path = (
+            environ.get("KEEPER_CYBERARK_CLIENT_CERT_P12")
+            or environ.get("_CYBERARK_CLIENT_CERT_P12")
+        )
+        if p12_path is None:
+            try:
+                entered = prompt(
+                    "CyberArk PVWA client certificate P12 path (leave empty if none): "
+                ).strip()
+            except (EOFError, KeyboardInterrupt):
+                return False
+            p12_path = entered or None
+
+        if not p12_path:
+            return True
+        if not path.isfile(p12_path):
+            print_formatted_text(
+                HTML(f"<ansired>P12 file not found</ansired>: <b>{_esc(p12_path)}</b>")
+            )
+            return False
+
+        p12_password = (
+            environ.get("KEEPER_CYBERARK_CLIENT_CERT_PASSWORD")
+            or environ.get("_CYBERARK_CLIENT_CERT_PASSWORD")
+        )
+        if p12_password is None:
+            p12_password = prompt("P12 passphrase: ", is_password=True)
+        cert_tuple = self._load_p12_client_cert(p12_path, p12_password)
+        if cert_tuple is None:
+            return False
+        self.client_cert = cert_tuple
+        print_formatted_text(
+            HTML("Loaded PVWA client certificate from <b>P12</b> — using mutual TLS.")
+        )
+        return True
 
     @staticmethod
     def _normalize_host(filename):
@@ -166,30 +375,29 @@ class CyberArkPVWAClient:
     def logoff(self):
         """Log off from CyberArk PVWA. Best-effort — failures are silently ignored."""
         if not self.auth_token:
+            self._cleanup_tmp_cert_files()
             return
         try:
             base = self._get_url("safes").rsplit("/Safes", 1)[0]
-            requests.post(
+            self._pvwa_request(
+                "POST",
                 f"{base}/Auth/Logoff",
                 headers={"Authorization": self.auth_token, "Content-Type": "application/json"},
-                timeout=self.TIMEOUT,
-                verify=self.verify_ssl,
-                allow_redirects=False,
             )
         except Exception:
             pass  # Best-effort logoff
         self.auth_token = None
+        self._cleanup_tmp_cert_files()
 
     def _get(self, url, params=None):
         """GET with automatic retry on HTTP 429 (rate limit). Redirects disabled."""
         response = None
         for attempt in range(self.MAX_RETRIES):
-            response = requests.get(
+            response = self._pvwa_request(
+                "GET",
                 url,
                 headers={"Authorization": self.auth_token, "Content-Type": "application/json"},
                 params=params,
-                timeout=self.TIMEOUT,
-                verify=self.verify_ssl,
                 allow_redirects=False,
             )
             if response.status_code != 429:
@@ -781,8 +989,14 @@ class CyberArkPVWAClient:
         return result
 
     def _auth_self_hosted(self) -> bool:
-        login_type = environ.get("KEEPER_CYBERARK_LOGON_TYPE") or prompt(
+        if not self._maybe_configure_client_cert():
+            return False
+        login_type = (
+            environ.get("KEEPER_CYBERARK_LOGON_TYPE")
+            or environ.get("_CYBERARK_LOGON_TYPE")
+            or prompt(
             "CyberArk logon type (Cyberark, LDAP, RADIUS or Windows): "
+            )
         )
         # Validate login_type to prevent URL path injection (case-insensitive)
         if login_type.lower() not in VALID_LOGON_TYPES:
@@ -790,31 +1004,71 @@ class CyberArkPVWAClient:
                 f"<ansired>Invalid logon type</ansired>: must be one of Cyberark, LDAP, RADIUS, Windows"
             ))
             return False
-        username = environ.get("KEEPER_CYBERARK_USERNAME") or prompt("CyberArk username: ")
-        password = environ.get("KEEPER_CYBERARK_PASSWORD") or prompt("CyberArk password: ", is_password=True)
+        username = (
+            environ.get("KEEPER_CYBERARK_USERNAME")
+            or environ.get("_CYBERARK_USERNAME")
+            or prompt("CyberArk username: ")
+        )
+        password = (
+            environ.get("KEEPER_CYBERARK_PASSWORD")
+            or environ.get("_CYBERARK_PASSWORD")
+            or prompt("CyberArk password: ", is_password=True)
+        )
         try:
-            response = requests.post(
+            response = self._pvwa_request(
+                "POST",
                 self._get_url("logon").format(type=login_type),
                 json={"username": username, "password": password},
-                timeout=self.TIMEOUT,
-                verify=self.verify_ssl,
             )
+        except _requests_module.ConnectionError as e:
+            print_formatted_text(
+                HTML(
+                    f"CyberArk Log on <ansired>failed</ansired>: "
+                    f"{self._connection_error_hint(self.pvwa_host, e)}"
+                )
+            )
+            print_formatted_text(HTML(f"<ansired>Details:</ansired> {_esc(e)}"))
+            logging.warning("Logon connection error: %s", e)
+            return False
         except _requests_module.RequestException as e:
-            print_formatted_text(HTML(f"CyberArk Log on <ansired>failed</ansired>: connection error"))
-            logging.debug(f"Logon connection error: {type(e).__name__}")
+            print_formatted_text(
+                HTML(f"CyberArk Log on <ansired>failed</ansired>: {_esc(e)}")
+            )
+            logging.warning("Logon request error: %s", e)
             return False
         if response.status_code != 200:
             print_formatted_text(HTML(
                 f"CyberArk Log on <ansired>failed</ansired> with status code <b>{response.status_code}</b>"
             ))
+            try:
+                body = (response.text or "")[:500]
+                if body:
+                    print_formatted_text(HTML(f"<ansired>Response:</ansired> {_esc(body)}"))
+            except Exception:
+                pass
             return False
-        # CyberArk's Logon endpoint returns the token as a JSON string.
-        # Use json() for proper quote/escape handling rather than strip('"').
+        # Match ``import --format=cyberark``: Logon returns a JSON-quoted string.
         try:
-            token = response.json()
+            parsed = response.json()
         except ValueError:
-            token = response.text.strip('"')
-        self.auth_token = token if isinstance(token, str) else ""
+            parsed = None
+        if isinstance(parsed, str) and parsed.strip():
+            token = parsed.strip()
+        elif isinstance(parsed, dict):
+            token = (
+                parsed.get("CyberArkLogonResult")
+                or parsed.get("token")
+                or parsed.get("sessionToken")
+                or ""
+            )
+        else:
+            token = (response.text or "").strip().strip('"')
+        self.auth_token = str(token).strip().strip('"')
+        if not self.auth_token:
+            print_formatted_text(HTML(
+                "<ansired>CyberArk Log on succeeded but no session token was returned</ansired>"
+            ))
+            return False
         print_formatted_text(HTML("Log on <ansigreen>successful</ansigreen>"))
         return True
 
@@ -832,8 +1086,24 @@ class CyberArkPVWAClient:
         while True:
             time.sleep(self.DELAY)
             response = self._get(next_url, params=page_params)
+            if response is None:
+                logging.warning('Paginated fetch failed: %s (no response)', next_url)
+                break
             if response.status_code != 200:
-                logging.debug('Paginated fetch failed: %s status %d', next_url, response.status_code)
+                print_formatted_text(HTML(
+                    f"Request to <b>{_esc(next_url)}</b> <ansired>failed</ansired> "
+                    f"with status <b>{response.status_code}</b>"
+                ))
+                try:
+                    body = (response.text or "")[:300]
+                    if body:
+                        print_formatted_text(HTML(f"<ansired>Response:</ansired> {_esc(body)}"))
+                except Exception:
+                    pass
+                logging.warning(
+                    'Paginated fetch failed: %s status %d',
+                    next_url, response.status_code,
+                )
                 break
             try:
                 data = response.json()
@@ -901,6 +1171,11 @@ class CyberArkPVWAClient:
             # Fetch from server — now with pagination
             print_formatted_text(HTML("Getting safes from the server..."))
             safes = self._paginate(self._get_url("safes"), limit=200)
+            if not safes:
+                safes = self._paginate(
+                    f"https://{self.pvwa_host}/PasswordVault/api/Safes",
+                    limit=200,
+                )
             if not safes:
                 print_formatted_text(HTML(f"No Safes on server <ansired>{_esc(self.pvwa_host)}</ansired>"))
             return safes
@@ -1393,67 +1668,115 @@ class CyberArkPVWAClient:
                           account_id, type(e).__name__)
         return None
 
+    @staticmethod
+    def _safe_account_id(account_id) -> Optional[str]:
+        """Return a path-safe CyberArk account id, or None if it looks malicious."""
+        s = str(account_id or "").strip()
+        if not s or len(s) > 128:
+            return None
+        if any(ch in s for ch in ("/", "\\", "?", "#", "\x00")) or ".." in s:
+            return None
+        return s
+
     def retrieve_password(self, account_id: str, account_name: str = "",
                           safe_name: str = "", skip_all: Optional[dict] = None) -> Optional[str]:
         """Retrieve password for an account. Returns password string or None."""
         if skip_all is None:
             skip_all = {}
-        # Validate account_id format before URL interpolation
-        if not re.match(r'^[a-zA-Z0-9_]+$', str(account_id)):
+        account_id_raw = account_id
+        account_id = self._safe_account_id(account_id)
+        if not account_id:
             logging.warning('Invalid account ID for password retrieval: %s',
-                            re.sub(r'[^a-zA-Z0-9_]', '?', str(account_id)))
+                            re.sub(r'[^a-zA-Z0-9_.\-]', '?', str(account_id_raw)))
             return None
+        payload = {"reason": "Keeper Commander Import"}
+        if "KEEPER_CYBERARK_TICKETING_SYSTEM" in environ:
+            payload["TicketingSystemName"] = environ["KEEPER_CYBERARK_TICKETING_SYSTEM"]
+        if "KEEPER_CYBERARK_TICKET_ID" in environ:
+            payload["TicketId"] = environ["KEEPER_CYBERARK_TICKET_ID"]
+        retrieve_urls = [
+            self._get_url("account_password").format(account_id=account_id),
+            f"https://{self.pvwa_host}/PasswordVault/api/Accounts/{account_id}/Password/Retrieve",
+        ]
         retry = True
+        url_index = 0
         while retry is True:
+            url = retrieve_urls[url_index]
             try:
-                response = requests.post(
-                    self._get_url("account_password").format(account_id=account_id),
-                    headers={"Authorization": self.auth_token, "Content-Type": "application/json"},
-                    json={
-                        "reason": "test",
-                        **({"TicketingSystemName": environ["KEEPER_CYBERARK_TICKETING_SYSTEM"]}
-                           if "KEEPER_CYBERARK_TICKETING_SYSTEM" in environ else {}),
-                        **({"TicketId": environ["KEEPER_CYBERARK_TICKET_ID"]}
-                           if "KEEPER_CYBERARK_TICKET_ID" in environ else {}),
+                response = self._pvwa_request(
+                    "POST",
+                    url,
+                    headers={
+                        "Authorization": self.auth_token,
+                        "Content-Type": "application/json",
                     },
-                    timeout=self.TIMEOUT,
-                    verify=self.verify_ssl,
+                    json=payload,
+                    allow_redirects=False,
                 )
             except _requests_module.RequestException as e:
-                logging.debug('Password retrieval network error for %s: %s',
-                              account_id, type(e).__name__)
+                print_formatted_text(HTML(
+                    f"Password retrieval <ansired>failed</ansired> for "
+                    f"<i>{_esc(account_name)}</i>: {_esc(e)}"
+                ))
+                logging.warning('Password retrieval network error for %s: %s',
+                                account_id, e)
                 return None
             if response.status_code == 200:
-                # Password endpoint returns a JSON string; parse properly
-                # to avoid edge cases in embedded quotes or escapes.
                 try:
                     pw = response.json()
                 except ValueError:
                     pw = response.text.strip('"')
                 return pw if isinstance(pw, str) else None
-            elif 400 <= response.status_code < 500:
+            if response.status_code in (401, 404, 405) and url_index < len(retrieve_urls) - 1:
+                url_index += 1
+                logging.debug(
+                    'Password retrieve %s at %s — trying fallback URL',
+                    response.status_code, url,
+                )
+                continue
+            if 400 <= response.status_code < 500:
                 try:
                     error = response.json()
+                    if not isinstance(error, dict):
+                        error = {"ErrorCode": "UNKNOWN", "ErrorMessage": str(error)}
                 except ValueError:
-                    error = {"ErrorCode": "UNKNOWN", "ErrorMessage": "Non-JSON error response"}
+                    error = {
+                        "ErrorCode": "UNKNOWN",
+                        "ErrorMessage": (response.text or "Non-JSON error response")[:300],
+                    }
                 error_code = error.get("ErrorCode")
+                error_message = error.get("ErrorMessage") or ""
+                print_formatted_text(HTML(
+                    f"Password retrieval <ansired>failed</ansired> "
+                    f"(HTTP {response.status_code}) for <i>{_esc(account_name)}</i> "
+                    f"in safe <i>{_esc(safe_name)}</i>: "
+                    f"{_esc(error_code)} {_esc(error_message)}"
+                ))
                 if error_code in skip_all:
                     return None
-                retry = button_dialog(
-                    title=f"{response.status_code}",
-                    text=HTML(
-                        f"Error {_esc(error_code)}: <ansired>{_esc(error.get('ErrorMessage', ''))}</ansired>\n"
-                        f"Account <i>{_esc(account_name)}</i> with ID <i>{_esc(account_id)}</i> in Safe <i>{_esc(safe_name)}</i>"
-                    ),
-                    buttons=[("Retry", True), ("Skip", False), ("Skip All", None)],
-                    style=Style.from_dict({"dialog": "bg:ansiblack"}),
-                ).run()
+                try:
+                    retry = button_dialog(
+                        title=f"{response.status_code}",
+                        text=HTML(
+                            f"Error {_esc(error_code)}: <ansired>{_esc(error_message)}</ansired>\n"
+                            f"Account <i>{_esc(account_name)}</i> with ID "
+                            f"<i>{_esc(account_id)}</i> in Safe <i>{_esc(safe_name)}</i>"
+                        ),
+                        buttons=[("Retry", True), ("Skip", False), ("Skip All", None)],
+                        style=Style.from_dict({"dialog": "bg:ansiblack"}),
+                    ).run()
+                except Exception:
+                    return None
                 if retry is None:
                     skip_all[error_code] = True
                     return None
                 if retry is False:
                     return None
+                url_index = 0
             else:
-                print_formatted_text(HTML(f"Password retrieval <ansired>aborted</ansired> (status {response.status_code})"))
+                print_formatted_text(HTML(
+                    f"Password retrieval <ansired>aborted</ansired> "
+                    f"(status {response.status_code})"
+                ))
                 return None
         return None

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -752,6 +752,14 @@ def _import(params, file_format, filename, **kwargs):
     show_skipped = kwargs.get('show_skipped') is True
     secret_ids = kwargs.get('secret_ids')
     target_node = kwargs.get('target_node')
+    cyberark_skip = {
+        x.strip().lower()
+        for x in str(kwargs.get('skip') or '').split(',')
+        if x.strip()
+    }
+    skip_team = kwargs.get('skip_team') is True or 'team' in cyberark_skip
+    skip_role = kwargs.get('skip_role') is True or 'role' in cyberark_skip
+    skip_user = kwargs.get('skip_user') is True or 'user' in cyberark_skip
 
     import_into_raw = kwargs.get('import_into') or ''
     import_into = import_into_raw
@@ -779,7 +787,8 @@ def _import(params, file_format, filename, **kwargs):
 
     for x in importer.execute(filename, params=params, users_only=import_users, filter_folder=filter_folder,
                               old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids,
-                              dry_run=dry_run, target_node=target_node, use_nsf=use_nsf):
+                              dry_run=dry_run, target_node=target_node, use_nsf=use_nsf,
+                              skip_team=skip_team, skip_role=skip_role, skip_user=skip_user):
         if isinstance(x, ImportRecord):
             if filter_folder and not importer.support_folder_filter():
                 if not x.folders:
@@ -2083,12 +2092,14 @@ def tokenize_record_key(record, folder):   # type: (ImportRecord, str) -> Iterat
                 yield hash_value
 
 
-def tokenize_full_import_record(record):   # type: (ImportRecord) -> Iterator[str]
+def tokenize_full_import_record(record, folder=None):   # type: (ImportRecord, Optional[str]) -> Iterator[str]
     """
     Turn a record-to-import into an iterable of str's for hashing.
 
     Examine the entire record.
     """
+    if folder is not None:
+        yield f'$folder:{folder.casefold()}'
     yield f'$type:{record.type or ""}'
     yield f'$title:{record.title or ""}'
     yield f'$login:{record.login or ""}'
@@ -2102,6 +2113,19 @@ def tokenize_full_import_record(record):   # type: (ImportRecord) -> Iterator[st
         hash_key = field.hash_key()
         if hash_key:
             yield hash_key
+
+
+def get_import_record_folder_paths(params, record):   # type: (KeeperParams, ImportRecord) -> List[str]
+    folders = []
+    for folder in record.folders or []:
+        if folder.uid and folder.uid in params.folder_cache:
+            folders.append(get_folder_path(params, folder.uid))
+        else:
+            folders.append(folder.get_folder_path())
+    folders = [x for x in folders if x]
+    if not folders:
+        folders.append('')
+    return folders
 
 
 def _construct_record_v2(rec_to_import, orig_extra=None):  # type: (ImportRecord, Optional[dict]) -> (dict, dict)
@@ -2327,8 +2351,13 @@ def prepare_record_add_or_update(update_flag, no_shortcuts, params, records):
     for record_uid in params.record_cache:
         import_record = convert_keeper_record(params.record_cache[record_uid])
         if import_record:
-            record_hash = build_record_hash(tokenize_full_import_record(import_record))
-            preexisting_entire_record_hash[record_hash] = record_uid
+            folders = [get_folder_path(params, x) for x in find_folders(params, record_uid)]
+            folders = [x for x in folders if x]
+            if len(folders) == 0:
+                folders.append('')
+            for folder in folders:
+                record_hash = build_record_hash(tokenize_full_import_record(import_record, folder))
+                preexisting_entire_record_hash[record_hash] = record_uid
             if update_flag:
                 folders = [get_folder_path(params, x) for x in find_folders(params, record_uid)]
                 folders = [x for x in folders if x]
@@ -2368,14 +2397,21 @@ def prepare_record_add_or_update(update_flag, no_shortcuts, params, records):
                     import_record.attachments.append(atta)
                     f.value = LARGE_FIELD_MSG.format(atta.name)
 
-        record_hash = build_record_hash(tokenize_full_import_record(import_record))
-        if no_shortcuts is False and record_hash in preexisting_entire_record_hash:
-            record_uid = preexisting_entire_record_hash[record_hash]
-            if import_record.uid:
-                external_lookup[import_record.uid] = record_uid
-            import_record.uid = record_uid
-            record_exists.append(import_record)
-            continue
+        if no_shortcuts is False:
+            record_uid = next((
+                preexisting_entire_record_hash[record_hash]
+                for record_hash in (
+                    build_record_hash(tokenize_full_import_record(import_record, folder))
+                    for folder in get_import_record_folder_paths(params, import_record)
+                )
+                if record_hash in preexisting_entire_record_hash
+            ), None)
+            if record_uid:
+                if import_record.uid:
+                    external_lookup[import_record.uid] = record_uid
+                import_record.uid = record_uid
+                record_exists.append(import_record)
+                continue
 
         if import_record.uid and import_record.uid in params.record_cache:
             record_uid_to_update.add(import_record.uid)

--- a/tests/test_cyberark_pam_import.py
+++ b/tests/test_cyberark_pam_import.py
@@ -836,6 +836,74 @@ class TestSSLVerification:
         assert client.verify_ssl is True
 
 
+class TestSelfHostedClientCert:
+
+    @patch("keepercommander.importer.cyberark.cyberark_pam.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark_pam.requests")
+    @patch("keepercommander.importer.cyberark.cyberark_pam.prompt")
+    @patch("keepercommander.importer.cyberark.cyberark_pam.socket.getaddrinfo",
+           return_value=[(2, 1, 6, '', ('93.184.216.34', 0))])
+    def test_auth_self_hosted_sends_client_cert(self, mock_dns, mock_prompt, mock_requests, mock_print):
+        mock_prompt.side_effect = ["Cyberark", "admin", "pass"]
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = "token123"
+        mock_requests.post.return_value = mock_resp
+
+        client = CyberArkPVWAClient("pvwa.example.com")
+        client.client_cert = ("cert.pem", "key.pem")
+
+        assert client._auth_self_hosted() is True
+        _, kwargs = mock_requests.post.call_args
+        assert kwargs.get("cert") == ("cert.pem", "key.pem")
+        assert kwargs.get("verify") is True
+        assert kwargs.get("allow_redirects") is not False
+
+    @patch("keepercommander.importer.cyberark.cyberark_pam.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark_pam.requests")
+    @patch("keepercommander.importer.cyberark.cyberark_pam.socket.getaddrinfo",
+           return_value=[(2, 1, 6, '', ('93.184.216.34', 0))])
+    def test_retrieve_password_sends_client_cert(self, mock_dns, mock_requests, mock_print):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = "secret"
+        mock_requests.post.return_value = mock_resp
+        client = CyberArkPVWAClient("pvwa.example.com")
+        client.client_cert = ("cert.pem", "key.pem")
+        client.auth_token = "session-token"
+        assert client.retrieve_password("12_3", "acct", "Safe") == "secret"
+        _, kwargs = mock_requests.post.call_args
+        assert kwargs.get("cert") == ("cert.pem", "key.pem")
+        assert kwargs.get("json") == {"reason": "test"}
+        assert kwargs.get("allow_redirects") is False
+
+    @patch("keepercommander.importer.cyberark.cyberark_pam.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.pam.client.CyberArkPVWAClient._load_p12_client_cert",
+           return_value=("cert.pem", "key.pem"))
+    @patch("keepercommander.importer.cyberark.pam.client.path.isfile", return_value=True)
+    @patch("keepercommander.importer.cyberark.cyberark_pam.socket.getaddrinfo",
+           return_value=[(2, 1, 6, '', ('93.184.216.34', 0))])
+    def test_maybe_configure_client_cert_from_env(self, mock_dns, mock_isfile, mock_load, mock_print, monkeypatch):
+        monkeypatch.setenv("KEEPER_CYBERARK_CLIENT_CERT_P12", "client.p12")
+        monkeypatch.setenv("KEEPER_CYBERARK_CLIENT_CERT_PASSWORD", "p12-secret")
+        client = CyberArkPVWAClient("pvwa.example.com")
+        assert client._maybe_configure_client_cert() is True
+        assert client.client_cert == ("cert.pem", "key.pem")
+
+    @patch("keepercommander.importer.cyberark.cyberark_pam.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.pam.client.CyberArkPVWAClient._load_p12_client_cert",
+           return_value=("cert.pem", "key.pem"))
+    @patch("keepercommander.importer.cyberark.pam.client.path.isfile", return_value=True)
+    @patch("keepercommander.importer.cyberark.cyberark_pam.socket.getaddrinfo",
+           return_value=[(2, 1, 6, '', ('93.184.216.34', 0))])
+    def test_maybe_configure_client_cert_from_legacy_env(self, mock_dns, mock_isfile, mock_load, mock_print, monkeypatch):
+        monkeypatch.setenv("_CYBERARK_CLIENT_CERT_P12", "legacy-client.p12")
+        monkeypatch.setenv("_CYBERARK_CLIENT_CERT_PASSWORD", "legacy-secret")
+        client = CyberArkPVWAClient("pvwa.example.com")
+        assert client._maybe_configure_client_cert() is True
+        assert client.client_cert == ("cert.pem", "key.pem")
+
+
 # ── CyberArkPAMImportCommand Tests ──────────────────────────
 
 
@@ -867,6 +935,8 @@ class TestCyberArkPAMImportCommandParser:
             "--platform-map", "map.json",
             "--state-filter", "active,inactive",
             "--no-verify-ssl",
+            "--client-cert-p12", "client.p12",
+            "--client-cert-password", "secret",
         ])
         assert args.server == "pvwa.example.com"
         assert args.project_name == "My Project"
@@ -891,6 +961,8 @@ class TestCyberArkPAMImportCommandParser:
         assert args.platform_map == "map.json"
         assert args.state_filter == "active,inactive"
         assert args.no_verify_ssl is True
+        assert args.client_cert_p12 == "client.p12"
+        assert args.client_cert_password == "secret"
 
     def test_minimal_args(self):
         cmd = CyberArkPAMImportCommand()
@@ -1417,6 +1489,132 @@ class TestExistingImporterUnchanged:
         assert expected_endpoints.items() <= CyberArkImporter.ENDPOINTS.items()
 
 
+class TestClassicCyberArkMetadataImport:
+    """Metadata preservation for ``import --format=cyberark``."""
+
+    def test_account_name_becomes_keeper_title(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        account = {
+            "id": "account-1",
+            "name": "demo account",
+            "platformId": "GenericPlatform",
+            "platformAccountProperties": {
+                "ItemName": "friendly name",
+            },
+        }
+
+        assert CyberArkImporter._account_title(account) == "demo account"
+
+    def test_imports_relevant_platform_fields_only(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record, RecordField
+
+        account = {
+            "id": "account-2",
+            "name": "demo account",
+            "platformName": "Generic Platform",
+            "deviceType": "Server",
+            "safeName": "Source Safe",
+            "address": "host.example.com",
+            "userName": "admin",
+            "createdTime": 1756374692000,
+            "modifiedTime": 1756374700000,
+            "secretManagement": {"status": "success"},
+            "platformAccountProperties": {
+                "OwnerName": "service-owner",
+                "Environment": {"Name": "prod"},
+                "Enabled": False,
+                "Aliases": ["primary", "legacy"],
+                "Protocol": "SSH",
+                "Address": "host.example.com",
+                "Username": "admin",
+            },
+        }
+        record = Record()
+        record.title = account["name"]
+        record.login = account["userName"]
+        record.fields.append(RecordField(
+            "host", value={"hostName": account["address"]},
+        ))
+
+        CyberArkImporter._add_account_metadata(record, account)
+
+        fields = {field.label: field.value for field in record.fields if field.label}
+        assert fields["Platform Name"] == "Generic Platform"
+        assert fields["Device Type"] == "Server"
+        assert fields["Owner Name"] == "service-owner"
+        assert fields["Environment.Name"] == "prod"
+        assert fields["Enabled"] == "false"
+        assert fields["Aliases"] == '["primary","legacy"]'
+        assert fields["Protocol"] == "SSH"
+        assert "id" not in fields
+        assert "safeName" not in fields
+        assert "createdTime" not in fields
+        assert "modifiedTime" not in fields
+        assert "secretManagement" not in fields
+        assert "Address" not in fields
+        assert "Username" not in fields
+
+    def test_standard_mapped_platform_properties_are_not_duplicated(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record, RecordField
+
+        account = {
+            "platformAccountProperties": {
+                "ItemName": "server-title",
+                "URL": "https://server.example.com",
+                "LogonDomain": "CORP",
+                "Account Name": "sample-user",
+                "Address": "server.example.com",
+                "Port": "3389",
+                "Protocol": "RDP",
+                "Device Type": "Generic Device",
+            },
+        }
+        record = Record()
+        record.title = "server-title"
+        record.login = "CORP\\sample-user"
+        record.login_url = "https://server.example.com"
+        record.fields.append(RecordField(
+            "host", value={"hostName": "server.example.com", "port": "3389"},
+        ))
+
+        CyberArkImporter._add_account_metadata(record, account)
+
+        custom_fields = {field.label: field.value for field in record.fields if field.label}
+        assert custom_fields == {
+            "Protocol": "RDP",
+            "Device Type": "Generic Device",
+        }
+
+    def test_metadata_is_serialized_as_keeper_custom_fields(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record
+        from keepercommander.importer.imp_exp import _construct_record_v3_data
+
+        record = Record()
+        record.title = "server-account"
+        record.type = "login"
+        CyberArkImporter._add_account_metadata(record, {
+            "platformId": "GenericPlatform",
+            "platformAccountProperties": {
+                "Protocol": "SSH",
+                "Device Type": "Server",
+            },
+        })
+
+        data = _construct_record_v3_data(record)
+        custom = {
+            field.get("label"): field.get("value", [None])[0]
+            for field in data["custom"] if field.get("label")
+        }
+
+        assert custom["Platform Name"] == "GenericPlatform"
+        assert custom["Protocol"] == "SSH"
+        assert custom["Device Type"] == "Server"
+
+
 # ── Phase 2 Tests: System Safe Exclusion + Safe Filtering ─────
 
 class TestSystemSafeExclusion:
@@ -1905,6 +2103,310 @@ class TestImportTargetNodeArgparse:
         with patch("keepercommander.importer.commands.imp_exp._import") as mock_import:
             cmd.execute(params, format="cyberark", name="https://pvwa", target_node="Eng")
         assert mock_import.call_args.kwargs.get("target_node") == "Eng"
+
+
+class TestClassicCyberArkSkipProvisioningArgs:
+    """Skip flags for ``import --format=cyberark``."""
+
+    @pytest.mark.parametrize("skip_value,expected", [
+        ("team", "team"),
+        ("role", "role"),
+        ("user", "user"),
+        ("team,role,user", "team,role,user"),
+        ("teams,roles,users", "team,role,user"),
+    ])
+    def test_parser_accepts_skip_targets(self, skip_value, expected):
+        from keepercommander.importer.commands import import_parser
+
+        ns = import_parser.parse_args([
+            "--format", "cyberark", f"--skip={skip_value}", "https://pvwa",
+        ])
+
+        assert ns.skip == expected
+
+    @pytest.mark.parametrize("flag", [
+        "--skipt-team",
+        "--skip-team",
+        "--skip-role",
+        "--skip-user",
+    ])
+    def test_parser_rejects_old_skip_flags(self, flag):
+        from keepercommander.importer.commands import import_parser
+        from keepercommander.commands.base import ParseError
+
+        with pytest.raises(ParseError):
+            import_parser.parse_args([
+                "--format", "cyberark", flag, "https://pvwa",
+            ])
+
+    def test_parser_rejects_unknown_skip_target(self):
+        from keepercommander.importer.commands import import_parser
+        from keepercommander.commands.base import ParseError
+
+        with pytest.raises(ParseError):
+            import_parser.parse_args([
+                "--format", "cyberark", "--skip=folder", "https://pvwa",
+            ])
+
+    def test_skip_targets_are_forwarded_for_cyberark(self):
+        from keepercommander.importer.commands import RecordImportCommand
+
+        params = MagicMock(enforcements=None)
+        with patch("keepercommander.importer.commands.imp_exp._import") as mock_import:
+            RecordImportCommand().execute(
+                params, format="cyberark", name="https://pvwa",
+                skip="team,role,user",
+            )
+
+        forwarded = mock_import.call_args.kwargs
+        assert forwarded["skip"] == "team,role,user"
+
+    def test_generic_import_engine_forwards_skip_targets_to_cyberark_importer(self):
+        from keepercommander.importer import imp_exp
+
+        class StopAfterCapture(Exception):
+            pass
+
+        captured = {}
+
+        class CapturingImporter:
+            verbose_import_summary = False
+
+            def execute(self, _filename, **kwargs):
+                captured.update(kwargs)
+                raise StopAfterCapture()
+
+        params = MagicMock()
+        params.record_cache = {}
+
+        with patch.object(imp_exp, "importer_for_format", return_value=CapturingImporter):
+            with pytest.raises(StopAfterCapture):
+                imp_exp._import(
+                    params, "cyberark", "https://pvwa",
+                    skip="team,role,user",
+                )
+
+        assert captured["skip_team"] is True
+        assert captured["skip_role"] is True
+        assert captured["skip_user"] is True
+
+    def test_skip_targets_are_ignored_for_other_formats(self):
+        from keepercommander.importer.commands import RecordImportCommand
+
+        params = MagicMock(enforcements=None)
+        with patch("keepercommander.importer.commands.imp_exp._import") as mock_import:
+            RecordImportCommand().execute(
+                params, format="json", name="vault.json",
+                skip="team,role,user",
+            )
+
+        forwarded = mock_import.call_args.kwargs
+        assert forwarded["skip"] == ""
+
+    @staticmethod
+    def _group_response():
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "value": [{
+                "id": "group-1",
+                "groupName": "Operations",
+                "members": [{"username": "operator"}],
+            }],
+        }
+        return response
+
+    @staticmethod
+    def _account_response():
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "value": [{
+                "id": "account-1",
+                "safeName": "SourceSafe",
+                "name": "demo account",
+                "platformId": "GenericPlatform",
+                "address": "host.example.com",
+                "userName": "admin",
+                "platformAccountProperties": {"Protocol": "SSH", "port": "2222"},
+            }],
+        }
+        return response
+
+    @patch("keepercommander.importer.cyberark.cyberark.sleep")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
+    def test_skip_user_does_not_fetch_cyberark_users_or_reprint_account_table(self, progress_bar, mock_print, _sleep):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        class FakeProgressBar:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __call__(self, iterable, total=None):
+                return iterable
+
+        progress_bar.side_effect = FakeProgressBar
+
+        importer = CyberArkImporter()
+        importer._authenticate_pvwa = MagicMock(return_value=("pvwa.example.com", "token", {}))
+        importer._resolve_safes = MagicMock(return_value=["SourceSafe"])
+        importer.get_response = MagicMock(return_value=self._account_response())
+        importer.fetch_cyberark_users = MagicMock(return_value=[])
+        importer._enterprise_existing = MagicMock(return_value=(set(), set(), {}))
+        importer._confirm_import = MagicMock(return_value=True)
+        password_response = MagicMock(status_code=200)
+        password_response.text = '"secret"'
+        importer._request = MagicMock(return_value=password_response)
+
+        records = list(importer._do_import_inner(
+            "https://pvwa.example.com", params=MagicMock(),
+            skip_team=True, skip_role=True, skip_user=True,
+        ))
+
+        importer.fetch_cyberark_users.assert_not_called()
+        assert len(records) == 1
+        typed_fields = {field.type: field.value for field in records[0].fields if not field.label}
+        custom_fields = {field.label: field.value for field in records[0].fields if field.label}
+        assert typed_fields["host"] == {"hostName": "host.example.com", "port": "2222"}
+        assert custom_fields == {
+            "Protocol": "SSH",
+            "Platform Name": "GenericPlatform",
+        }
+        table_prints = [
+            call for call in mock_print.call_args_list
+            if len(call.args) > 1 and "demo account" in str(call.args)
+        ]
+        assert len(table_prints) == 1
+
+    @patch("keepercommander.importer.cyberark.cyberark.api.execute_batch")
+    @patch("keepercommander.importer.cyberark.cyberark.api.query_enterprise")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.path.isfile", return_value=False)
+    def test_skip_team_still_allows_roles_and_users(self, _isfile, _print, _query, execute_batch):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        importer = CyberArkImporter()
+        importer.get_response = MagicMock(return_value=self._group_response())
+        importer._create_keeper_roles = MagicMock()
+        importer._create_keeper_users_and_assign_roles = MagicMock()
+        params = MagicMock()
+        params.enterprise = {"teams": [], "queued_teams": []}
+
+        importer.import_user_groups(
+            "pvwa.example.com", "token", params,
+            cyberark_users=[], node_id=1, skip_teams=True,
+        )
+
+        execute_batch.assert_not_called()
+        importer._create_keeper_roles.assert_called_once()
+        importer._create_keeper_users_and_assign_roles.assert_called_once()
+
+    @patch("keepercommander.importer.cyberark.cyberark.api.execute_batch")
+    @patch("keepercommander.importer.cyberark.cyberark.api.query_enterprise")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.path.isfile", return_value=False)
+    def test_all_skip_flags_prevent_all_enterprise_writes(self, _isfile, _print, _query, execute_batch):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        importer = CyberArkImporter()
+        importer.get_response = MagicMock(return_value=self._group_response())
+        importer._create_keeper_roles = MagicMock()
+        importer._create_keeper_users_and_assign_roles = MagicMock()
+        params = MagicMock()
+        params.enterprise = {"teams": [], "queued_teams": []}
+
+        importer.import_user_groups(
+            "pvwa.example.com", "token", params,
+            cyberark_users=[], node_id=1, skip_teams=True,
+            skip_roles=True, skip_users=True,
+        )
+
+        execute_batch.assert_not_called()
+        importer._create_keeper_roles.assert_not_called()
+        importer._create_keeper_users_and_assign_roles.assert_not_called()
+
+
+class TestImportDuplicateDetection:
+    """Duplicate detection should be scoped to the target folder."""
+
+    @staticmethod
+    def _params(existing_folder_uid):
+        def folder(name, parent_uid):
+            node = MagicMock()
+            node.name = name
+            node.parent_uid = parent_uid
+            node.type = "user_folder"
+            return node
+
+        params = MagicMock()
+        params.record_cache = {
+            "existing_uid": {
+                "record_uid": "existing_uid",
+                "version": 3,
+                "data_unencrypted": json.dumps({
+                    "title": "demo account",
+                    "type": "serverCredentials",
+                    "notes": "",
+                    "fields": [
+                        {"type": "login", "value": ["admin"]},
+                        {"type": "password", "value": ["secret"]},
+                        {"type": "host", "value": [{"hostName": "host.example.com"}]},
+                    ],
+                    "custom": [],
+                }),
+            },
+        }
+        params.record_type_cache = {}
+        params.subfolder_record_cache = {
+            existing_folder_uid: {"existing_uid"},
+        }
+        params.folder_cache = {
+            "migration": folder("TargetRoot", ""),
+            "target": folder("TargetFolder", "migration"),
+            "other": folder("OtherFolder", ""),
+        }
+        return params
+
+    @staticmethod
+    def _record():
+        from keepercommander.importer.importer import Folder, Record, RecordField
+
+        record = Record()
+        record.title = "demo account"
+        record.type = "serverCredentials"
+        record.login = "admin"
+        record.password = "secret"
+        record.fields.append(RecordField(
+            "host", value={"hostName": "host.example.com"},
+        ))
+        folder = Folder()
+        folder.path = "TargetRoot\\TargetFolder"
+        record.folders = [folder]
+        return record
+
+    def test_matching_record_in_different_folder_is_imported(self):
+        from keepercommander.importer.imp_exp import prepare_record_add_or_update
+
+        records_to_import, record_exists, _ = prepare_record_add_or_update(
+            False, False, self._params("other"), [self._record()],
+        )
+
+        assert len(records_to_import) == 1
+        assert record_exists == []
+        assert records_to_import[0].uid != "existing_uid"
+
+    def test_matching_record_in_same_folder_is_skipped(self):
+        from keepercommander.importer.imp_exp import prepare_record_add_or_update
+
+        records_to_import, record_exists, _ = prepare_record_add_or_update(
+            False, False, self._params("target"), [self._record()],
+        )
+
+        assert records_to_import == []
+        assert len(record_exists) == 1
+        assert record_exists[0].uid == "existing_uid"
 
 
 class TestListSafesDetailed:
@@ -3330,12 +3832,12 @@ class TestRealDataEdgeCases:
         assert result is not None
         assert result["type"] == "pamMachine"
 
-    def test_palo_alto_maps_to_ssh(self):
+    def test_generic_network_account_maps_to_ssh(self):
         mapper = AccountMapper()
         account = {
-            "id": "25_28", "name": "Network Device-PaloAltoNetworks-10.8.8.8-palo",
-            "platformId": "PaloAltoNetworks",
-            "address": "10.8.8.8", "userName": "palo",
+            "id": "network-account-1", "name": "network-device-sample",
+            "platformId": "UnixSSH",
+            "address": "192.0.2.10", "userName": "network-user",
         }
         result = mapper.map_account(account, "pass")
         assert result["type"] == "pamMachine"
@@ -3568,11 +4070,11 @@ REAL_PVWA_ACCOUNTS = [
      "secretManagement": {"automaticManagementEnabled": True},
      "createdTime": 1670950940},
 
-    # Network device — PaloAlto
-    {"id": "25_28",
-     "name": "Network Device-PaloAltoNetworks-10.8.8.8-palo",
-     "platformId": "PaloAltoNetworks", "safeName": "Test",
-     "address": "10.8.8.8", "userName": "palo", "secretType": "password",
+    # Generic network device account
+    {"id": "network-account-1",
+     "name": "network-device-sample",
+     "platformId": "UnixSSH", "safeName": "Test",
+     "address": "192.0.2.10", "userName": "network-user", "secretType": "password",
      "platformAccountProperties": {},
      "secretManagement": {"automaticManagementEnabled": True},
      "createdTime": 1692833795},
@@ -3810,11 +4312,11 @@ class TestResourceOutputStructure:
         assert "FAILURE" in notes
         assert u["rotation_settings"]["enabled"] == "off"
 
-    def test_palo_alto_network_device(self):
+    def test_generic_network_device(self):
         data, _, _, _ = _run_full_pipeline()
-        r = self._find_resource(data, "palo")
+        r = self._find_resource(data, "network-device-sample")
         assert r["type"] == "pamMachine"
-        assert r["host"] == "10.8.8.8"
+        assert r["host"] == "192.0.2.10"
         assert r["pam_settings"]["connection"]["protocol"] == "ssh"
 
     def test_empty_platform_id_handled(self):


### PR DESCRIPTION
## Summary

Updates the classic `import --format=cyberark` flow to preserve relevant CyberArk platform metadata as Keeper custom fields

## Changes

- Adds support for `--skip=team,role,user` to selectively skip CyberArk team, role and user provisioning.
- Preserves relevant CyberArk platform metadata as Keeper custom fields.