### PR TITLE
Fix folder case sensitivity, custom-field mapping and custom --record-type handling in CyberArk imports.

### DIFF
--- a/keepercommander/importer/cyberark/cyberark.py
+++ b/keepercommander/importer/cyberark/cyberark.py
@@ -319,20 +319,28 @@ class CyberArkImporter(BaseImporter):
         return None
 
     @classmethod
-    def _get_account_property(cls, account, name):
+    def _get_account_property(cls, account, name, include_logon_domain_username=False):
         if not isinstance(account, dict):
             return None
+        normalized_name = cls._normalize_property_key(name)
+        if include_logon_domain_username and normalized_name in {"username", "accountname"}:
+            username = account.get("userName")
+            if username not in (None, ""):
+                logon_domain = cls._get_platform_property(account, "LogonDomain", "Logon Domain")
+                if logon_domain not in (None, ""):
+                    return str(logon_domain) + "\\" + str(username)
+                return username
         value = cls._get_platform_property(account, name)
         if value not in (None, ""):
             return value
-        normalized_name = cls._normalize_property_key(name)
         for key, value in account.items():
             if cls._normalize_property_key(key) == normalized_name:
                 return value
         return None
 
     @classmethod
-    def _add_account_metadata(cls, record, account, platform_property_labels=None):
+    def _add_account_metadata(cls, record, account, platform_property_labels=None,
+                              include_logon_domain_username=False):
         """Add CyberArk platform account properties as Keeper custom fields."""
         if not isinstance(account, dict):
             return
@@ -342,7 +350,10 @@ class CyberArkImporter(BaseImporter):
         platform_properties = cls._platform_properties(account)
         properties = dict(platform_properties) if isinstance(platform_properties, dict) else {}
         for property_key in platform_property_labels:
-            value = cls._get_account_property(account, property_key)
+            value = cls._get_account_property(
+                account, property_key,
+                include_logon_domain_username=include_logon_domain_username,
+            )
             if value not in (None, ""):
                 properties.setdefault(property_key, value)
         for key in cls._PLATFORM_NAME_KEYS:
@@ -432,6 +443,19 @@ class CyberArkImporter(BaseImporter):
                 return "serverCredentials"
             return "login"
         return "Password"
+
+    @classmethod
+    def _apply_standard_account_fields(cls, record, account, record_type=None):
+        """Apply the standard CyberArk-to-Keeper fields used by classic imports."""
+        if record_type:
+            return
+        if not isinstance(account, dict) or "userName" not in account:
+            return
+        record.login = account["userName"]
+        if "address" in account:
+            logon_domain = cls._get_platform_property(account, "LogonDomain", "Logon Domain")
+            if logon_domain:
+                record.login = str(logon_domain) + "\\" + account["userName"]
 
     @classmethod
     def get_url(cls, pvwa_host, endpoint):
@@ -1362,6 +1386,7 @@ class CyberArkImporter(BaseImporter):
                     record.folders = [folder]
                     record.title = self._account_title(r)
                     record.type = self._account_record_type(r, target_record_type)
+                    self._apply_standard_account_fields(record, r, target_record_type)
                     if "address" in r:
                         host_value = {"hostName": r["address"]}
                         port = self._get_platform_property(r, "Port", "PortNumber", "Port Number")
@@ -1372,7 +1397,10 @@ class CyberArkImporter(BaseImporter):
                     if url:
                         record.login_url = str(url)
                     account_platform_labels = platform_property_labels.get(str(r.get("platformId") or ""), {})
-                    self._add_account_metadata(record, r, account_platform_labels)
+                    self._add_account_metadata(
+                        record, r, account_platform_labels,
+                        include_logon_domain_username=bool(target_record_type),
+                    )
                     retry = True
                     while retry is True:
                         try:

--- a/keepercommander/importer/cyberark/cyberark.py
+++ b/keepercommander/importer/cyberark/cyberark.py
@@ -272,6 +272,7 @@ class CyberArkImporter(BaseImporter):
         "accounts": "Accounts",
         "account_password": "Accounts/{account_id}/Password/Retrieve",
         "logon": "Auth/{type}/Logon",
+        "platforms": "Platforms/",
         "safes": "Safes",
         "user_groups": "UserGroups",
         "user_group": "UserGroups/{group_id}",
