### PR TITLE
KC-935, KC-1123: Fix Service Mode background mode and tunneling on Windows

### DIFF
--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -201,6 +201,13 @@ def main(from_package=False):
     if from_package:
         sys.excepthook = handle_exceptions
 
+    # Internal: Background service mode for PyInstaller frozen executable
+    # This env var is set by service_manager when spawning the background subprocess
+    if os.environ.get('KEEPER_SERVICE_MODE') == '1':
+        from .service.core.service_app import run_background_service
+        run_background_service()
+        return
+
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
     opts, flags = parser.parse_known_args(sys.argv[1:])
     

--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -201,12 +201,13 @@ def main(from_package=False):
     if from_package:
         sys.excepthook = handle_exceptions
 
-    # Internal: Background service mode for PyInstaller frozen executable
-    # This env var is set by service_manager when spawning the background subprocess
-    if os.environ.get('KEEPER_SERVICE_MODE') == '1':
-        from .service.core.service_app import run_background_service
-        run_background_service()
-        return
+    # Internal: background service mode for a frozen (PyInstaller) executable - see service_app.py.
+    is_frozen = getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+    if is_frozen:
+        from .service.core.service_app import KEEPER_SERVICE_MODE_ENV, run_background_service
+        if os.environ.get(KEEPER_SERVICE_MODE_ENV) == '1':
+            run_background_service()
+            return
 
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
     opts, flags = parser.parse_known_args(sys.argv[1:])

--- a/keepercommander/__main__.py
+++ b/keepercommander/__main__.py
@@ -204,8 +204,8 @@ def main(from_package=False):
     # Internal: background service mode for a frozen (PyInstaller) executable - see service_app.py.
     is_frozen = getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
     if is_frozen:
-        from .service.core.service_app import KEEPER_SERVICE_MODE_ENV, run_background_service
-        if os.environ.get(KEEPER_SERVICE_MODE_ENV) == '1':
+        from .service.core.service_app import SERVICE_MODE_FLAG, run_background_service
+        if len(sys.argv) > 1 and sys.argv[1] == SERVICE_MODE_FLAG:
             run_background_service()
             return
 

--- a/keepercommander/commands/utils.py
+++ b/keepercommander/commands/utils.py
@@ -521,6 +521,8 @@ class SyncDownCommand(Command):
 
 class ThisDeviceCommand(Command):
 
+    skip_sync_on_auth = True
+
     def get_parser(self):
         return this_device_parser
 

--- a/keepercommander/service/config/cloudflare_config.py
+++ b/keepercommander/service/config/cloudflare_config.py
@@ -16,7 +16,7 @@ import psutil
     
 from ..decorators.logging import logger, debug_decorator
 from .service_config import ServiceConfig
-from ..util.tunneling import generate_cloudflare_url
+from ..util.tunneling import generate_cloudflare_url, get_tunnel_log_file
 from ..util.exceptions import ValidationError
 
 class CloudflareConfigurator:
@@ -86,8 +86,7 @@ class CloudflareConfigurator:
     @staticmethod
     def _get_cloudflare_log_path() -> str:
         """Get the path to the Cloudflare tunnel log file."""
-        service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-        return os.path.join(service_core_dir, "logs", "cloudflare_tunnel_subprocess.log")
+        return get_tunnel_log_file("cloudflare_tunnel_subprocess.log")
 
     @staticmethod
     def _analyze_tunnel_log(log_file: str) -> Tuple[Optional[bool], str]:

--- a/keepercommander/service/core/service_app.py
+++ b/keepercommander/service/core/service_app.py
@@ -11,15 +11,15 @@
 
 import sys
 
-# Env var service_manager sets so __main__.py can detect a frozen background-service subprocess.
-KEEPER_SERVICE_MODE_ENV = 'KEEPER_SERVICE_MODE'
+# Argv flag (not an env var, which could leak into subprocesses) signaling a frozen background service.
+SERVICE_MODE_FLAG = '--internal-run-service'
 
 
 def run_background_service():
     """
     Run the Flask service in background mode.
     This function is called both when running as a module (-m) and
-    when the frozen executable detects the KEEPER_SERVICE_MODE env var.
+    when the frozen executable is invoked with SERVICE_MODE_FLAG.
     """
     # PyInstaller's bootloader doesn't reliably honor PYTHONUNBUFFERED, so force it here too.
     for stream in (sys.stdout, sys.stderr):

--- a/keepercommander/service/core/service_app.py
+++ b/keepercommander/service/core/service_app.py
@@ -9,17 +9,30 @@
 # Contact: ops@keepersecurity.com
 #
 
-from ...service.app import create_app
-from ...service.config.service_config import ServiceConfig
-from ...service.core.service_manager import ServiceManager
-
-flask_app = create_app()
+import sys
 
 
-if __name__ == '__main__':
+def run_background_service():
+    """
+    Run the Flask service in background mode.
+    This function is called both when running as a module (-m) and
+    when the frozen executable detects the KEEPER_SERVICE_MODE env var.
+    """
+    # PyInstaller's bootloader doesn't reliably honor PYTHONUNBUFFERED, so force it here too.
+    for stream in (sys.stdout, sys.stderr):
+        if stream is not None and hasattr(stream, 'reconfigure'):
+            stream.reconfigure(line_buffering=True)
+
+    from ...service.app import create_app
+    from ...service.config.service_config import ServiceConfig
+    from ...service.core.service_manager import ServiceManager
+    
+    flask_app = create_app()
+    
     service_config = ServiceConfig()
     config_data = service_config.load_config()
     
+    # Pre-load Keeper parameters for background mode
     try:
         from ...service.core.globals import ensure_params_loaded
         print("Pre-loading Keeper parameters for background mode...")
@@ -29,10 +42,10 @@ if __name__ == '__main__':
         print(f"Warning: Failed to pre-load parameters during startup: {e}")
         print("Parameters will be loaded on first API call if needed")
     
-    ssl_context = None
-    
-    if not (port := config_data.get("port")):
+    port = config_data.get("port")
+    if not port:
         print("Error: Service configuration is incomplete. Please configure the service port in service_config")
+        sys.exit(1)
 
     ssl_context = ServiceManager.get_ssl_context(config_data)
     
@@ -41,4 +54,8 @@ if __name__ == '__main__':
         port=port,
         ssl_context=ssl_context
     )
+
+
+if __name__ == '__main__':
+    run_background_service()
 

--- a/keepercommander/service/core/service_app.py
+++ b/keepercommander/service/core/service_app.py
@@ -11,6 +11,9 @@
 
 import sys
 
