### PR TITLE
KC-1456: Enforce allow_pam_gateway policy on pam gateway new/remove

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -3754,6 +3754,28 @@ def _is_rotation_allowed_by_enforcement(params):
         return True
 
 
+def ensure_gateway_management_allowed(params):
+    # type: (KeeperParams) -> bool
+    """Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
+    (confirmed via live account_summary payload). Prints an error and returns
+    False when the user's enterprise enforcement disallows Gateway management.
+    Shared by both PAMCreateGatewayCommand and PAMGatewayRemoveCommand (and
+    their legacy discoveryrotation_v1 counterparts) to avoid duplicating the
+    check at every call site.
+    """
+    try:
+        from .workflow.helpers import is_pam_action_allowed_by_enforcement
+    except ImportError as _e:
+        logging.debug('workflow.helpers not available; skipping gateway enforcement check: %s', _e)
+        return True
+
+    if not is_pam_action_allowed_by_enforcement(params, 'allow_pam_gateway'):
+        print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
+              f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
+        return False
+    return True
+
+
 class PAMGatewayActionRotateCommand(Command):
     parser = argparse.ArgumentParser(prog='pam action rotate')
     parser.add_argument('--record-uid', '-r', dest='record_uid', action='store',
@@ -4393,18 +4415,8 @@ class PAMGatewayRemoveCommand(Command):
         return PAMGatewayRemoveCommand.dr_remove_controller_parser
 
     def execute(self, params, **kwargs):
-        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
-        # (confirmed via live account_summary payload). Bail before any further
-        # work when the user's enterprise enforcement disallows Gateway management.
-        try:
-            from .workflow.helpers import is_pam_action_allowed_by_enforcement
-            if not is_pam_action_allowed_by_enforcement(
-                    params, 'allow_pam_gateway'):
-                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
-                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
-                return
-        except ImportError:
-            pass
+        if not ensure_gateway_management_allowed(params):
+            return
 
         gateway_name = kwargs.get('gateway')
         gateways = gateway_helper.get_all_gateways(params)
@@ -4474,18 +4486,8 @@ class PAMCreateGatewayCommand(Command):
         return PAMCreateGatewayCommand.dr_create_controller_parser
 
     def execute(self, params, **kwargs):
-        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
-        # (confirmed via live account_summary payload). Bail before any further
-        # work when the user's enterprise enforcement disallows Gateway management.
-        try:
-            from .workflow.helpers import is_pam_action_allowed_by_enforcement
-            if not is_pam_action_allowed_by_enforcement(
-                    params, 'allow_pam_gateway'):
-                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
-                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
-                return
-        except ImportError:
-            pass
+        if not ensure_gateway_management_allowed(params):
+            return
 
         gateway_name = kwargs.get('gateway_name')
         ksm_app = kwargs.get('ksm_app')

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -4393,6 +4393,19 @@ class PAMGatewayRemoveCommand(Command):
         return PAMGatewayRemoveCommand.dr_remove_controller_parser
 
     def execute(self, params, **kwargs):
+        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
+        # (confirmed via live account_summary payload). Bail before any further
+        # work when the user's enterprise enforcement disallows Gateway management.
+        try:
+            from .workflow.helpers import is_pam_action_allowed_by_enforcement
+            if not is_pam_action_allowed_by_enforcement(
+                    params, 'allow_pam_gateway'):
+                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
+                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
+                return
+        except ImportError:
+            pass
+
         gateway_name = kwargs.get('gateway')
         gateways = gateway_helper.get_all_gateways(params)
 
@@ -4461,6 +4474,18 @@ class PAMCreateGatewayCommand(Command):
         return PAMCreateGatewayCommand.dr_create_controller_parser
 
     def execute(self, params, **kwargs):
+        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
+        # (confirmed via live account_summary payload). Bail before any further
+        # work when the user's enterprise enforcement disallows Gateway management.
+        try:
+            from .workflow.helpers import is_pam_action_allowed_by_enforcement
+            if not is_pam_action_allowed_by_enforcement(
+                    params, 'allow_pam_gateway'):
+                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
+                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
+                return
+        except ImportError:
+            pass
 
         gateway_name = kwargs.get('gateway_name')
         ksm_app = kwargs.get('ksm_app')

--- a/keepercommander/commands/discoveryrotation_v1.py
+++ b/keepercommander/commands/discoveryrotation_v1.py
@@ -1710,6 +1710,19 @@ class PAMGatewayRemoveCommand(Command):
         return PAMGatewayRemoveCommand.dr_remove_controller_parser
 
     def execute(self, params, **kwargs):
+        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
+        # (confirmed via live account_summary payload). Bail before any further
+        # work when the user's enterprise enforcement disallows Gateway management.
+        try:
+            from .workflow.helpers import is_pam_action_allowed_by_enforcement
+            if not is_pam_action_allowed_by_enforcement(
+                    params, 'allow_pam_gateway'):
+                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
+                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
+                return
+        except ImportError:
+            pass
+
         gateway_name = kwargs.get('gateway')
         gateways = gateway_helper.get_all_gateways(params)
 
@@ -1745,6 +1758,18 @@ class PAMCreateGatewayCommand(Command):
         return PAMCreateGatewayCommand.dr_create_controller_parser
 
     def execute(self, params, **kwargs):
+        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
+        # (confirmed via live account_summary payload). Bail before any further
+        # work when the user's enterprise enforcement disallows Gateway management.
+        try:
+            from .workflow.helpers import is_pam_action_allowed_by_enforcement
+            if not is_pam_action_allowed_by_enforcement(
+                    params, 'allow_pam_gateway'):
+                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
+                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
+                return
+        except ImportError:
+            pass
 
         gateway_name = kwargs.get('gateway_name')
         ksm_app = kwargs.get('ksm_app')

--- a/keepercommander/commands/discoveryrotation_v1.py
+++ b/keepercommander/commands/discoveryrotation_v1.py
@@ -22,7 +22,7 @@ import requests
 from keeper_secrets_manager_core.utils import url_safe_str_to_bytes
 
 from .base import Command, GroupCommand, user_choice, dump_report_data, report_output_parser, json_output_parser, field_to_title, FolderMixin
-from .discoveryrotation import PAMLegacyCommand
+from .discoveryrotation import PAMLegacyCommand, ensure_gateway_management_allowed
 from .folder import FolderMoveCommand
 from .ksm import KSMCommand
 from .pam import gateway_helper, router_helper
@@ -1710,18 +1710,8 @@ class PAMGatewayRemoveCommand(Command):
         return PAMGatewayRemoveCommand.dr_remove_controller_parser
 
     def execute(self, params, **kwargs):
-        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
-        # (confirmed via live account_summary payload). Bail before any further
-        # work when the user's enterprise enforcement disallows Gateway management.
-        try:
-            from .workflow.helpers import is_pam_action_allowed_by_enforcement
-            if not is_pam_action_allowed_by_enforcement(
-                    params, 'allow_pam_gateway'):
-                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
-                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
-                return
-        except ImportError:
-            pass
+        if not ensure_gateway_management_allowed(params):
+            return
 
         gateway_name = kwargs.get('gateway')
         gateways = gateway_helper.get_all_gateways(params)
@@ -1758,18 +1748,8 @@ class PAMCreateGatewayCommand(Command):
         return PAMCreateGatewayCommand.dr_create_controller_parser
 
     def execute(self, params, **kwargs):
-        # Per-user enforcement gate on the 'allow_pam_gateway' role enforcement
-        # (confirmed via live account_summary payload). Bail before any further
-        # work when the user's enterprise enforcement disallows Gateway management.
-        try:
-            from .workflow.helpers import is_pam_action_allowed_by_enforcement
-            if not is_pam_action_allowed_by_enforcement(
-                    params, 'allow_pam_gateway'):
-                print(f"{bcolors.FAIL}Gateway management is not allowed by your enterprise "
-                      f"enforcement (allow_pam_gateway).{bcolors.ENDC}")
-                return
-        except ImportError:
-            pass
+        if not ensure_gateway_management_allowed(params):
+            return
 
         gateway_name = kwargs.get('gateway_name')
         ksm_app = kwargs.get('ksm_app')

--- a/unit-tests/pam/test_gateway_enforcement_gate.py
+++ b/unit-tests/pam/test_gateway_enforcement_gate.py
@@ -1,0 +1,121 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
+#
+
+"""Tests for PAM Gateway create/remove enforcement gating.
+
+Regression coverage for: a role with the "Can create, deploy, and manage
+Keeper Gateways" enforcement policy disabled could still create and delete
+Gateways via `pam gateway new` / `pam gateway remove`, even though the same
+role is correctly blocked in the Web Vault UI.
+"""
+
+import io
+import unittest
+from unittest.mock import MagicMock, patch
+
+from keepercommander.commands.discoveryrotation import (
+    PAMCreateGatewayCommand,
+    PAMGatewayRemoveCommand,
+)
+
+
+def _params_with_enforcement(allowed):
+    params = MagicMock()
+    if allowed is None:
+        params.enforcements = None
+        return params
+    params.enforcements = {
+        'booleans': (
+            [{'key': 'allow_pam_gateway', 'value': True}]
+            if allowed else
+            [{'key': 'some_other_key', 'value': True}]
+        )
+    }
+    return params
+
+
+class TestPAMCreateGatewayCommandEnforcement(unittest.TestCase):
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_denied_when_enforcement_false(self, mock_get_app_record, mock_create_gateway):
+        params = _params_with_enforcement(False)
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            result = PAMCreateGatewayCommand().execute(
+                params, gateway_name='pocbyuser', ksm_app='PAM_application')
+
+        self.assertIsNone(result)
+        self.assertFalse(mock_get_app_record.called)
+        self.assertFalse(mock_create_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_ksm_app_display_info')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_allowed_when_enforcement_true(
+            self, mock_get_app_record, mock_get_ksm_app_display_info, mock_create_gateway):
+        params = _params_with_enforcement(True)
+        mock_get_app_record.return_value = {'record_uid': 'app_uid'}
+        mock_get_ksm_app_display_info.return_value = ('PAM_application', True, 'PAM_application (app_uid)')
+        mock_create_gateway.return_value = 'US:one-time-token'
+
+        PAMCreateGatewayCommand().execute(
+            params, gateway_name='pocbyuser', ksm_app='PAM_application', return_value=True)
+
+        self.assertTrue(mock_create_gateway.called)
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_ksm_app_display_info')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_allowed_when_no_enforcements(
+            self, mock_get_app_record, mock_get_ksm_app_display_info, mock_create_gateway):
+        # Personal / non-enterprise account: no enforcement context, fail open.
+        params = _params_with_enforcement(None)
+        mock_get_app_record.return_value = {'record_uid': 'app_uid'}
+        mock_get_ksm_app_display_info.return_value = ('PAM_application', True, 'PAM_application (app_uid)')
+        mock_create_gateway.return_value = 'US:one-time-token'
+
+        PAMCreateGatewayCommand().execute(
+            params, gateway_name='pocbyuser', ksm_app='PAM_application', return_value=True)
+
+        self.assertTrue(mock_create_gateway.called)
+
+
+class TestPAMGatewayRemoveCommandEnforcement(unittest.TestCase):
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
+    def test_denied_when_enforcement_false(self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement(False)
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
+
+        self.assertFalse(mock_get_all_gateways.called)
+        self.assertFalse(mock_remove_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
+    @patch('keepercommander.commands.discoveryrotation.utils.base64_url_encode')
+    def test_allowed_when_enforcement_true(
+            self, mock_base64_url_encode, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement(True)
+        gateway = MagicMock(controllerUid=b'controller_uid', controllerName='pocbyuser')
+        mock_get_all_gateways.return_value = [gateway]
+        mock_base64_url_encode.return_value = 'gateway_uid'
+
+        PAMGatewayRemoveCommand().execute(params, gateway='gateway_uid')
+
+        self.assertTrue(mock_remove_gateway.called)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/pam/test_gateway_enforcement_gate.py
+++ b/unit-tests/pam/test_gateway_enforcement_gate.py
@@ -54,6 +54,47 @@ def _params_with_enforcement(mode):
     return params
 
 
+# A real multi-key `booleans` payload (captured from a live account_summary
+# response) — models a role with many unrelated PAM permissions granted,
+# to confirm the key lookup isn't fooled by a "some true entries exist"
+# shortcut and actually finds/omits allow_pam_gateway specifically.
+_MIXED_ROLE_BOOLEANS_TEMPLATE = [
+    {'key': 'send_breach_watch_events', 'value': True},
+    {'key': 'allow_alternate_passwords', 'value': True},
+    {'key': 'allow_pam_discovery', 'value': True},
+    {'key': 'allow_pam_rotation', 'value': True},
+    {'key': 'allow_configure_pam_cloud_connection_settings', 'value': True},
+    {'key': 'restrict_mac_fingerprint', 'value': True},
+    {'key': 'allow_launch_pam_on_cloud_connection', 'value': True},
+    {'key': 'allow_configure_rbi', 'value': True},
+    {'key': 'allow_launch_rbi', 'value': True},
+    {'key': 'allow_secrets_manager', 'value': True},
+    {'key': 'allow_launch_pam_tunnels', 'value': True},
+    {'key': 'allow_configure_workflow_settings', 'value': True},
+    {'key': 'allow_configure_uss_settings', 'value': True},
+    {'key': 'allow_rotate_credentials', 'value': True},
+    {'key': 'allow_view_kcm_recordings', 'value': True},
+    {'key': 'allow_view_rbi_recordings', 'value': True},
+    {'key': 'allow_configure_rotation_settings', 'value': True},
+    {'key': 'allow_configure_pam_tunneling_settings', 'value': True},
+    {'key': 'allow_can_edit_external_shares', 'value': True},
+]
+
+
+def _params_with_mixed_role(gateway_allowed):
+    # type: (bool) -> MagicMock
+    """A role holding ~19 unrelated PAM/vault permissions, with
+    allow_pam_gateway either granted or omitted alongside them — the
+    real-world "partial permissions" shape, as opposed to a single-key
+    toy list."""
+    params = MagicMock()
+    booleans = list(_MIXED_ROLE_BOOLEANS_TEMPLATE)
+    if gateway_allowed:
+        booleans = booleans + [{'key': 'allow_pam_gateway', 'value': True}]
+    params.enforcements = {'booleans': booleans}
+    return params
+
+
 class TestPAMCreateGatewayCommandEnforcement(unittest.TestCase):
 
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
@@ -229,6 +270,53 @@ class TestLegacyPAMGatewayRemoveCommandEnforcement(unittest.TestCase):
         discoveryrotation_v1.PAMGatewayRemoveCommand().execute(params, gateway='gateway_uid')
 
         self.assertTrue(mock_remove_gateway.called)
+
+
+class TestMixedRolePermissions(unittest.TestCase):
+    """Partial-permission / mixed-role coverage: a role holding many other
+    PAM permissions must still be gated on allow_pam_gateway specifically,
+    neither over-denying (other permissions present) nor over-allowing
+    (mistaking "booleans list is non-empty" for "gateway is allowed")."""
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_create_denied_with_many_other_permissions_granted(
+            self, mock_get_app_record, mock_create_gateway):
+        params = _params_with_mixed_role(gateway_allowed=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            PAMCreateGatewayCommand().execute(
+                params, gateway_name='pocbyuser', ksm_app='PAM_application')
+
+        self.assertFalse(mock_get_app_record.called)
+        self.assertFalse(mock_create_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_ksm_app_display_info')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_create_allowed_with_many_other_permissions_granted(
+            self, mock_get_app_record, mock_get_ksm_app_display_info, mock_create_gateway):
+        params = _params_with_mixed_role(gateway_allowed=True)
+        mock_get_app_record.return_value = {'record_uid': 'app_uid'}
+        mock_get_ksm_app_display_info.return_value = ('PAM_application', True, 'PAM_application (app_uid)')
+        mock_create_gateway.return_value = 'US:one-time-token'
+
+        PAMCreateGatewayCommand().execute(
+            params, gateway_name='pocbyuser', ksm_app='PAM_application', return_value=True)
+
+        self.assertTrue(mock_create_gateway.called)
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
+    def test_remove_denied_with_many_other_permissions_granted(
+            self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_mixed_role(gateway_allowed=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
+
+        self.assertFalse(mock_get_all_gateways.called)
+        self.assertFalse(mock_remove_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
 
 
 if __name__ == '__main__':

--- a/unit-tests/pam/test_gateway_enforcement_gate.py
+++ b/unit-tests/pam/test_gateway_enforcement_gate.py
@@ -14,7 +14,10 @@
 Regression coverage for: a role with the "Can create, deploy, and manage
 Keeper Gateways" enforcement policy disabled could still create and delete
 Gateways via `pam gateway new` / `pam gateway remove`, even though the same
-role is correctly blocked in the Web Vault UI.
+role is correctly blocked in the Web Vault UI. Covers both the primary
+discoveryrotation module and the legacy discoveryrotation_v1 module
+(reachable at runtime via `pam legacy`), which had an identical, separately
+implemented gap.
 """
 
 import io
@@ -25,20 +28,29 @@ from keepercommander.commands.discoveryrotation import (
     PAMCreateGatewayCommand,
     PAMGatewayRemoveCommand,
 )
+from keepercommander.commands import discoveryrotation_v1
 
 
-def _params_with_enforcement(allowed):
+def _params_with_enforcement(mode):
+    # type: (str) -> MagicMock
+    """mode: 'allowed' (key present, True), 'denied_explicit_false' (key
+    present, False), 'denied_absent' (booleans non-empty but key missing —
+    what Commander's account-summary parser actually produces when a
+    checkbox is unchecked, since it drops `:false` entries), or
+    'no_enterprise' (no enforcement context at all — personal account)."""
     params = MagicMock()
-    if allowed is None:
+    if mode == 'no_enterprise':
         params.enforcements = None
         return params
-    params.enforcements = {
-        'booleans': (
-            [{'key': 'allow_pam_gateway', 'value': True}]
-            if allowed else
-            [{'key': 'some_other_key', 'value': True}]
-        )
-    }
+    if mode == 'allowed':
+        booleans = [{'key': 'allow_pam_gateway', 'value': True}]
+    elif mode == 'denied_explicit_false':
+        booleans = [{'key': 'allow_pam_gateway', 'value': False}]
+    elif mode == 'denied_absent':
+        booleans = [{'key': 'some_other_key', 'value': True}]
+    else:
+        raise ValueError(f'unknown mode: {mode}')
+    params.enforcements = {'booleans': booleans}
     return params
 
 
@@ -46,8 +58,21 @@ class TestPAMCreateGatewayCommandEnforcement(unittest.TestCase):
 
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
     @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
-    def test_denied_when_enforcement_false(self, mock_get_app_record, mock_create_gateway):
-        params = _params_with_enforcement(False)
+    def test_denied_when_enforcement_absent(self, mock_get_app_record, mock_create_gateway):
+        params = _params_with_enforcement('denied_absent')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            result = PAMCreateGatewayCommand().execute(
+                params, gateway_name='pocbyuser', ksm_app='PAM_application')
+
+        self.assertIsNone(result)
+        self.assertFalse(mock_get_app_record.called)
+        self.assertFalse(mock_create_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.create_gateway')
+    @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
+    def test_denied_when_enforcement_explicit_false(self, mock_get_app_record, mock_create_gateway):
+        params = _params_with_enforcement('denied_explicit_false')
         with patch('sys.stdout', new_callable=io.StringIO) as stdout:
             result = PAMCreateGatewayCommand().execute(
                 params, gateway_name='pocbyuser', ksm_app='PAM_application')
@@ -62,7 +87,7 @@ class TestPAMCreateGatewayCommandEnforcement(unittest.TestCase):
     @patch('keepercommander.commands.discoveryrotation.KSMCommand.get_app_record')
     def test_allowed_when_enforcement_true(
             self, mock_get_app_record, mock_get_ksm_app_display_info, mock_create_gateway):
-        params = _params_with_enforcement(True)
+        params = _params_with_enforcement('allowed')
         mock_get_app_record.return_value = {'record_uid': 'app_uid'}
         mock_get_ksm_app_display_info.return_value = ('PAM_application', True, 'PAM_application (app_uid)')
         mock_create_gateway.return_value = 'US:one-time-token'
@@ -78,7 +103,7 @@ class TestPAMCreateGatewayCommandEnforcement(unittest.TestCase):
     def test_allowed_when_no_enforcements(
             self, mock_get_app_record, mock_get_ksm_app_display_info, mock_create_gateway):
         # Personal / non-enterprise account: no enforcement context, fail open.
-        params = _params_with_enforcement(None)
+        params = _params_with_enforcement('no_enterprise')
         mock_get_app_record.return_value = {'record_uid': 'app_uid'}
         mock_get_ksm_app_display_info.return_value = ('PAM_application', True, 'PAM_application (app_uid)')
         mock_create_gateway.return_value = 'US:one-time-token'
@@ -93,8 +118,19 @@ class TestPAMGatewayRemoveCommandEnforcement(unittest.TestCase):
 
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.remove_gateway')
     @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
-    def test_denied_when_enforcement_false(self, mock_get_all_gateways, mock_remove_gateway):
-        params = _params_with_enforcement(False)
+    def test_denied_when_enforcement_absent(self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement('denied_absent')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
+
+        self.assertFalse(mock_get_all_gateways.called)
+        self.assertFalse(mock_remove_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation.gateway_helper.get_all_gateways')
+    def test_denied_when_enforcement_explicit_false(self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement('denied_explicit_false')
         with patch('sys.stdout', new_callable=io.StringIO) as stdout:
             PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
 
@@ -107,12 +143,90 @@ class TestPAMGatewayRemoveCommandEnforcement(unittest.TestCase):
     @patch('keepercommander.commands.discoveryrotation.utils.base64_url_encode')
     def test_allowed_when_enforcement_true(
             self, mock_base64_url_encode, mock_get_all_gateways, mock_remove_gateway):
-        params = _params_with_enforcement(True)
+        params = _params_with_enforcement('allowed')
         gateway = MagicMock(controllerUid=b'controller_uid', controllerName='pocbyuser')
         mock_get_all_gateways.return_value = [gateway]
         mock_base64_url_encode.return_value = 'gateway_uid'
 
         PAMGatewayRemoveCommand().execute(params, gateway='gateway_uid')
+
+        self.assertTrue(mock_remove_gateway.called)
+
+
+# --- Legacy discoveryrotation_v1 module (reachable via `pam legacy`) ---
+# Same enforcement gate, imported from discoveryrotation and reused, but
+# exercised against the v1 command classes to guard the legacy bypass path.
+
+class TestLegacyPAMCreateGatewayCommandEnforcement(unittest.TestCase):
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.create_gateway')
+    def test_denied_when_enforcement_absent(self, mock_create_gateway):
+        params = _params_with_enforcement('denied_absent')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            result = discoveryrotation_v1.PAMCreateGatewayCommand().execute(
+                params, gateway_name='pocbyuser', ksm_app='PAM_application')
+
+        self.assertIsNone(result)
+        self.assertFalse(mock_create_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.create_gateway')
+    def test_denied_when_enforcement_explicit_false(self, mock_create_gateway):
+        params = _params_with_enforcement('denied_explicit_false')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            result = discoveryrotation_v1.PAMCreateGatewayCommand().execute(
+                params, gateway_name='pocbyuser', ksm_app='PAM_application')
+
+        self.assertIsNone(result)
+        self.assertFalse(mock_create_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.create_gateway')
+    def test_allowed_when_enforcement_true(self, mock_create_gateway):
+        params = _params_with_enforcement('allowed')
+        mock_create_gateway.return_value = 'US:one-time-token'
+
+        discoveryrotation_v1.PAMCreateGatewayCommand().execute(
+            params, gateway_name='pocbyuser', ksm_app='PAM_application', return_value=True)
+
+        self.assertTrue(mock_create_gateway.called)
+
+
+class TestLegacyPAMGatewayRemoveCommandEnforcement(unittest.TestCase):
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.get_all_gateways')
+    def test_denied_when_enforcement_absent(self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement('denied_absent')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            discoveryrotation_v1.PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
+
+        self.assertFalse(mock_get_all_gateways.called)
+        self.assertFalse(mock_remove_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.get_all_gateways')
+    def test_denied_when_enforcement_explicit_false(self, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement('denied_explicit_false')
+        with patch('sys.stdout', new_callable=io.StringIO) as stdout:
+            discoveryrotation_v1.PAMGatewayRemoveCommand().execute(params, gateway='some_gateway_uid')
+
+        self.assertFalse(mock_get_all_gateways.called)
+        self.assertFalse(mock_remove_gateway.called)
+        self.assertIn('gateway management', stdout.getvalue().lower())
+
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.remove_gateway')
+    @patch('keepercommander.commands.discoveryrotation_v1.gateway_helper.get_all_gateways')
+    @patch('keepercommander.commands.discoveryrotation_v1.utils.base64_url_encode')
+    def test_allowed_when_enforcement_true(
+            self, mock_base64_url_encode, mock_get_all_gateways, mock_remove_gateway):
+        params = _params_with_enforcement('allowed')
+        gateway = MagicMock(controllerUid=b'controller_uid', controllerName='pocbyuser')
+        mock_get_all_gateways.return_value = [gateway]
+        mock_base64_url_encode.return_value = 'gateway_uid'
+
+        discoveryrotation_v1.PAMGatewayRemoveCommand().execute(params, gateway='gateway_uid')
 
         self.assertTrue(mock_remove_gateway.called)
 


### PR DESCRIPTION
## Summary

Any user could create and delete PAM Gateways via `pam gateway new`/`pam gateway remove` regardless of their role's "Can create, deploy, and manage Keeper Gateways" enforcement policy, since both commands only checked KSM Application record access (i.e. that the app was shared to them) and never checked the gateway-specific enforcement flag — even though the same restriction is correctly enforced in the Web Vault UI. The legacy PAM command set (`discoveryrotation_v1.py`, reachable at runtime via `pam legacy`) had the identical, separately implemented gap. Both create and remove now verify the current user's `allow_pam_gateway` role enforcement before performing the action, mirroring the existing pattern used for PAM tunnel/connection/rotation/workflow enforcement gates.

## Changes
- `discoveryrotation.py`:
  - Add `allow_pam_gateway` enforcement check to `PAMCreateGatewayCommand.execute` and `PAMGatewayRemoveCommand.execute`, using the shared `is_pam_action_allowed_by_enforcement` helper; reject with an error before any KSM lookup or gateway create/remove call when the user's role denies gateway management
- `discoveryrotation_v1.py`:
  - Apply the identical enforcement check to the legacy `PAMCreateGatewayCommand`/`PAMGatewayRemoveCommand` implementations, closing the same bypass reachable via `pam legacy`
- `unit-tests/pam/test_gateway_enforcement_gate.py`: Add 5 tests covering denial when `allow_pam_gateway` is false/absent, allowed when true, and fail-open for non-enterprise accounts (no enforcement context), for both create and remove
