### PR TITLE
Block '--' and legacy commands as Service Mode bypass vectors

### DIFF
--- a/keepercommander/service/util/command_util.py
+++ b/keepercommander/service/util/command_util.py
@@ -164,7 +164,7 @@ class CommandExecutor:
             command = ensure_record_add_json_format(html.unescape(command))
 
             try:
-                command_tokens = shlex.split(command)
+                command_tokens = shlex.split(command.replace('\\', '\\\\'))
             except ValueError:
                 command_tokens = command.split()
 

--- a/keepercommander/service/util/request_validation.py
+++ b/keepercommander/service/util/request_validation.py
@@ -83,12 +83,17 @@ class RequestValidator:
                     
                     # Replace FILEDATA placeholder with temporary file path, but only when it's used as a file parameter
                     # Supports: PAM import (--filename), Import (positional), Enterprise-push (positional)
+                    # Callable replacement -- a plain string would let a Windows path's backslashes be parsed as regex backreferences.
                     file_param_pattern = r'(--filename[=\s]+["\']?)FILEDATA(["\']?)'
-                    processed_command = re.sub(file_param_pattern, f'\\1{temp_file_path}\\2', processed_command)
-                    
+                    processed_command = re.sub(
+                        file_param_pattern,
+                        lambda m: f'{m.group(1)}{temp_file_path}{m.group(2)}',
+                        processed_command,
+                    )
+
                     # Also handle standalone FILEDATA (not in quotes)
                     standalone_pattern = r'\bFILEDATA\b(?!["\'])'
-                    processed_command = re.sub(standalone_pattern, temp_file_path, processed_command)
+                    processed_command = re.sub(standalone_pattern, lambda _: temp_file_path, processed_command)
                     
                     logger.debug(f"Created temporary file {temp_file_path} for filedata")
                     

--- a/keepercommander/service/util/verified_command.py
+++ b/keepercommander/service/util/verified_command.py
@@ -17,6 +17,25 @@ class Verifycommand:
     # Aliases from record.py — CommandExecutor checks tokens before cli expands them.
     _RECORD_EDIT_COMMANDS = frozenset({'record-add', 'ra', 'record-update', 'ru'})
 
+    # Legacy Commands category — plugin-based rotation/connection commands have no safe Service Mode form
+    # and are blocked unconditionally, regardless of what an API key's command_list allows.
+    _LEGACY_COMMANDS = frozenset({
+        'rotate', 'r',
+        'connect', 'ssh', 'ssh-agent', 'rdp', 'rsync',
+        'set', 'echo',
+        'mysql', 'postgresql', 'pg',
+        'run-as', 'supershell', 'ss',
+    })
+    _LEGACY_COMMAND_MSG = (
+        'Legacy commands are not permitted through Service Mode'
+    )
+
+    # GroupCommand.execute_args (commands/base.py) strips a leading '-- ' at each
+    # nested group boundary, desyncing position-based checks below (e.g. pam tunnel).
+    _DOUBLE_DASH_MSG = (
+        "The '--' argument separator is not permitted through Service Mode"
+    )
+
     # WARNING: everything below is a DENYLIST. Any command/flag that reads or
     # writes a host file and is NOT enumerated here is allowed by default.
     # Adding a new command with local file I/O? Add it here, or it silently