+# Env var service_manager sets so __main__.py can detect a frozen background-service subprocess.
+KEEPER_SERVICE_MODE_ENV = 'KEEPER_SERVICE_MODE'
+
 
 def run_background_service():
     """

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -97,7 +97,7 @@ class ServiceManager:
                 ngrok_pid = NgrokConfigurator.configure_ngrok(config_data, service_config)
             except Exception as e:
                 ProcessInfo.clear()
-                logger.info(f"\n{str(e)}")
+                logger.error(f"\n{str(e)}")
                 return
             cloudflare_pid = None
 
@@ -116,7 +116,7 @@ class ServiceManager:
 
                 ProcessInfo.clear()
 
-                logger.info(f"\n{str(e)}")
+                logger.error(f"\n{str(e)}")
                 return
 
             # Custom logging filter to replace SSL handshake errors with user-friendly message
@@ -154,18 +154,19 @@ class ServiceManager:
                     subprocess_env['PYTHONUNBUFFERED'] = '1'
 
                     if is_frozen:
-                        # Running as PyInstaller executable - set env var to trigger service mode
-                        # The executable will detect KEEPER_SERVICE_MODE and start the service directly
-                        from .service_app import KEEPER_SERVICE_MODE_ENV
-                        subprocess_env[KEEPER_SERVICE_MODE_ENV] = '1'
-                        cmd = [python_executable]
+                        # -m doesn't work for a frozen exe, so pass an explicit internal flag instead.
+                        from .service_app import SERVICE_MODE_FLAG
+                        cmd = [python_executable, SERVICE_MODE_FLAG]
                     else:
                         # Running as Python script - use -m flag
                         cmd = [python_executable, '-m', 'keepercommander.service.core.service_app']
 
+                    # append=True to preserve history across restarts (tunnel logs truncate instead).
                     process = spawn_detached_process(
                         cmd, log_file, cwd=os.getcwd(), env=subprocess_env, append=True
                     )
+                    # Command output can include vault data - don't leave it world-readable.
+                    utils.set_file_permissions(log_file)
 
                     logger.debug(f"Service subprocess logs available at: {log_file}")
                     print(f"Commander Service started with PID: {process.pid}")
@@ -260,7 +261,7 @@ class ServiceManager:
                 cls._flask_app = create_app()
                 cls._is_running = True
 
-                ProcessInfo.save(os.getpid(), is_running, ngrok_pid)
+                ProcessInfo.save(os.getpid(), is_running, ngrok_pid, cloudflare_pid)
                 ssl_context = ServiceManager.get_ssl_context(config_data)
                 
                 try:

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -169,7 +169,7 @@ class ServiceManager:
 
                     logger.debug(f"Service subprocess logs available at: {log_file}")
                     print(f"Commander Service started with PID: {process.pid}")
-                    ProcessInfo.save(process.pid, is_running, ngrok_pid)
+                    ProcessInfo.save(process.pid, is_running, ngrok_pid, cloudflare_pid)
 
                 except Exception as e:
                     logger.error(f"Failed to start service subprocess: {e}")

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -17,15 +17,11 @@ import psutil
 from ... import utils
 from ...service.config.service_config import ServiceConfig
 from ..decorators.logging import logger, debug_decorator
+from ..util.process_util import spawn_detached_process, CREATE_NO_WINDOW
 from .process_info import ProcessInfo
 from .terminal_handler import TerminalHandler
 from .signal_handler import SignalHandler
 import sys, subprocess
-
-# Windows CreateProcess flags to run service subprocesses fully detached and hidden
-CREATE_NO_WINDOW = 0x08000000
-DETACHED_PROCESS = 0x00000008
-CREATE_NEW_PROCESS_GROUP = 0x00000200
 
 class ServiceManager:
     """Manages the lifecycle of the service including start, stop, and status operations."""
@@ -97,7 +93,12 @@ class ServiceManager:
             else:
                 print(f"Commander Service starting on \033[1m{protocol}://localhost:{port}/api/v1/executecommand\033[0m")
             
-            ngrok_pid = NgrokConfigurator.configure_ngrok(config_data, service_config)
+            try:
+                ngrok_pid = NgrokConfigurator.configure_ngrok(config_data, service_config)
+            except Exception as e:
+                ProcessInfo.clear()
+                logger.info(f"\n{str(e)}")
+                return
             cloudflare_pid = None
 
             try:
@@ -146,7 +147,7 @@ class ServiceManager:
 
                 try:
                     python_executable = sys.executable
-                    
+
                     # Set up environment for subprocess
                     subprocess_env = os.environ.copy()
                     # Redirected (non-TTY) stdout defaults to full buffering, delaying log output.
@@ -155,41 +156,17 @@ class ServiceManager:
                     if is_frozen:
                         # Running as PyInstaller executable - set env var to trigger service mode
                         # The executable will detect KEEPER_SERVICE_MODE and start the service directly
-                        subprocess_env['KEEPER_SERVICE_MODE'] = '1'
+                        from .service_app import KEEPER_SERVICE_MODE_ENV
+                        subprocess_env[KEEPER_SERVICE_MODE_ENV] = '1'
                         cmd = [python_executable]
                     else:
                         # Running as Python script - use -m flag
                         cmd = [python_executable, '-m', 'keepercommander.service.core.service_app']
-                    
-                    # Open log file in append mode with line buffering
-                    log_f = open(log_file, 'a', buffering=1)
-                    
-                    try:
-                        if sys.platform == "win32":
-                            process = subprocess.Popen(
-                                cmd,
-                                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
-                                stdout=log_f,
-                                stderr=subprocess.STDOUT,
-                                stdin=subprocess.DEVNULL,
-                                cwd=os.getcwd(),
-                                env=subprocess_env
-                            )
-                        else:
-                            # For macOS and Linux
-                            process = subprocess.Popen(
-                                cmd,
-                                stdout=log_f,
-                                stderr=subprocess.STDOUT,
-                                stdin=subprocess.DEVNULL,
-                                preexec_fn=os.setpgrp,
-                                cwd=os.getcwd(),
-                                env=subprocess_env
-                            )
-                    except Exception:
-                        log_f.close()
-                        raise
-                    
+
+                    process = spawn_detached_process(
+                        cmd, log_file, cwd=os.getcwd(), env=subprocess_env, append=True
+                    )
+
                     logger.debug(f"Service subprocess logs available at: {log_file}")
                     print(f"Commander Service started with PID: {process.pid}")
                     ProcessInfo.save(process.pid, is_running, ngrok_pid)

--- a/keepercommander/service/core/service_manager.py
+++ b/keepercommander/service/core/service_manager.py
@@ -22,6 +22,11 @@ from .terminal_handler import TerminalHandler
 from .signal_handler import SignalHandler
 import sys, subprocess
 
+# Windows CreateProcess flags to run service subprocesses fully detached and hidden
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
 class ServiceManager:
     """Manages the lifecycle of the service including start, stop, and status operations."""
     
@@ -130,43 +135,64 @@ class ServiceManager:
             werkzeug_logger.addFilter(SSLHandshakeFilter())
 
             if config_data.get("run_mode") == "background":
-
-                base_dir = os.path.dirname(os.path.abspath(__file__))
-                service_module = "keepercommander.service.core.service_app"  # Use module path instead of file path
-                python_executable = sys.executable
-
-                # Create logs directory for subprocess output
-                log_dir = os.path.join(base_dir, "logs")
+                
+                # Detect if running as PyInstaller executable
+                is_frozen = getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS')
+                
+                # Create logs directory for subprocess output in user-writable location
+                log_dir = os.path.join(utils.get_default_path(), "service_logs")
                 os.makedirs(log_dir, exist_ok=True)
                 log_file = os.path.join(log_dir, "service_subprocess.log")
 
                 try:
-                    if sys.platform == "win32":
-                        subprocess.DETACHED_PROCESS = 0x00000008
-                        with open(log_file, 'w') as log_f:
-                            cls = subprocess.Popen(
-                                [python_executable, '-m', service_module],
-                                creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
-                                stdout=log_f,
-                                stderr=subprocess.STDOUT,  # Combine stderr with stdout
-                                cwd=os.getcwd(),  # Use current working directory to access config files
-                                env=os.environ.copy()  # Inherit environment variables
-                            )
+                    python_executable = sys.executable
+                    
+                    # Set up environment for subprocess
+                    subprocess_env = os.environ.copy()
+                    # Redirected (non-TTY) stdout defaults to full buffering, delaying log output.
+                    subprocess_env['PYTHONUNBUFFERED'] = '1'
+
+                    if is_frozen:
+                        # Running as PyInstaller executable - set env var to trigger service mode
+                        # The executable will detect KEEPER_SERVICE_MODE and start the service directly
+                        subprocess_env['KEEPER_SERVICE_MODE'] = '1'
+                        cmd = [python_executable]
                     else:
-                        # For macOS and Linux - improved subprocess handling
-                        with open(log_file, 'w') as log_f:
-                            cls = subprocess.Popen(
-                                [python_executable, '-m', service_module],
+                        # Running as Python script - use -m flag
+                        cmd = [python_executable, '-m', 'keepercommander.service.core.service_app']
+                    
+                    # Open log file in append mode with line buffering
+                    log_f = open(log_file, 'a', buffering=1)
+                    
+                    try:
+                        if sys.platform == "win32":
+                            process = subprocess.Popen(
+                                cmd,
+                                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
                                 stdout=log_f,
-                                stderr=subprocess.STDOUT,  # Combine stderr with stdout
-                                preexec_fn=os.setpgrp,
-                                cwd=os.getcwd(),  # Use current working directory to access config files
-                                env=os.environ.copy()  # Inherit environment variables
+                                stderr=subprocess.STDOUT,
+                                stdin=subprocess.DEVNULL,
+                                cwd=os.getcwd(),
+                                env=subprocess_env
                             )
+                        else:
+                            # For macOS and Linux
+                            process = subprocess.Popen(
+                                cmd,
+                                stdout=log_f,
+                                stderr=subprocess.STDOUT,
+                                stdin=subprocess.DEVNULL,
+                                preexec_fn=os.setpgrp,
+                                cwd=os.getcwd(),
+                                env=subprocess_env
+                            )
+                    except Exception:
+                        log_f.close()
+                        raise
                     
                     logger.debug(f"Service subprocess logs available at: {log_file}")
-                    print(f"Commander Service started with PID: {cls.pid}")
-                    ProcessInfo.save(cls.pid, is_running, ngrok_pid)
+                    print(f"Commander Service started with PID: {process.pid}")
+                    ProcessInfo.save(process.pid, is_running, ngrok_pid)
 
                 except Exception as e:
                     logger.error(f"Failed to start service subprocess: {e}")
@@ -268,9 +294,6 @@ class ServiceManager:
                     )
                 finally:
                     cleanup_cloudflare_on_foreground_exit()
-
-            # Save the process ID for future reference
-            ProcessInfo.save(cls.pid, is_running, ngrok_pid, cloudflare_pid)
             
         except FileNotFoundError:
             logging.info("Error: Service configuration file not found. Please use 'service-create' command to create a service_config file.")
@@ -459,7 +482,13 @@ class ServiceManager:
         try:
             if sys.platform.startswith("win"):  #  Windows
                 logger.debug(f"Using Windows taskkill for PID {pid}")
-                subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=True)
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/F"],
+                    check=True,
+                    creationflags=CREATE_NO_WINDOW,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
                 return True
             else:  #  Linux & macOS
                 try:

--- a/keepercommander/service/util/process_util.py
+++ b/keepercommander/service/util/process_util.py
@@ -1,0 +1,47 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2024 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+import os
+import subprocess
+import sys
+
+# Windows CreateProcess flags to run subprocesses fully detached and hidden
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+
+def spawn_detached_process(cmd, log_file, cwd=None, env=None, append=False):
+    """
+    Start cmd as a fully detached background subprocess, hidden on Windows, with
+    stdout/stderr redirected to log_file. Returns the Popen object.
+    """
+    mode = 'a' if append else 'w'
+    with open(log_file, mode) as log_f:
+        if sys.platform == "win32":
+            return subprocess.Popen(
+                cmd,
+                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                cwd=cwd,
+                env=env,
+            )
+        return subprocess.Popen(
+            cmd,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            preexec_fn=os.setpgrp,
+            cwd=cwd,
+            env=env,
+        )

--- a/keepercommander/service/util/process_util.py
+++ b/keepercommander/service/util/process_util.py
@@ -9,7 +9,6 @@
 # Contact: ops@keepersecurity.com
 #
 
-import os
 import subprocess
 import sys
 
@@ -41,7 +40,7 @@ def spawn_detached_process(cmd, log_file, cwd=None, env=None, append=False):
             stdout=log_f,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
-            preexec_fn=os.setpgrp,
+            start_new_session=True,  # os.setsid() in the child - not thread-unsafe like preexec_fn
             cwd=cwd,
             env=env,
         )

--- a/keepercommander/service/util/request_validation.py
+++ b/keepercommander/service/util/request_validation.py
@@ -11,6 +11,7 @@
 
 from typing import Optional, Tuple, Dict, Any
 from flask import request, jsonify
+from werkzeug.exceptions import BadRequest
 from html import escape
 import tempfile
 import os
@@ -148,11 +149,12 @@ class RequestValidator:
         
         try:
             json_data = request.get_json(force=True, silent=False)
-            if json_data is None:
+            if not json_data:
                 logger.info("Request validation failed: Invalid or empty JSON")
                 return jsonify({"status": "error", "error": "Invalid or empty JSON"}), 400
-        except Exception as e:
+        except (BadRequest, ValueError) as e:
+            # The parser's message can include a payload excerpt - log it, don't echo it back.
             logger.warning(f"Request validation failed: JSON parsing error - {e}")
-            return jsonify({"status": "error", "error": f"Invalid JSON format: {str(e)}"}), 400
-        
+            return jsonify({"status": "error", "error": "Invalid JSON format"}), 400
+
         return None

--- a/keepercommander/service/util/request_validation.py
+++ b/keepercommander/service/util/request_validation.py
@@ -146,8 +146,13 @@ class RequestValidator:
             logger.info("Request validation failed: Content-Type must be application/json")
             return jsonify({"status": "error", "error": "Content-Type must be application/json"}), 400
         
-        if not request.json:
-            logger.info("Request validation failed: Invalid or empty JSON")
-            return jsonify({"status": "error", "error": "Invalid or empty JSON"}), 400
+        try:
+            json_data = request.get_json(force=True, silent=False)
+            if json_data is None:
+                logger.info("Request validation failed: Invalid or empty JSON")
+                return jsonify({"status": "error", "error": "Invalid or empty JSON"}), 400
+        except Exception as e:
+            logger.warning(f"Request validation failed: JSON parsing error - {e}")
+            return jsonify({"status": "error", "error": f"Invalid JSON format: {str(e)}"}), 400
         
         return None

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -20,10 +20,25 @@ import re
 import json
 import tempfile
 
+from ... import utils
+
 # Windows CreateProcess flags to run tunnel subprocesses fully detached and hidden
 CREATE_NO_WINDOW = 0x08000000
 DETACHED_PROCESS = 0x00000008
 CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+# Same user-writable log directory service_manager.py uses for the service subprocess log
+TUNNEL_LOG_DIR = os.path.join(utils.get_default_path(), "service_logs")
+
+
+def get_ngrok_log_file():
+    os.makedirs(TUNNEL_LOG_DIR, exist_ok=True)
+    return os.path.join(TUNNEL_LOG_DIR, "ngrok_subprocess.log")
+
+
+def get_cloudflare_log_file():
+    os.makedirs(TUNNEL_LOG_DIR, exist_ok=True)
+    return os.path.join(TUNNEL_LOG_DIR, "cloudflare_tunnel_subprocess.log")
 
 
 def start_ngrok(port, auth_token=None, subdomain=None):
@@ -41,9 +56,7 @@ def start_ngrok(port, auth_token=None, subdomain=None):
 
 
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-    log_dir = os.path.join(service_core_dir, "logs")
-    os.makedirs(log_dir, exist_ok=True)
-    log_file = os.path.join(log_dir, "ngrok_subprocess.log")
+    log_file = get_ngrok_log_file()
 
     if sys.platform == "win32":
         with open(log_file, 'w') as log_f:
@@ -174,9 +187,7 @@ def start_ngrok_with_url(port, auth_token=None, subdomain=None):
 
     # If API method fails, try parsing the log file
     if not public_url:
-        service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-        log_file = os.path.join(service_core_dir, "logs", "ngrok_subprocess.log")
-        public_url = get_ngrok_url_from_log(log_file)
+        public_url = get_ngrok_url_from_log(get_ngrok_log_file())
     
     # If we still don't have a URL and subdomain was provided, construct it
     if not public_url and subdomain:
@@ -351,10 +362,8 @@ def _start_cloudflare_with_binary(port, tunnel_token, custom_domain=None):
         )
     
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-    log_dir = os.path.join(service_core_dir, "logs")
-    os.makedirs(log_dir, exist_ok=True)
-    log_file = os.path.join(log_dir, "cloudflare_tunnel_subprocess.log")
-    
+    log_file = get_cloudflare_log_file()
+
     if sys.platform == "win32":
         with open(log_file, 'w') as log_f:
             process = subprocess.Popen(

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -21,24 +21,15 @@ import json
 import tempfile
 
 from ... import utils
-
-# Windows CreateProcess flags to run tunnel subprocesses fully detached and hidden
-CREATE_NO_WINDOW = 0x08000000
-DETACHED_PROCESS = 0x00000008
-CREATE_NEW_PROCESS_GROUP = 0x00000200
+from .process_util import spawn_detached_process, CREATE_NO_WINDOW
 
 # Same user-writable log directory service_manager.py uses for the service subprocess log
 TUNNEL_LOG_DIR = os.path.join(utils.get_default_path(), "service_logs")
 
 
-def get_ngrok_log_file():
+def get_tunnel_log_file(name):
     os.makedirs(TUNNEL_LOG_DIR, exist_ok=True)
-    return os.path.join(TUNNEL_LOG_DIR, "ngrok_subprocess.log")
-
-
-def get_cloudflare_log_file():
-    os.makedirs(TUNNEL_LOG_DIR, exist_ok=True)
-    return os.path.join(TUNNEL_LOG_DIR, "cloudflare_tunnel_subprocess.log")
+    return os.path.join(TUNNEL_LOG_DIR, name)
 
 
 def start_ngrok(port, auth_token=None, subdomain=None):
@@ -56,30 +47,8 @@ def start_ngrok(port, auth_token=None, subdomain=None):
 
 
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-    log_file = get_ngrok_log_file()
-
-    if sys.platform == "win32":
-        with open(log_file, 'w') as log_f:
-            process = subprocess.Popen(
-                ngrok_cmd,
-                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
-                stdout=log_f,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.DEVNULL,
-                cwd=service_core_dir,
-                env=os.environ.copy()
-            )
-    else:
-        with open(log_file, 'w') as log_f:
-            process = subprocess.Popen(
-                ngrok_cmd,
-                stdout=log_f,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.DEVNULL,
-                preexec_fn=os.setpgrp,
-                cwd=service_core_dir,
-                env=os.environ.copy()
-            )
+    log_file = get_tunnel_log_file("ngrok_subprocess.log")
+    process = spawn_detached_process(ngrok_cmd, log_file, cwd=service_core_dir, env=os.environ.copy())
 
     actual_ngrok_pid = process.pid
     try:
@@ -187,7 +156,7 @@ def start_ngrok_with_url(port, auth_token=None, subdomain=None):
 
     # If API method fails, try parsing the log file
     if not public_url:
-        public_url = get_ngrok_url_from_log(get_ngrok_log_file())
+        public_url = get_ngrok_url_from_log(get_tunnel_log_file("ngrok_subprocess.log"))
     
     # If we still don't have a URL and subdomain was provided, construct it
     if not public_url and subdomain:
@@ -362,31 +331,9 @@ def _start_cloudflare_with_binary(port, tunnel_token, custom_domain=None):
         )
     
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
-    log_file = get_cloudflare_log_file()
+    log_file = get_tunnel_log_file("cloudflare_tunnel_subprocess.log")
+    process = spawn_detached_process(cloudflared_cmd, log_file, cwd=service_core_dir, env=os.environ.copy())
 
-    if sys.platform == "win32":
-        with open(log_file, 'w') as log_f:
-            process = subprocess.Popen(
-                cloudflared_cmd,
-                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
-                stdout=log_f,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.DEVNULL,
-                cwd=service_core_dir,
-                env=os.environ.copy()
-            )
-    else:
-        with open(log_file, 'w') as log_f:
-            process = subprocess.Popen(
-                cloudflared_cmd,
-                stdout=log_f,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.DEVNULL,
-                preexec_fn=os.setpgrp,
-                cwd=service_core_dir,
-                env=os.environ.copy()
-            )
-    
     tunnel_url = get_cloudflare_url_from_log(log_file, custom_domain)
     
     return process.pid, tunnel_url

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -20,12 +20,19 @@ import re
 import json
 import tempfile
 
+# Windows CreateProcess flags to run tunnel subprocesses fully detached and hidden
+CREATE_NO_WINDOW = 0x08000000
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
 
 def start_ngrok(port, auth_token=None, subdomain=None):
     """
     Start ngrok as a fully detached subprocess and return the PID.
     """
-    ngrok_cmd = ["ngrok", "http", str(port), "--log=stdout", "--log-level=info"]
+    ngrok_config = conf.get_default()
+    ngrok.install_ngrok(ngrok_config)
+    ngrok_cmd = [ngrok_config.ngrok_path, "http", str(port), "--log=stdout", "--log-level=info"]
     
     if subdomain:
         ngrok_cmd += ["--subdomain", subdomain]
@@ -39,25 +46,26 @@ def start_ngrok(port, auth_token=None, subdomain=None):
     log_file = os.path.join(log_dir, "ngrok_subprocess.log")
 
     if sys.platform == "win32":
-        subprocess.DETACHED_PROCESS = 0x00000008
         with open(log_file, 'w') as log_f:
             process = subprocess.Popen(
                 ngrok_cmd,
-                creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
                 stdout=log_f,
-                stderr=subprocess.STDOUT,  # Combine stderr with stdout
-                cwd=service_core_dir,  # Set working directory
-                env=os.environ.copy()  # Inherit environment variables
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                cwd=service_core_dir,
+                env=os.environ.copy()
             )
     else:
         with open(log_file, 'w') as log_f:
             process = subprocess.Popen(
                 ngrok_cmd,
                 stdout=log_f,
-                stderr=subprocess.STDOUT,  # Combine stderr with stdout
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
                 preexec_fn=os.setpgrp,
-                cwd=service_core_dir,  # Set working directory
-                env=os.environ.copy()  # Inherit environment variables
+                cwd=service_core_dir,
+                env=os.environ.copy()
             )
 
     actual_ngrok_pid = process.pid
@@ -200,32 +208,40 @@ def generate_ngrok_url(port, auth_token, ngrok_custom_domain, run_mode):
         log_event_callback=None,
     )
     
-    with open(os.devnull, 'w') as devnull:
+    if run_mode == "background":
+        # Own subprocess with its own log file - skip the console-unsafe fd redirection below.
+        if ngrok_custom_domain:
+            ngrok_pid, public_url = start_ngrok_with_url(port=port, auth_token=auth_token, subdomain=ngrok_custom_domain)
+        else:
+            ngrok_pid, public_url = start_ngrok_with_url(port=port, auth_token=auth_token)
+        return public_url, ngrok_pid
+
+    old_stdout_fd = None
+    old_stderr_fd = None
+    try:
         old_stdout_fd = os.dup(1)
         old_stderr_fd = os.dup(2)
-        os.dup2(devnull.fileno(), 1)
-        os.dup2(devnull.fileno(), 2)
-        
-        try:
-            if run_mode == "background":
-                # Background mode: use subprocess for both custom and non-custom domains
-                if ngrok_custom_domain:
-                    ngrok_pid, public_url = start_ngrok_with_url(port=port, auth_token=auth_token, subdomain=ngrok_custom_domain)
-                else:
-                    ngrok_pid, public_url = start_ngrok_with_url(port=port, auth_token=auth_token)
-                return public_url, ngrok_pid
-            else:
-                # Foreground mode: use pyngrok library
-                if ngrok_custom_domain:
-                    tunnel = ngrok.connect(port, subdomain=ngrok_custom_domain, pyngrok_config=ngrok_config)
-                else:
-                    tunnel = ngrok.connect(port, pyngrok_config=ngrok_config)
-                return tunnel.public_url, None
-            
-        finally:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull_fd, 1)
+        os.dup2(devnull_fd, 2)
+        os.close(devnull_fd)
+    except OSError:
+        old_stdout_fd = None
+        old_stderr_fd = None
+
+    try:
+        if ngrok_custom_domain:
+            tunnel = ngrok.connect(port, subdomain=ngrok_custom_domain, pyngrok_config=ngrok_config)
+        else:
+            tunnel = ngrok.connect(port, pyngrok_config=ngrok_config)
+        return tunnel.public_url, None
+
+    finally:
+        if old_stdout_fd is not None:
             os.dup2(old_stdout_fd, 1)
-            os.dup2(old_stderr_fd, 2) 
             os.close(old_stdout_fd)
+        if old_stderr_fd is not None:
+            os.dup2(old_stderr_fd, 2)
             os.close(old_stderr_fd)
 
 
@@ -238,9 +254,18 @@ def _download_cloudflared():
     """
     try:
         # First try to find existing cloudflared
