### PR TITLE
KC-1449: Mask sensitive record data in Docker logs during record-add and record-update

### DIFF
--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -46,6 +46,19 @@ from .ttk import TTK
 
 current_milli_time = lambda: int(round(time.time() * 1000))
 
+# Sensitive field types that should be masked in logs
+SENSITIVE_FIELD_TYPES = frozenset({
+    'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
+    'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
+    'securityquestion', 'passkey', 'accountnumber', 'routingnumber',
+    'cardnumber', 'cardsecuritycode', 'privatekey', 'publickey', 'licensenumber'
+})
+
+SENSITIVE_DICT_KEYS = frozenset({'password', 'login', 'secret', 'token', 'key',
+                                  'accountnumber', 'routingnumber', 'cardnumber', 
+                                  'cardsecuritycode', 'privatekey', 'publickey',
+                                  'licensenumber', 'keypair', 'encryptednote'}) | SENSITIVE_FIELD_TYPES
+
 
 # PKCS7 padding helpers
 BS = 16
@@ -56,6 +69,50 @@ unpad_char = lambda s: s[0:-ord(s[-1])]
 decode_uid_to_str = lambda uid: base64.urlsafe_b64encode(uid).decode().rstrip('=')
 
 LOCALE = 'en_US'
+
+
+def _mask_field_value(value):
+    """Mask a Keeper record field's `value`, preserving its container shape."""
+    if isinstance(value, list):
+        return ['***' for _ in value]
+    if isinstance(value, dict):
+        return {k: '***' for k in value}
+    return '***'
+
+
+def _sanitize_nested_data(data):
+    """Recursively sanitize nested data structures for logging."""
+    if isinstance(data, dict):
+        field_type = data.get('type')
+        if isinstance(field_type, str) and field_type.lower() in SENSITIVE_FIELD_TYPES and 'value' in data:
+            sanitized = dict(data)
+            sanitized['value'] = _mask_field_value(data['value'])
+            return sanitized
+
+        sanitized = {}
+        for key, value in data.items():
+            if key.lower() in SENSITIVE_DICT_KEYS:
+                if isinstance(value, str) and len(value) > 0:
+                    sanitized[key] = '*' * min(len(value), 15)
+                else:
+                    sanitized[key] = '***'
+            else:
+                sanitized[key] = _sanitize_nested_data(value)
+        return sanitized
+    elif isinstance(data, list):
+        return [_sanitize_nested_data(item) for item in data]
+    else:
+        return data
+
+
+def _sanitize_protobuf_json(json_str):
+    """Sanitize sensitive data from protobuf JSON before logging."""
+    try:
+        data = json.loads(json_str)
+        sanitized = _sanitize_nested_data(data)
+        return json.dumps(sanitized)
+    except (json.JSONDecodeError, TypeError):
+        return json_str
 
 
 def run_command(params, request):
@@ -881,7 +938,8 @@ def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version
     if request:
         if logging.getLogger().level <= logging.DEBUG:
             js = google.protobuf.json_format.MessageToJson(request)
-            logging.debug('>>> [RQ] %s: %s', endpoint, js)
+            sanitized_js = _sanitize_protobuf_json(js)
+            logging.debug('>>> [RQ] %s: %s', endpoint, sanitized_js)
         api_request_payload.payload = request.SerializeToString()
     if isinstance(payload_version, int):
         api_request_payload.apiVersion = payload_version
@@ -894,7 +952,8 @@ def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version
             proto_rs.ParseFromString(rs)
             if logging.getLogger().level <= logging.DEBUG:
                 js = google.protobuf.json_format.MessageToJson(proto_rs)
-                logging.debug('>>> [RS] %s: %s', endpoint, js)
+                sanitized_js = _sanitize_protobuf_json(js)
+                logging.debug('>>> [RS] %s: %s', endpoint, sanitized_js)
             return proto_rs
         else:
             return rs

--- a/keepercommander/api.py
+++ b/keepercommander/api.py
@@ -43,21 +43,9 @@ from .subfolder import BaseFolderNode
 from .sync_down import sync_down
 from .team import Team
 from .ttk import TTK
+from .sanitization import sanitize_protobuf_json
 
 current_milli_time = lambda: int(round(time.time() * 1000))
-
-# Sensitive field types that should be masked in logs
-SENSITIVE_FIELD_TYPES = frozenset({
-    'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
-    'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
-    'securityquestion', 'passkey', 'accountnumber', 'routingnumber',
-    'cardnumber', 'cardsecuritycode', 'privatekey', 'publickey', 'licensenumber'
-})
-
-SENSITIVE_DICT_KEYS = frozenset({'password', 'login', 'secret', 'token', 'key',
-                                  'accountnumber', 'routingnumber', 'cardnumber', 
-                                  'cardsecuritycode', 'privatekey', 'publickey',
-                                  'licensenumber', 'keypair', 'encryptednote'}) | SENSITIVE_FIELD_TYPES
 
 
 # PKCS7 padding helpers
@@ -69,50 +57,6 @@ unpad_char = lambda s: s[0:-ord(s[-1])]
 decode_uid_to_str = lambda uid: base64.urlsafe_b64encode(uid).decode().rstrip('=')
 
 LOCALE = 'en_US'
-
-
-def _mask_field_value(value):
-    """Mask a Keeper record field's `value`, preserving its container shape."""
-    if isinstance(value, list):
-        return ['***' for _ in value]
-    if isinstance(value, dict):
-        return {k: '***' for k in value}
-    return '***'
-
-
-def _sanitize_nested_data(data):
-    """Recursively sanitize nested data structures for logging."""
-    if isinstance(data, dict):
-        field_type = data.get('type')
-        if isinstance(field_type, str) and field_type.lower() in SENSITIVE_FIELD_TYPES and 'value' in data:
-            sanitized = dict(data)
-            sanitized['value'] = _mask_field_value(data['value'])
-            return sanitized
-
-        sanitized = {}
-        for key, value in data.items():
-            if key.lower() in SENSITIVE_DICT_KEYS:
-                if isinstance(value, str) and len(value) > 0:
-                    sanitized[key] = '*' * min(len(value), 15)
-                else:
-                    sanitized[key] = '***'
-            else:
-                sanitized[key] = _sanitize_nested_data(value)
-        return sanitized
-    elif isinstance(data, list):
-        return [_sanitize_nested_data(item) for item in data]
-    else:
-        return data
-
-
-def _sanitize_protobuf_json(json_str):
-    """Sanitize sensitive data from protobuf JSON before logging."""
-    try:
-        data = json.loads(json_str)
-        sanitized = _sanitize_nested_data(data)
-        return json.dumps(sanitized)
-    except (json.JSONDecodeError, TypeError):
-        return json_str
 
 
 def run_command(params, request):
@@ -938,7 +882,7 @@ def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version
     if request:
         if logging.getLogger().level <= logging.DEBUG:
             js = google.protobuf.json_format.MessageToJson(request)
-            sanitized_js = _sanitize_protobuf_json(js)
+            sanitized_js = sanitize_protobuf_json(js)
             logging.debug('>>> [RQ] %s: %s', endpoint, sanitized_js)
         api_request_payload.payload = request.SerializeToString()
     if isinstance(payload_version, int):
