### PR TITLE
DR-1368 add hashicorp pam config updated pr

### DIFF
--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2556,6 +2556,7 @@ github_group.add_argument('--github-base-url', dest='github_base_url', action='s
                        help='GitHub Base URL')
 
 hashicorp_group = common_parser.add_argument_group('hashicorp', 'HashiCorp Vault configuration')
+hashicorp_group.add_argument('--hashicorp-id', dest='hashicorp_id', action='store', help='HashiCorp Id')
 hashicorp_group.add_argument('--vault-base-url', dest='vault_base_url', action='store',
                             help='Vault Base URL (e.g., https://vault.company.com:8200)')
 hashicorp_group.add_argument('--vault-token', dest='vault_token', action='store',

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2870,6 +2870,9 @@ class PamConfigurationEditMixin(RecordEditMixin):
             if oci_region:
                 extra_properties.append(f'text.regionOci={oci_region}')
         elif record.record_type == 'pamHashiCorpConfiguration':
+            hashicorp_id = kwargs.get('hashicorp_id')
+            if hashicorp_id:
+                extra_properties.append(f'text.pamHashiCorpId={hashicorp_id}')
             vault_base_url = kwargs.get('vault_base_url')
             if vault_base_url:
                 extra_properties.append(f'text.pamHashiCorpVaultBaseUrl={vault_base_url}')

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2429,7 +2429,7 @@ class PAMConfigurationListCommand(Command):
         for c in configurations:  # type: vault.TypedRecord
             if c.record_type in ('pamAwsConfiguration', 'pamAzureConfiguration', 'pamGcpConfiguration',
                                  'pamDomainConfiguration', 'pamNetworkConfiguration', 'pamOciConfiguration',
-                                 'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration'):
+                                 'pamGitHubConfiguration', 'pamHashiCorpConfiguration'):
                 facade.record = c
                 folder_info = resolve_pam_config_folder_info(
                     params, facade, c.record_uid)