-        result = subprocess.run(['which', 'cloudflared'], capture_output=True, text=True)
+        if sys.platform == "win32":
+            result = subprocess.run(
+                ['where', 'cloudflared'],
+                capture_output=True,
+                text=True,
+                creationflags=CREATE_NO_WINDOW
+            )
+        else:
+            result = subprocess.run(['which', 'cloudflared'], capture_output=True, text=True)
         if result.returncode == 0:
-            return result.stdout.strip()
+            # 'where' can print multiple matches, one per line; take the first
+            return result.stdout.strip().split('\n')[0]
     except:
         pass
         
@@ -331,13 +356,13 @@ def _start_cloudflare_with_binary(port, tunnel_token, custom_domain=None):
     log_file = os.path.join(log_dir, "cloudflare_tunnel_subprocess.log")
     
     if sys.platform == "win32":
-        subprocess.DETACHED_PROCESS = 0x00000008
         with open(log_file, 'w') as log_f:
             process = subprocess.Popen(
                 cloudflared_cmd,
-                creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+                creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW,
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
                 cwd=service_core_dir,
                 env=os.environ.copy()
             )
@@ -347,6 +372,7 @@ def _start_cloudflare_with_binary(port, tunnel_token, custom_domain=None):
                 cloudflared_cmd,
                 stdout=log_f,
                 stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
                 preexec_fn=os.setpgrp,
                 cwd=service_core_dir,
                 env=os.environ.copy()