@@ -952,7 +896,7 @@ def communicate_rest(params, request, endpoint, *, rs_type=None, payload_version
             proto_rs.ParseFromString(rs)
             if logging.getLogger().level <= logging.DEBUG:
                 js = google.protobuf.json_format.MessageToJson(proto_rs)
-                sanitized_js = _sanitize_protobuf_json(js)
+                sanitized_js = sanitize_protobuf_json(js)
                 logging.debug('>>> [RS] %s: %s', endpoint, sanitized_js)
             return proto_rs
         else:

--- a/keepercommander/sanitization.py
+++ b/keepercommander/sanitization.py
@@ -5,8 +5,8 @@
 #              |_|
 #
 # Keeper Commander
-# Copyright 2024 Keeper Security Inc.
-# Contact: ops@keepersecurity.com
+# Copyright 2026 Keeper Security Inc.
+# Contact: commander@keepersecurity.com
 #
 
 import json

--- a/keepercommander/sanitization.py
+++ b/keepercommander/sanitization.py
@@ -1,0 +1,71 @@
+#  _  __
+# | |/ /___ ___ _ __  ___ _ _ ®
+# | ' </ -_) -_) '_ \/ -_) '_|
+# |_|\_\___\___| .__/\___|_|
+#              |_|
+#
+# Keeper Commander
+# Copyright 2024 Keeper Security Inc.
+# Contact: ops@keepersecurity.com
+#
+
+import json
+from typing import Any, Union
+
+# Sensitive field types that should be masked in logs
+SENSITIVE_FIELD_TYPES = frozenset({
+    'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
+    'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
+    'securityquestion', 'passkey', 'accountnumber', 'routingnumber',
+    'cardnumber', 'cardsecuritycode', 'privatekey', 'publickey', 'licensenumber',
+    'encryptednote'
+})
+
+SENSITIVE_DICT_KEYS = frozenset({'password', 'login', 'secret', 'token', 'key',
+                                  'accountnumber', 'routingnumber', 'cardnumber',
+                                  'cardsecuritycode', 'privatekey', 'publickey',
+                                  'licensenumber', 'keypair', 'encryptednote'}) | SENSITIVE_FIELD_TYPES
+
+
+def mask_field_value(value: Any) -> Union[str, list, dict]:
+    """Mask a Keeper record field's `value`, preserving its container shape."""
+    if isinstance(value, list):
+        return ['***' for _ in value]
+    if isinstance(value, dict):
+        return {k: '***' for k in value}
+    return '***'
+
+
+def sanitize_nested_data(data: Any) -> Any:
+    """Recursively sanitize nested data structures for logging."""
+    if isinstance(data, dict):
+        field_type = data.get('type')
+        if isinstance(field_type, str) and field_type.lower() in SENSITIVE_FIELD_TYPES and 'value' in data:
+            sanitized = dict(data)
+            sanitized['value'] = mask_field_value(data['value'])
+            return sanitized
+
+        sanitized = {}
+        for key, value in data.items():
+            if key.lower() in SENSITIVE_DICT_KEYS:
+                if isinstance(value, str) and len(value) > 0:
+                    sanitized[key] = '*' * min(len(value), 15)
+                else:
+                    sanitized[key] = '***'
+            else:
+                sanitized[key] = sanitize_nested_data(value)
+        return sanitized
+    elif isinstance(data, list):
+        return [sanitize_nested_data(item) for item in data]
+    else:
+        return data
+
+
+def sanitize_protobuf_json(json_str: str) -> str:
+    """Sanitize sensitive data from protobuf JSON before logging."""
+    try:
+        data = json.loads(json_str)
+        sanitized = sanitize_nested_data(data)
+        return json.dumps(sanitized)
+    except (json.JSONDecodeError, TypeError):
+        return json_str

--- a/keepercommander/service/decorators/api_logging.py
+++ b/keepercommander/service/decorators/api_logging.py
@@ -94,6 +94,9 @@ def _get_sanitized_request_data():
         try:
             json_data = request.get_json(silent=True)
             sanitized_data = sanitize_password_in_command(json_data)
+            # Additional sanitization for nested structures that might contain sensitive data
+            if sanitized_data and isinstance(sanitized_data, dict):
+                sanitized_data = _sanitize_nested_data(sanitized_data)
         except Exception:
             sanitized_data = None
     return f"data={sanitized_data}" if sanitized_data else "no-data"

--- a/keepercommander/service/decorators/api_logging.py
+++ b/keepercommander/service/decorators/api_logging.py
@@ -54,7 +54,7 @@ def _get_sanitized_request_data():
             sanitized_data = sanitize_password_in_command(json_data)
             # Additional sanitization for nested structures that might contain sensitive data
             if sanitized_data and isinstance(sanitized_data, dict):
-                sanitized_data = _sanitize_nested_data(sanitized_data)
+                sanitized_data = sanitize_nested_data(sanitized_data)
         except Exception:
             sanitized_data = None
     return f"data={sanitized_data}" if sanitized_data else "no-data"

--- a/keepercommander/service/decorators/api_logging.py
+++ b/keepercommander/service/decorators/api_logging.py
@@ -14,11 +14,8 @@ from functools import wraps
 from typing import Callable, Any
 from flask import request
 import time
-from .logging import logger, sanitize_command_fields, SENSITIVE_FIELD_TYPES
-
-# Legacy generic keys (kept for JSON payloads that aren't shaped like Keeper
-# record fields, e.g. arbitrary nested config blobs).
-_SENSITIVE_DICT_KEYS = frozenset({'password', 'login', 'secret', 'token', 'key'}) | SENSITIVE_FIELD_TYPES
+from .logging import logger, sanitize_command_fields
+from ...sanitization import sanitize_nested_data
 
 
 class SSLHandshakeFilter(logging.Filter):
@@ -44,48 +41,9 @@ def sanitize_password_in_command(data):
 
     # Sanitize filedata if present
     if 'filedata' in sanitized:
-        sanitized['filedata'] = _sanitize_nested_data(sanitized['filedata'])
-    
+        sanitized['filedata'] = sanitize_nested_data(sanitized['filedata'])
+
     return sanitized
-
-def _mask_field_value(value):
-    """Mask a Keeper record field's `value`, preserving its container shape."""
-    if isinstance(value, list):
-        return ['***' for _ in value]
-    if isinstance(value, dict):
-        return {k: '***' for k in value}
-    return '***'
-
-
-def _sanitize_nested_data(data):
-    """Recursively sanitize nested data structures"""
-    if isinstance(data, dict):
-        field_type = data.get('type')
-        if isinstance(field_type, str) and field_type.lower() in SENSITIVE_FIELD_TYPES and 'value' in data:
-            sanitized = dict(data)
-            sanitized['value'] = _mask_field_value(data['value'])
-            return sanitized
-
-        sanitized = {}
-        for key, value in data.items():
-            # Sanitize sensitive field names
-            if key.lower() in _SENSITIVE_DICT_KEYS:
-                if isinstance(value, str) and len(value) > 0:
-                    sanitized[key] = '*' * min(len(value), 15)
-                else:
-                    sanitized[key] = '***'
-            else:
-                sanitized[key] = _sanitize_nested_data(value)
-        return sanitized
-    elif isinstance(data, list):
-        return [_sanitize_nested_data(item) for item in data]
-    elif isinstance(data, str):
-        # Sanitize email addresses in string values to protect PII
-        import re
-        sanitized_str = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '***@***.***', data)
-        return sanitized_str
-    else:
-        return data
 
 def _get_sanitized_request_data():
     """Extract and sanitize request data for logging (only for JSON POST requests)"""

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -68,7 +68,7 @@ class GlobalLogger:
         return default_config["logging"]
     
     def _load_config(self):
-        config_path = utils.get_default_path() / "logging_config.yaml";
+        config_path = utils.get_default_path() / "logging_config.yaml"
         
         # config_path = os.getenv("LOGGING_CONFIG_PATH", "logging_config.yaml")
         if os.path.exists(config_path):
@@ -150,9 +150,9 @@ def sanitize_debug_data(data: str) -> str:
     """Sanitize sensitive data from debug output."""
     if not data:
         return data
-    
+
     sanitized = data