@@ -2570,7 +2570,7 @@ class PamConfigurationEditMixin(RecordEditMixin):
     PAM_CONFIG_RECORD_TYPES = frozenset({
         'pamAwsConfiguration', 'pamAzureConfiguration', 'pamGcpConfiguration',
         'pamDomainConfiguration', 'pamNetworkConfiguration', 'pamOciConfiguration',
-        'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration',
+        'pamGitHubConfiguration', 'pamHashiCorpConfiguration',
     })
     PAM_RESOURCE_RECORD_TYPES = frozenset({
         'pamDatabase', 'pamDirectory', 'pamMachine', 'pamRemoteBrowser',
@@ -2869,7 +2869,7 @@ class PamConfigurationEditMixin(RecordEditMixin):
             oci_region = kwargs.get('oci_region')
             if oci_region:
                 extra_properties.append(f'text.regionOci={oci_region}')
-        elif record.record_type == 'pamHashiCorpVaultConfiguration':
+        elif record.record_type == 'pamHashiCorpConfiguration':
             vault_base_url = kwargs.get('vault_base_url')
             if vault_base_url:
                 extra_properties.append(f'text.pamHashiCorpVaultBaseUrl={vault_base_url}')
@@ -2960,7 +2960,7 @@ class PAMConfigurationNewCommand(Command, PamConfigurationEditMixin):
         elif config_type == 'oci':
             record_type = 'pamOciConfiguration'
         elif config_type == 'hashicorp':
-            record_type = 'pamHashiCorpVaultConfiguration'
+            record_type = 'pamHashiCorpConfiguration'
         else:
             raise CommandError('pam-config-new', f'--environment {config_type} is not supported'
                                                  ' - supported options: local, aws, azure, gcp, domain, oci, github, hashicorp')

--- a/keepercommander/commands/discoveryrotation.py
+++ b/keepercommander/commands/discoveryrotation.py
@@ -2429,7 +2429,7 @@ class PAMConfigurationListCommand(Command):
         for c in configurations:  # type: vault.TypedRecord
             if c.record_type in ('pamAwsConfiguration', 'pamAzureConfiguration', 'pamGcpConfiguration',
                                  'pamDomainConfiguration', 'pamNetworkConfiguration', 'pamOciConfiguration',
-                                 'pamGitHubConfiguration'):
+                                 'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration'):
                 facade.record = c
                 folder_info = resolve_pam_config_folder_info(
                     params, facade, c.record_uid)
@@ -2489,7 +2489,7 @@ class PAMConfigurationListCommand(Command):
 
 common_parser = argparse.ArgumentParser(add_help=False)
 common_parser.add_argument('--environment', '-env', dest='config_type', action='store',
-                           choices=['local', 'aws', 'azure', 'gcp', 'domain', 'oci', 'github'], help='PAM Configuration Type')
+                           choices=['local', 'aws', 'azure', 'gcp', 'domain', 'oci', 'github', 'hashicorp'], help='PAM Configuration Type')
 common_parser.add_argument('--title', '-t', dest='title', action='store', help='Title of the PAM Configuration')
 common_parser.add_argument('--gateway', '-g', dest='gateway_uid', action='store', help='Gateway UID or Name')
 common_parser.add_argument('--shared-folder', '-sf', dest='shared_folder_uid', action='store',
@@ -2555,12 +2555,22 @@ github_group.add_argument('--personal-access-token', dest='personal_access_token
 github_group.add_argument('--github-base-url', dest='github_base_url', action='store',
                        help='GitHub Base URL')
 
+hashicorp_group = common_parser.add_argument_group('hashicorp', 'HashiCorp Vault configuration')
+hashicorp_group.add_argument('--vault-base-url', dest='vault_base_url', action='store',
+                            help='Vault Base URL (e.g., https://vault.company.com:8200)')
+hashicorp_group.add_argument('--vault-token', dest='vault_token', action='store',
+                            help='Vault Token (optional; syncIdentity takes precedence)')
+hashicorp_group.add_argument('--vault-namespace', dest='vault_namespace', action='store',
+                            help='Vault Namespace (optional; leave blank for Community Edition)')
+hashicorp_group.add_argument('--vault-mount-path', dest='vault_mount_path', action='store',
+                            help='Vault KV Mount Path (optional; defaults to "secret")')
+
 class PamConfigurationEditMixin(RecordEditMixin):
     pam_record_types = None
     PAM_CONFIG_RECORD_TYPES = frozenset({
         'pamAwsConfiguration', 'pamAzureConfiguration', 'pamGcpConfiguration',
         'pamDomainConfiguration', 'pamNetworkConfiguration', 'pamOciConfiguration',
-        'pamGitHubConfiguration',
+        'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration',
     })
     PAM_RESOURCE_RECORD_TYPES = frozenset({
         'pamDatabase', 'pamDirectory', 'pamMachine', 'pamRemoteBrowser',
@@ -2859,6 +2869,19 @@ class PamConfigurationEditMixin(RecordEditMixin):
             oci_region = kwargs.get('oci_region')
             if oci_region:
                 extra_properties.append(f'text.regionOci={oci_region}')
+        elif record.record_type == 'pamHashiCorpVaultConfiguration':
+            vault_base_url = kwargs.get('vault_base_url')
+            if vault_base_url:
+                extra_properties.append(f'text.pamHashiCorpVaultBaseUrl={vault_base_url}')
+            vault_token = kwargs.get('vault_token')
+            if vault_token:
+                extra_properties.append(f'secret.pamHashiCorpVaultToken={vault_token}')
+            vault_namespace = kwargs.get('vault_namespace')
+            if vault_namespace:
+                extra_properties.append(f'text.pamHashiCorpVaultNamespace={vault_namespace}')
+            vault_mount_path = kwargs.get('vault_mount_path')
+            if vault_mount_path:
+                extra_properties.append(f'text.pamHashiCorpVaultMountPath={vault_mount_path}')
         if extra_properties:
             self.assign_typed_fields(record, [RecordEditMixin.parse_field(x) for x in extra_properties])
 
@@ -2936,9 +2959,11 @@ class PAMConfigurationNewCommand(Command, PamConfigurationEditMixin):
             record_type = 'pamDomainConfiguration'
         elif config_type == 'oci':
             record_type = 'pamOciConfiguration'
+        elif config_type == 'hashicorp':
+            record_type = 'pamHashiCorpVaultConfiguration'
         else:
             raise CommandError('pam-config-new', f'--environment {config_type} is not supported'
-                                                 ' - supported options: local, aws, azure, gcp, domain, oci, github')
+                                                 ' - supported options: local, aws, azure, gcp, domain, oci, github, hashicorp')
 
         title = kwargs.get('title')
         if not title:

--- a/keepercommander/commands/universalsecretsync.py
+++ b/keepercommander/commands/universalsecretsync.py
@@ -79,7 +79,7 @@ class PAMUniversalSyncConfigListCommand(Command):
 
             # Only process these specific configuration types
             uss_supported_types = ('pamGcpConfiguration', 'pamAzureConfiguration', 'pamAwsConfiguration',
-                                   'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration')
+                                   'pamGitHubConfiguration', 'pamHashiCorpConfiguration')
 
             configs_data = []
             for record in configurations:
@@ -290,7 +290,7 @@ class PAMUniversalSyncConfigListCommand(Command):
 
         # Check if it's a supported USS configuration type
         uss_supported_types = ('pamGcpConfiguration', 'pamAzureConfiguration', 'pamAwsConfiguration',
-                               'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration')
+                               'pamGitHubConfiguration', 'pamHashiCorpConfiguration')
         if not isinstance(network, vault.TypedRecord) or network.record_type not in uss_supported_types:
             if format_type == 'json':
                 return json.dumps({"error": f'Record "{network_uid}" is not a USS configuration'})

--- a/keepercommander/commands/universalsecretsync.py
+++ b/keepercommander/commands/universalsecretsync.py
@@ -79,7 +79,7 @@ class PAMUniversalSyncConfigListCommand(Command):
 
             # Only process these specific configuration types
             uss_supported_types = ('pamGcpConfiguration', 'pamAzureConfiguration', 'pamAwsConfiguration',
-                                   'pamGitHubConfiguration')
+                                   'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration')
 
             configs_data = []
             for record in configurations:
