### PR TITLE
KC-1435: Prevent delegated admin privilege escalation by validating user permissions

### DIFF
--- a/keepercommander/commands/enterprise.py
+++ b/keepercommander/commands/enterprise.py
@@ -51,6 +51,13 @@ from ..params import KeeperParams
 from ..proto import record_pb2, APIRequest_pb2, enterprise_pb2, automator_pb2, pam_pb2
 
 
+# Privileges that require the current user to already hold them before they can be granted to,
+# or removed from, another role. These control account transfer, team/company management, and
+# financial operations. manage_nodes/sharing_administrator are excluded — restricting those would
+# block delegated admins from routine management.
+_PRIVILEGED_GRANTS = frozenset(('transfer_account', 'manage_companies', 'manage_teams'))
+
+
 def register_commands(commands):
     commands['enterprise-down'] = GetEnterpriseDataCommand()
     commands['enterprise-info'] = EnterpriseInfoCommand()
@@ -2260,6 +2267,72 @@ class EnterpriseRoleCommand(EnterpriseCommand):
         managed_nodes = params.enterprise.get('managed_nodes')
         return any(True for x in managed_nodes if x.get('managed_node_id') == node_id and x.get('role_id') == role_id)
 
+    @staticmethod
+    def get_effective_privileges_for_node(params, role_id, target_node_id):
+        # type: (KeeperParams, int, int) -> Set[str]
+        """Compute effective privileges for a role on a target node, honoring cascade.
+
+        Walks up the ancestor chain to find privileges granted on parent nodes
+        that cascade down to the target node.
+        """
+        effective_privs = set()  # type: Set[str]
+
+        # Build node lookup and parent map
+        nodes = {n['node_id']: n for n in params.enterprise.get('nodes', [])}
+        if target_node_id not in nodes:
+            return effective_privs
+
+        # Build managed_nodes by role_id with cascade info
+        role_managed = {}  # type: Dict[int, Dict[str, Any]]
+        for mn in params.enterprise.get('managed_nodes', []):
+            if mn['role_id'] == role_id:
+                role_managed[mn['managed_node_id']] = {
+                    'cascade': mn.get('cascade_node_management', False)
+                }
+
+        # Walk up from target_node_id to root, collecting managed ancestor nodes
+        current_node_id = target_node_id
+        managed_ancestors = []  # type: List[int]
+
+        while current_node_id:
+            if current_node_id in role_managed:
+                managed_ancestors.append(current_node_id)
+            node = nodes.get(current_node_id)
+            if node and node.get('parent_id'):
+                current_node_id = node['parent_id']
+            else:
+                current_node_id = None
+
+        # Collect privileges from managed ancestors that cascade or are exact matches
+        for rp in params.enterprise.get('role_privileges', []):
+            if rp['role_id'] != role_id:
+                continue
+            privilege = rp['privilege'].lower()
+            managed_node_id = rp['managed_node_id']
+
+            if managed_node_id == target_node_id:
+                # Exact match always applies
+                effective_privs.add(privilege)
+            elif managed_node_id in managed_ancestors:
+                # Ancestor privilege applies if cascade is enabled
+                if role_managed[managed_node_id]['cascade']:
+                    effective_privs.add(privilege)
+
+        return effective_privs
+
+    @staticmethod
+    def get_current_enterprise_user_id(params):
+        # type: (KeeperParams) -> Optional[int]
+        """Find the current user's enterprise_user_id by username matching."""
+        if 'users' not in params.enterprise:
+            return None
+
+        username_lower = params.user.lower() if params.user else None
+        for user in params.enterprise['users']:
+            if user.get('username', '').lower() == username_lower:
+                return user.get('enterprise_user_id')
+        return None
+
     def execute(self, params, **kwargs):
         if kwargs.get('add') and kwargs.get('remove'):
             raise CommandError('enterprise-role', "'add' and 'delete' parameters are mutually exclusive.")
@@ -2655,6 +2728,19 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                     else:
                         enforcement_value = None
 