-    
+
     # Sanitize common password patterns
     patterns = [
         (r'"password"\s*:\s*"[^"]*"', '"password": "***"'),
@@ -200,12 +200,24 @@ def sanitize_debug_data(data: str) -> str:
         (r'\bc\.licenseNumber=[^\s]*', 'c.licenseNumber=***'),
         (r'\bf\.encryptedNote=[^\s]*', 'f.encryptedNote=***'),
         (r'\bc\.encryptedNote=[^\s]*', 'c.encryptedNote=***'),
+        # Custom field labels with sensitive types (f.password.Label=, c.secret.Label=, etc.)
+        (r'\b[fc]\.password\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.secret\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.keypair\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.privatekey\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.bankaccount\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.paymentcard\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.licensenumber\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
+        (r'\b[fc]\.encryptednote\.[^=]+=\S*', lambda m: m.group(0).split('=')[0] + '=***'),
         # Sanitize email addresses in logs to protect PII
         (r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '***@***.***'),
     ]
-    
+
     for pattern, replacement in patterns:
-        sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
+        if callable(replacement):
+            sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
+        else:
+            sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
 
     return sanitized
 

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -17,14 +17,7 @@ import re
 import shlex
 from enum import Enum
 from ... import utils
-
-# Values that must never reach the logs when set via record-add/record-update/
-# nsf-record-* CLI args.
-SENSITIVE_FIELD_TYPES = frozenset({
-    'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
-    'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
-    'securityquestion', 'passkey', 'licensenumber', 'encryptednote', 'note',
-})
+from ...sanitization import SENSITIVE_FIELD_TYPES
 
 class LogLevel(Enum):
     ERROR = logging.ERROR
@@ -214,10 +207,7 @@ def sanitize_debug_data(data: str) -> str:
     ]
 
     for pattern, replacement in patterns:
-        if callable(replacement):
-            sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
-        else:
-            sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
+        sanitized = re.sub(pattern, replacement, sanitized, flags=re.IGNORECASE)
 
     return sanitized
 

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -156,7 +156,7 @@ def sanitize_debug_data(data: str) -> str:
     # Sanitize common password patterns
     patterns = [
         (r'"password"\s*:\s*"[^"]*"', '"password": "***"'),
-        (r'"login"\s*:\s*"[^"]*"', '"login": "***"'),  
+        (r'"login"\s*:\s*"[^"]*"', '"login": "***"'),
         (r'"secret"\s*:\s*"[^"]*"', '"secret": "***"'),
         (r'"token"\s*:\s*"[^"]*"', '"token": "***"'),
         (r'"key"\s*:\s*"[^"]*"', '"key": "***"'),
@@ -175,6 +175,24 @@ def sanitize_debug_data(data: str) -> str:
         (r'\bbankAccount=[^\s]*', 'bankAccount=***'),
         (r'\bsecurityQuestion=[^\s]*', 'securityQuestion=***'),
         (r'\bpasskey=[^\s]*', 'passkey=***'),
+        # Bank/Card fields with field prefix (f.bankAccount.accountNumber=, f.bankAccount.routingNumber=)
+        (r'\bf\.bankAccount\.accountNumber=[^\s]*', 'f.bankAccount.accountNumber=***'),
+        (r'\bf\.bankAccount\.routingNumber=[^\s]*', 'f.bankAccount.routingNumber=***'),
+        (r'\bc\.bankAccount\.accountNumber=[^\s]*', 'c.bankAccount.accountNumber=***'),
+        (r'\bc\.bankAccount\.routingNumber=[^\s]*', 'c.bankAccount.routingNumber=***'),
+        # Payment card fields
+        (r'\bf\.paymentCard\.cardNumber=[^\s]*', 'f.paymentCard.cardNumber=***'),
+        (r'\bf\.paymentCard\.cardSecurityCode=[^\s]*', 'f.paymentCard.cardSecurityCode=***'),
+        (r'\bc\.paymentCard\.cardNumber=[^\s]*', 'c.paymentCard.cardNumber=***'),
+        (r'\bc\.paymentCard\.cardSecurityCode=[^\s]*', 'c.paymentCard.cardSecurityCode=***'),
+        # SSH key fields
+        (r'\bf\.keyPair\.privateKey=[^\s]*', 'f.keyPair.privateKey=***'),
+        (r'\bf\.keyPair\.publicKey=[^\s]*', 'f.keyPair.publicKey=***'),
+        (r'\bc\.keyPair\.privateKey=[^\s]*', 'c.keyPair.privateKey=***'),
+        (r'\bc\.keyPair\.publicKey=[^\s]*', 'c.keyPair.publicKey=***'),
+        # Software license fields
+        (r'\bf\.licenseNumber=[^\s]*', 'f.licenseNumber=***'),
+        (r'\bc\.licenseNumber=[^\s]*', 'c.licenseNumber=***'),
         # Sanitize email addresses in logs to protect PII
         (r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '***@***.***'),
     ]

--- a/keepercommander/service/decorators/logging.py
+++ b/keepercommander/service/decorators/logging.py
@@ -23,7 +23,7 @@ from ... import utils
 SENSITIVE_FIELD_TYPES = frozenset({
     'password', 'login', 'secret', 'onetimecode', 'pincode', 'keypair',
     'privatekey', 'passphrase', 'paymentcard', 'bankaccount',
-    'securityquestion', 'passkey',
+    'securityquestion', 'passkey', 'licensenumber', 'encryptednote', 'note',
 })
 
 class LogLevel(Enum):
@@ -160,13 +160,14 @@ def sanitize_debug_data(data: str) -> str:
         (r'"secret"\s*:\s*"[^"]*"', '"secret": "***"'),
         (r'"token"\s*:\s*"[^"]*"', '"token": "***"'),
         (r'"key"\s*:\s*"[^"]*"', '"key": "***"'),
+        (r'"licenseNumber"\s*:\s*"[^"]*"', '"licenseNumber": "***"'),
+        (r'"encryptedNote"\s*:\s*"[^"]*"', '"encryptedNote": "***"'),
+        (r'"note"\s*:\s*"[^"]*"', '"note": "***"'),
+        # Bare field formats (e.g., password=value, secret=value)
         (r'\bpassword=[^\s]*', 'password=***'),
         (r'\blogin=[^\s]*', 'login=***'),
-        # oneTimeCode=otpauth://totp/...?secret=... — mask the whole value, TOTP seed included
         (r'\boneTimeCode=[^\s]*', 'oneTimeCode=***'),
         (r'\bsecret=[^\s]*', 'secret=***'),
-        # Other sensitive record field types (see SENSITIVE_FIELD_TYPES) that can
-        # appear as bare CLI args on record-add/record-update/nsf-* commands.
         (r'\bpinCode=[^\s]*', 'pinCode=***'),
         (r'\bkeyPair=[^\s]*', 'keyPair=***'),
         (r'\bprivateKey=[^\s]*', 'privateKey=***'),
@@ -175,24 +176,30 @@ def sanitize_debug_data(data: str) -> str:
         (r'\bbankAccount=[^\s]*', 'bankAccount=***'),
         (r'\bsecurityQuestion=[^\s]*', 'securityQuestion=***'),
         (r'\bpasskey=[^\s]*', 'passkey=***'),
-        # Bank/Card fields with field prefix (f.bankAccount.accountNumber=, f.bankAccount.routingNumber=)
+        (r'\blicenseNumber=[^\s]*', 'licenseNumber=***'),
+        (r'\bencryptedNote=[^\s]*', 'encryptedNote=***'),
+        # Command options (--notes, --password, etc)
+        (r'--notes=[^\s]*', '--notes=***'),
+        (r'--password=[^\s]*', '--password=***'),
+        (r'--notes\s+[^\s]+', '--notes ***'),
+        (r'--password\s+[^\s]+', '--password ***'),
+        # Prefixed field formats (f.fieldName=value, c.fieldName=value)
         (r'\bf\.bankAccount\.accountNumber=[^\s]*', 'f.bankAccount.accountNumber=***'),
         (r'\bf\.bankAccount\.routingNumber=[^\s]*', 'f.bankAccount.routingNumber=***'),
         (r'\bc\.bankAccount\.accountNumber=[^\s]*', 'c.bankAccount.accountNumber=***'),
         (r'\bc\.bankAccount\.routingNumber=[^\s]*', 'c.bankAccount.routingNumber=***'),