@@ -114,6 +114,21 @@ class PAMUniversalSyncConfigListCommand(Command):
 
                     # GitHub-specific fields are nested under the 'github' key.
                     github_data = config_data.get('github') or {}
+
+                    # HashiCorp-specific fields are nested under the 'hashicorp' key.
+                    hashicorp_data = config_data.get('hashicorp') or {}
+
+                    # Decrypt HashiCorp vault_base_url if present
+                    vault_base_url = 'N/A'
+                    vault_base_url_encrypted = hashicorp_data.get('vaultBaseUrl')
+                    if vault_base_url_encrypted:
+                        try:
+                            vault_base_url_bytes = crypto.decrypt_aes_v2(
+                                utils.base64_url_decode(vault_base_url_encrypted), record.record_key)
+                            vault_base_url = vault_base_url_bytes.decode('utf-8')
+                        except Exception as e:
+                            logging.debug(f"Failed to decrypt vault_base_url for record {record.record_uid}: {e}")
+                            vault_base_url = 'N/A'
 
                     # Decrypt vault_name if present. The router stores it under the
                     # 'vaultName' key as a base64-url string of the encrypted bytes.
@@ -206,6 +221,7 @@ class PAMUniversalSyncConfigListCommand(Command):
                         'owner': owner,
                         'organization_visibility': org_visibility_str,
                         'repos': repo_names,
+                        'vault_base_url': vault_base_url,
                     })
                 except Exception as e:
                     # Skip records that fail to load or don't have USS config
@@ -227,7 +243,7 @@ class PAMUniversalSyncConfigListCommand(Command):
         # Display as simple summary table
         table = []
         headers = ['Network UID', 'Title', 'Type', 'Enabled', 'Dry Run', 'Folders', 'Vault Name', 'Sync Identity',
-                   'Scope', 'Owner', 'Org Visibility', 'Repos']
+                   'Scope', 'Owner', 'Org Visibility', 'Repos', 'Vault Base URL']
 
         for config in configs_data:
             enabled_str = f"{bcolors.OKGREEN}Yes{bcolors.ENDC}" if config['enabled'] else f"{bcolors.FAIL}No{bcolors.ENDC}"
@@ -249,7 +265,8 @@ class PAMUniversalSyncConfigListCommand(Command):
                 config.get('scope', 'N/A'),
                 config.get('owner', 'N/A'),
                 config.get('organization_visibility', 'N/A'),
-                repos_str
+                repos_str,
+                config.get('vault_base_url', 'N/A')
             ]
             table.append(row)
 
@@ -273,7 +290,7 @@ class PAMUniversalSyncConfigListCommand(Command):
 
         # Check if it's a supported USS configuration type
         uss_supported_types = ('pamGcpConfiguration', 'pamAzureConfiguration', 'pamAwsConfiguration',
-                               'pamGitHubConfiguration')
+                               'pamGitHubConfiguration', 'pamHashiCorpVaultConfiguration')
         if not isinstance(network, vault.TypedRecord) or network.record_type not in uss_supported_types:
             if format_type == 'json':
                 return json.dumps({"error": f'Record "{network_uid}" is not a USS configuration'})
@@ -309,6 +326,21 @@ class PAMUniversalSyncConfigListCommand(Command):
 
             # GitHub-specific fields are nested under the 'github' key.
             github_data = config_data.get('github') or {}