@@ -318,13 +319,32 @@ class CyberArkImporter(BaseImporter):
         return None
 
     @classmethod
-    def _add_account_metadata(cls, record, account):
+    def _get_account_property(cls, account, name):
+        if not isinstance(account, dict):
+            return None
+        value = cls._get_platform_property(account, name)
+        if value not in (None, ""):
+            return value
+        normalized_name = cls._normalize_property_key(name)
+        for key, value in account.items():
+            if cls._normalize_property_key(key) == normalized_name:
+                return value
+        return None
+
+    @classmethod
+    def _add_account_metadata(cls, record, account, platform_property_labels=None):
         """Add CyberArk platform account properties as Keeper custom fields."""
         if not isinstance(account, dict):
             return
 
+        if not isinstance(platform_property_labels, dict):
+            platform_property_labels = {}
         platform_properties = cls._platform_properties(account)
         properties = dict(platform_properties) if isinstance(platform_properties, dict) else {}
+        for property_key in platform_property_labels:
+            value = cls._get_account_property(account, property_key)
+            if value not in (None, ""):
+                properties.setdefault(property_key, value)
         for key in cls._PLATFORM_NAME_KEYS:
             value = account.get(key)
             if value not in (None, ""):
@@ -343,20 +363,6 @@ class CyberArkImporter(BaseImporter):
             for field in getattr(record, "fields", [])
             if getattr(field, "label", None)
         }
-        host_values = set()
-        port_values = set()
-        for field in getattr(record, "fields", []):
-            if getattr(field, "type", None) != "host":
-                continue
-            host_value = getattr(field, "value", None)
-            if isinstance(host_value, dict):
-                for host_key in ("hostName", "host"):
-                    if host_value.get(host_key):
-                        host_values.add(str(host_value[host_key]))
-                if host_value.get("port"):
-                    port_values.add(str(host_value["port"]))
-            elif host_value:
-                host_values.add(str(host_value))
 
         def field_value_to_text(value):
             if isinstance(value, str):
@@ -365,30 +371,6 @@ class CyberArkImporter(BaseImporter):
                 value, ensure_ascii=False, sort_keys=True,
                 separators=(",", ":"),
             )
-
-        def is_standard_mapped_value(label, field_value):
-            label_key = label.casefold()
-            normalized_label_key = cls._normalize_property_key(label)
-            if normalized_label_key in {"name", "itemname"}:
-                return bool(record.title) and field_value == record.title
-            if normalized_label_key == "url":
-                return bool(record.login_url) and field_value == record.login_url
-            if normalized_label_key == "logondomain":
-                return bool(record.login) and record.login.casefold().startswith(
-                    f"{field_value}\\".casefold()
-                )
-            if normalized_label_key in {"address", "host", "hostname"}:
-                return field_value in host_values
-            if normalized_label_key in {"port", "portnumber"}:
-                return field_value in port_values or any(
-                    getattr(field, "type", None) == "port" and str(getattr(field, "value", "")) == field_value
-                    for field in getattr(record, "fields", [])
-                )
-            if normalized_label_key in {"username", "accountname"}:
-                return bool(record.login) and (
-                    field_value == record.login or record.login.endswith(f"\\{field_value}")
-                )
-            return False
 
         def field_label_to_text(label):
             parts = []
@@ -399,15 +381,11 @@ class CyberArkImporter(BaseImporter):
             return ".".join(parts)
 
         def add_value(label, value):
-            raw_label = str(label)
-            label = field_label_to_text(raw_label)
+            label = field_label_to_text(label)
             label_key = label.casefold()
             if not label or label_key in existing_labels:
                 return
             field_value = field_value_to_text(value)
-            if (is_standard_mapped_value(raw_label, field_value)
-                    or is_standard_mapped_value(label, field_value)):
-                return
             record.fields.append(RecordField(
                 "text", label=label, value=field_value,
             ))
@@ -422,7 +400,11 @@ class CyberArkImporter(BaseImporter):
                 add_value(label, value)
 
         for property_key, property_value in properties.items():
-            property_label = str(property_key)
+            property_label = (
+                platform_property_labels.get(property_key)
+                or platform_property_labels.get(cls._normalize_property_key(property_key))
+                or str(property_key)
+            )
             flatten(property_value, property_label)
 
     @classmethod