@@ -410,36 +436,22 @@ def start_cloudflare_tunnel_with_url(port, tunnel_token, custom_domain=None):
 
 def generate_cloudflare_url(port, tunnel_token, custom_domain, run_mode):
     """
-    Start a Cloudflare tunnel with complete log suppression.
-    Returns a tuple of (public_url, tunnel_pid) for background mode, or (public_url, None) for foreground mode.
+    Start a Cloudflare tunnel as a detached subprocess and return its public URL.
+    Returns a tuple of (public_url, tunnel_pid).
     """
     if not port:
         raise ValueError("Port must be provided for Cloudflare tunnel.")
-    
+
     if not tunnel_token or not tunnel_token.strip():
         raise ValueError(
             "Tunnel token is required for secure Cloudflare tunnel operation. "
             "Temporary tunnels are not supported for production use."
         )
-    
-    # Cloudflare tunnel configuration
-    
-    with open(os.devnull, 'w') as devnull:
-        old_stdout_fd = os.dup(1)
-        old_stderr_fd = os.dup(2)
-        os.dup2(devnull.fileno(), 1)
-        os.dup2(devnull.fileno(), 2)
-        
-        try:
-            tunnel_pid, public_url = start_cloudflare_tunnel_with_url(
-                port=port, 
-                tunnel_token=tunnel_token, 
-                custom_domain=custom_domain
-            )
-            return public_url, tunnel_pid
-            
-        finally:
-            os.dup2(old_stdout_fd, 1)
-            os.dup2(old_stderr_fd, 2) 
-            os.close(old_stdout_fd)
-            os.close(old_stderr_fd)
+
+    # Always runs as a detached subprocess with its own log file - nothing to suppress here.
+    tunnel_pid, public_url = start_cloudflare_tunnel_with_url(
+        port=port,
+        tunnel_token=tunnel_token,
+        custom_domain=custom_domain
+    )
+    return public_url, tunnel_pid

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -21,15 +21,17 @@ import json
 import tempfile
 
 from ... import utils
-from .process_util import spawn_detached_process, CREATE_NO_WINDOW
-
-# Same user-writable log directory service_manager.py uses for the service subprocess log
-TUNNEL_LOG_DIR = os.path.join(utils.get_default_path(), "service_logs")
-
+from .process_util import spawn_detached_process
 
 def get_tunnel_log_file(name):
-    os.makedirs(TUNNEL_LOG_DIR, exist_ok=True)
-    return os.path.join(TUNNEL_LOG_DIR, name)
+    # Resolved per call, not cached at import time, so a later --data-dir override is respected.
+    log_dir = os.path.join(utils.get_default_path(), "service_logs")
+    os.makedirs(log_dir, exist_ok=True)
+    return os.path.join(log_dir, name)
+
+
+# DOA check only catches immediate crashes; a slower failure (bad auth) is caught later below.
+NGROK_STARTUP_CHECK_DELAY_SECONDS = 0.5
 
 
 def start_ngrok(port, auth_token=None, subdomain=None):
@@ -39,7 +41,7 @@ def start_ngrok(port, auth_token=None, subdomain=None):
     ngrok_config = conf.get_default()
     ngrok.install_ngrok(ngrok_config)
     ngrok_cmd = [ngrok_config.ngrok_path, "http", str(port), "--log=stdout", "--log-level=info"]
-    
+
     if subdomain:
         ngrok_cmd += ["--subdomain", subdomain]
     if auth_token:
@@ -49,8 +51,9 @@ def start_ngrok(port, auth_token=None, subdomain=None):
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
     log_file = get_tunnel_log_file("ngrok_subprocess.log")
     process = spawn_detached_process(ngrok_cmd, log_file, cwd=service_core_dir, env=os.environ.copy())
+    utils.set_file_permissions(log_file)
 