+
+            # HashiCorp-specific fields are nested under the 'hashicorp' key.
+            hashicorp_data = config_data.get('hashicorp') or {}
+
+            # Decrypt HashiCorp vault_base_url if present
+            vault_base_url = 'N/A'
+            vault_base_url_encrypted = hashicorp_data.get('vaultBaseUrl')
+            if vault_base_url_encrypted:
+                try:
+                    vault_base_url_bytes = crypto.decrypt_aes_v2(
+                        utils.base64_url_decode(vault_base_url_encrypted), network.record_key)
+                    vault_base_url = vault_base_url_bytes.decode('utf-8')
+                except Exception as e:
+                    logging.debug(f"Failed to decrypt vault_base_url for network {network.record_uid}: {e}")
+                    vault_base_url = 'N/A'
 
             # Decrypt vault_name if present. The router stores it under the
             # 'vaultName' key as a base64-url string of the encrypted bytes.
@@ -438,6 +470,7 @@ class PAMUniversalSyncConfigListCommand(Command):
                 'owner': owner,
                 'organization_visibility': org_visibility_str,
                 'repos': repo_names,
+                'vault_base_url': vault_base_url,
                 'folders': []
             }
 
@@ -473,6 +506,7 @@ class PAMUniversalSyncConfigListCommand(Command):
             table.append(['Owner', owner])
             table.append(['Org Visibility', org_visibility_str])
             table.append(['Repos', ', '.join(repo_names) if repo_names else 'None'])
+            table.append(['Vault Base URL', vault_base_url])
             table.append(['', ''])  # Blank row separator
 
             # Display folder sync details
@@ -521,6 +555,7 @@ class PAMUniversalSyncConfigListCommand(Command):
 
 class PAMUniversalSyncConfigAddCommand(Command):
     parser = argparse.ArgumentParser(prog='pam universal-sync-config add')
+
     parser.add_argument('--network', '-n', required=True, dest='network', action='store',
                         help='Network UID or name to configure universal sync')
     parser.add_argument('--enabled', '-e', dest='enabled', action='store',
@@ -543,6 +578,14 @@ class PAMUniversalSyncConfigAddCommand(Command):
                         help='Repository visibility to sync when scope is organization')
     parser.add_argument('--repo', '-r', dest='repo', action='append',
                         help='GitHub repository name to sync (can be specified multiple times; scope must be repository)')
+    parser.add_argument('--vault-base-url', '-vbu', dest='vault_base_url', action='store',
+                        help='HashiCorp Vault Base URL (e.g., https://vault.company.com:8200)')
+    parser.add_argument('--vault-token', '-vt', dest='vault_token', action='store',
+                        help='HashiCorp Vault Token (optional; syncIdentity takes precedence)')
+    parser.add_argument('--vault-namespace', '-vns', dest='vault_namespace', action='store',
+                        help='HashiCorp Vault Namespace (optional; leave blank for Community Edition)')
+    parser.add_argument('--vault-mount-path', '-vmp', dest='vault_mount_path', action='store',
+                        help='HashiCorp Vault KV Mount Path (optional; defaults to "secret")')
 
     def get_parser(self):
         return PAMUniversalSyncConfigAddCommand.parser
@@ -616,6 +659,30 @@ class PAMUniversalSyncConfigAddCommand(Command):
                 repo_obj.name = crypto.encrypt_aes_v2(repo_bytes, network.record_key)
                 rq.github.repos.append(repo_obj)
 
+        vault_base_url = kwargs.get('vault_base_url')
+        if vault_base_url:
+            vault_base_url_bytes = string_to_bytes(vault_base_url)
+            encrypted_vault_base_url = crypto.encrypt_aes_v2(vault_base_url_bytes, network.record_key)
+            rq.hashicorp.vaultBaseUrl = encrypted_vault_base_url
+
+        vault_token = kwargs.get('vault_token')
+        if vault_token:
+            vault_token_bytes = string_to_bytes(vault_token)
+            encrypted_vault_token = crypto.encrypt_aes_v2(vault_token_bytes, network.record_key)
+            rq.hashicorp.vaultToken = encrypted_vault_token
+
+        vault_namespace = kwargs.get('vault_namespace')
+        if vault_namespace:
+            vault_namespace_bytes = string_to_bytes(vault_namespace)
+            encrypted_vault_namespace = crypto.encrypt_aes_v2(vault_namespace_bytes, network.record_key)
+            rq.hashicorp.vaultNamespace = encrypted_vault_namespace
+
+        vault_mount_path = kwargs.get('vault_mount_path')
+        if vault_mount_path:
+            vault_mount_path_bytes = string_to_bytes(vault_mount_path)
+            encrypted_vault_mount_path = crypto.encrypt_aes_v2(vault_mount_path_bytes, network.record_key)
+            rq.hashicorp.vaultMountPath = encrypted_vault_mount_path
+
         encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
 
         try:
@@ -651,6 +718,14 @@ class PAMUniversalSyncConfigEditCommand(Command):
                         help='Repository visibility to sync when scope is organization')
     parser.add_argument('--repo', '-r', dest='repo', action='append',
                         help='GitHub repository name to sync (can be specified multiple times; scope must be repository)')
+    parser.add_argument('--vault-base-url', '-vbu', dest='vault_base_url', action='store',
+                        help='HashiCorp Vault Base URL (e.g., https://vault.company.com:8200)')
+    parser.add_argument('--vault-token', '-vt', dest='vault_token', action='store',
+                        help='HashiCorp Vault Token (optional; syncIdentity takes precedence)')
+    parser.add_argument('--vault-namespace', '-vns', dest='vault_namespace', action='store',
+                        help='HashiCorp Vault Namespace (optional; leave blank for Community Edition)')
+    parser.add_argument('--vault-mount-path', '-vmp', dest='vault_mount_path', action='store',
+                        help='HashiCorp Vault KV Mount Path (optional; defaults to "secret")')
 
     def get_parser(self):
         return PAMUniversalSyncConfigEditCommand.parser
@@ -785,6 +860,41 @@ class PAMUniversalSyncConfigEditCommand(Command):
                 repo_obj = pam_pb2.GitHubRepository()
                 repo_obj.name = utils.base64_url_decode(existing_repo)
                 rq.github.repos.append(repo_obj)
+
+        # HashiCorp-specific fields live under the nested 'hashicorp' object
+        existing_hashicorp = existing_config.get('hashicorp') or {}
+
+        vault_base_url = kwargs.get('vault_base_url')
+        if vault_base_url:
+            vault_base_url_bytes = string_to_bytes(vault_base_url)
+            encrypted_vault_base_url = crypto.encrypt_aes_v2(vault_base_url_bytes, network.record_key)
+            rq.hashicorp.vaultBaseUrl = encrypted_vault_base_url
+        elif existing_hashicorp.get('vaultBaseUrl'):
+            rq.hashicorp.vaultBaseUrl = utils.base64_url_decode(existing_hashicorp['vaultBaseUrl'])
+
+        vault_token = kwargs.get('vault_token')
+        if vault_token:
+            vault_token_bytes = string_to_bytes(vault_token)
+            encrypted_vault_token = crypto.encrypt_aes_v2(vault_token_bytes, network.record_key)
+            rq.hashicorp.vaultToken = encrypted_vault_token
+        elif existing_hashicorp.get('vaultToken'):
+            rq.hashicorp.vaultToken = utils.base64_url_decode(existing_hashicorp['vaultToken'])
+
+        vault_namespace = kwargs.get('vault_namespace')
+        if vault_namespace:
+            vault_namespace_bytes = string_to_bytes(vault_namespace)
+            encrypted_vault_namespace = crypto.encrypt_aes_v2(vault_namespace_bytes, network.record_key)
+            rq.hashicorp.vaultNamespace = encrypted_vault_namespace
+        elif existing_hashicorp.get('vaultNamespace'):
+            rq.hashicorp.vaultNamespace = utils.base64_url_decode(existing_hashicorp['vaultNamespace'])
+
+        vault_mount_path = kwargs.get('vault_mount_path')
+        if vault_mount_path:
+            vault_mount_path_bytes = string_to_bytes(vault_mount_path)
+            encrypted_vault_mount_path = crypto.encrypt_aes_v2(vault_mount_path_bytes, network.record_key)
+            rq.hashicorp.vaultMountPath = encrypted_vault_mount_path
+        elif existing_hashicorp.get('vaultMountPath'):
+            rq.hashicorp.vaultMountPath = utils.base64_url_decode(existing_hashicorp['vaultMountPath'])
 
         encrypted_session_token, encrypted_transmission_key, transmission_key = get_keeper_tokens(params)
 


### PR DESCRIPTION
Replacement PR for https://github.com/Keeper-Security/Commander/pull/2337.  Ready for review:

Add support for new HashiCorp PAM config record type via pam config new/edit. Also added support to kick off the sync via pam universal-sync-run but this is untested until corresponding support is actually added to the gateway.

Design doc here: https://docs.google.com/document/d/1oL3H83zp8wxJq3VUzhvo4DDJtXcm2DvbuChCxq2WZJg/edit?usp=sharing