@@ -65,6 +84,8 @@ class Verifycommand:
             return None
 
         for validator in (
+            Verifycommand.validate_service_mode_double_dash,
+            Verifycommand.validate_service_mode_legacy_command,
             Verifycommand.validate_service_mode_pam_tunnel_command,
             Verifycommand.validate_service_mode_download_attachment_command,
             Verifycommand.validate_service_mode_upload_attachment_command,
@@ -77,6 +98,22 @@ class Verifycommand:
             if error:
                 return error
         return None
+
+    @staticmethod
+    def validate_service_mode_double_dash(command_tokens, request_temp_dir=None):
+        """Block bare '--' anywhere in Service Mode input; error or None."""
+        if '--' in command_tokens:
+            return Verifycommand._DOUBLE_DASH_MSG
+        return None
+
+    @staticmethod
+    def validate_service_mode_legacy_command(command_tokens, request_temp_dir=None):
+        """Block legacy commands in Service Mode; error or None."""
+        if not command_tokens:
+            return None
+        if command_tokens[0].lower() not in Verifycommand._LEGACY_COMMANDS:
+            return None
+        return Verifycommand._LEGACY_COMMAND_MSG
 
     @staticmethod
     def validate_service_mode_pam_tunnel_command(command_tokens, request_temp_dir=None):
@@ -370,8 +407,11 @@ class Verifycommand:
         if not path or not request_temp_dir:
             return False
         try:
-            resolved = os.path.realpath(os.path.expanduser(path))
-            root = os.path.realpath(request_temp_dir)
+            expanded = os.path.expanduser(path)
+            if os.path.islink(expanded):
+                return False
+            resolved = os.path.normcase(os.path.abspath(expanded))
+            root = os.path.normcase(os.path.abspath(request_temp_dir))
             return resolved == root or resolved.startswith(root + os.sep)
         except (OSError, ValueError):
             return False

--- a/unit-tests/pam/test_pam_project_export.py
+++ b/unit-tests/pam/test_pam_project_export.py
@@ -247,6 +247,7 @@ class TestPAMProjectExportCommand(unittest.TestCase):
             for key in ("uid", "type", "title", "login"):
                 self.assertIn(key, usr, f"user missing key: {key}")
 
+    @unittest.skipIf(os.name == 'nt', 'NTFS has no POSIX permission bits; chmod is a no-op on Windows')
     def test_output_file_mode_is_private(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             tmp_path = tmp.name
@@ -259,6 +260,7 @@ class TestPAMProjectExportCommand(unittest.TestCase):
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
 
+    @unittest.skipIf(os.name == 'nt', 'NTFS has no POSIX permission bits; chmod is a no-op on Windows')
     def test_output_file_mode_overwrites_existing_world_readable(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             tmp.write("{}")

--- a/unit-tests/service/test_verified_command.py
+++ b/unit-tests/service/test_verified_command.py
@@ -13,7 +13,7 @@ def _tokens(command: str):
     """Same normalization CommandExecutor uses before policy checks."""
     command = unescape(command)
     try:
-        return shlex.split(command)
+        return shlex.split(command.replace('\\', '\\\\'))
     except ValueError:
         return command.split()
 
@@ -289,6 +289,78 @@ class TestServiceModeCommandPolicy(TestCase):
         self.assertIsNone(
             check(_tokens('credential-provision --config-base64 dGVzdA== -c PAMUID'))
         )
+
+    def test_legacy_commands_blocked_regardless_of_command_list(self):
+        """rotate/connect/ssh/etc. must be denied unconditionally -- this is not
+        an allow-list check, so it isn't affected by what an API key's
+        command_list permits."""
+        check = Verifycommand.validate_service_mode_restrictions
+        ban = 'Legacy commands'
+        for cmd in (
+            'rotate --match ".*" --force --plugin ssh --host 1.2.3.4 --port 22',
+            'rotate RECORD_UID',
+            'connect RECORD_UID',
+            'ssh RECORD_UID',
+            'ssh-agent list',
+            'rdp RECORD_UID',
+            'rsync',
+            'set var value',
+            'echo hello',
+            'mysql RECORD_UID',
+            'postgresql RECORD_UID',
+            'run-as -r RECORD_UID --application cmd.exe',
+            'supershell',
+            'ss',
+        ):
+            with self.subTest(cmd=cmd):
+                err = check(_tokens(cmd))
+                self.assertIsNotNone(err)
+                self.assertIn(ban, err)
+
+        # Aliases checked before cli expansion (r -> rotate, pg -> postgresql).
+        self.assertIn(ban, check(_tokens('r --match ".*" --force --host 1.2.3.4 --port 22')))
+        self.assertIn(ban, check(_tokens('pg RECORD_UID')))
+
+        # Unrelated commands remain unaffected.
+        self.assertIsNone(check(_tokens('get RECORD_UID')))
+        self.assertIsNone(check(_tokens('record-add --title t -rt login login=user')))
+
+    def test_double_dash_blocked_everywhere(self):
+        """'--' used to desync position-based checks (pam tunnel verb, pam project path)."""
+        check = Verifycommand.validate_service_mode_restrictions
+        ban = "'--'"
+        for cmd in (
+            'pam -- tunnel start uid --run id',
+            'pam -- tunnel stop uid',
+            'pam -- tunnel list',
+            'pam -- t s uid',
+            'pam -- project export -o /etc/passwd',
+            'pam -- project import -f -etc/passwd',
+            'get -- RECORD_UID',
+        ):
+            with self.subTest(cmd=cmd):
+                err = check(_tokens(cmd))
+                self.assertIsNotNone(err)
+                self.assertIn(ban, err)
+
+        # Unrelated commands without a bare '--' token remain unaffected.
+        self.assertIsNone(check(_tokens('pam tunnel edit uid')))
+        self.assertIsNone(check(_tokens('get RECORD_UID')))
+
+    def test_temp_path_leaf_symlink_is_not_containment(self):
+        """A symlink planted at the temp-dir leaf must not escape containment."""
+        request_temp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, request_temp_dir, ignore_errors=True)
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir, ignore_errors=True)
+
+        link_path = os.path.join(request_temp_dir, 'escape.json')
+        try:
+            os.symlink(outside_dir, link_path)
+        except OSError:
+            self.skipTest('symlinks not supported in this environment')
+
+        self.assertFalse(Verifycommand._is_service_temp_path(link_path, request_temp_dir))
 
     def test_is_record_file_attachment_arg(self):
         is_file = Verifycommand._is_record_file_attachment_arg


### PR DESCRIPTION
## Summary
Fixed bypass of Service Mode's command restrictions to run commands they shouldn't be able to, including running arbitrary commands on the server.

## Changes
- Blocked a hidden trick (`--`) that let restricted commands slip past the security check and run anyway.
- Fully blocked a set of old/legacy commands in Service Mode that were never safe to allow there.
- Fixed a Windows-only bug that crashed file uploads when the file path contained certain characters.
- Fixed a Windows-only bug where a valid file path was incorrectly rejected as unsafe.