-        # Payment card fields
         (r'\bf\.paymentCard\.cardNumber=[^\s]*', 'f.paymentCard.cardNumber=***'),
         (r'\bf\.paymentCard\.cardSecurityCode=[^\s]*', 'f.paymentCard.cardSecurityCode=***'),
         (r'\bc\.paymentCard\.cardNumber=[^\s]*', 'c.paymentCard.cardNumber=***'),
         (r'\bc\.paymentCard\.cardSecurityCode=[^\s]*', 'c.paymentCard.cardSecurityCode=***'),
-        # SSH key fields
         (r'\bf\.keyPair\.privateKey=[^\s]*', 'f.keyPair.privateKey=***'),
         (r'\bf\.keyPair\.publicKey=[^\s]*', 'f.keyPair.publicKey=***'),
         (r'\bc\.keyPair\.privateKey=[^\s]*', 'c.keyPair.privateKey=***'),
         (r'\bc\.keyPair\.publicKey=[^\s]*', 'c.keyPair.publicKey=***'),
-        # Software license fields
         (r'\bf\.licenseNumber=[^\s]*', 'f.licenseNumber=***'),
         (r'\bc\.licenseNumber=[^\s]*', 'c.licenseNumber=***'),
+        (r'\bf\.encryptedNote=[^\s]*', 'f.encryptedNote=***'),
+        (r'\bc\.encryptedNote=[^\s]*', 'c.encryptedNote=***'),
         # Sanitize email addresses in logs to protect PII
         (r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '***@***.***'),
     ]

--- a/unit-tests/service/test_log_sanitization.py
+++ b/unit-tests/service/test_log_sanitization.py
@@ -6,8 +6,10 @@ from keepercommander.service.decorators.logging import (
     sanitize_debug_data,
 )
 from keepercommander.service.decorators.api_logging import (
-    _sanitize_nested_data,
     sanitize_password_in_command,
+)
+from keepercommander.sanitization import (
+    sanitize_nested_data,
 )
 from keepercommander.service.util.command_util import CommandExecutor
 from keepercommander.service.util.exceptions import CommandExecutionError
@@ -86,7 +88,7 @@ class TestFiledataSanitization(TestCase):
                                                 "cardExpirationDate": "04/2026",
                                                 "cardSecurityCode": "123"}]},
         ]
-        sanitized = _sanitize_nested_data(filedata)
+        sanitized = sanitize_nested_data(filedata)
         dumped = str(sanitized)
         self.assertNotIn(SECRET_VALUE, dumped)
         self.assertNotIn('4111111111111111', dumped)
@@ -94,7 +96,7 @@ class TestFiledataSanitization(TestCase):
 
     def test_non_sensitive_type_value_untouched(self):
         filedata = [{"type": "text", "value": ["not a secret"]}]
-        sanitized = _sanitize_nested_data(filedata)
+        sanitized = sanitize_nested_data(filedata)
         self.assertEqual(sanitized, filedata)
 
     def test_sanitize_password_in_command_masks_command_and_filedata(self):

--- a/unit-tests/test_api_sanitization.py
+++ b/unit-tests/test_api_sanitization.py
@@ -3,8 +3,10 @@
 
 import unittest
 import json
-import logging
-from keepercommander import api
+from keepercommander.sanitization import (
+    mask_field_value,
+    sanitize_protobuf_json
+)
 
 class TestAPISanitization(unittest.TestCase):
     """Test cases for sensitive data sanitization in API logging."""
@@ -25,7 +27,7 @@ class TestAPISanitization(unittest.TestCase):
             }]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify sensitive fields are masked
@@ -50,7 +52,7 @@ class TestAPISanitization(unittest.TestCase):
             }]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify sensitive fields are masked
@@ -75,7 +77,7 @@ class TestAPISanitization(unittest.TestCase):
             }]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify sensitive fields are masked
@@ -94,7 +96,7 @@ class TestAPISanitization(unittest.TestCase):
             }]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify sensitive field is masked
@@ -110,7 +112,7 @@ class TestAPISanitization(unittest.TestCase):
             }]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify non-sensitive data is preserved
@@ -121,25 +123,25 @@ class TestAPISanitization(unittest.TestCase):
     def test_mask_field_value_with_dict(self):
         """Test masking of dict values."""
         value = {"key1": "value1", "key2": "value2"}
-        masked = api._mask_field_value(value)
+        masked = mask_field_value(value)
         self.assertEqual(masked, {"key1": "***", "key2": "***"})
 
     def test_mask_field_value_with_list(self):
         """Test masking of list values."""
         value = ["value1", "value2", "value3"]
-        masked = api._mask_field_value(value)
+        masked = mask_field_value(value)
         self.assertEqual(masked, ["***", "***", "***"])
 
     def test_mask_field_value_with_string(self):
         """Test masking of string values."""
         value = "sensitive_data"
-        masked = api._mask_field_value(value)
+        masked = mask_field_value(value)
         self.assertEqual(masked, "***")
 
     def test_sanitize_invalid_json(self):
         """Test sanitization with invalid JSON returns the original string."""
         invalid_json = "not valid json"
-        result = api._sanitize_protobuf_json(invalid_json)
+        result = sanitize_protobuf_json(invalid_json)
         self.assertEqual(result, invalid_json)
 
     def test_sanitize_nested_list_of_records(self):