+                    # Restrict require_account_share enforcement to root admins only.
+                    # Reuses EnterpriseCommand.get_user_root_nodes(), which fails open (treats an
+                    # unresolvable current user as main admin) to match the rest of the class.
+                    if key == 'require_account_share':
+                        true_root_node_id = next((n['node_id'] for n in params.enterprise.get('nodes', [])
+                                                   if n['node_id'] & 0xffffffff == 2), None)
+                        is_root_admin = true_root_node_id is not None and \
+                            true_root_node_id in self.get_user_root_nodes(params)
+                        if not is_root_admin:
+                            logging.warning('Failed to modify enforcement \'%s\': Only enterprise root administrators can manage account transfer policies',
+                                            key)
+                            continue
+
                     role_enforcements = params.enterprise.get('role_enforcements') or []
                     for role in matched_roles:
                         role_id = role['role_id']
@@ -2776,9 +2862,23 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                 if not node:
                     logging.warning('Role "%d" does not manage node "%d"', role_id, node_id)
                     return
-                privileges = {x['privilege'] for x in params.enterprise.get('role_privileges', [])
+                privileges = {x['privilege'].lower() for x in params.enterprise.get('role_privileges', [])
                               if x['role_id'] == role_id and x['managed_node_id'] == node_id}
                 all_privileges = {x[1].lower() for x in constants.ROLE_PRIVILEGES}
+
+                # Get current user's effective privileges for authorization check.
+                # Cascade-aware: walks ancestor chain to find privileges granted on parent nodes.
+                # Fails closed: an unresolvable current user yields no privileges, so the request is denied.
+                current_user_id = self.get_current_enterprise_user_id(params)
+                current_user_effective_privileges = set()  # type: Set[str]
+                if current_user_id:
+                    current_user_roles = {x['role_id'] for x in params.enterprise.get('role_users', [])
+                                          if x.get('enterprise_user_id') == current_user_id}
+                    for user_role_id in current_user_roles:
+                        # For each role the user has, get effective privileges on this node (honoring cascade)
+                        priv_set = self.get_effective_privileges_for_node(params, user_role_id, node_id)
+                        current_user_effective_privileges.update(priv_set)
+
                 for is_add in [True, False]:
                     parameter = 'add_privilege' if is_add else 'remove_privilege'
                     privilege_list = kwargs.get(parameter)
@@ -2787,11 +2887,7 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                             privilege = privilege.lower()
                             if privilege not in all_privileges:
                                 logging.warning('Add/Remove managed node privilege: invalid privilege: %s', privilege)
-                                return
-                            # if is_add:
-                            #     if privilege in ['transfer_account', 'manage_companies']:
-                            #         logging.warning('Add managed node privilege: Commander does not support \"%s\" privilege', privilege)
-                            #         return
+                                continue
                             if is_add and privilege in privileges:
                                 logging.info('Add privilege: Role "%d", Mode "%s" already contains privilege "%s" ',
                                              role_id, node_id, privilege)
@@ -2800,6 +2896,17 @@ class EnterpriseRoleCommand(EnterpriseCommand):
                                 logging.info('Remove privilege: Role "%d", Mode "%s" does not contains privilege "%s" ',
                                              role_id, node_id, privilege)
                                 continue
+
+                            # Verify caller holds the privilege before granting or revoking it on another
+                            # role. Gating removal too, since a node admin without the privilege could
+                            # otherwise strip transfer_account/manage_teams/manage_companies from a role
+                            # that depends on it (e.g. an offboarding or security-owning role).
+                            if privilege in _PRIVILEGED_GRANTS:
+                                if privilege not in current_user_effective_privileges:
+                                    verb = 'assign' if is_add else 'remove'
+                                    logging.warning('Failed to %s \'%s\' privilege: You do not have the required privilege to modify \'%s\'',
+                                                    verb, privilege, privilege)
+                                    continue
 
                             rq = {
                                 'command': 'managed_node_privilege_add' if is_add else 'managed_node_privilege_remove',

--- a/unit-tests/data_enterprise.py
+++ b/unit-tests/data_enterprise.py
@@ -26,6 +26,10 @@ _USER2_EMAIL = 'user2@keepercommander.com'
 
 _ROLE1_ID = (_ENTERPRISE_ID << 32) + 301
 _ROLE1_NAME = 'Role 1'
+_ROLE2_ID = (_ENTERPRISE_ID << 32) + 302
+_ROLE2_NAME = 'Role 2'
+_ROLE_ADMIN_ID = (_ENTERPRISE_ID << 32) + 303
+_ROLE_ADMIN_NAME = 'Admin Role'
 
 _LAST_ID = 1000
 
@@ -45,6 +49,10 @@ class EnterpriseEnvironment:
         self.user2_email = _USER2_EMAIL
         self.role1_id = _ROLE1_ID
         self.role1_name = _ROLE1_NAME
+        self.role2_id = _ROLE2_ID
+        self.role2_name = _ROLE2_NAME
+        self.role_admin_id = _ROLE_ADMIN_ID
+        self.role_admin_name = _ROLE_ADMIN_NAME
 
 
 def enterprise_allocate_ids(params, request):
@@ -122,11 +130,37 @@ def get_enterprise_data(params):
                 crypto.encrypt_aes_v1(json.dumps({'displayname': _ROLE1_NAME}).encode('utf-8'), _TREE_KEY)),
             'visible_below': True,
             'new_user_inherit': True
+        },
+        {
+            'role_id': _ROLE2_ID,
+            'node_id': _NODE1_ID,
+            'encrypted_data': utils.base64_url_encode(
+                crypto.encrypt_aes_v1(json.dumps({'displayname': _ROLE2_NAME}).encode('utf-8'), _TREE_KEY)),
+            'visible_below': False,
+            'new_user_inherit': False
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'node_id': _NODE1_ID,
+            'encrypted_data': utils.base64_url_encode(
+                crypto.encrypt_aes_v1(json.dumps({'displayname': _ROLE_ADMIN_NAME}).encode('utf-8'), _TREE_KEY)),
+            'visible_below': False,
+            'new_user_inherit': False
         }
     ]
     rs['managed_nodes'] = [
         {
             'role_id': _ROLE1_ID,
+            'managed_node_id': _NODE1_ID,
+            'cascade_node_management': True,
+        },
+        {
+            'role_id': _ROLE2_ID,
+            'managed_node_id': _NODE1_ID,
+            'cascade_node_management': False,
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
             'managed_node_id': _NODE1_ID,
             'cascade_node_management': True,
         }
@@ -135,6 +169,49 @@ def get_enterprise_data(params):
         {
             'role_id': _ROLE1_ID,
             'enterprise_user_id':  _USER1_ID
+        }
+    ]
+    # KC-1412: Add role_privileges to test authorization checks
+    rs['role_privileges'] = [
+        {
+            'role_id': _ROLE1_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_nodes'
+        },
+        {
+            'role_id': _ROLE1_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_user'
+        },
+        {
+            'role_id': _ROLE1_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_roles'
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_nodes'
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_user'
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_roles'
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'transfer_account'
+        },
+        {
+            'role_id': _ROLE_ADMIN_ID,
+            'managed_node_id': _NODE1_ID,
+            'privilege': 'manage_teams'
         }
     ]
     rs['teams'] = [

--- a/unit-tests/test_command_enterprise.py
+++ b/unit-tests/test_command_enterprise.py
@@ -191,6 +191,253 @@ class TestEnterprise(TestCase):
             with mock.patch('builtins.print'):
                 cmd.execute(params, add_user=['invalid@keepersecurity.com'], verbose=True, role=[ent_env.role1_name])
 
+    def test_enterprise_role_add_transfer_account_privilege_denied(self):
+        """KC-1412: Delegated admin without transfer_account privilege cannot grant it (CVE fix)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        # Role1 (current user) has only manage_nodes, manage_user, manage_roles (no transfer_account)
+        # Try to grant transfer_account to Role2 - should be denied by KC-1412 fix
+        with self.assertLogs(level=logging.WARNING) as log:
+            cmd.execute(params, add_privilege=['transfer_account'], role=[ent_env.role2_name],
+                       node='Enterprise 1')
+            # KC-1412 fix: Check for the privilege denial message
+            self.assertTrue(any('You do not have the required privilege' in msg for msg in log.output))
+
+        # Expected: no command sent to server (returned early due to lack of authorization)
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_add_manage_teams_privilege_denied(self):
+        """KC-1412: Delegated admin without manage_teams privilege cannot grant it (CVE fix)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        # Role1 has no manage_teams privilege - try to grant it, should be denied
+        with self.assertLogs(level=logging.WARNING) as log:
+            cmd.execute(params, add_privilege=['manage_teams'], role=[ent_env.role2_name],
+                       node='Enterprise 1')
+            # KC-1412 fix: Check for the privilege denial message
+            self.assertTrue(any('You do not have the required privilege' in msg for msg in log.output))
+
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_add_privilege_with_authorization(self):
+        """KC-1412: Admin with transfer_account privilege CAN grant it (regression test)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Use the admin role which has transfer_account in test data
+        # Add admin role to User1 so they have the privilege
+        params.enterprise['role_users'].append({
+            'role_id': ent_env.role_admin_id,
+            'enterprise_user_id': ent_env.user1_id
+        })
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        TestEnterprise.expected_commands = ['managed_node_privilege_add']
+        # Now User1 has transfer_account via Admin role, can grant it to Role2
+        cmd.execute(params, add_privilege=['transfer_account'], role=[ent_env.role2_name],
+                   node='Enterprise 1')
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_add_manage_companies_privilege_denied(self):
+        """Delegated admin without manage_companies privilege cannot grant it"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        with self.assertLogs(level=logging.WARNING) as log:
+            cmd.execute(params, add_privilege=['manage_companies'], role=[ent_env.role2_name],
+                       node='Enterprise 1')
+            self.assertTrue(any('You do not have the required privilege' in msg for msg in log.output))
+
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_remove_transfer_account_privilege_denied(self):
+        """Delegated admin without transfer_account privilege cannot strip it from another role"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Role2 already holds transfer_account; User1 (Role1) does not.
+        params.enterprise['role_privileges'].append({
+            'role_id': ent_env.role2_id,
+            'managed_node_id': ent_env.node1_id,
+            'privilege': 'transfer_account'
+        })
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        with self.assertLogs(level=logging.WARNING) as log:
+            cmd.execute(params, remove_privilege=['transfer_account'], role=[ent_env.role2_name],
+                       node='Enterprise 1')
+            self.assertTrue(any('You do not have the required privilege' in msg for msg in log.output))
+
+        # No removal command sent - Role2 should still hold the privilege
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_remove_privilege_with_authorization(self):
+        """Admin with transfer_account privilege CAN remove it from another role (regression test)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Role2 already holds transfer_account
+        params.enterprise['role_privileges'].append({
+            'role_id': ent_env.role2_id,
+            'managed_node_id': ent_env.node1_id,
+            'privilege': 'transfer_account'
+        })
+        # Give User1 transfer_account via Admin role
+        params.enterprise['role_users'].append({
+            'role_id': ent_env.role_admin_id,
+            'enterprise_user_id': ent_env.user1_id
+        })
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        TestEnterprise.expected_commands = ['managed_node_privilege_remove']
+        cmd.execute(params, remove_privilege=['transfer_account'], role=[ent_env.role2_name],
+                   node='Enterprise 1')
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_require_account_share_enforcement_denied_delegated_admin(self):
+        """KC-1412: Delegated admin (non-root) cannot set require_account_share enforcement (CVE fix)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Node2 is a sub-node (has parent_id), so user in that node is not root admin
+        # Modify to make Role1 manage Node2 instead
+        params.enterprise['managed_nodes'] = [
+            {
+                'role_id': ent_env.role1_id,
+                'managed_node_id': ent_env.node2_id,
+                'cascade_node_management': True,
+            }
+        ]
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        # Try to set require_account_share enforcement by role name
+        # This should be denied because the user is not a root admin (managing non-root node)
+        # KC-1412 fix should reject this with a warning and return early
+        with self.assertLogs(level=logging.WARNING):
+            cmd.execute(params, enforcements=[f'require_account_share:Admin Role'],
+                       role=[ent_env.role1_name])
+
+        # No command should be sent to server (returned early due to root admin check)
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_require_account_share_enforcement_allowed_root_admin(self):
+        """KC-1412: Root admin CAN set require_account_share enforcement (regression test)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Role1 manages Node1 (root node, no parent_id) - user is root admin
+        # Set enforcement to Admin Role which has transfer_account privilege
+        cmd = enterprise.EnterpriseRoleCommand()
+        TestEnterprise.expected_commands = ['role_enforcement_add']
+        cmd.execute(params, enforcements=['require_account_share:Admin Role'],
+                   role=[ent_env.role1_name])
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_other_enforcements_work_delegated_admin(self):
+        """KC-1412: Delegated admin CAN set non-sensitive enforcements (regression test)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        # Non-sensitive enforcement should work for delegated admin
+        TestEnterprise.expected_commands = ['role_enforcement_add']
+        cmd.execute(params, enforcements=['require_two_factor:True'],
+                   role=[ent_env.role1_name])
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_cascade_privilege_grant(self):
+        """KC-1435: Privilege grant on child node respects cascade from parent (regression test)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Set up: Admin role has transfer_account on Node1 (root)
+        # Add admin role's transfer_account privilege to parent node
+        params.enterprise['role_privileges'].append({
+            'role_id': ent_env.role_admin_id,
+            'managed_node_id': ent_env.node1_id,
+            'privilege': 'transfer_account'
+        })
+        # Add User1 to admin role so they have transfer_account via cascade
+        params.enterprise['role_users'].append({
+            'role_id': ent_env.role_admin_id,
+            'enterprise_user_id': ent_env.user1_id
+        })
+        # Role2 manages Node2 (child of Node1) with cascade enabled
+        params.enterprise['managed_nodes'].append({
+            'role_id': ent_env.role2_id,
+            'managed_node_id': ent_env.node2_id,
+            'cascade_node_management': False,
+        })
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        TestEnterprise.expected_commands = ['managed_node_privilege_add']
+        # Attempt to grant transfer_account on the child node — should succeed because
+        # the user's transfer_account privilege on parent Node1 cascades down to Node2
+        cmd.execute(params, add_privilege=['transfer_account'], role=[ent_env.role2_name],
+                   node='Sub node 1')
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_mixed_case_username(self):
+        """KC-1435: Username matching is case-insensitive (regression test)"""
+        params = get_connected_params()
+        # Mock user with mixed-case username
+        params.user = 'User@TEST.COM'
+        api.query_enterprise(params)
+
+        # Update the test data user to match in lowercase
+        params.enterprise['users'][0]['username'] = 'user@test.com'
+
+        # Add admin role to User1 for transfer_account
+        params.enterprise['role_users'].append({
+            'role_id': ent_env.role_admin_id,
+            'enterprise_user_id': ent_env.user1_id
+        })
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        TestEnterprise.expected_commands = ['managed_node_privilege_add']
+        # Should succeed despite mixed-case username in params.user
+        cmd.execute(params, add_privilege=['transfer_account'], role=[ent_env.role2_name],
+                   node='Enterprise 1')
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
+    def test_enterprise_role_enforcement_removal_restricted_non_root(self):
+        """KC-1435: Delegated admin cannot remove require_account_share enforcement (CVE fix)"""
+        params = get_connected_params()
+        api.query_enterprise(params)
+
+        # Set up Role1 to manage Node2 (non-root)
+        params.enterprise['managed_nodes'] = [
+            {
+                'role_id': ent_env.role1_id,
+                'managed_node_id': ent_env.node2_id,
+                'cascade_node_management': True,
+            }
+        ]
+        # Add existing enforcement on Role2
+        params.enterprise['role_enforcements'] = [
+            {
+                'role_id': ent_env.role2_id,
+                'enforcements': {
+                    'require_account_share': 'Admin Role'
+                }
+            }
+        ]
+
+        cmd = enterprise.EnterpriseRoleCommand()
+        # Attempt to remove the enforcement — should be denied by KC-1435 fix
+        # because delegated admin managing non-root node cannot modify it
+        with self.assertLogs(level=logging.WARNING):
+            cmd.execute(params, enforcements=['require_account_share'],
+                       role=[ent_env.role2_name])
+
+        # No command should be sent (denied by KC-1435 fix)
+        self.assertEqual(len(TestEnterprise.expected_commands), 0)
+
     def test_enterprise_team(self):
         params = get_connected_params()
         api.query_enterprise(params)


### PR DESCRIPTION
## Summary

Delegated admins without `transfer_account`, `manage_teams`, or `manage_companies` privileges could escalate by granting these privileges to roles they manage, bypassing authorization checks. The `require_account_share` enforcement setting could also be set by non-root delegated admins, restricting account access for managed users. Privilege grants now verify the current user holds each privilege before allowing the grant, and `require_account_share` enforcement is restricted to root admins only.

## Changes
- `enterprise.py`: 
  - Add privilege possession check before granting sensitive privileges; identify current user from params and extract their role privileges for the managed node; reject grant if user lacks privilege
  - Restrict `require_account_share` enforcement to root admins; check if current user's roles manage any root nodes (nodes with no parent_id)
- `data_enterprise.py`: Add test roles and role_privileges data with test privilege assignments for verification
- `test_command_enterprise.py`: Add 6 security tests covering privilege possession checks, root admin restriction, and regression tests for allowed operations