@@ -437,6 +419,19 @@ class CyberArkImporter(BaseImporter):
             if value:
                 return str(value)
         return "CyberArk Account"
+
+    @staticmethod
+    def _account_record_type(account, record_type=None):
+        """Return the Keeper record type for a CyberArk account import."""
+        if record_type:
+            return record_type
+        if not isinstance(account, dict):
+            return "Password"
+        if "userName" in account:
+            if "address" in account:
+                return "serverCredentials"
+            return "login"
+        return "Password"
 
     @classmethod
     def get_url(cls, pvwa_host, endpoint):
@@ -651,6 +646,52 @@ class CyberArkImporter(BaseImporter):
                 HTML(f"Request to <b>{_esc(url)}</b> <ansired>failed</ansired>: {_esc(e)}")
             )
             return None
+
+    @classmethod
+    def _platform_property_display_names(cls, platforms_payload):
+        display_names = {}
+        if not isinstance(platforms_payload, dict):
+            return display_names
+        platforms = platforms_payload.get("Platforms") or platforms_payload.get("platforms") or []
+        if not isinstance(platforms, list):
+            return display_names
+        for platform in platforms:
+            if not isinstance(platform, dict):
+                continue
+            general = platform.get("general") or {}
+            platform_id = general.get("id") or platform.get("id")
+            if not platform_id:
+                continue
+            labels = {}
+            properties = platform.get("properties") or {}
+            for group_name in ("required", "optional"):
+                for property_info in properties.get(group_name) or []:
+                    if not isinstance(property_info, dict):
+                        continue
+                    name = property_info.get("name")
+                    display_name = property_info.get("displayName")
+                    if name and display_name:
+                        labels[str(name)] = str(display_name)
+                        labels[cls._normalize_property_key(name)] = str(display_name)
+            if labels:
+                display_names[str(platform_id)] = labels
+        return display_names
+
+    def fetch_platform_property_display_names(self, pvwa_host, authorization_token):
+        """Return CyberArk platform property name -> displayName mappings by platform ID."""
+        sleep(self.DELAY)
+        response = self.get_response(self.get_url(pvwa_host, "platforms"), authorization_token, {})
+        if response is None:
+            return {}
+        if response.status_code != 200:
+            logging.debug("Getting CyberArk platforms failed with status %s", response.status_code)
+            return {}
+        try:
+            payload = response.json()
+        except ValueError:
+            logging.debug("Getting CyberArk platforms returned invalid JSON")
+            return {}
+        return self._platform_property_display_names(payload)
 
     @staticmethod
     def _extract_user_email(user):
@@ -1122,6 +1163,7 @@ class CyberArkImporter(BaseImporter):
         use_nsf = bool(kwargs.get("use_nsf"))
 
         params = kwargs.get("params")