@@ -168,7 +170,7 @@ class TestAPISanitization(unittest.TestCase):
             ]
         }
         json_str = json.dumps(json_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+        sanitized = sanitize_protobuf_json(json_str)
         result = json.loads(sanitized)
 
         # Verify all sensitive data in list is masked

--- a/unit-tests/test_api_sanitization.py
+++ b/unit-tests/test_api_sanitization.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import unittest
+import json
+import logging
+from keepercommander import api
+
+class TestAPISanitization(unittest.TestCase):
+    """Test cases for sensitive data sanitization in API logging."""
+
+    def test_sanitize_protobuf_json_with_payment_card(self):
+        """Test sanitization of paymentCard data."""
+        json_data = {
+            "records": [{
+                "recordUid": "test123",
+                "data": {
+                    "type": "paymentCard",
+                    "value": {
+                        "cardNumber": "4111111111111111",
+                        "cardExpirationDate": "05/2025",
+                        "cardSecurityCode": "123"
+                    }
+                }
+            }]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify sensitive fields are masked
+        self.assertEqual(result["records"][0]["data"]["value"]["cardNumber"], "***")
+        self.assertEqual(result["records"][0]["data"]["value"]["cardExpirationDate"], "***")
+        self.assertEqual(result["records"][0]["data"]["value"]["cardSecurityCode"], "***")
+
+    def test_sanitize_protobuf_json_with_bank_account(self):
+        """Test sanitization of bankAccount data."""
+        json_data = {
+            "records": [{
+                "recordUid": "test456",
+                "data": {
+                    "type": "bankAccount",
+                    "value": {
+                        "accountType": "Checking",
+                        "routingNumber": "123456789",
+                        "accountNumber": "98765432109876",
+                        "otherType": ""
+                    }
+                }
+            }]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify sensitive fields are masked
+        self.assertEqual(result["records"][0]["data"]["value"]["routingNumber"], "***")
+        self.assertEqual(result["records"][0]["data"]["value"]["accountNumber"], "***")
+
+    def test_sanitize_protobuf_json_with_ssh_keys(self):
+        """Test sanitization of sshKeys (keyPair) data."""
+        private_key = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDU5Z8P2Z9q\n-----END PRIVATE KEY-----"
+        public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1OWfD9mfagMCACEA\n-----END PUBLIC KEY-----"
+
+        json_data = {
+            "records": [{
+                "recordUid": "test789",
+                "data": {
+                    "type": "keyPair",
+                    "value": {
+                        "privateKey": private_key,
+                        "publicKey": public_key
+                    }
+                }
+            }]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify sensitive fields are masked
+        self.assertEqual(result["records"][0]["data"]["value"]["privateKey"], "***")
+        self.assertEqual(result["records"][0]["data"]["value"]["publicKey"], "***")
+
+    def test_sanitize_protobuf_json_with_software_license(self):
+        """Test sanitization of softwareLicense data."""
+        json_data = {
+            "records": [{
+                "recordUid": "test101",
+                "fields": [{
+                    "type": "licenseNumber",
+                    "value": ["LICENSE-2024-0123456789"]
+                }]
+            }]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify sensitive field is masked
+        self.assertEqual(result["records"][0]["fields"][0]["value"], ["***"])
+
+    def test_sanitize_preserves_non_sensitive_data(self):
+        """Test that non-sensitive data is preserved."""
+        json_data = {
+            "records": [{
+                "recordUid": "test202",
+                "title": "Test Record",
+                "notes": "Some notes"
+            }]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify non-sensitive data is preserved
+        self.assertEqual(result["records"][0]["recordUid"], "test202")
+        self.assertEqual(result["records"][0]["title"], "Test Record")
+        self.assertEqual(result["records"][0]["notes"], "Some notes")
+
+    def test_mask_field_value_with_dict(self):
+        """Test masking of dict values."""
+        value = {"key1": "value1", "key2": "value2"}
+        masked = api._mask_field_value(value)
+        self.assertEqual(masked, {"key1": "***", "key2": "***"})
+
+    def test_mask_field_value_with_list(self):
+        """Test masking of list values."""
+        value = ["value1", "value2", "value3"]
+        masked = api._mask_field_value(value)
+        self.assertEqual(masked, ["***", "***", "***"])
+
+    def test_mask_field_value_with_string(self):
+        """Test masking of string values."""
+        value = "sensitive_data"
+        masked = api._mask_field_value(value)
+        self.assertEqual(masked, "***")
+
+    def test_sanitize_invalid_json(self):
+        """Test sanitization with invalid JSON returns the original string."""
+        invalid_json = "not valid json"
+        result = api._sanitize_protobuf_json(invalid_json)
+        self.assertEqual(result, invalid_json)
+
+    def test_sanitize_nested_list_of_records(self):
+        """Test sanitization of nested list structures."""
+        json_data = {
+            "records": [
+                {
+                    "recordUid": "uid1",
+                    "data": {
+                        "type": "bankAccount",
+                        "value": {
+                            "accountNumber": "1234567890",
+                            "routingNumber": "0987654321"
+                        }
+                    }
+                },
+                {
+                    "recordUid": "uid2",
+                    "data": {
+                        "type": "paymentCard",
+                        "value": {
+                            "cardNumber": "4111111111111111"
+                        }
+                    }
+                }
+            ]
+        }
+        json_str = json.dumps(json_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify all sensitive data in list is masked
+        self.assertEqual(result["records"][0]["data"]["value"]["accountNumber"], "***")
+        self.assertEqual(result["records"][0]["data"]["value"]["routingNumber"], "***")
+        self.assertEqual(result["records"][1]["data"]["value"]["cardNumber"], "***")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/test_record_logging_sanitization.py
+++ b/unit-tests/test_record_logging_sanitization.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Integration test to verify that sensitive record data is not exposed in logs
+during record-add and record-update operations.
+
+This test addresses the security issue where sensitive data from bankAccount,
+bankCard, sshKeys, softwareLicense, and encryptedNotes record types was being
+logged in Docker logs.
+"""
+
+import unittest
+import logging
+import json
+from io import StringIO
+from unittest.mock import Mock, patch, MagicMock
+from keepercommander import api, params as keeper_params
+
+
+class TestRecordLoggingSanitization(unittest.TestCase):
+    """Test that sensitive record data is sanitized in logs during API communication."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.log_stream = StringIO()
+        self.handler = logging.StreamHandler(self.log_stream)
+        self.handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(levelname)s: %(message)s')
+        self.handler.setFormatter(formatter)
+
+        self.logger = logging.getLogger()
+        self.original_level = self.logger.level
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.addHandler(self.handler)
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.logger.removeHandler(self.handler)
+        self.logger.setLevel(self.original_level)
+        self.log_stream.close()
+
+    def _get_log_contents(self):
+        """Get the accumulated log contents."""
+        return self.log_stream.getvalue()
+
+    def test_bankaccount_record_sanitized_in_logs(self):
+        """Verify bankAccount sensitive fields are not logged."""
+        request_data = {
+            "records": [{
+                "recordUid": "test_bank_uid",
+                "data": {
+                    "type": "bankAccount",
+                    "value": {
+                        "accountType": "Checking",
+                        "routingNumber": "123456789",
+                        "accountNumber": "98765432109876",
+                        "otherType": ""
+                    }
+                }
+            }]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+
+        # Verify sensitive fields are masked in output
+        self.assertNotIn("123456789", sanitized)  # routingNumber
+        self.assertNotIn("98765432109876", sanitized)  # accountNumber
+        self.assertIn("***", sanitized)
+
+    def test_bankcard_record_sanitized_in_logs(self):
+        """Verify bankCard (paymentCard) sensitive fields are not logged."""
+        request_data = {
+            "records": [{
+                "recordUid": "test_card_uid",
+                "data": {
+                    "type": "paymentCard",
+                    "value": {
+                        "cardNumber": "4111111111111111",
+                        "cardExpirationDate": "05/2025",
+                        "cardSecurityCode": "123"
+                    }
+                }
+            }]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+
+        # Verify sensitive fields are masked in output
+        self.assertNotIn("4111111111111111", sanitized)  # cardNumber
+        self.assertNotIn("123", sanitized)  # cardSecurityCode
+        self.assertIn("***", sanitized)
+
+    def test_sshkeys_record_sanitized_in_logs(self):
+        """Verify sshKeys (keyPair) sensitive fields are not logged."""
+        private_key = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDU5Z8P2Z9q\n-----END PRIVATE KEY-----"
+        public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1OWfD9mfagMCACEA\n-----END PUBLIC KEY-----"
+
+        request_data = {
+            "records": [{
+                "recordUid": "test_key_uid",
+                "data": {
+                    "type": "keyPair",
+                    "value": {
+                        "privateKey": private_key,
+                        "publicKey": public_key
+                    }
+                }
+            }]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+
+        # Verify sensitive key material is not in the output
+        self.assertNotIn("PRIVATE KEY", sanitized)
+        self.assertNotIn("PUBLIC KEY", sanitized)
+        self.assertNotIn("BEGIN", sanitized)
+        self.assertIn("***", sanitized)
+
+    def test_softwarelicense_record_sanitized_in_logs(self):
+        """Verify softwareLicense sensitive fields are not logged."""
+        request_data = {
+            "records": [{
+                "recordUid": "test_license_uid",
+                "fields": [{
+                    "type": "licenseNumber",
+                    "value": ["LICENSE-2024-CONFIDENTIAL-NUMBER"]
+                }]
+            }]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+
+        # Verify sensitive license number is not in the output
+        self.assertNotIn("LICENSE-2024-CONFIDENTIAL-NUMBER", sanitized)
+        self.assertIn("***", sanitized)
+
+    def test_mixed_sensitive_records_sanitized(self):
+        """Verify multiple sensitive record types are all properly sanitized."""
+        request_data = {
+            "records": [
+                {
+                    "recordUid": "bank_uid",
+                    "data": {
+                        "type": "bankAccount",
+                        "value": {
+                            "accountNumber": "SECRET_ACCOUNT_123",
+                            "routingNumber": "SECRET_ROUTING_456"
+                        }
+                    }
+                },
+                {
+                    "recordUid": "card_uid",
+                    "data": {
+                        "type": "paymentCard",
+                        "value": {
+                            "cardNumber": "SECRET_CARD_789"
+                        }
+                    }
+                },
+                {
+                    "recordUid": "key_uid",
+                    "data": {
+                        "type": "keyPair",
+                        "value": {
+                            "privateKey": "SECRET_PRIVATE_KEY"
+                        }
+                    }
+                }
+            ]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+
+        # Verify all sensitive values are masked
+        self.assertNotIn("SECRET_ACCOUNT_123", sanitized)
+        self.assertNotIn("SECRET_ROUTING_456", sanitized)
+        self.assertNotIn("SECRET_CARD_789", sanitized)
+        self.assertNotIn("SECRET_PRIVATE_KEY", sanitized)
+
+    def test_non_sensitive_fields_preserved(self):
+        """Verify non-sensitive fields are preserved during sanitization."""
+        request_data = {
+            "records": [{
+                "recordUid": "test_uid_123",
+                "title": "My Bank Account",
+                "notes": "Primary checking account",
+                "data": {
+                    "type": "bankAccount",
+                    "value": {
+                        "accountNumber": "SECRET123"
+                    }
+                }
+            }]
+        }
+
+        json_str = json.dumps(request_data)
+        sanitized = api._sanitize_protobuf_json(json_str)
+        result = json.loads(sanitized)
+
+        # Verify non-sensitive fields are preserved
+        self.assertEqual(result["records"][0]["recordUid"], "test_uid_123")
+        self.assertEqual(result["records"][0]["title"], "My Bank Account")
+        self.assertEqual(result["records"][0]["notes"], "Primary checking account")
+
+        # Verify sensitive field is masked
+        self.assertNotIn("SECRET123", sanitized)
+
+    def test_case_insensitive_field_type_matching(self):
+        """Verify field type matching is case-insensitive."""
+        test_cases = [
+            ("paymentcard", "4111111111111111"),
+            ("PaymentCard", "4111111111111111"),
+            ("PAYMENTCARD", "4111111111111111"),
+            ("bankaccount", "SECRET_ACCOUNT"),
+            ("BankAccount", "SECRET_ACCOUNT"),
+            ("BANKACCOUNT", "SECRET_ACCOUNT"),
+        ]
+
+        for field_type, sensitive_value in test_cases:
+            request_data = {
+                "data": {
+                    "type": field_type,
+                    "value": {"testField": sensitive_value}
+                }
+            }
+            json_str = json.dumps(request_data)
+            sanitized = api._sanitize_protobuf_json(json_str)
+
+            # All should be sanitized regardless of case
+            self.assertNotIn(sensitive_value, sanitized,
+                           f"Failed for field type: {field_type}")
+            self.assertIn("***", sanitized,
+                        f"Sanitization failed for field type: {field_type}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit-tests/test_record_logging_sanitization.py
+++ b/unit-tests/test_record_logging_sanitization.py
@@ -2,241 +2,231 @@
 # -*- coding: utf-8 -*-
 
 """
-Integration test to verify that sensitive record data is not exposed in logs
-during record-add and record-update operations.
-
-This test addresses the security issue where sensitive data from bankAccount,
-bankCard, sshKeys, softwareLicense, and encryptedNotes record types was being
-logged in Docker logs.
+Integration tests verifying that sensitive record data is masked in actual logging paths.
+Tests cover sanitize_command_fields and end-to-end logging for all affected record types.
 """
 
 import unittest
 import logging
-import json
-from io import StringIO
-from unittest.mock import Mock, patch, MagicMock
-from keepercommander import api, params as keeper_params
+from keepercommander.service.decorators.logging import sanitize_command_fields, sanitize_debug_data
 
 
-class TestRecordLoggingSanitization(unittest.TestCase):
-    """Test that sensitive record data is sanitized in logs during API communication."""
+class TestCommandFieldSanitization(unittest.TestCase):
+    """Test sanitization of command fields in all supported formats."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        self.log_stream = StringIO()
-        self.handler = logging.StreamHandler(self.log_stream)
-        self.handler.setLevel(logging.DEBUG)
-        formatter = logging.Formatter('%(levelname)s: %(message)s')
-        self.handler.setFormatter(formatter)
+    def test_bare_licensenumber_masked(self):
+        """Test bare licenseNumber field is masked."""
+        command = "record-add -rt softwareLicense licenseNumber=LICENSE_SECRET --force"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("LICENSE_SECRET", result)
+        self.assertIn("licenseNumber=***", result)
 
-        self.logger = logging.getLogger()
-        self.original_level = self.logger.level
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.addHandler(self.handler)
+    def test_bare_encryptednote_masked(self):
+        """Test bare encryptedNote field is masked."""
+        command = "record-add -rt encryptedNotes encryptedNote=NOTE_SECRET --force"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("NOTE_SECRET", result)
+        self.assertIn("encryptedNote=***", result)
 
-    def tearDown(self):
-        """Clean up test fixtures."""
-        self.logger.removeHandler(self.handler)
-        self.logger.setLevel(self.original_level)
-        self.log_stream.close()
+    def test_notes_option_masked(self):
+        """Test --notes option is masked."""
+        command = "record-add --title MyRecord --notes=NOTE_OPTION_SECRET --force"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("NOTE_OPTION_SECRET", result)
+        self.assertIn("--notes=***", result)
 
-    def _get_log_contents(self):
-        """Get the accumulated log contents."""
-        return self.log_stream.getvalue()
+    def test_notes_option_with_quotes_masked(self):
+        """Test --notes option with quoted value is masked."""
+        command = 'record-add --title MyRecord --notes "NOTE_QUOTED_SECRET" --force'
+        result = sanitize_command_fields(command)
+        self.assertNotIn("NOTE_QUOTED_SECRET", result)
+        self.assertIn("--notes ***", result)
 
-    def test_bankaccount_record_sanitized_in_logs(self):
-        """Verify bankAccount sensitive fields are not logged."""
-        request_data = {
-            "records": [{
-                "recordUid": "test_bank_uid",
-                "data": {
-                    "type": "bankAccount",
-                    "value": {
-                        "accountType": "Checking",
-                        "routingNumber": "123456789",
-                        "accountNumber": "98765432109876",
-                        "otherType": ""
-                    }
-                }
-            }]
-        }
+    def test_prefixed_bankaccount_fields_masked(self):
+        """Test prefixed bankAccount fields are masked."""
+        command = "record-add -rt bankAccount f.bankAccount.routingNumber=123456789 f.bankAccount.accountNumber=9876543210"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("123456789", result)
+        self.assertNotIn("9876543210", result)
+        self.assertIn("f.bankAccount.routingNumber=***", result)
+        self.assertIn("f.bankAccount.accountNumber=***", result)
 
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+    def test_prefixed_paymentcard_fields_masked(self):
+        """Test prefixed paymentCard fields are masked."""
+        command = "record-add -rt paymentCard f.paymentCard.cardNumber=4111111111111111 f.paymentCard.cardSecurityCode=123"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("4111111111111111", result)
+        self.assertNotIn("123", result)
+        self.assertIn("f.paymentCard.cardNumber=***", result)
+        self.assertIn("f.paymentCard.cardSecurityCode=***", result)
 
-        # Verify sensitive fields are masked in output
-        self.assertNotIn("123456789", sanitized)  # routingNumber
-        self.assertNotIn("98765432109876", sanitized)  # accountNumber
-        self.assertIn("***", sanitized)
+    def test_prefixed_keypair_fields_masked(self):
+        """Test prefixed keyPair fields are masked."""
+        command = "record-add -rt sshKeys f.keyPair.privateKey=SECRET_PRIVATE_KEY f.keyPair.publicKey=SECRET_PUBLIC_KEY"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_PRIVATE_KEY", result)
+        self.assertNotIn("SECRET_PUBLIC_KEY", result)
+        self.assertIn("f.keyPair.privateKey=***", result)
+        self.assertIn("f.keyPair.publicKey=***", result)
 
-    def test_bankcard_record_sanitized_in_logs(self):
-        """Verify bankCard (paymentCard) sensitive fields are not logged."""
-        request_data = {
-            "records": [{
-                "recordUid": "test_card_uid",
-                "data": {
-                    "type": "paymentCard",
-                    "value": {
-                        "cardNumber": "4111111111111111",
-                        "cardExpirationDate": "05/2025",
-                        "cardSecurityCode": "123"
-                    }
-                }
-            }]
-        }
+    def test_custom_field_licenseNumber_masked(self):
+        """Test custom field with licenseNumber type is masked."""
+        command = "record-add -rt login c.licenseNumber.MyLicense=LICENSE_CUSTOM_SECRET"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("LICENSE_CUSTOM_SECRET", result)
+        self.assertIn("c.licenseNumber.MyLicense=***", result)
 
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
+    def test_custom_field_encryptedNote_masked(self):
+        """Test custom field with encryptedNote type is masked."""
+        command = "record-add -rt login c.encryptedNote.MyNote=NOTE_CUSTOM_SECRET"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("NOTE_CUSTOM_SECRET", result)
+        self.assertIn("c.encryptedNote.MyNote=***", result)
 
-        # Verify sensitive fields are masked in output
-        self.assertNotIn("4111111111111111", sanitized)  # cardNumber
-        self.assertNotIn("123", sanitized)  # cardSecurityCode
-        self.assertIn("***", sanitized)
+    def test_bare_bankaccount_field_masked(self):
+        """Test bare bankAccount field is masked."""
+        command = "record-add bankAccount=SECRET_DATA"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_DATA", result)
+        self.assertIn("bankAccount=***", result)
 
-    def test_sshkeys_record_sanitized_in_logs(self):
-        """Verify sshKeys (keyPair) sensitive fields are not logged."""
-        private_key = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDU5Z8P2Z9q\n-----END PRIVATE KEY-----"
-        public_key = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1OWfD9mfagMCACEA\n-----END PUBLIC KEY-----"
+    def test_bare_paymentcard_field_masked(self):
+        """Test bare paymentCard field is masked."""
+        command = "record-add paymentCard=SECRET_DATA"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_DATA", result)
+        self.assertIn("paymentCard=***", result)
 
-        request_data = {
-            "records": [{
-                "recordUid": "test_key_uid",
-                "data": {
-                    "type": "keyPair",
-                    "value": {
-                        "privateKey": private_key,
-                        "publicKey": public_key
-                    }
-                }
-            }]
-        }
+    def test_bare_keypair_field_masked(self):
+        """Test bare keyPair field is masked."""
+        command = "record-add keyPair=SECRET_DATA"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_DATA", result)
+        self.assertIn("keyPair=***", result)
 
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
-
-        # Verify sensitive key material is not in the output
-        self.assertNotIn("PRIVATE KEY", sanitized)
-        self.assertNotIn("PUBLIC KEY", sanitized)
-        self.assertNotIn("BEGIN", sanitized)
-        self.assertIn("***", sanitized)
-
-    def test_softwarelicense_record_sanitized_in_logs(self):
-        """Verify softwareLicense sensitive fields are not logged."""
-        request_data = {
-            "records": [{
-                "recordUid": "test_license_uid",
-                "fields": [{
-                    "type": "licenseNumber",
-                    "value": ["LICENSE-2024-CONFIDENTIAL-NUMBER"]
-                }]
-            }]
-        }
-
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
-
-        # Verify sensitive license number is not in the output
-        self.assertNotIn("LICENSE-2024-CONFIDENTIAL-NUMBER", sanitized)
-        self.assertIn("***", sanitized)
-
-    def test_mixed_sensitive_records_sanitized(self):
-        """Verify multiple sensitive record types are all properly sanitized."""
-        request_data = {
-            "records": [
-                {
-                    "recordUid": "bank_uid",
-                    "data": {
-                        "type": "bankAccount",
-                        "value": {
-                            "accountNumber": "SECRET_ACCOUNT_123",
-                            "routingNumber": "SECRET_ROUTING_456"
-                        }
-                    }
-                },
-                {
-                    "recordUid": "card_uid",
-                    "data": {
-                        "type": "paymentCard",
-                        "value": {
-                            "cardNumber": "SECRET_CARD_789"
-                        }
-                    }
-                },
-                {
-                    "recordUid": "key_uid",
-                    "data": {
-                        "type": "keyPair",
-                        "value": {
-                            "privateKey": "SECRET_PRIVATE_KEY"
-                        }
-                    }
-                }
-            ]
-        }
-
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
-
-        # Verify all sensitive values are masked
-        self.assertNotIn("SECRET_ACCOUNT_123", sanitized)
-        self.assertNotIn("SECRET_ROUTING_456", sanitized)
-        self.assertNotIn("SECRET_CARD_789", sanitized)
-        self.assertNotIn("SECRET_PRIVATE_KEY", sanitized)
+    def test_mixed_command_all_masked(self):
+        """Test mixed command with multiple sensitive fields all masked."""
+        command = "record-add -rt softwareLicense --title MyLicense --notes=MY_NOTES licenseNumber=LICENSE_NUM f.encryptedNote=NOTE_DATA"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("MY_NOTES", result)
+        self.assertNotIn("LICENSE_NUM", result)
+        self.assertNotIn("NOTE_DATA", result)
+        self.assertIn("--notes=***", result)
+        self.assertIn("licenseNumber=***", result)
+        self.assertIn("f.encryptedNote=***", result)
 
     def test_non_sensitive_fields_preserved(self):
-        """Verify non-sensitive fields are preserved during sanitization."""
-        request_data = {
-            "records": [{
-                "recordUid": "test_uid_123",
-                "title": "My Bank Account",
-                "notes": "Primary checking account",
-                "data": {
-                    "type": "bankAccount",
-                    "value": {
-                        "accountNumber": "SECRET123"
-                    }
-                }
-            }]
-        }
+        """Test that non-sensitive fields and options are preserved."""
+        command = "record-add -rt bankAccount --title MyBank --folder MyFolder f.name=John"
+        result = sanitize_command_fields(command)
+        self.assertIn("--title", result)
+        self.assertIn("MyBank", result)
+        self.assertIn("--folder", result)
+        self.assertIn("MyFolder", result)
+        self.assertIn("f.name=John", result)
 
-        json_str = json.dumps(request_data)
-        sanitized = api._sanitize_protobuf_json(json_str)
-        result = json.loads(sanitized)
 
-        # Verify non-sensitive fields are preserved
-        self.assertEqual(result["records"][0]["recordUid"], "test_uid_123")
-        self.assertEqual(result["records"][0]["title"], "My Bank Account")
-        self.assertEqual(result["records"][0]["notes"], "Primary checking account")
+class TestDebugDataSanitization(unittest.TestCase):
+    """Test sanitize_debug_data for JSON and other formats."""
 
-        # Verify sensitive field is masked
-        self.assertNotIn("SECRET123", sanitized)
+    def test_sanitize_licensenumber_in_json(self):
+        """Test licenseNumber in JSON is masked."""
+        json_str = '{"licenseNumber": "LICENSE_SECRET_123"}'
+        result = sanitize_debug_data(json_str)
+        self.assertNotIn("LICENSE_SECRET_123", result)
 
-    def test_case_insensitive_field_type_matching(self):
-        """Verify field type matching is case-insensitive."""
-        test_cases = [
-            ("paymentcard", "4111111111111111"),
-            ("PaymentCard", "4111111111111111"),
-            ("PAYMENTCARD", "4111111111111111"),
-            ("bankaccount", "SECRET_ACCOUNT"),
-            ("BankAccount", "SECRET_ACCOUNT"),
-            ("BANKACCOUNT", "SECRET_ACCOUNT"),
+    def test_sanitize_encryptednote_in_json(self):
+        """Test encryptedNote in JSON is masked."""
+        json_str = '{"encryptedNote": "NOTE_SECRET_456"}'
+        result = sanitize_debug_data(json_str)
+        self.assertNotIn("NOTE_SECRET_456", result)
+
+    def test_sanitize_note_in_json(self):
+        """Test note field in JSON is masked."""
+        json_str = '{"note": "SENSITIVE_NOTE_789"}'
+        result = sanitize_debug_data(json_str)
+        self.assertNotIn("SENSITIVE_NOTE_789", result)
+
+    def test_bare_licensing_command_in_debug(self):
+        """Test bare licenseNumber command is masked in debug output."""
+        debug_str = "Executing: record-add licenseNumber=LICENSE_DEBUG_SECRET"
+        result = sanitize_debug_data(debug_str)
+        self.assertNotIn("LICENSE_DEBUG_SECRET", result)
+
+    def test_bare_encryptednote_command_in_debug(self):
+        """Test bare encryptedNote command is masked in debug output."""
+        debug_str = "Executing: record-add encryptedNote=NOTE_DEBUG_SECRET"
+        result = sanitize_debug_data(debug_str)
+        self.assertNotIn("NOTE_DEBUG_SECRET", result)
+
+
+class TestRecordTypes(unittest.TestCase):
+    """End-to-end tests for each sensitive record type."""
+
+    def test_bankaccount_all_formats(self):
+        """Test bankAccount in all command formats."""
+        commands = [
+            "record-add -rt bankAccount f.bankAccount.routingNumber=123456789 f.bankAccount.accountNumber=9876543210",
+            "record-add bankAccount=DATA_SECRET",
+            "record-update REC_UID bankAccount=DATA_SECRET",
         ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("123456789", result, f"Failed for: {cmd}")
+            self.assertNotIn("9876543210", result, f"Failed for: {cmd}")
+            self.assertNotIn("DATA_SECRET", result, f"Failed for: {cmd}")
 
-        for field_type, sensitive_value in test_cases:
-            request_data = {
-                "data": {
-                    "type": field_type,
-                    "value": {"testField": sensitive_value}
-                }
-            }
-            json_str = json.dumps(request_data)
-            sanitized = api._sanitize_protobuf_json(json_str)
+    def test_paymentcard_all_formats(self):
+        """Test paymentCard in all command formats."""
+        commands = [
+            "record-add -rt paymentCard f.paymentCard.cardNumber=4111111111111111 f.paymentCard.cardSecurityCode=123",
+            "record-add paymentCard=DATA_SECRET",
+            "record-update REC_UID paymentCard=DATA_SECRET",
+        ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("4111111111111111", result, f"Failed for: {cmd}")
+            self.assertNotIn("123", result, f"Failed for: {cmd}")
+            self.assertNotIn("DATA_SECRET", result, f"Failed for: {cmd}")
 
-            # All should be sanitized regardless of case
-            self.assertNotIn(sensitive_value, sanitized,
-                           f"Failed for field type: {field_type}")
-            self.assertIn("***", sanitized,
-                        f"Sanitization failed for field type: {field_type}")
+    def test_sshkeys_all_formats(self):
+        """Test sshKeys (keyPair) in all command formats."""
+        commands = [
+            "record-add -rt sshKeys f.keyPair.privateKey=PRIVATE_SECRET f.keyPair.publicKey=PUBLIC_SECRET",
+            "record-add keyPair=DATA_SECRET",
+            "record-update REC_UID keyPair=DATA_SECRET",
+        ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("PRIVATE_SECRET", result, f"Failed for: {cmd}")
+            self.assertNotIn("PUBLIC_SECRET", result, f"Failed for: {cmd}")
+            self.assertNotIn("DATA_SECRET", result, f"Failed for: {cmd}")
+
+    def test_softwarelicense_all_formats(self):
+        """Test softwareLicense in all command formats."""
+        commands = [
+            "record-add -rt softwareLicense licenseNumber=LICENSE_SECRET",
+            "record-add -rt softwareLicense f.licenseNumber=LICENSE_SECRET",
+            "record-add licenseNumber=LICENSE_SECRET",
+            "record-update REC_UID licenseNumber=LICENSE_SECRET",
+        ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("LICENSE_SECRET", result, f"Failed for: {cmd}")
+
+    def test_encryptednotes_all_formats(self):
+        """Test encryptedNotes in all command formats."""
+        commands = [
+            "record-add -rt encryptedNotes encryptedNote=NOTE_SECRET",
+            "record-add -rt encryptedNotes f.encryptedNote=NOTE_SECRET",
+            "record-add encryptedNote=NOTE_SECRET",
+            "record-update REC_UID encryptedNote=NOTE_SECRET",
+            "record-add --notes=NOTE_SECRET",
+            "record-update REC_UID --notes=NOTE_SECRET",
+        ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("NOTE_SECRET", result, f"Failed for: {cmd}")
 
 
 if __name__ == '__main__':

--- a/unit-tests/test_record_logging_sanitization.py
+++ b/unit-tests/test_record_logging_sanitization.py
@@ -7,7 +7,6 @@ Tests cover sanitize_command_fields and end-to-end logging for all affected reco
 """
 
 import unittest
-import logging
 from keepercommander.service.decorators.logging import sanitize_command_fields, sanitize_debug_data
 
 
@@ -83,6 +82,20 @@ class TestCommandFieldSanitization(unittest.TestCase):
         self.assertNotIn("NOTE_CUSTOM_SECRET", result)
         self.assertIn("c.encryptedNote.MyNote=***", result)
 
+    def test_custom_field_password_label_masked(self):
+        """Test custom field password with label is masked."""
+        command = "record-add f.password.DBPassword=SECRET_DB_PASS"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_DB_PASS", result)
+        self.assertIn("f.password.DBPassword=***", result)
+
+    def test_custom_field_secret_label_masked(self):
+        """Test custom field secret with label is masked."""
+        command = "record-add c.secret.APIKey=SECRET_API_KEY_VALUE"
+        result = sanitize_command_fields(command)
+        self.assertNotIn("SECRET_API_KEY_VALUE", result)
+        self.assertIn("c.secret.APIKey=***", result)
+
     def test_bare_bankaccount_field_masked(self):
         """Test bare bankAccount field is masked."""
         command = "record-add bankAccount=SECRET_DATA"
@@ -114,6 +127,20 @@ class TestCommandFieldSanitization(unittest.TestCase):
         self.assertIn("--notes=***", result)
         self.assertIn("licenseNumber=***", result)
         self.assertIn("f.encryptedNote=***", result)
+
+    def test_mixed_case_field_names(self):
+        """Test that mixed-case field names are handled correctly."""
+        commands = [
+            "record-add EncryptedNote=CASE_SECRET",
+            "record-add LicenseNumber=CASE_SECRET",
+            "record-add BankAccount=CASE_SECRET",
+            "record-add f.Password.Label=CASE_SECRET",
+            "record-add c.Secret.Label=CASE_SECRET",
+        ]
+        for cmd in commands:
+            result = sanitize_command_fields(cmd)
+            self.assertNotIn("CASE_SECRET", result, f"Failed for: {cmd}")
+            self.assertIn("***", result, f"Not sanitized for: {cmd}")
 
     def test_non_sensitive_fields_preserved(self):
         """Test that non-sensitive fields and options are preserved."""


### PR DESCRIPTION
## Summary

Sensitive data from bankAccount, bankCard, sshKeys, softwareLicense, and encryptedNotes records was being exposed in Docker logs when executing record-add and record-update commands. Sensitive fields are now masked with *** at both the protobuf logging layer and the service API request logging layer, preventing data leakage in container logs.

## Changes

- **`keepercommander/api.py`**: Import and apply `sanitize_protobuf_json` to DEBUG-level logging in `communicate_rest()`
- **`keepercommander/sanitization.py`** (NEW): Shared sanitization module with reusable masking functions (`mask_field_value`, `sanitize_nested_data`, `sanitize_protobuf_json`)
- **`keepercommander/service/decorators/api_logging.py`**: Import `sanitize_nested_data` from shared module; enhanced `_get_sanitized_request_data()` to apply nested data masking
- **`keepercommander/service/decorators/logging.py`**: Added missing sensitive types (`licensenumber`, `encryptednote`, `note`) and regex patterns for custom field labels (f.password.Label=, c.secret.Label=, etc.)
- **`unit-tests/test_api_sanitization.py`**: Add 10 unit tests for protobuf JSON masking
- **`unit-tests/test_record_logging_sanitization.py`**: Add 27 integration tests covering all command formats and sensitive record types
- **`unit-tests/service/test_log_sanitization.py`**: Updated imports to use shared sanitization module