-    time.sleep(0.5)  # Give ngrok a moment to start
+    time.sleep(NGROK_STARTUP_CHECK_DELAY_SECONDS)
     if process.poll() is not None:
         raise RuntimeError(
             f"ngrok exited immediately (exit code {process.returncode}); see {log_file} for details"
@@ -167,7 +170,16 @@ def start_ngrok_with_url(port, auth_token=None, subdomain=None):
     if not public_url and subdomain:
         public_url = f"https://{subdomain}.ngrok.io"
         logging.warning("Could not retrieve dynamic ngrok URL, using constructed URL")
-    
+
+    # No URL and the process is gone (e.g. bad auth token) is a real failure, not just slow.
+    if not public_url:
+        try:
+            import psutil
+            if not psutil.pid_exists(pid):
+                raise RuntimeError(f"ngrok process {pid} is no longer running; see logs for details")
+        except ImportError:
+            pass
+
     return pid, public_url
 
 def generate_ngrok_url(port, auth_token, ngrok_custom_domain, run_mode):
@@ -213,11 +225,13 @@ def generate_ngrok_url(port, auth_token, ngrok_custom_domain, run_mode):
         finally:
             os.close(devnull_fd)
     except OSError:
-        # Redirection didn't fully succeed - close whatever we already opened and
-        # continue without suppressing ngrok's console output.
-        for fd in (old_stdout_fd, old_stderr_fd):
+        # Restore anything already redirected (else fd 1 could stay pointed at devnull forever).
+        for fd, target in ((old_stdout_fd, 1), (old_stderr_fd, 2)):
             if fd is not None:
-                os.close(fd)
+                try:
+                    os.dup2(fd, target)
+                finally:
+                    os.close(fd)
         old_stdout_fd = None
         old_stderr_fd = None
 
@@ -244,22 +258,14 @@ def _download_cloudflared():
     Download cloudflared binary if not available.
     Returns path to cloudflared binary.
     """
-    try:
-        # First try to find existing cloudflared
-        if sys.platform == "win32":
-            result = subprocess.run(
-                ['where', 'cloudflared'],
-                capture_output=True,
-                text=True,
-                creationflags=CREATE_NO_WINDOW
-            )
-        else:
+    # Windows `where`/shutil.which both search cwd before PATH (planted-binary risk) - only search on POSIX.
+    if sys.platform != "win32":
+        try:
             result = subprocess.run(['which', 'cloudflared'], capture_output=True, text=True)
-        if result.returncode == 0:
-            # 'where' can print multiple matches, one per line; take the first
-            return result.stdout.strip().split('\n')[0]
-    except Exception as e:
-        logging.debug(f"Could not find existing cloudflared on PATH: {e}")
+            if result.returncode == 0:
+                return result.stdout.strip().splitlines()[0]
+        except Exception as e:
+            logging.debug(f"Could not find existing cloudflared on PATH: {e}")
 
     # Download cloudflared binary
     import platform
@@ -345,6 +351,7 @@ def _start_cloudflare_with_binary(port, tunnel_token, custom_domain=None):
     service_core_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core")
     log_file = get_tunnel_log_file("cloudflare_tunnel_subprocess.log")
     process = spawn_detached_process(cloudflared_cmd, log_file, cwd=service_core_dir, env=os.environ.copy())
+    utils.set_file_permissions(log_file)
 
     tunnel_url = get_cloudflare_url_from_log(log_file, custom_domain)
     

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -50,11 +50,16 @@ def start_ngrok(port, auth_token=None, subdomain=None):
     log_file = get_tunnel_log_file("ngrok_subprocess.log")
     process = spawn_detached_process(ngrok_cmd, log_file, cwd=service_core_dir, env=os.environ.copy())
 
+    time.sleep(0.5)  # Give ngrok a moment to start
+    if process.poll() is not None:
+        raise RuntimeError(
+            f"ngrok exited immediately (exit code {process.returncode}); see {log_file} for details"
+        )
+
     actual_ngrok_pid = process.pid
     try:
         import psutil
-        time.sleep(0.5)  # Give ngrok a moment to start
-        
+
         # Look for the actual ngrok binary process
         for proc in psutil.process_iter(['pid', 'ppid', 'name', 'cmdline']):
             try:
@@ -202,10 +207,17 @@ def generate_ngrok_url(port, auth_token, ngrok_custom_domain, run_mode):
         old_stdout_fd = os.dup(1)
         old_stderr_fd = os.dup(2)
         devnull_fd = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull_fd, 1)
-        os.dup2(devnull_fd, 2)
-        os.close(devnull_fd)
+        try:
+            os.dup2(devnull_fd, 1)
+            os.dup2(devnull_fd, 2)
+        finally:
+            os.close(devnull_fd)
     except OSError:
+        # Redirection didn't fully succeed - close whatever we already opened and
+        # continue without suppressing ngrok's console output.
+        for fd in (old_stdout_fd, old_stderr_fd):
+            if fd is not None:
+                os.close(fd)
         old_stdout_fd = None
         old_stderr_fd = None
 
@@ -246,9 +258,9 @@ def _download_cloudflared():
         if result.returncode == 0:
             # 'where' can print multiple matches, one per line; take the first
             return result.stdout.strip().split('\n')[0]
-    except:
-        pass
-        
+    except Exception as e:
+        logging.debug(f"Could not find existing cloudflared on PATH: {e}")
+
     # Download cloudflared binary
     import platform
     import urllib.request

--- a/keepercommander/service/util/tunneling.py
+++ b/keepercommander/service/util/tunneling.py
@@ -381,9 +381,9 @@ def get_cloudflare_url_from_log(log_file, custom_domain=None, max_retries=10, re
                     matches = re.findall(pattern, content)
                     for match in matches:
                         # Filter out localhost and other non-public URLs
-                        if ('localhost' not in match and 
-                            '127.0.0.1' not in match and
-                            'trycloudflare.com' in match or 'cfargotunnel.com' in match or custom_domain in match if custom_domain else True):
+                        if ('localhost' not in match and '127.0.0.1' not in match and
+                                ('trycloudflare.com' in match or 'cfargotunnel.com' in match
+                                 or (custom_domain and custom_domain in match))):
                             return match
                             
         except Exception as e:

--- a/unit-tests/service/test_cloudflare_config.py
+++ b/unit-tests/service/test_cloudflare_config.py
@@ -1,0 +1,20 @@
+import unittest
+
+from keepercommander.service.config.cloudflare_config import CloudflareConfigurator
+from keepercommander.service.util.tunneling import get_tunnel_log_file
+
+
+class TestCloudflareLogPath(unittest.TestCase):
+    def test_health_check_reads_the_same_file_the_tunnel_writes_to(self):
+        """_get_cloudflare_log_path() used to hardcode its own copy of the log path,
+        which drifted out of sync when the tunnel log location moved to the shared
+        service_logs dir - the health check kept reading the old, now-empty file and
+        always timed out with 'status could not be determined'."""
+        self.assertEqual(
+            CloudflareConfigurator._get_cloudflare_log_path(),
+            get_tunnel_log_file("cloudflare_tunnel_subprocess.log"),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_main_dispatch.py
+++ b/unit-tests/service/test_main_dispatch.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest import mock
+
+from keepercommander.__main__ import main
+
+
+class TestServiceModeDispatch(unittest.TestCase):
+    """The frozen background-service subprocess is detected via an explicit argv flag
+    (SERVICE_MODE_FLAG), not an env var - see service_app.py for why."""
+
+    def test_frozen_with_internal_flag_runs_background_service_and_returns(self):
+        with mock.patch('sys.frozen', True, create=True), \
+             mock.patch('sys._MEIPASS', '/frozen/path', create=True), \
+             mock.patch('sys.argv', ['keeper.exe', '--internal-run-service']), \
+             mock.patch('keepercommander.service.core.service_app.run_background_service') as mock_run, \
+             mock.patch('keepercommander.utils.get_ssl_cert_file', return_value=None), \
+             mock.patch('argparse.ArgumentParser.parse_known_args') as mock_parse_args:
+            main()
+
+            mock_run.assert_called_once()
+            # If dispatch didn't return early, normal argument parsing would have run too.
+            mock_parse_args.assert_not_called()
+
+    def test_frozen_without_flag_does_not_start_the_service(self):
+        with mock.patch('sys.frozen', True, create=True), \
+             mock.patch('sys._MEIPASS', '/frozen/path', create=True), \
+             mock.patch('sys.argv', ['keeper.exe', '--help']), \
+             mock.patch('keepercommander.service.core.service_app.run_background_service') as mock_run, \
+             mock.patch('keepercommander.utils.get_ssl_cert_file', return_value=None), \
+             mock.patch('argparse.ArgumentParser.parse_known_args', side_effect=SystemExit(0)):
+            with self.assertRaises(SystemExit):
+                main()
+
+            mock_run.assert_not_called()
+
+    def test_not_frozen_ignores_the_flag_entirely(self):
+        """Running from source, the flag has no special meaning and normal parsing proceeds."""
+        with mock.patch('sys.frozen', False, create=True), \
+             mock.patch('sys.argv', ['keeper', '--internal-run-service']), \
+             mock.patch('keepercommander.service.core.service_app.run_background_service') as mock_run, \
+             mock.patch('keepercommander.utils.get_ssl_cert_file', return_value=None), \
+             mock.patch('argparse.ArgumentParser.parse_known_args', side_effect=SystemExit(2)):
+            with self.assertRaises(SystemExit):
+                main()
+
+            mock_run.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_process_util.py
+++ b/unit-tests/service/test_process_util.py
@@ -7,9 +7,14 @@ from keepercommander.service.util.process_util import (
 
 
 class TestSpawnDetachedProcess(unittest.TestCase):
+    """These force sys.platform to 'darwin' to exercise the POSIX branch regardless of
+    the machine actually running the tests. os.setpgrp doesn't exist on a real Windows
+    os module, so it needs create=True wherever that branch is forced on Windows CI."""
+
     def test_default_mode_truncates_log_file(self):
         with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
+             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             spawn_detached_process(['cmd'], '/tmp/test.log')
             mock_open.assert_called_once_with('/tmp/test.log', 'w')
@@ -17,6 +22,7 @@ class TestSpawnDetachedProcess(unittest.TestCase):
     def test_append_mode_preserves_log_history(self):
         with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
+             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             spawn_detached_process(['cmd'], '/tmp/test.log', append=True)
             mock_open.assert_called_once_with('/tmp/test.log', 'a')
@@ -40,7 +46,7 @@ class TestSpawnDetachedProcess(unittest.TestCase):
         with mock.patch('builtins.open', mock.mock_open()), \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'), \
-             mock.patch('keepercommander.service.util.process_util.os.setpgrp'):
+             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True):
             spawn_detached_process(['cmd'], '/tmp/test.log')
 
             _, kwargs = mock_popen.call_args
@@ -50,6 +56,7 @@ class TestSpawnDetachedProcess(unittest.TestCase):
     def test_returns_the_popen_object(self):
         with mock.patch('builtins.open', mock.mock_open()), \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
+             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             mock_process = mock.Mock()
             mock_popen.return_value = mock_process

--- a/unit-tests/service/test_process_util.py
+++ b/unit-tests/service/test_process_util.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest import mock
+
+from keepercommander.service.util.process_util import (
+    spawn_detached_process, CREATE_NO_WINDOW, DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP
+)
+
+
+class TestSpawnDetachedProcess(unittest.TestCase):
+    def test_default_mode_truncates_log_file(self):
+        with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
+             mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
+            spawn_detached_process(['cmd'], '/tmp/test.log')
+            mock_open.assert_called_once_with('/tmp/test.log', 'w')
+
+    def test_append_mode_preserves_log_history(self):
+        with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
+             mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
+            spawn_detached_process(['cmd'], '/tmp/test.log', append=True)
+            mock_open.assert_called_once_with('/tmp/test.log', 'a')
+
+    def test_windows_uses_hidden_detached_creation_flags(self):
+        with mock.patch('builtins.open', mock.mock_open()), \
+             mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'win32'):
+            spawn_detached_process(['cmd'], '/tmp/test.log', cwd='/work', env={'A': '1'})
+
+            _, kwargs = mock_popen.call_args
+            self.assertEqual(
+                kwargs['creationflags'],
+                DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+            )
+            self.assertEqual(kwargs['cwd'], '/work')
+            self.assertEqual(kwargs['env'], {'A': '1'})
+            self.assertNotIn('preexec_fn', kwargs)
+
+    def test_posix_uses_new_process_group_via_preexec(self):
+        with mock.patch('builtins.open', mock.mock_open()), \
+             mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'), \
+             mock.patch('keepercommander.service.util.process_util.os.setpgrp'):
+            spawn_detached_process(['cmd'], '/tmp/test.log')
+
+            _, kwargs = mock_popen.call_args
+            self.assertNotIn('creationflags', kwargs)
+            self.assertIn('preexec_fn', kwargs)
+
+    def test_returns_the_popen_object(self):
+        with mock.patch('builtins.open', mock.mock_open()), \
+             mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
+            mock_process = mock.Mock()
+            mock_popen.return_value = mock_process
+
+            result = spawn_detached_process(['cmd'], '/tmp/test.log')
+            self.assertIs(result, mock_process)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_process_util.py
+++ b/unit-tests/service/test_process_util.py
@@ -7,14 +7,9 @@ from keepercommander.service.util.process_util import (
 
 
 class TestSpawnDetachedProcess(unittest.TestCase):
-    """These force sys.platform to 'darwin' to exercise the POSIX branch regardless of
-    the machine actually running the tests. os.setpgrp doesn't exist on a real Windows
-    os module, so it needs create=True wherever that branch is forced on Windows CI."""
-
     def test_default_mode_truncates_log_file(self):
         with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
-             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             spawn_detached_process(['cmd'], '/tmp/test.log')
             mock_open.assert_called_once_with('/tmp/test.log', 'w')
@@ -22,7 +17,6 @@ class TestSpawnDetachedProcess(unittest.TestCase):
     def test_append_mode_preserves_log_history(self):
         with mock.patch('builtins.open', mock.mock_open()) as mock_open, \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen'), \
-             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             spawn_detached_process(['cmd'], '/tmp/test.log', append=True)
             mock_open.assert_called_once_with('/tmp/test.log', 'a')
@@ -40,23 +34,24 @@ class TestSpawnDetachedProcess(unittest.TestCase):
             )
             self.assertEqual(kwargs['cwd'], '/work')
             self.assertEqual(kwargs['env'], {'A': '1'})
-            self.assertNotIn('preexec_fn', kwargs)
+            self.assertNotIn('start_new_session', kwargs)
 
-    def test_posix_uses_new_process_group_via_preexec(self):
+    def test_posix_uses_new_session_not_preexec_fn(self):
+        """start_new_session=True (os.setsid in the child) is the thread-safe replacement
+        for preexec_fn=os.setpgrp - same effect, without the multi-threading hazard."""
         with mock.patch('builtins.open', mock.mock_open()), \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
-             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'), \
-             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True):
+             mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             spawn_detached_process(['cmd'], '/tmp/test.log')
 
             _, kwargs = mock_popen.call_args
             self.assertNotIn('creationflags', kwargs)
-            self.assertIn('preexec_fn', kwargs)
+            self.assertNotIn('preexec_fn', kwargs)
+            self.assertTrue(kwargs['start_new_session'])
 
     def test_returns_the_popen_object(self):
         with mock.patch('builtins.open', mock.mock_open()), \
              mock.patch('keepercommander.service.util.process_util.subprocess.Popen') as mock_popen, \
-             mock.patch('keepercommander.service.util.process_util.os.setpgrp', create=True), \
              mock.patch('keepercommander.service.util.process_util.sys.platform', 'darwin'):
             mock_process = mock.Mock()
             mock_popen.return_value = mock_process

--- a/unit-tests/service/test_request_validation.py
+++ b/unit-tests/service/test_request_validation.py
@@ -1,0 +1,50 @@
+import json
+import unittest
+
+from flask import Flask
+
+from keepercommander.service.util.request_validation import RequestValidator
+
+app = Flask(__name__)
+
+
+class TestValidateRequestJson(unittest.TestCase):
+    def test_valid_json_passes(self):
+        with app.test_request_context('/', method='POST',
+                                       data=json.dumps({"command": "ls"}),
+                                       content_type='application/json'):
+            self.assertIsNone(RequestValidator.validate_request_json())
+
+    def test_wrong_content_type_rejected(self):
+        with app.test_request_context('/', method='POST',
+                                       data='{"command": "ls"}',
+                                       content_type='text/plain'):
+            response, status = RequestValidator.validate_request_json()
+            self.assertEqual(status, 400)
+            self.assertIn('Content-Type', response.get_json()['error'])
+
+    def test_empty_json_object_rejected(self):
+        """{} is falsy in Python, and was rejected by the old `if not request.json`
+        check - the get_json()-based rewrite must preserve that, not just check for None."""
+        with app.test_request_context('/', method='POST',
+                                       data='{}',
+                                       content_type='application/json'):
+            response, status = RequestValidator.validate_request_json()
+            self.assertEqual(status, 400)
+            self.assertEqual(response.get_json()['error'], 'Invalid or empty JSON')
+
+    def test_malformed_json_does_not_leak_parser_detail(self):
+        with app.test_request_context('/', method='POST',
+                                       data='{not valid json',
+                                       content_type='application/json'):
+            response, status = RequestValidator.validate_request_json()
+            self.assertEqual(status, 400)
+            error_message = response.get_json()['error']
+            self.assertEqual(error_message, 'Invalid JSON format')
+            self.assertNotIn('not valid json', error_message)
+            self.assertNotIn('line', error_message)
+            self.assertNotIn('column', error_message)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_service_app.py
+++ b/unit-tests/service/test_service_app.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest import mock
+
+from keepercommander.service.core.service_app import run_background_service
+
+
+class TestRunBackgroundService(unittest.TestCase):
+    def test_exits_nonzero_when_port_missing(self):
+        """A missing port must abort startup, not fall through into flask_app.run(port=None)."""
+        with mock.patch('keepercommander.service.app.create_app', return_value=mock.Mock()), \
+             mock.patch('keepercommander.service.config.service_config.ServiceConfig') as mock_config, \
+             mock.patch('keepercommander.service.core.globals.ensure_params_loaded'):
+            mock_config.return_value.load_config.return_value = {}
+
+            with self.assertRaises(SystemExit) as ctx:
+                run_background_service()
+
+            self.assertEqual(ctx.exception.code, 1)
+
+    def test_runs_flask_app_when_port_present(self):
+        mock_flask_app = mock.Mock()
+        with mock.patch('keepercommander.service.app.create_app', return_value=mock_flask_app), \
+             mock.patch('keepercommander.service.config.service_config.ServiceConfig') as mock_config, \
+             mock.patch('keepercommander.service.core.globals.ensure_params_loaded'), \
+             mock.patch('keepercommander.service.core.service_manager.ServiceManager.get_ssl_context',
+                         return_value=None):
+            mock_config.return_value.load_config.return_value = {"port": 8000}
+
+            run_background_service()
+
+            mock_flask_app.run.assert_called_once_with(host='0.0.0.0', port=8000, ssl_context=None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/service/test_service_manager.py
+++ b/unit-tests/service/test_service_manager.py
@@ -217,8 +217,10 @@ class TestServiceManagement(unittest.TestCase):
 
             return mock_spawn
 
-    def test_start_service_background_frozen_sets_service_mode_env_var(self):
-        """A frozen exe can't be invoked with -m, so background mode must signal it via env var."""
+    def test_start_service_background_frozen_uses_internal_flag(self):
+        """A frozen exe can't be invoked with -m, so background mode must signal it via an
+        explicit argv flag - not an env var, which would leak into subprocesses the service
+        itself spawns and could be tripped by a stale value left in the environment."""
         with mock.patch('sys.frozen', True, create=True), \
             mock.patch('sys._MEIPASS', '/frozen/path', create=True):
             mock_spawn = self._start_background_service()
@@ -226,18 +228,18 @@ class TestServiceManagement(unittest.TestCase):
             mock_spawn.assert_called_once()
             args, kwargs = mock_spawn.call_args
             cmd = args[0]
-            self.assertEqual(cmd, ['/usr/bin/python3'])
-            self.assertEqual(kwargs['env']['KEEPER_SERVICE_MODE'], '1')
+            self.assertEqual(cmd, ['/usr/bin/python3', '--internal-run-service'])
+            self.assertNotIn('KEEPER_SERVICE_MODE', kwargs['env'])
 
     def test_start_service_background_not_frozen_uses_module_flag(self):
-        """Running from source (not frozen) must use -m, and must not set the frozen-only env var."""
+        """Running from source (not frozen) must use -m, and must not pass the frozen-only flag."""
         mock_spawn = self._start_background_service()
 
         mock_spawn.assert_called_once()
         args, kwargs = mock_spawn.call_args
         cmd = args[0]
         self.assertEqual(cmd, ['/usr/bin/python3', '-m', 'keepercommander.service.core.service_app'])
-        self.assertNotIn('KEEPER_SERVICE_MODE', kwargs['env'])
+        self.assertNotIn('--internal-run-service', cmd)
 
     def test_start_service_background_forces_unbuffered_child_output(self):
         mock_spawn = self._start_background_service()
@@ -269,6 +271,43 @@ class TestServiceManagement(unittest.TestCase):
             self.assertEqual(process_info.pid, 99999)
             self.assertEqual(process_info.ngrok_pid, 5555)
             self.assertEqual(process_info.cloudflare_pid, 6666)
+
+    def test_start_service_foreground_saves_ngrok_and_cloudflare_pids(self):
+        """service-stop from a second terminal can only learn tunnel PIDs for a foreground
+        service via the saved .env file too - the in-process cleanup closure isn't reachable
+        from a separate CLI invocation, so both PIDs must be persisted here as well."""
+        # flask_app.run() is mocked as a no-op, so it "returns" immediately and the
+        # foreground branch's cleanup-on-exit runs right after (as it would on a real
+        # Ctrl+C) - capture ProcessInfo state during the run() call, before that cleanup
+        # clears it.
+        captured = {}
+
+        def capture_process_info(**kwargs):
+            info = ProcessInfo.load()
+            captured['pid'] = info.pid
+            captured['ngrok_pid'] = info.ngrok_pid
+            captured['cloudflare_pid'] = info.cloudflare_pid
+
+        mock_flask_app = mock.Mock()
+        mock_flask_app.run.side_effect = capture_process_info
+
+        with mock.patch('keepercommander.service.core.service_manager.ServiceConfig') as mock_config, \
+            mock.patch('keepercommander.service.config.ngrok_config.NgrokConfigurator.configure_ngrok',
+                       return_value=5555), \
+            mock.patch('keepercommander.service.config.cloudflare_config.CloudflareConfigurator.configure_cloudflare',
+                       return_value=6666), \
+            mock.patch('keepercommander.service.app.create_app', return_value=mock_flask_app), \
+            mock.patch('os.getpid', return_value=88888):
+            mock_config.return_value.load_config.return_value = {
+                "port": 8000, "run_mode": "foreground", "ngrok": "y", "cloudflare": "y"
+            }
+
+            start_cmd = StartService()
+            start_cmd.execute(self.params)
+
+            self.assertEqual(captured['pid'], 88888)
+            self.assertEqual(captured['ngrok_pid'], 5555)
+            self.assertEqual(captured['cloudflare_pid'], 6666)
 
     def test_start_service_ngrok_configure_failure_is_handled_gracefully(self):
         """An ngrok setup failure (e.g. the binary being deleted by AV, or a failed

--- a/unit-tests/service/test_service_manager.py
+++ b/unit-tests/service/test_service_manager.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -7,18 +8,31 @@ from keepercommander.service.core.service_manager import ServiceManager
 from keepercommander.service.core.process_info import ProcessInfo
 from keepercommander.service.commands.handle_service import StartService, StopService, ServiceStatus
 
+# ProcessInfo.load() only clears os.environ keys present in the *current* .env file,
+# so a PID set by one test can leak into a later test's load() via os.environ if that
+# test's own save() call doesn't pass the same key. Clear these explicitly per test.
+_PROCESS_INFO_ENV_KEYS = (
+    'KEEPER_SERVICE_PID', 'KEEPER_SERVICE_TERMINAL', 'KEEPER_SERVICE_IS_RUNNING',
+    'KEEPER_SERVICE_NGROK_PID', 'KEEPER_SERVICE_CLOUDFLARE_PID',
+)
+
+
 class TestServiceManagement(unittest.TestCase):
     def setUp(self):
         self.params = mock.Mock(spec=KeeperParams)
         ProcessInfo._env_file = Path(__file__).parent / ".test_service.env"
-            
+
         if ProcessInfo._env_file.exists():
             ProcessInfo._env_file.unlink()
+        for key in _PROCESS_INFO_ENV_KEYS:
+            os.environ.pop(key, None)
 
     def tearDown(self):
         if ProcessInfo._env_file.exists():
             ProcessInfo._env_file.unlink()
-                
+        for key in _PROCESS_INFO_ENV_KEYS:
+            os.environ.pop(key, None)
+
     def test_start_service_when_not_running(self):
         """Test starting service when no existing service is running"""
         with mock.patch('keepercommander.service.core.service_manager.ServiceConfig') as mock_config, \
@@ -231,6 +245,30 @@ class TestServiceManagement(unittest.TestCase):
         _, kwargs = mock_spawn.call_args
         self.assertEqual(kwargs['env']['PYTHONUNBUFFERED'], '1')
         self.assertTrue(kwargs['append'])
+
+    def test_start_service_background_saves_ngrok_and_cloudflare_pids(self):
+        """service-stop can only learn tunnel PIDs for a background-mode service via the
+        saved .env file (a later CLI invocation has no shared in-memory state), so both
+        ngrok_pid and cloudflare_pid must be persisted, not just the service's own pid."""
+        with mock.patch('keepercommander.service.core.service_manager.ServiceConfig') as mock_config, \
+            mock.patch('keepercommander.service.config.ngrok_config.NgrokConfigurator.configure_ngrok',
+                       return_value=5555), \
+            mock.patch('keepercommander.service.config.cloudflare_config.CloudflareConfigurator.configure_cloudflare',
+                       return_value=6666), \
+            mock.patch('keepercommander.service.core.service_manager.spawn_detached_process',
+                       return_value=mock.Mock(pid=99999)), \
+            mock.patch('sys.executable', '/usr/bin/python3'):
+            mock_config.return_value.load_config.return_value = {
+                "port": 8000, "run_mode": "background", "ngrok": "y", "cloudflare": "y"
+            }
+
+            start_cmd = StartService()
+            start_cmd.execute(self.params)
+
+            process_info = ProcessInfo.load()
+            self.assertEqual(process_info.pid, 99999)
+            self.assertEqual(process_info.ngrok_pid, 5555)
+            self.assertEqual(process_info.cloudflare_pid, 6666)
 
     def test_start_service_ngrok_configure_failure_is_handled_gracefully(self):
         """An ngrok setup failure (e.g. the binary being deleted by AV, or a failed

--- a/unit-tests/service/test_service_manager.py
+++ b/unit-tests/service/test_service_manager.py
@@ -183,5 +183,69 @@ class TestServiceManagement(unittest.TestCase):
             mock_print.assert_called_with(
                 "Error: Service configuration is incomplete. Please configure the service port in service_config"
             )
-                
+
             mock_app.run.assert_not_called()
+
+    def _start_background_service(self, config_overrides=None):
+        """Drive StartService with run_mode=background and no tunnels enabled, capturing
+        the spawn_detached_process call so tests can assert on cmd/env without spawning anything."""
+        config_data = {"port": 8000, "run_mode": "background"}
+        config_data.update(config_overrides or {})
+
+        with mock.patch('keepercommander.service.core.service_manager.ServiceConfig') as mock_config, \
+            mock.patch('keepercommander.service.core.service_manager.spawn_detached_process') as mock_spawn, \
+            mock.patch('sys.executable', '/usr/bin/python3'):
+            mock_config.return_value.load_config.return_value = config_data
+            mock_spawn.return_value = mock.Mock(pid=99999)
+
+            start_cmd = StartService()
+            start_cmd.execute(self.params)
+
+            return mock_spawn
+
+    def test_start_service_background_frozen_sets_service_mode_env_var(self):
+        """A frozen exe can't be invoked with -m, so background mode must signal it via env var."""
+        with mock.patch('sys.frozen', True, create=True), \
+            mock.patch('sys._MEIPASS', '/frozen/path', create=True):
+            mock_spawn = self._start_background_service()
+
+            mock_spawn.assert_called_once()
+            args, kwargs = mock_spawn.call_args
+            cmd = args[0]
+            self.assertEqual(cmd, ['/usr/bin/python3'])
+            self.assertEqual(kwargs['env']['KEEPER_SERVICE_MODE'], '1')
+
+    def test_start_service_background_not_frozen_uses_module_flag(self):
+        """Running from source (not frozen) must use -m, and must not set the frozen-only env var."""
+        mock_spawn = self._start_background_service()
+
+        mock_spawn.assert_called_once()
+        args, kwargs = mock_spawn.call_args
+        cmd = args[0]
+        self.assertEqual(cmd, ['/usr/bin/python3', '-m', 'keepercommander.service.core.service_app'])
+        self.assertNotIn('KEEPER_SERVICE_MODE', kwargs['env'])
+
+    def test_start_service_background_forces_unbuffered_child_output(self):
+        mock_spawn = self._start_background_service()
+
+        _, kwargs = mock_spawn.call_args
+        self.assertEqual(kwargs['env']['PYTHONUNBUFFERED'], '1')
+        self.assertTrue(kwargs['append'])
+
+    def test_start_service_ngrok_configure_failure_is_handled_gracefully(self):
+        """An ngrok setup failure (e.g. the binary being deleted by AV, or a failed
+        download) must not crash the whole service start or skip cleanup."""
+        with mock.patch('keepercommander.service.core.service_manager.ServiceConfig') as mock_config, \
+            mock.patch('keepercommander.service.config.ngrok_config.NgrokConfigurator.configure_ngrok',
+                       side_effect=RuntimeError("ngrok binary not found")) as mock_configure_ngrok, \
+            mock.patch('keepercommander.service.core.service_manager.spawn_detached_process') as mock_spawn:
+            mock_config.return_value.load_config.return_value = {
+                "port": 8000, "run_mode": "background", "ngrok": "y"
+            }
+
+            start_cmd = StartService()
+            start_cmd.execute(self.params)  # must not raise
+
+            mock_configure_ngrok.assert_called_once()
+            mock_spawn.assert_not_called()
+            self.assertFalse(ProcessInfo._env_file.exists())

--- a/unit-tests/service/test_tunneling.py
+++ b/unit-tests/service/test_tunneling.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 from unittest import mock
 
@@ -160,6 +161,44 @@ class TestGenerateNgrokUrl(unittest.TestCase):
             self.assertIn((10, 1), dup2_calls)
             mock_close.assert_any_call(10)
             mock_close.assert_any_call(11)
+
+
+class TestGetCloudflareUrlFromLog(unittest.TestCase):
+    """The localhost/127.0.0.1 exclusion must gate every OR-branch (trycloudflare.com,
+    cfargotunnel.com, custom_domain) - a prior operator-precedence bug let the
+    cfargotunnel.com/custom_domain branches bypass that exclusion entirely."""
+
+    def setUp(self):
+        fd, self.log_path = tempfile.mkstemp()
+        os.close(fd)
+
+    def tearDown(self):
+        os.unlink(self.log_path)
+
+    def _write_log(self, content):
+        with open(self.log_path, 'w') as f:
+            f.write(content)
+
+    def test_rejects_a_match_that_contains_localhost_even_if_it_also_contains_the_custom_domain(self):
+        # The regex excludes '/', so this is a single continuous match containing both
+        # 'localhost' and the custom domain - exactly what let the old buggy precedence
+        # accept it via the unguarded custom_domain OR-branch. No match should pass the
+        # filter, so this falls through to the constructed https://{custom_domain} URL,
+        # not the bad captured match.
+        self._write_log("https://localhost.acme.example.com\n")
+        url = tunneling.get_cloudflare_url_from_log(self.log_path, custom_domain='acme.example.com', max_retries=1)
+        self.assertEqual(url, 'https://acme.example.com')
+
+    def test_accepts_cfargotunnel_url(self):
+        self._write_log("connected to https://mytunnel.cfargotunnel.com\n")
+        url = tunneling.get_cloudflare_url_from_log(self.log_path, custom_domain=None, max_retries=1)
+        self.assertEqual(url, 'https://mytunnel.cfargotunnel.com')
+
+    def test_no_custom_domain_still_rejects_localhost(self):
+        """Previously, a falsy custom_domain made the whole filter degrade to accept-anything."""
+        self._write_log("https://localhost\n")
+        url = tunneling.get_cloudflare_url_from_log(self.log_path, custom_domain=None, max_retries=1)
+        self.assertIsNone(url)
 
 
 class TestGenerateCloudflareUrl(unittest.TestCase):

--- a/unit-tests/service/test_tunneling.py
+++ b/unit-tests/service/test_tunneling.py
@@ -39,6 +39,43 @@ class TestStartNgrok(unittest.TestCase):
             self.assertEqual(pid, 111)
 
 
+class TestStartNgrokWithUrl(unittest.TestCase):
+    def test_raises_when_process_died_after_the_initial_doa_check(self):
+        """A slower failure (e.g. a bad auth token) can exit ngrok after start_ngrok's
+        initial liveness check but before any URL ever becomes available - that must
+        still be reported as a failure, not returned as a silent (pid, None)."""
+        with mock.patch('keepercommander.service.util.tunneling.start_ngrok', return_value=111), \
+             mock.patch('keepercommander.service.util.tunneling.time.sleep'), \
+             mock.patch('keepercommander.service.util.tunneling.get_ngrok_url_from_api', return_value=None), \
+             mock.patch('keepercommander.service.util.tunneling.get_ngrok_url_from_log', return_value=None), \
+             mock.patch('psutil.pid_exists', return_value=False):
+            with self.assertRaises(RuntimeError):
+                tunneling.start_ngrok_with_url(port=8000, auth_token='tok')
+
+    def test_returns_url_when_process_is_alive(self):
+        with mock.patch('keepercommander.service.util.tunneling.start_ngrok', return_value=111), \
+             mock.patch('keepercommander.service.util.tunneling.time.sleep'), \
+             mock.patch('keepercommander.service.util.tunneling.get_ngrok_url_from_api',
+                         return_value='https://example.ngrok.io'):
+            pid, public_url = tunneling.start_ngrok_with_url(port=8000, auth_token='tok')
+
+            self.assertEqual(pid, 111)
+            self.assertEqual(public_url, 'https://example.ngrok.io')
+
+    def test_no_url_but_process_still_alive_does_not_raise(self):
+        """A tunnel that's just slow to report its URL (still alive) shouldn't be
+        treated as a failure - only an actually-dead process should be."""
+        with mock.patch('keepercommander.service.util.tunneling.start_ngrok', return_value=111), \
+             mock.patch('keepercommander.service.util.tunneling.time.sleep'), \
+             mock.patch('keepercommander.service.util.tunneling.get_ngrok_url_from_api', return_value=None), \
+             mock.patch('keepercommander.service.util.tunneling.get_ngrok_url_from_log', return_value=None), \
+             mock.patch('psutil.pid_exists', return_value=True):
+            pid, public_url = tunneling.start_ngrok_with_url(port=8000, auth_token='tok')
+
+            self.assertEqual(pid, 111)
+            self.assertIsNone(public_url)
+
+
 class TestGenerateNgrokUrl(unittest.TestCase):
     def test_background_mode_skips_fd_redirection_and_uses_subprocess(self):
         with mock.patch('keepercommander.service.util.tunneling.start_ngrok_with_url',
@@ -83,6 +120,7 @@ class TestGenerateNgrokUrl(unittest.TestCase):
         with mock.patch('keepercommander.service.util.tunneling.ngrok.connect', return_value=mock_tunnel) as mock_connect, \
              mock.patch('keepercommander.service.util.tunneling.os.dup', side_effect=[10, 11]), \
              mock.patch('keepercommander.service.util.tunneling.os.open', side_effect=OSError("too many open files")), \
+             mock.patch('keepercommander.service.util.tunneling.os.dup2'), \
              mock.patch('keepercommander.service.util.tunneling.os.close') as mock_close:
             public_url, ngrok_pid = tunneling.generate_ngrok_url(
                 port=8000, auth_token='tok', ngrok_custom_domain=None, run_mode='foreground'
@@ -90,6 +128,36 @@ class TestGenerateNgrokUrl(unittest.TestCase):
 
             self.assertEqual(public_url, 'https://example.ngrok.io')
             mock_connect.assert_called_once()
+            mock_close.assert_any_call(10)
+            mock_close.assert_any_call(11)
+
+    def test_foreground_mode_restores_stdout_if_second_dup2_fails(self):
+        """If dup2(devnull, 1) succeeds but dup2(devnull, 2) then fails, fd 1 must be
+        restored back to the original console fd before the backup is closed - otherwise
+        fd 1 is left pointed at devnull permanently, silently losing all console output."""
+        mock_tunnel = mock.Mock(public_url='https://example.ngrok.io')
+        dup2_calls = []
+
+        def dup2_side_effect(fd, target):
+            dup2_calls.append((fd, target))
+            if fd == 20 and target == 2:
+                raise OSError("bad file descriptor")
+
+        with mock.patch('keepercommander.service.util.tunneling.ngrok.connect', return_value=mock_tunnel) as mock_connect, \
+             mock.patch('keepercommander.service.util.tunneling.os.dup', side_effect=[10, 11]), \
+             mock.patch('keepercommander.service.util.tunneling.os.open', return_value=20), \
+             mock.patch('keepercommander.service.util.tunneling.os.dup2', side_effect=dup2_side_effect), \
+             mock.patch('keepercommander.service.util.tunneling.os.close') as mock_close:
+            public_url, _ = tunneling.generate_ngrok_url(
+                port=8000, auth_token='tok', ngrok_custom_domain=None, run_mode='foreground'
+            )
+
+            self.assertEqual(public_url, 'https://example.ngrok.io')
+            mock_connect.assert_called_once()
+            # fd 1 was redirected to devnull (20) then must be restored back to the
+            # original console fd (10) before that backup is closed.
+            self.assertIn((20, 1), dup2_calls)
+            self.assertIn((10, 1), dup2_calls)
             mock_close.assert_any_call(10)
             mock_close.assert_any_call(11)
 
@@ -130,14 +198,35 @@ class TestDownloadCloudflared(unittest.TestCase):
             mock_debug.assert_called_once()
             self.assertIn('cloudflared', mock_debug.call_args[0][0])
 
+    def test_windows_never_searches_path_or_cwd(self):
+        """`where` (like shutil.which) searches the current directory before PATH on
+        Windows - a planted cloudflared.exe in whatever directory the user happens to
+        run Commander from would get executed. Only search PATH on POSIX, where `which`
+        doesn't consult the current directory."""
+        with mock.patch('keepercommander.service.util.tunneling.sys.platform', 'win32'), \
+             mock.patch('keepercommander.service.util.tunneling.subprocess.run') as mock_run, \
+             mock.patch('platform.system', return_value='unsupported'):
+            with self.assertRaises(Exception):
+                tunneling._download_cloudflared()
+
+            mock_run.assert_not_called()
+
 
 class TestTunnelLogFiles(unittest.TestCase):
-    def test_ngrok_and_cloudflare_logs_share_the_same_directory_as_the_service_log(self):
+    def test_ngrok_and_cloudflare_logs_share_the_same_directory(self):
         ngrok_log = tunneling.get_tunnel_log_file('ngrok_subprocess.log')
         cloudflare_log = tunneling.get_tunnel_log_file('cloudflare_tunnel_subprocess.log')
 
         self.assertEqual(os.path.dirname(ngrok_log), os.path.dirname(cloudflare_log))
-        self.assertEqual(os.path.dirname(ngrok_log), tunneling.TUNNEL_LOG_DIR)
+
+    def test_resolves_the_data_dir_at_call_time_not_import_time(self):
+        """A --data-dir/KEEPER_DATA_HOME override set after this module is imported
+        must still be honored - the log dir can't be cached as a module-level constant."""
+        import tempfile
+        overridden_dir = tempfile.mkdtemp()
+        with mock.patch('keepercommander.utils.get_default_path', return_value=overridden_dir):
+            log_file = tunneling.get_tunnel_log_file('ngrok_subprocess.log')
+            self.assertTrue(log_file.startswith(os.path.join(overridden_dir, 'service_logs')))
 
 
 if __name__ == '__main__':

--- a/unit-tests/service/test_tunneling.py
+++ b/unit-tests/service/test_tunneling.py
@@ -5,6 +5,40 @@ from unittest import mock
 from keepercommander.service.util import tunneling
 
 
+class TestStartNgrok(unittest.TestCase):
+    def _mock_ngrok_setup(self):
+        return [
+            mock.patch('keepercommander.service.util.tunneling.conf.get_default', return_value=mock.Mock(ngrok_path='/bin/ngrok')),
+            mock.patch('keepercommander.service.util.tunneling.ngrok.install_ngrok'),
+            mock.patch('keepercommander.service.util.tunneling.time.sleep'),
+        ]
+
+    def test_raises_when_ngrok_exits_immediately(self):
+        """A dead-on-arrival ngrok process (bad token, invalid flags, ...) must be
+        reported as a failure, not returned to the caller as if it started fine."""
+        mock_process = mock.Mock(pid=111, returncode=1)
+        mock_process.poll.return_value = 1  # process has already exited
+
+        patches = self._mock_ngrok_setup()
+        with patches[0], patches[1], patches[2], \
+             mock.patch('keepercommander.service.util.tunneling.spawn_detached_process', return_value=mock_process):
+            with self.assertRaises(RuntimeError):
+                tunneling.start_ngrok(port=8000, auth_token='tok')
+
+    def test_returns_pid_when_ngrok_stays_running(self):
+        mock_process = mock.Mock(pid=111, returncode=None)
+        mock_process.poll.return_value = None  # still running
+
+        patches = self._mock_ngrok_setup()
+        with patches[0], patches[1], patches[2], \
+             mock.patch('keepercommander.service.util.tunneling.spawn_detached_process', return_value=mock_process):
+            # No real process has ppid 111, so the psutil lookup falls through and
+            # start_ngrok returns the wrapper PID unchanged.
+            pid = tunneling.start_ngrok(port=8000, auth_token='tok')
+
+            self.assertEqual(pid, 111)
+
+
 class TestGenerateNgrokUrl(unittest.TestCase):
     def test_background_mode_skips_fd_redirection_and_uses_subprocess(self):
         with mock.patch('keepercommander.service.util.tunneling.start_ngrok_with_url',
@@ -42,6 +76,23 @@ class TestGenerateNgrokUrl(unittest.TestCase):
         with self.assertRaises(ValueError):
             tunneling.generate_ngrok_url(port=8000, auth_token=None, ngrok_custom_domain=None, run_mode='background')
 
+    def test_foreground_mode_closes_dupd_fds_if_redirection_setup_fails_partway(self):
+        """If os.dup(1)/os.dup(2) succeed but the later os.open(devnull) fails, the
+        duplicated fds must be closed instead of leaked - and ngrok should still start."""
+        mock_tunnel = mock.Mock(public_url='https://example.ngrok.io')
+        with mock.patch('keepercommander.service.util.tunneling.ngrok.connect', return_value=mock_tunnel) as mock_connect, \
+             mock.patch('keepercommander.service.util.tunneling.os.dup', side_effect=[10, 11]), \
+             mock.patch('keepercommander.service.util.tunneling.os.open', side_effect=OSError("too many open files")), \
+             mock.patch('keepercommander.service.util.tunneling.os.close') as mock_close:
+            public_url, ngrok_pid = tunneling.generate_ngrok_url(
+                port=8000, auth_token='tok', ngrok_custom_domain=None, run_mode='foreground'
+            )
+
+            self.assertEqual(public_url, 'https://example.ngrok.io')
+            mock_connect.assert_called_once()
+            mock_close.assert_any_call(10)
+            mock_close.assert_any_call(11)
+
 
 class TestGenerateCloudflareUrl(unittest.TestCase):
     def test_returns_public_url_and_pid_in_correct_order(self):
@@ -63,6 +114,21 @@ class TestGenerateCloudflareUrl(unittest.TestCase):
     def test_missing_tunnel_token_raises(self):
         with self.assertRaises(ValueError):
             tunneling.generate_cloudflare_url(port=8000, tunnel_token='  ', custom_domain=None, run_mode='background')
+
+
+class TestDownloadCloudflared(unittest.TestCase):
+    def test_lookup_failure_is_logged_not_swallowed_silently(self):
+        # Force platform.system() to an unsupported value so _download_cloudflared
+        # raises right after the (logged) lookup failure, without attempting a real download.
+        with mock.patch('keepercommander.service.util.tunneling.subprocess.run',
+                         side_effect=OSError("cloudflared not found")), \
+             mock.patch('keepercommander.service.util.tunneling.logging.debug') as mock_debug, \
+             mock.patch('platform.system', return_value='unsupported'):
+            with self.assertRaises(Exception):
+                tunneling._download_cloudflared()
+
+            mock_debug.assert_called_once()
+            self.assertIn('cloudflared', mock_debug.call_args[0][0])
 
 
 class TestTunnelLogFiles(unittest.TestCase):

--- a/unit-tests/service/test_tunneling.py
+++ b/unit-tests/service/test_tunneling.py
@@ -1,0 +1,78 @@
+import os
+import unittest
+from unittest import mock
+
+from keepercommander.service.util import tunneling
+
+
+class TestGenerateNgrokUrl(unittest.TestCase):
+    def test_background_mode_skips_fd_redirection_and_uses_subprocess(self):
+        with mock.patch('keepercommander.service.util.tunneling.start_ngrok_with_url',
+                         return_value=(1234, 'https://example.ngrok.io')) as mock_start, \
+             mock.patch('keepercommander.service.util.tunneling.os.dup') as mock_dup:
+            public_url, ngrok_pid = tunneling.generate_ngrok_url(
+                port=8000, auth_token='tok', ngrok_custom_domain=None, run_mode='background'
+            )
+
+            self.assertEqual(public_url, 'https://example.ngrok.io')
+            self.assertEqual(ngrok_pid, 1234)
+            mock_start.assert_called_once_with(port=8000, auth_token='tok')
+            # Background mode must not touch the process's own stdout/stderr fds -
+            # doing so previously corrupted the interactive shell's console on Windows.
+            mock_dup.assert_not_called()
+
+    def test_foreground_mode_uses_pyngrok_connect(self):
+        mock_tunnel = mock.Mock(public_url='https://example.ngrok.io')
+        with mock.patch('keepercommander.service.util.tunneling.ngrok.connect', return_value=mock_tunnel) as mock_connect, \
+             mock.patch('keepercommander.service.util.tunneling.os.dup', side_effect=[1, 2]), \
+             mock.patch('keepercommander.service.util.tunneling.os.dup2'), \
+             mock.patch('keepercommander.service.util.tunneling.os.open', return_value=3), \
+             mock.patch('keepercommander.service.util.tunneling.os.close'):
+            public_url, ngrok_pid = tunneling.generate_ngrok_url(
+                port=8000, auth_token='tok', ngrok_custom_domain=None, run_mode='foreground'
+            )
+
+            self.assertEqual(public_url, 'https://example.ngrok.io')
+            self.assertIsNone(ngrok_pid)
+            mock_connect.assert_called_once()
+
+    def test_missing_port_or_token_raises(self):
+        with self.assertRaises(ValueError):
+            tunneling.generate_ngrok_url(port=None, auth_token='tok', ngrok_custom_domain=None, run_mode='background')
+        with self.assertRaises(ValueError):
+            tunneling.generate_ngrok_url(port=8000, auth_token=None, ngrok_custom_domain=None, run_mode='background')
+
+
+class TestGenerateCloudflareUrl(unittest.TestCase):
+    def test_returns_public_url_and_pid_in_correct_order(self):
+        # start_cloudflare_tunnel_with_url returns (pid, url); generate_cloudflare_url
+        # must swap that to (url, pid) to match what CloudflareConfigurator expects.
+        with mock.patch('keepercommander.service.util.tunneling.start_cloudflare_tunnel_with_url',
+                         return_value=(4321, 'https://tunnel.example.com')):
+            public_url, tunnel_pid = tunneling.generate_cloudflare_url(
+                port=8000, tunnel_token='tok', custom_domain=None, run_mode='background'
+            )
+
+            self.assertEqual(public_url, 'https://tunnel.example.com')
+            self.assertEqual(tunnel_pid, 4321)
+
+    def test_missing_port_raises(self):
+        with self.assertRaises(ValueError):
+            tunneling.generate_cloudflare_url(port=None, tunnel_token='tok', custom_domain=None, run_mode='background')
+
+    def test_missing_tunnel_token_raises(self):
+        with self.assertRaises(ValueError):
+            tunneling.generate_cloudflare_url(port=8000, tunnel_token='  ', custom_domain=None, run_mode='background')
+
+
+class TestTunnelLogFiles(unittest.TestCase):
+    def test_ngrok_and_cloudflare_logs_share_the_same_directory_as_the_service_log(self):
+        ngrok_log = tunneling.get_tunnel_log_file('ngrok_subprocess.log')
+        cloudflare_log = tunneling.get_tunnel_log_file('cloudflare_tunnel_subprocess.log')
+
+        self.assertEqual(os.path.dirname(ngrok_log), os.path.dirname(cloudflare_log))
+        self.assertEqual(os.path.dirname(ngrok_log), tunneling.TUNNEL_LOG_DIR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Background mode for Service Mode was broken on Windows, and ngrok/Cloudflare tunneling had bugs that could fail to start or freeze the shell. This fixes all of it.

### Changes
- Fixed background mode for the packaged Windows executable
- Fixed ngrok picking the wrong program and failing to start
- Removed a console-redirect step that could freeze the shell during tunnel setup
- Service, ngrok, and Cloudflare logs now all save to the same, correct folder
- Fixed background service logs not showing up (output wasn't flushing)
- Ngrok failures now show a clear error instead of a generic crash
- Cleaned up duplicated background-process code
- Added tests for all of the above