+        target_record_type = kwargs.get("record_type")
         skip_teams = (bool(kwargs.get("skip_team"))
                       or environ.get("_CYBERARK_SKIP_TEAMS", "").lower() in ("1", "true", "yes"))
         skip_roles = (bool(kwargs.get("skip_role"))
@@ -1180,7 +1222,8 @@ class CyberArkImporter(BaseImporter):
             if not accounts:
                 print_formatted_text(HTML(f"<ansiyellow>No accounts in safe {safe}</ansiyellow>"))
                 continue
-            safe_accounts[safe] = accounts
+            canonical_safe = next((x.get("safeName") for x in accounts if x.get("safeName")), None) or safe
+            safe_accounts.setdefault(canonical_safe, []).extend(accounts)
 
         # Gather the CyberArk identities (groups + users) that will become Keeper
         # teams, roles and users so they can be previewed before the import. The
@@ -1201,6 +1244,11 @@ class CyberArkImporter(BaseImporter):
         if total_accounts == 0 and not group_names and not eligible_users:
             print_formatted_text(HTML("\n<ansiyellow>Nothing to migrate from CyberArk.</ansiyellow>"))
             return
+
+        platform_property_labels = (
+            self.fetch_platform_property_display_names(pvwa_host, authorization_token)
+            if safe_accounts else {}
+        )
 
         # Show exactly what will be migrated (records, teams, roles, users), then confirm.
         if safe_accounts:
@@ -1313,15 +1361,7 @@ class CyberArkImporter(BaseImporter):
                     record = Record()
                     record.folders = [folder]
                     record.title = self._account_title(r)
-                    record.type = "Password"
-                    if "userName" in r:
-                        record.type = "login"
-                        record.login = r["userName"]
-                        if "address" in r:
-                            record.type = "serverCredentials"
-                            logon_domain = self._get_platform_property(r, "LogonDomain", "Logon Domain")
-                            if logon_domain:
-                                record.login = str(logon_domain) + "\\" + r["userName"]
+                    record.type = self._account_record_type(r, target_record_type)
                     if "address" in r:
                         host_value = {"hostName": r["address"]}
                         port = self._get_platform_property(r, "Port", "PortNumber", "Port Number")
@@ -1331,7 +1371,8 @@ class CyberArkImporter(BaseImporter):
                     url = self._get_platform_property(r, "URL")
                     if url:
                         record.login_url = str(url)
-                    self._add_account_metadata(record, r)
+                    account_platform_labels = platform_property_labels.get(str(r.get("platformId") or ""), {})
+                    self._add_account_metadata(record, r, account_platform_labels)
                     retry = True
                     while retry is True:
                         try:

--- a/keepercommander/importer/imp_exp.py
+++ b/keepercommander/importer/imp_exp.py
@@ -787,7 +787,7 @@ def _import(params, file_format, filename, **kwargs):
 
     for x in importer.execute(filename, params=params, users_only=import_users, filter_folder=filter_folder,
                               old_domain=old_domain, new_domain=new_domain, tmpdir=tmpdir, secret_ids=secret_ids,
-                              dry_run=dry_run, target_node=target_node, use_nsf=use_nsf,
+                              dry_run=dry_run, target_node=target_node, use_nsf=use_nsf, record_type=record_type,
                               skip_team=skip_team, skip_role=skip_role, skip_user=skip_user):
         if isinstance(x, ImportRecord):
             if filter_folder and not importer.support_folder_filter():

--- a/tests/test_cyberark_pam_import.py
+++ b/tests/test_cyberark_pam_import.py
@@ -1680,6 +1680,27 @@ class TestClassicCyberArkMetadataImport:
             "Platform Name": "GenericLoginPlatform",
         }
 
+    def test_custom_metadata_username_can_include_logon_domain(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record
+
+        record = Record()
+        account = {
+            "platformId": "GenericPlatform",
+            "userName": "user",
+            "platformAccountProperties": {
+                "LogonDomain": "DOMAIN",
+            },
+        }
+
+        CyberArkImporter._add_account_metadata(
+            record, account, {"Username": "Username"},
+            include_logon_domain_username=True,
+        )
+
+        custom_fields = {field.label: field.value for field in record.fields if field.label}
+        assert custom_fields["Username"] == "DOMAIN\\user"
+
     def test_platform_property_display_names_parse_platforms_response(self):
         from keepercommander.importer.cyberark.cyberark import CyberArkImporter
 
@@ -2385,7 +2406,7 @@ class TestClassicCyberArkSkipProvisioningArgs:
         importer.fetch_cyberark_users.assert_not_called()
         assert len(records) == 1
         assert records[0].type == "serverCredentials"
-        assert not records[0].login
+        assert records[0].login == "admin"
         typed_fields = {field.type: field.value for field in records[0].fields if not field.label}
         custom_fields = {field.label: field.value for field in records[0].fields if field.label}
         assert typed_fields["host"] == {"hostName": "host.example.com", "port": "2222"}
@@ -2404,7 +2425,7 @@ class TestClassicCyberArkSkipProvisioningArgs:
     @patch("keepercommander.importer.cyberark.cyberark.sleep")
     @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
     @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
-    def test_login_record_does_not_duplicate_username_into_keeper_login(self, progress_bar, _print, _sleep):
+    def test_login_record_keeps_release_login_behavior_and_custom_metadata(self, progress_bar, _print, _sleep):
         from keepercommander.importer.cyberark.cyberark import CyberArkImporter
 
         class FakeProgressBar:
@@ -2443,6 +2464,57 @@ class TestClassicCyberArkSkipProvisioningArgs:
 
         assert len(records) == 1
         assert records[0].type == "login"
+        assert records[0].login == "sample_user"
+        custom_fields = {field.label: field.value for field in records[0].fields if field.label}
+        assert custom_fields == {
+            "Display Username": "sample_user",
+            "Display Custom ID": "custom-value",
+            "Platform Name": "GenericLoginPlatform",
+        }
+
+    @patch("keepercommander.importer.cyberark.cyberark.sleep")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
+    def test_custom_record_type_keeps_username_as_custom_metadata(self, progress_bar, _print, _sleep):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        class FakeProgressBar:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __call__(self, iterable, total=None):
+                return iterable
+
+        progress_bar.side_effect = FakeProgressBar
+
+        importer = CyberArkImporter()
+        importer._authenticate_pvwa = MagicMock(return_value=("pvwa.example.com", "token", {}))
+        importer._resolve_safes = MagicMock(return_value=["SampleSafe"])
+        importer.get_response = MagicMock(return_value=self._login_account_response())
+        importer.fetch_platform_property_display_names = MagicMock(return_value={
+            "GenericLoginPlatform": {
+                "Username": "Display Username",
+                "CustomID": "Display Custom ID",
+            },
+        })
+        importer.fetch_cyberark_users = MagicMock(return_value=[])
+        importer._enterprise_existing = MagicMock(return_value=(set(), set(), {}))
+        importer._confirm_import = MagicMock(return_value=True)
+        password_response = MagicMock(status_code=200)
+        password_response.text = '"secret"'
+        importer._request = MagicMock(return_value=password_response)
+
+        records = list(importer._do_import_inner(
+            "https://pvwa.example.com", params=MagicMock(),
+            record_type="customCyberArkAccount",
+            skip_team=True, skip_role=True, skip_user=True,
+        ))
+
+        assert len(records) == 1
+        assert records[0].type == "customCyberArkAccount"
         assert not records[0].login
         custom_fields = {field.label: field.value for field in records[0].fields if field.label}
         assert custom_fields == {

--- a/tests/test_cyberark_pam_import.py
+++ b/tests/test_cyberark_pam_import.py
@@ -1484,6 +1484,7 @@ class TestExistingImporterUnchanged:
             "accounts": "Accounts",
             "account_password": "Accounts/{account_id}/Password/Retrieve",
             "logon": "Auth/{type}/Logon",
+            "platforms": "Platforms/",
             "safes": "Safes",
         }
         assert expected_endpoints.items() <= CyberArkImporter.ENDPOINTS.items()
@@ -1553,10 +1554,10 @@ class TestClassicCyberArkMetadataImport:
         assert "createdTime" not in fields
         assert "modifiedTime" not in fields
         assert "secretManagement" not in fields
-        assert "Address" not in fields
-        assert "Username" not in fields
+        assert fields["Address"] == "host.example.com"
+        assert fields["Username"] == "admin"
 
-    def test_standard_mapped_platform_properties_are_not_duplicated(self):
+    def test_standard_mapped_platform_properties_are_preserved_as_custom_metadata(self):
         from keepercommander.importer.cyberark.cyberark import CyberArkImporter
         from keepercommander.importer.importer import Record, RecordField
 
@@ -1584,6 +1585,12 @@ class TestClassicCyberArkMetadataImport:
 
         custom_fields = {field.label: field.value for field in record.fields if field.label}
         assert custom_fields == {
+            "Item Name": "server-title",
+            "URL": "https://server.example.com",
+            "Logon Domain": "CORP",
+            "Account Name": "sample-user",
+            "Address": "server.example.com",
+            "Port": "3389",
             "Protocol": "RDP",
             "Device Type": "Generic Device",
         }
@@ -1613,6 +1620,92 @@ class TestClassicCyberArkMetadataImport:
         assert custom["Platform Name"] == "GenericPlatform"
         assert custom["Protocol"] == "SSH"
         assert custom["Device Type"] == "Server"
+
+    def test_platform_property_display_names_are_used_as_custom_field_labels(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record
+
+        record = Record()
+        record.title = "server-account"
+        record.login = "CORP\\admin"
+        account = {
+            "platformId": "WinDomain",
+            "platformAccountProperties": {
+                "LogonDomain": "CORP",
+                "UserDN": "CN=admin,DC=corp,DC=local",
+                "OwnerName": "service-owner",
+            },
+        }
+
+        CyberArkImporter._add_account_metadata(record, account, {
+            "LogonDomain": "Logon To",
+            "UserDN": "User DN",
+            "OwnerName": "Owner",
+        })
+
+        custom_fields = {field.label: field.value for field in record.fields if field.label}
+        assert "LogonDomain" not in custom_fields
+        assert "UserDN" not in custom_fields
+        assert "OwnerName" not in custom_fields
+        assert custom_fields["Logon To"] == "CORP"
+        assert custom_fields["User DN"] == "CN=admin,DC=corp,DC=local"
+        assert custom_fields["Owner"] == "service-owner"
+
+    def test_display_name_fields_can_read_top_level_account_values(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record
+
+        record = Record()
+        record.title = "sample account"
+        account = {
+            "platformId": "GenericLoginPlatform",
+            "safeName": "SampleSafe",
+            "id": "account-1",
+            "name": "sample account",
+            "userName": "sample_user",
+            "platformAccountProperties": {
+                "CustomID": "custom-value",
+            },
+        }
+
+        CyberArkImporter._add_account_metadata(record, account, {
+            "Username": "Display Username",
+            "CustomID": "Display Custom ID",
+        })
+
+        custom_fields = {field.label: field.value for field in record.fields if field.label}
+        assert custom_fields == {
+            "Display Username": "sample_user",
+            "Display Custom ID": "custom-value",
+            "Platform Name": "GenericLoginPlatform",
+        }
+
+    def test_platform_property_display_names_parse_platforms_response(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        display_names = CyberArkImporter._platform_property_display_names({
+            "Platforms": [{
+                "general": {"id": "WinDomain", "name": "Windows Domain Account"},
+                "properties": {
+                    "required": [
+                        {"name": "Address", "displayName": "Address"},
+                        {"name": "Username", "displayName": "Username"},
+                    ],
+                    "optional": [
+                        {"name": "LogonDomain", "displayName": "Logon To"},
+                        {"name": "UserDN", "displayName": "User DN"},
+                    ],
+                },
+            }],
+            "Total": 1,
+        })
+
+        assert display_names["WinDomain"]["Address"] == "Address"
+        assert display_names["WinDomain"]["address"] == "Address"
+        assert display_names["WinDomain"]["Username"] == "Username"
+        assert display_names["WinDomain"]["LogonDomain"] == "Logon To"
+        assert display_names["WinDomain"]["logondomain"] == "Logon To"
+        assert display_names["WinDomain"]["UserDN"] == "User DN"
 
 
 # ── Phase 2 Tests: System Safe Exclusion + Safe Filtering ─────
@@ -2231,6 +2324,23 @@ class TestClassicCyberArkSkipProvisioningArgs:
         }
         return response
 
+    @staticmethod
+    def _login_account_response():
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "value": [{
+                "id": "account-1",
+                "safeName": "SampleSafe",
+                "name": "sample account",
+                "platformId": "GenericLoginPlatform",
+                "userName": "sample_user",
+                "platformAccountProperties": {
+                    "CustomID": "custom-value",
+                },
+            }],
+        }
+        return response
+
     @patch("keepercommander.importer.cyberark.cyberark.sleep")
     @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
     @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
@@ -2253,6 +2363,13 @@ class TestClassicCyberArkSkipProvisioningArgs:
         importer._authenticate_pvwa = MagicMock(return_value=("pvwa.example.com", "token", {}))
         importer._resolve_safes = MagicMock(return_value=["SourceSafe"])
         importer.get_response = MagicMock(return_value=self._account_response())
+        importer.fetch_platform_property_display_names = MagicMock(return_value={
+            "GenericPlatform": {
+                "Username": "Username",
+                "Protocol": "Protocol",
+                "port": "Port",
+            },
+        })
         importer.fetch_cyberark_users = MagicMock(return_value=[])
         importer._enterprise_existing = MagicMock(return_value=(set(), set(), {}))
         importer._confirm_import = MagicMock(return_value=True)
@@ -2267,11 +2384,15 @@ class TestClassicCyberArkSkipProvisioningArgs:
 
         importer.fetch_cyberark_users.assert_not_called()
         assert len(records) == 1
+        assert records[0].type == "serverCredentials"
+        assert not records[0].login
         typed_fields = {field.type: field.value for field in records[0].fields if not field.label}
         custom_fields = {field.label: field.value for field in records[0].fields if field.label}
         assert typed_fields["host"] == {"hostName": "host.example.com", "port": "2222"}
         assert custom_fields == {
+            "Username": "admin",
             "Protocol": "SSH",
+            "Port": "2222",
             "Platform Name": "GenericPlatform",
         }
         table_prints = [
@@ -2279,6 +2400,99 @@ class TestClassicCyberArkSkipProvisioningArgs:
             if len(call.args) > 1 and "demo account" in str(call.args)
         ]
         assert len(table_prints) == 1
+
+    @patch("keepercommander.importer.cyberark.cyberark.sleep")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
+    def test_login_record_does_not_duplicate_username_into_keeper_login(self, progress_bar, _print, _sleep):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        class FakeProgressBar:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __call__(self, iterable, total=None):
+                return iterable
+
+        progress_bar.side_effect = FakeProgressBar
+
+        importer = CyberArkImporter()
+        importer._authenticate_pvwa = MagicMock(return_value=("pvwa.example.com", "token", {}))
+        importer._resolve_safes = MagicMock(return_value=["SampleSafe"])
+        importer.get_response = MagicMock(return_value=self._login_account_response())
+        importer.fetch_platform_property_display_names = MagicMock(return_value={
+            "GenericLoginPlatform": {
+                "Username": "Display Username",
+                "CustomID": "Display Custom ID",
+            },
+        })
+        importer.fetch_cyberark_users = MagicMock(return_value=[])
+        importer._enterprise_existing = MagicMock(return_value=(set(), set(), {}))
+        importer._confirm_import = MagicMock(return_value=True)
+        password_response = MagicMock(status_code=200)
+        password_response.text = '"secret"'
+        importer._request = MagicMock(return_value=password_response)
+
+        records = list(importer._do_import_inner(
+            "https://pvwa.example.com", params=MagicMock(),
+            skip_team=True, skip_role=True, skip_user=True,
+        ))
+
+        assert len(records) == 1
+        assert records[0].type == "login"
+        assert not records[0].login
+        custom_fields = {field.label: field.value for field in records[0].fields if field.label}
+        assert custom_fields == {
+            "Display Username": "sample_user",
+            "Display Custom ID": "custom-value",
+            "Platform Name": "GenericLoginPlatform",
+        }
+
+    @patch("keepercommander.importer.cyberark.cyberark.sleep")
+    @patch("keepercommander.importer.cyberark.cyberark.print_formatted_text")
+    @patch("keepercommander.importer.cyberark.cyberark.ProgressBar")
+    def test_nsf_folder_uses_cyberark_safe_name_casing(self, progress_bar, _print, _sleep):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record, SharedFolder
+
+        class FakeProgressBar:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __call__(self, iterable, total=None):
+                return iterable
+
+        progress_bar.side_effect = FakeProgressBar
+
+        importer = CyberArkImporter()
+        importer._authenticate_pvwa = MagicMock(return_value=("pvwa.example.com", "token", {}))
+        importer._resolve_safes = MagicMock(return_value=["sourcesafe"])
+        importer.get_response = MagicMock(return_value=self._account_response())
+        importer.fetch_platform_property_display_names = MagicMock(return_value={})
+        importer.fetch_cyberark_users = MagicMock(return_value=[])
+        importer._enterprise_existing = MagicMock(return_value=(set(), set(), {}))
+        importer._confirm_import = MagicMock(return_value=True)
+        password_response = MagicMock(status_code=200)
+        password_response.text = '"secret"'
+        importer._request = MagicMock(return_value=password_response)
+
+        items = list(importer._do_import_inner(
+            "https://pvwa.example.com", params=MagicMock(), use_nsf=True,
+            skip_team=True, skip_role=True, skip_user=True,
+        ))
+
+        nsf_folders = [x for x in items if isinstance(x, SharedFolder)]
+        records = [x for x in items if isinstance(x, Record)]
+        assert len(nsf_folders) == 1
+        assert len(records) == 1
+        assert nsf_folders[0].path == "SourceSafe"
+        assert records[0].folders[0].path == "SourceSafe"
 
     @patch("keepercommander.importer.cyberark.cyberark.api.execute_batch")
     @patch("keepercommander.importer.cyberark.cyberark.api.query_enterprise")
@@ -4666,3 +4880,95 @@ class TestApplicationMapperStub:
 
     def test_field_map_starts_empty(self):
         assert ApplicationMapper._field_map == {}
+
+
+class TestClassicCyberArkRecordTypeOverride:
+    """Record type selection for ``import --format=cyberark``."""
+
+    def test_default_record_type_is_login_without_address(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        assert CyberArkImporter._account_record_type({"userName": "sample_user"}) == "login"
+
+    def test_default_record_type_is_server_credentials_with_address(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        assert CyberArkImporter._account_record_type({
+            "userName": "admin",
+            "address": "host.example.com",
+        }) == "serverCredentials"
+
+    def test_explicit_record_type_overrides_cyberark_default(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+
+        assert CyberArkImporter._account_record_type(
+            {"userName": "admin", "address": "host.example.com"},
+            "customCyberArkAccount",
+        ) == "customCyberArkAccount"
+
+    def test_custom_record_type_keeps_unmapped_cyberark_data_as_custom_fields(self):
+        from keepercommander.importer.cyberark.cyberark import CyberArkImporter
+        from keepercommander.importer.importer import Record, RecordField
+        from keepercommander.importer.imp_exp import _construct_record_v3_data
+
+        record = Record()
+        record.title = "server-account"
+        record.type = CyberArkImporter._account_record_type({}, "customCyberArkAccount")
+        record.login = "admin"
+        record.password = "secret"
+        record.login_url = "https://server.example.com"
+        record.fields.append(RecordField("host", value={"hostName": "server.example.com", "port": "22"}))
+        CyberArkImporter._add_account_metadata(record, {
+            "platformId": "GenericPlatform",
+            "platformAccountProperties": {
+                "OwnerName": "service-owner",
+                "Protocol": "SSH",
+                "Environment": {"Name": "prod"},
+            },
+        })
+
+        data = _construct_record_v3_data(record)
+        custom_by_type = {
+            field.get("type"): field.get("value", [None])[0]
+            for field in data["custom"] if not field.get("label")
+        }
+        custom_by_label = {
+            field.get("label"): field.get("value", [None])[0]
+            for field in data["custom"] if field.get("label")
+        }
+
+        assert data["type"] == "customCyberArkAccount"
+        assert custom_by_type["login"] == "admin"
+        assert custom_by_type["password"] == "secret"
+        assert custom_by_type["url"] == "https://server.example.com"
+        assert custom_by_type["host"] == {"hostName": "server.example.com", "port": "22"}
+        assert custom_by_label["Platform Name"] == "GenericPlatform"
+        assert custom_by_label["Owner Name"] == "service-owner"
+        assert custom_by_label["Protocol"] == "SSH"
+        assert custom_by_label["Environment.Name"] == "prod"
+
+    def test_import_engine_forwards_record_type_to_importer(self, monkeypatch):
+        from keepercommander.importer import imp_exp
+
+        captured = {}
+
+        class FakeImporter:
+            verbose_import_summary = False
+
+            def execute(self, filename, **kwargs):
+                captured["filename"] = filename
+                captured["kwargs"] = kwargs
+                raise RuntimeError("stop after importer dispatch")
+
+        monkeypatch.setattr(imp_exp, "importer_for_format", lambda _: FakeImporter)
+
+        with pytest.raises(RuntimeError, match="stop after importer dispatch"):
+            imp_exp._import(
+                MagicMock(record_cache={}),
+                "cyberark",
+                "https://pvwa.example.com",
+                record_type="test custom",
+            )
+
+        assert captured["filename"] == "https://pvwa.example.com"
+        assert captured["kwargs"]["record_type"] == "test custom"


### PR DESCRIPTION
### Summary

Improves the CyberArk import (`import --format=cyberark`) by preserving platform account properties as labeled Keeper custom fields.

### Changes

- **Platform display names:** Fetches `GET /Platforms` once per import and maps property `name` to `displayName` (e.g. `LogonDomain` → `Logon To`). Falls back to the raw property name if unavailable.
- **Preserve metadata:** Properties overlapping with standard fields (address, username, port, URL, logon domain, etc.) are now retained as custom fields.
- **`--record-type` override:** Adds an optional flag to force a specific Keeper/custom record type.
- **NSF safe-name casing:** Uses the server's canonical `safeName` to prevent duplicate NSF folders caused by casing differences.

### Examples

```bash
# Standard import
import --format=cyberark https://pvwa.example.com

# Import using a specific record type
import --format=cyberark --record-type=<custom_record_type> https://pvwa.example.com